### PR TITLE
feat(api): create Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^16.12.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,66 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  if (!env.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create payment intents");
+  }
+
+  stripeClient = new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+export function __setStripeClientForTests(client) {
+  stripeClient = client;
+}
+
+export function validatePaymentIntentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("amount is required and must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = typeof payload.currency === "string" && payload.currency.trim()
+    ? payload.currency.trim().toLowerCase()
+    : "usd";
+
+  if (!/^[a-z]{3}$/.test(currency)) {
+    throw new Error("currency must be a three-letter ISO currency code");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency,
+    metadata: payload.metadata && typeof payload.metadata === "object" && !Array.isArray(payload.metadata)
+      ? payload.metadata
+      : undefined
   };
+}
+
+export async function createPaymentIntent(payload) {
+  const { amount, currency, metadata } = validatePaymentIntentPayload(payload);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error?.message ?? "Stripe payment intent creation failed";
+    throw new Error(`Stripe payment intent creation failed: ${message}`);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  __setStripeClientForTests,
+  createPaymentIntent,
+  validatePaymentIntentPayload
+} from "../services/paymentService.js";
+
+test("validates required positive integer amount", () => {
+  assert.throws(
+    () => validatePaymentIntentPayload({ amount: 0 }),
+    /positive integer/
+  );
+  assert.throws(
+    () => validatePaymentIntentPayload({ amount: 10.5 }),
+    /positive integer/
+  );
+});
+
+test("defaults currency to usd and normalizes provided currency", () => {
+  assert.deepEqual(validatePaymentIntentPayload({ amount: 500 }), {
+    amount: 500,
+    currency: "usd",
+    metadata: undefined
+  });
+  assert.equal(
+    validatePaymentIntentPayload({ amount: 500, currency: "EUR" }).currency,
+    "eur"
+  );
+});
+
+test("creates Stripe payment intent and maps response fields", async () => {
+  const calls = [];
+  __setStripeClientForTests({
+    paymentIntents: {
+      async create(payload) {
+        calls.push(payload);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_abc"
+        };
+      }
+    }
+  });
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: { jobId: "job_123" }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { jobId: "job_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("preserves Stripe error message", async () => {
+  __setStripeClientForTests({
+    paymentIntents: {
+      async create() {
+        throw new Error("Invalid API Key provided");
+      }
+    }
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }),
+    /Invalid API Key provided/
+  );
+});

--- a/apps/api/src/tests/paymentSmoke.test.js
+++ b/apps/api/src/tests/paymentSmoke.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("guarded Stripe smoke test creates a test-mode PaymentIntent", { skip: process.env.STRIPE_SMOKE_TEST !== "1" }, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smoke: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^16.12.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Replace the timestamp-based payment stub with Stripe PaymentIntent creation using STRIPE_SECRET_KEY
- Validate positive integer amount, normalize/default currency, and pass metadata safely
- Return paymentId and clientSecret from Stripe and preserve Stripe error messages
- Add mocked unit coverage plus a guarded smoke test that only runs with STRIPE_SMOKE_TEST=1
- Fix the API test script so Node's test runner targets the actual test files

## Verification
- npm test

/claim #1

Closes #1