### PR TITLE
fix: create Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,80 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+import Stripe from "stripe";
+import { env as defaultEnv } from "../config/env.js";
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("amount must be a positive integer in the smallest currency unit");
+  }
+
+  return amount;
+}
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return "usd";
+  }
+
+  if (typeof currency !== "string" || !/^[a-zA-Z]{3}$/.test(currency)) {
+    throw new Error("currency must be a three-letter ISO currency code");
+  }
+
+  return currency.toLowerCase();
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error("metadata must be an object when provided");
+  }
+
+  return metadata;
+}
+
+function createStripeClient(options) {
+  if (options.stripeClient) {
+    return options.stripeClient;
+  }
+
+  const stripeSecretKey = options.env?.stripeSecretKey ?? defaultEnv.stripeSecretKey;
+
+  if (!stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create a Stripe PaymentIntent");
+  }
+
+  const stripeFactory = options.stripeFactory ?? ((secretKey) => new Stripe(secretKey));
+  return stripeFactory(stripeSecretKey);
+}
+
+export async function createPaymentIntent(payload = {}, options = {}) {
+  const amount = validateAmount(payload.amount);
+  const currency = normalizeCurrency(payload.currency);
+  const metadata = validateMetadata(payload.metadata);
+  const stripe = createStripeClient(options);
+
+  const paymentIntentPayload = {
+    amount,
+    currency
   };
+
+  if (metadata !== undefined) {
+    paymentIntentPayload.metadata = metadata;
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(paymentIntentPayload);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Stripe payment intent creation failed: ${message}`);
+  }
 }

--- a/apps/api/src/tests/paymentService.smoke.test.js
+++ b/apps/api/src/tests/paymentService.smoke.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+const shouldRunSmokeTest =
+  process.env.RUN_STRIPE_SMOKE_TEST === "true" && Boolean(process.env.STRIPE_SECRET_KEY);
+
+test("createPaymentIntent creates a Stripe test-mode PaymentIntent when smoke testing is enabled", {
+  skip: shouldRunSmokeTest ? false : "Set RUN_STRIPE_SMOKE_TEST=true and STRIPE_SECRET_KEY to run live Stripe smoke test"
+}, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smokeTest: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+function createMockStripeClient(responseOrError, calls = []) {
+  return {
+    paymentIntents: {
+      async create(args) {
+        calls.push(args);
+
+        if (responseOrError instanceof Error) {
+          throw responseOrError;
+        }
+
+        return responseOrError;
+      }
+    }
+  };
+}
+
+test("createPaymentIntent validates amount before calling Stripe", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient({ id: "pi_unused", client_secret: "secret_unused" }, calls);
+
+  for (const amount of [undefined, null, 0, -1, 10.5, "100"]) {
+    await assert.rejects(
+      () => createPaymentIntent({ amount }, { stripeClient }),
+      /amount must be a positive integer/i
+    );
+  }
+
+  assert.deepEqual(calls, []);
+});
+
+test("createPaymentIntent defaults currency to usd and maps Stripe response fields", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(
+    { id: "pi_123", client_secret: "pi_123_secret_456" },
+    calls
+  );
+
+  const result = await createPaymentIntent(
+    { amount: 2599, metadata: { jobId: "job_123" } },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2599,
+      currency: "usd",
+      metadata: { jobId: "job_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_123",
+    clientSecret: "pi_123_secret_456",
+    amount: 2599,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent initializes Stripe from STRIPE_SECRET_KEY when no client is injected", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient({ id: "pi_live", client_secret: "secret_live" }, calls);
+  const factoryCalls = [];
+
+  const result = await createPaymentIntent(
+    { amount: 1000, currency: "eur" },
+    {
+      env: { stripeSecretKey: "unit-test-secret" },
+      stripeFactory(secretKey) {
+        factoryCalls.push(secretKey);
+        return stripeClient;
+      }
+    }
+  );
+
+  assert.deepEqual(factoryCalls, ["unit-test-secret"]);
+  assert.deepEqual(calls, [{ amount: 1000, currency: "eur" }]);
+  assert.equal(result.paymentId, "pi_live");
+  assert.equal(result.clientSecret, "secret_live");
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("No such customer: cus_missing");
+  stripeError.type = "StripeInvalidRequestError";
+  const stripeClient = createMockStripeClient(stripeError);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }, { stripeClient }),
+    (error) =>
+      error.message.includes("Stripe payment intent creation failed") &&
+      error.message.includes("No such customer: cus_missing")
+  );
+});
+
+test("createPaymentIntent rejects invalid metadata values", async () => {
+  const stripeClient = createMockStripeClient({ id: "pi_unused", client_secret: "secret_unused" });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: "job_123" }, { stripeClient }),
+    /metadata must be an object/i
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaced the timestamp-based payment stub with a Stripe SDK-backed `PaymentIntent` creation path.
- Validate `amount` as a required positive integer, normalize/default `currency` to `usd`, and validate optional metadata before calling Stripe.
- Return the real Stripe `paymentIntent.id` as `paymentId` and `paymentIntent.client_secret` as `clientSecret`.
- Preserve Stripe API error messages in the thrown service error.
- Added focused unit coverage plus a guarded Stripe smoke test that only runs when `RUN_STRIPE_SMOKE_TEST=true` and `STRIPE_SECRET_KEY` are set.

## Root Cause
`createPaymentIntent` was still a placeholder that generated `pay_${Date.now()}` locally. It never initialized the Stripe SDK, never called `stripe.paymentIntents.create()`, never returned a `client_secret`, and accepted invalid amounts before the provider call.

## Demo / Verification
- `node --test apps/api/src/tests/paymentService.test.js` first failed against the stub, confirming the test covered the missing behavior.
- `npm test --workspace apps/api` now passes: 7 tests total, 6 passed, 1 guarded Stripe smoke test skipped by default.
- The live Stripe smoke test is intentionally opt-in to avoid requiring secrets in CI: `RUN_STRIPE_SMOKE_TEST=true STRIPE_SECRET_KEY=<test key> npm test --workspace apps/api`.

## Scope Notes
- No Stripe keys or private credentials are committed.
- The smoke test is skipped unless explicitly enabled.
- The API test script now points to `src/tests/*.test.js` so the existing test suite runs correctly under Node's built-in test runner.
