### PR TITLE
Fix Stripe payment intent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,68 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("STRIPE_SECRET_KEY environment variable is required");
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY);
+  }
+
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("Payment amount must be a positive integer in the smallest currency unit");
+  }
+
+  if (
+    payload.metadata !== undefined &&
+    (typeof payload.metadata !== "object" || payload.metadata === null || Array.isArray(payload.metadata))
+  ) {
+    throw new Error("Payment metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    metadata: payload.metadata
   };
+}
+
+export async function createPaymentIntent(payload) {
+  const { amount, currency, metadata } = validatePaymentPayload(payload);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error?.type?.startsWith("Stripe")) {
+      throw new Error(`Stripe payment intent failed: ${error.message}`);
+    }
+
+    throw error;
+  }
+}
+
+export function __setStripeClientForTest(client) {
+  stripeClient = client;
+}
+
+export function __resetStripeClientForTest() {
+  stripeClient = undefined;
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  __resetStripeClientForTest,
+  __setStripeClientForTest,
+  createPaymentIntent
+} from "../services/paymentService.js";
+
+function createStripeMock(response, error) {
+  const calls = [];
+
+  return {
+    calls,
+    client: {
+      paymentIntents: {
+        create: async (payload) => {
+          calls.push(payload);
+
+          if (error) {
+            throw error;
+          }
+
+          return response;
+        }
+      }
+    }
+  };
+}
+
+test.afterEach(() => {
+  __resetStripeClientForTest();
+  delete process.env.STRIPE_SECRET_KEY;
+});
+
+test("createPaymentIntent creates a Stripe payment intent with default currency", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const stripe = createStripeMock({
+    id: "pi_mocked",
+    client_secret: "pi_mocked_secret",
+    amount: 2500,
+    currency: "usd"
+  });
+  __setStripeClientForTest(stripe.client);
+
+  const result = await createPaymentIntent({ amount: 2500 });
+
+  assert.deepEqual(stripe.calls, [{ amount: 2500, currency: "usd" }]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mocked",
+    clientSecret: "pi_mocked_secret",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent passes currency and metadata to Stripe", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const stripe = createStripeMock({
+    id: "pi_metadata",
+    client_secret: "pi_metadata_secret",
+    amount: 1200,
+    currency: "eur"
+  });
+  __setStripeClientForTest(stripe.client);
+
+  await createPaymentIntent({
+    amount: 1200,
+    currency: "eur",
+    metadata: { jobId: "job_123" }
+  });
+
+  assert.deepEqual(stripe.calls, [
+    {
+      amount: 1200,
+      currency: "eur",
+      metadata: { jobId: "job_123" }
+    }
+  ]);
+});
+
+test("createPaymentIntent rejects missing or invalid amounts before calling Stripe", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const stripe = createStripeMock({});
+  __setStripeClientForTest(stripe.client);
+
+  await assert.rejects(() => createPaymentIntent({}), /positive integer/);
+  await assert.rejects(() => createPaymentIntent({ amount: 0 }), /positive integer/);
+  await assert.rejects(() => createPaymentIntent({ amount: 12.5 }), /positive integer/);
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent requires a Stripe secret key", async () => {
+  const stripe = createStripeMock({});
+  __setStripeClientForTest(stripe.client);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 2500 }),
+    /STRIPE_SECRET_KEY environment variable is required/
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const stripeError = new Error("Your card was declined");
+  stripeError.type = "StripeCardError";
+  const stripe = createStripeMock(null, stripeError);
+  __setStripeClientForTest(stripe.client);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 2500 }),
+    /Stripe payment intent failed: Your card was declined/
+  );
+});
+
+test("createPaymentIntent can create a real test-mode Stripe payment intent", { skip: !process.env.RUN_STRIPE_SMOKE_TEST }, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smokeTest: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmmirror.com/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Closes #1.

## Summary
- Replaced the stub payment intent generator with the Stripe Node SDK.
- Validates `amount`, defaults `currency` to `usd`, and forwards optional metadata.
- Returns Stripe `paymentIntent.id` as `paymentId` and `client_secret` as `clientSecret`.
- Preserves Stripe API error messages in thrown errors.
- Adds unit tests with a mocked Stripe client plus a guarded real Stripe smoke test.

## Validation
- `npm test`
- `npm run lint` (root script currently reports no lint configured)

The real Stripe smoke test is skipped by default and can be enabled with `RUN_STRIPE_SMOKE_TEST=1` and a test-mode `STRIPE_SECRET_KEY`.