### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,73 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("STRIPE_SECRET_KEY is required to create payment intents");
+  }
+
+  stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY);
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("payload.amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("payload.currency must be a 3-letter ISO currency code");
+  }
+
+  if (payload.metadata !== undefined && (payload.metadata === null || typeof payload.metadata !== "object" || Array.isArray(payload.metadata))) {
+    throw new Error("payload.metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    ...(payload.metadata ? { metadata: payload.metadata } : {})
   };
+}
+
+function normalizeStripeError(error) {
+  const message = error?.message || "Stripe payment intent creation failed";
+
+  if (error?.type?.startsWith("Stripe")) {
+    throw new Error(`Stripe error: ${message}`);
+  }
+
+  throw error;
+}
+
+export function buildPaymentService({ stripe = getStripeClient() } = {}) {
+  return {
+    async createPaymentIntent(payload) {
+      const paymentIntentPayload = validatePaymentPayload(payload);
+
+      try {
+        const paymentIntent = await stripe.paymentIntents.create(paymentIntentPayload);
+
+        return {
+          paymentId: paymentIntent.id,
+          clientSecret: paymentIntent.client_secret,
+          amount: paymentIntent.amount,
+          currency: paymentIntent.currency,
+          provider: "stripe"
+        };
+      } catch (error) {
+        normalizeStripeError(error);
+      }
+    }
+  };
+}
+
+export async function createPaymentIntent(payload) {
+  return buildPaymentService().createPaymentIntent(payload);
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildPaymentService } from "../services/paymentService.js";
+
+function createStripeMock({ createResponse, createError } = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    stripe: {
+      paymentIntents: {
+        async create(payload) {
+          calls.push(payload);
+
+          if (createError) {
+            throw createError;
+          }
+
+          return createResponse ?? {
+            id: "pi_test_123",
+            client_secret: "pi_test_123_secret_abc",
+            amount: payload.amount,
+            currency: payload.currency
+          };
+        }
+      }
+    }
+  };
+}
+
+test("createPaymentIntent validates and maps Stripe PaymentIntent responses", async () => {
+  const { stripe, calls } = createStripeMock();
+  const service = buildPaymentService({ stripe });
+
+  const result = await service.createPaymentIntent({
+    amount: 2500,
+    metadata: { orderId: "order_123" }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { orderId: "order_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent rejects invalid payment payloads before calling Stripe", async () => {
+  const { stripe, calls } = createStripeMock();
+  const service = buildPaymentService({ stripe });
+
+  await assert.rejects(
+    () => service.createPaymentIntent({ amount: 0 }),
+    /payload\.amount must be a positive integer/
+  );
+  await assert.rejects(
+    () => service.createPaymentIntent({ amount: 100, currency: "us" }),
+    /payload\.currency must be a 3-letter ISO currency code/
+  );
+  await assert.rejects(
+    () => service.createPaymentIntent({ amount: 100, metadata: null }),
+    /payload\.metadata must be an object/
+  );
+
+  assert.deepEqual(calls, []);
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  const stripeError = new Error("No such customer: cus_missing");
+  stripeError.type = "StripeInvalidRequestError";
+
+  const { stripe } = createStripeMock({ createError: stripeError });
+  const service = buildPaymentService({ stripe });
+
+  await assert.rejects(
+    () => service.createPaymentIntent({ amount: 1000, currency: "EUR" }),
+    /Stripe error: No such customer: cus_missing/
+  );
+});
+
+test("createPaymentIntent smoke test creates a Stripe test-mode PaymentIntent", { skip: !process.env.RUN_STRIPE_SMOKE_TEST }, async () => {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("STRIPE_SECRET_KEY is required when RUN_STRIPE_SMOKE_TEST is set");
+  }
+
+  const { createPaymentIntent } = await import("../services/paymentService.js");
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smokeTest: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.equal(typeof result.clientSecret, "string");
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -690,7 +691,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -704,7 +705,7 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -752,7 +753,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -978,7 +979,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1703,7 +1704,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2051,6 +2052,23 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {


### PR DESCRIPTION
## Summary
/claim #1

- Replace the timestamp-based payment stub with a Stripe PaymentIntent implementation using `STRIPE_SECRET_KEY`.
- Validate `amount`, default and normalize `currency`, validate optional `metadata`, and pass the checked payload to `stripe.paymentIntents.create()`.
- Return `paymentId` from `paymentIntent.id` and `clientSecret` from `paymentIntent.client_secret`.
- Preserve Stripe API error messages while avoiding hardcoded keys.
- Add mocked unit coverage plus a guarded Stripe test-mode smoke test.

## Verification / demo notes
- `npm test -w apps/api`
- Result: 4 passed, 1 skipped. The skipped test is the live Stripe smoke test and only runs when `RUN_STRIPE_SMOKE_TEST=1` plus `STRIPE_SECRET_KEY` are set.

## Demo video
I do not have a Stripe test key in this environment, so the live API path is guarded by env vars. The mocked unit test demonstrates the exact `paymentIntents.create()` arguments and the returned `clientSecret`/`paymentId` mapping.