### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error.statusCode) {
+      return fail(res, error.message, error.statusCode);
+    }
+
+    return next(error);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,122 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+    this.statusCode = 500;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = cause?.type ?? "StripeError";
+    this.statusCode = 502;
+    this.cause = cause;
+  }
+}
+
+export function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentConfigurationError(
+      "STRIPE_SECRET_KEY is required to create payment intents"
+    );
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(env.stripeSecretKey);
+  }
+
+  return stripeClient;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata == null) {
+    return undefined;
+  }
+
+  if (
+    typeof metadata !== "object" ||
+    Array.isArray(metadata)
+  ) {
+    throw new PaymentValidationError("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [key, String(value)])
+  );
+}
+
+function normalizePayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentValidationError("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentValidationError(
+      "amount is required and must be a positive integer in the smallest currency unit"
+    );
+  }
+
+  const currency = payload.currency ?? "usd";
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError(
+      "currency must be a three-letter ISO currency code"
+    );
+  }
+
+  const metadata = normalizeMetadata(payload.metadata);
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    ...(metadata ? { metadata } : {})
   };
+}
+
+function isStripeError(error) {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      typeof error.type === "string" &&
+      typeof error.message === "string"
+  );
+}
+
+export async function createPaymentIntent(payload, client) {
+  const paymentIntentPayload = normalizePayload(payload);
+  const paymentClient = client ?? getStripeClient();
+
+  try {
+    const paymentIntent = await paymentClient.paymentIntents.create(
+      paymentIntentPayload
+    );
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntentPayload.amount,
+      currency: paymentIntentPayload.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(error.message, error);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  PaymentProviderError,
+  PaymentValidationError,
+  createPaymentIntent
+} from "../services/paymentService.js";
+
+function createMockStripeClient(paymentIntentOrError) {
+  const calls = [];
+
+  return {
+    calls,
+    paymentIntents: {
+      async create(payload) {
+        calls.push(payload);
+
+        if (paymentIntentOrError instanceof Error) {
+          throw paymentIntentOrError;
+        }
+
+        return paymentIntentOrError;
+      }
+    }
+  };
+}
+
+test("createPaymentIntent validates input and creates a Stripe PaymentIntent", async () => {
+  const stripe = createMockStripeClient({
+    id: "pi_test_123",
+    client_secret: "pi_test_123_secret_test"
+  });
+
+  const result = await createPaymentIntent(
+    {
+      amount: 1299,
+      metadata: {
+        jobId: "job_123",
+        expedited: true
+      }
+    },
+    stripe
+  );
+
+  assert.deepEqual(stripe.calls, [
+    {
+      amount: 1299,
+      currency: "usd",
+      metadata: {
+        jobId: "job_123",
+        expedited: "true"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_test",
+    amount: 1299,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent rejects missing or invalid amounts before calling Stripe", async () => {
+  const stripe = createMockStripeClient({
+    id: "pi_should_not_be_created",
+    client_secret: "unused"
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, stripe),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message.includes("positive integer")
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Missing required param: amount.");
+  stripeError.type = "StripeInvalidRequestError";
+
+  const stripe = createMockStripeClient(stripeError);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 500, currency: "USD" }, stripe),
+    (error) =>
+      error instanceof PaymentProviderError &&
+      error.name === "StripeInvalidRequestError" &&
+      error.message === "Missing required param: amount."
+  );
+});
+
+test("POST /api/payments surfaces validation errors", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: -100 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /positive integer/);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test(
+  "createPaymentIntent can run a live Stripe smoke test when explicitly enabled",
+  {
+    skip:
+      process.env.RUN_STRIPE_SMOKE_TEST === "1" &&
+      process.env.STRIPE_SECRET_KEY
+        ? false
+        : "Set RUN_STRIPE_SMOKE_TEST=1 and STRIPE_SECRET_KEY to run the live Stripe smoke test"
+  },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: {
+        source: "api-smoke-test"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.equal(typeof result.clientSecret, "string");
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

Closes #1

## Summary
- Replace the timestamp-based payment stub with a real Stripe `paymentIntents.create()` flow using `STRIPE_SECRET_KEY`.
- Validate payment payloads before calling Stripe: required positive integer `amount`, normalized three-letter `currency`, and optional metadata as string values.
- Return `paymentId` and `clientSecret` from Stripe, preserve Stripe error messages, and surface validation/provider errors through the API route.
- Add focused `node:test` coverage with a mocked Stripe client plus an opt-in live Stripe smoke test gated by `RUN_STRIPE_SMOKE_TEST=1` and `STRIPE_SECRET_KEY`.

## Verification
- `npm test`
- `npm run build` (root script currently prints the package-specific build hint)
- `npm run lint` (root script currently reports no lint configured)
- `git diff --check`

## Demo
Backend-only flow demo is covered by the test run above: it exercises the mocked Stripe PaymentIntent creation, validation failure handling through `POST /api/payments`, and the guarded live smoke-test path.

## AI assistance disclosure
This was implemented with Codex AI assistance. I inspected the repository, kept the patch scoped to #1, and ran the verification commands locally before opening the PR.