### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^17.7.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return fail(res, error.message, error.statusCode ?? 500);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,144 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+const STRIPE_API_VERSION = "2024-06-20";
+const STRIPE_ERROR_TYPES = new Set([
+  "StripeAPIError",
+  "StripeAuthenticationError",
+  "StripeCardError",
+  "StripeConnectionError",
+  "StripeIdempotencyError",
+  "StripeInvalidGrantError",
+  "StripeInvalidRequestError",
+  "StripePermissionError",
+  "StripeRateLimitError",
+  "StripeSignatureVerificationError"
+]);
+
+let cachedStripeClient;
+let cachedStripeSecretKey;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, cause) {
+    super(message, { cause });
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
+}
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentValidationError("STRIPE_SECRET_KEY is required to create Stripe payments");
+  }
+
+  if (!cachedStripeClient || cachedStripeSecretKey !== secretKey) {
+    cachedStripeClient = new Stripe(secretKey, {
+      apiVersion: STRIPE_API_VERSION
+    });
+    cachedStripeSecretKey = secretKey;
+  }
+
+  return cachedStripeClient;
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentValidationError("Payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentValidationError("Payment amount is required and must be a positive integer");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError("Payment currency must be a three-letter ISO currency code");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: validateMetadata(payload.metadata)
   };
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentValidationError("Payment metadata must be an object when provided");
+  }
+
+  const entries = Object.entries(metadata);
+  if (entries.length > 50) {
+    throw new PaymentValidationError("Payment metadata cannot contain more than 50 keys");
+  }
+
+  return entries.reduce((normalized, [key, value]) => {
+    if (typeof key !== "string" || key.length === 0 || key.length > 40) {
+      throw new PaymentValidationError("Payment metadata keys must be 1 to 40 characters long");
+    }
+
+    if (value === null || value === undefined || typeof value === "object") {
+      throw new PaymentValidationError("Payment metadata values must be strings, numbers, or booleans");
+    }
+
+    const stringValue = String(value);
+    if (stringValue.length > 500) {
+      throw new PaymentValidationError("Payment metadata values cannot exceed 500 characters");
+    }
+
+    normalized[key] = stringValue;
+    return normalized;
+  }, {});
+}
+
+function normalizeStripeError(error) {
+  if (error?.type && STRIPE_ERROR_TYPES.has(error.type)) {
+    return new PaymentProviderError(`Stripe payment failed: ${error.message}`, error);
+  }
+
+  return error;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const validated = validatePaymentPayload(payload);
+  const stripeClient = options.stripeClient ?? getStripeClient();
+  const createParams = {
+    amount: validated.amount,
+    currency: validated.currency
+  };
+
+  if (validated.metadata) {
+    createParams.metadata = validated.metadata;
+  }
+
+  try {
+    const paymentIntent = await stripeClient.paymentIntents.create(createParams);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: validated.amount,
+      currency: validated.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw normalizeStripeError(error);
+  }
+}
+
+export function resetStripeClientForTests() {
+  cachedStripeClient = undefined;
+  cachedStripeSecretKey = undefined;
 }

--- a/apps/api/src/tests/paymentRoute.test.js
+++ b/apps/api/src/tests/paymentRoute.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments returns validation errors from the payment service", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        currency: "usd"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Payment amount is required and must be a positive integer"
+    });
+  });
+});

--- a/apps/api/src/tests/paymentService.smoke.test.js
+++ b/apps/api/src/tests/paymentService.smoke.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+const shouldRunStripeSmokeTest =
+  process.env.RUN_STRIPE_SMOKE_TEST === "1" &&
+  typeof process.env.STRIPE_SECRET_KEY === "string" &&
+  process.env.STRIPE_SECRET_KEY.startsWith("sk_test_");
+
+test(
+  "createPaymentIntent creates a test-mode Stripe PaymentIntent",
+  { skip: shouldRunStripeSmokeTest ? false : "Set RUN_STRIPE_SMOKE_TEST=1 with a sk_test_ STRIPE_SECRET_KEY" },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: {
+        source: "api-smoke-test"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_.*_secret_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  resetStripeClientForTests
+} from "../services/paymentService.js";
+
+function createMockStripeClient({ response, error } = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    client: {
+      paymentIntents: {
+        create: async (params) => {
+          calls.push(params);
+
+          if (error) {
+            throw error;
+          }
+
+          return (
+            response ?? {
+              id: "pi_mock_123",
+              client_secret: "pi_mock_123_secret_mock"
+            }
+          );
+        }
+      }
+    }
+  };
+}
+
+test("createPaymentIntent validates payload and maps Stripe PaymentIntent response", async () => {
+  const stripe = createMockStripeClient();
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2499,
+      currency: "USD",
+      metadata: {
+        checkoutId: "checkout_123",
+        userId: 42,
+        recurring: false
+      }
+    },
+    { stripeClient: stripe.client }
+  );
+
+  assert.deepEqual(stripe.calls, [
+    {
+      amount: 2499,
+      currency: "usd",
+      metadata: {
+        checkoutId: "checkout_123",
+        userId: "42",
+        recurring: "false"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mock_123",
+    clientSecret: "pi_mock_123_secret_mock",
+    amount: 2499,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd and omits metadata when not provided", async () => {
+  const stripe = createMockStripeClient({
+    response: {
+      id: "pi_without_metadata",
+      client_secret: "secret_without_metadata"
+    }
+  });
+
+  const result = await createPaymentIntent({ amount: 500 }, { stripeClient: stripe.client });
+
+  assert.deepEqual(stripe.calls, [
+    {
+      amount: 500,
+      currency: "usd"
+    }
+  ]);
+  assert.equal(result.paymentId, "pi_without_metadata");
+  assert.equal(result.clientSecret, "secret_without_metadata");
+});
+
+test("createPaymentIntent rejects missing or invalid amount before calling Stripe", async () => {
+  const stripe = createMockStripeClient();
+
+  await assert.rejects(
+    () => createPaymentIntent({ currency: "usd" }, { stripeClient: stripe.client }),
+    /Payment amount is required and must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10.5 }, { stripeClient: stripe.client }),
+    /Payment amount is required and must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient: stripe.client }),
+    /Payment amount is required and must be a positive integer/
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent rejects invalid currency and metadata before calling Stripe", async () => {
+  const stripe = createMockStripeClient();
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usdollars" }, { stripeClient: stripe.client }),
+    /Payment currency must be a three-letter ISO currency code/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: ["order"] }, { stripeClient: stripe.client }),
+    /Payment metadata must be an object when provided/
+  );
+  await assert.rejects(
+    () =>
+      createPaymentIntent(
+        {
+          amount: 1000,
+          metadata: {
+            nested: { id: "order_123" }
+          }
+        },
+        { stripeClient: stripe.client }
+      ),
+    /Payment metadata values must be strings, numbers, or booleans/
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY when no Stripe client is injected", async () => {
+  const previousKey = process.env.STRIPE_SECRET_KEY;
+  delete process.env.STRIPE_SECRET_KEY;
+  resetStripeClientForTests();
+
+  try {
+    await assert.rejects(
+      () => createPaymentIntent({ amount: 1000 }),
+      /STRIPE_SECRET_KEY is required to create Stripe payments/
+    );
+  } finally {
+    if (previousKey === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousKey;
+    }
+    resetStripeClientForTests();
+  }
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  const stripe = createMockStripeClient({
+    error: {
+      type: "StripeInvalidRequestError",
+      message: "No such customer: cus_missing"
+    }
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }, { stripeClient: stripe.client }),
+    /Stripe payment failed: No such customer: cus_missing/
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^17.7.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,18 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2140,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaced the timestamp-based payment stub with a Stripe SDK paymentIntents.create call initialized from STRIPE_SECRET_KEY.
- Validates amount, currency, and optional Stripe metadata before any provider call.
- Maps Stripe id and client_secret to paymentId and clientSecret while preserving amount, currency, and provider fields.
- Catches Stripe API error types and rethrows provider errors with the original Stripe message preserved.
- Returns payment validation/provider messages from the payment route instead of dropping async errors into the generic handler.

## Tests
- Added mocked Stripe unit coverage for create arguments, default currency, response mapping, validation failures, missing STRIPE_SECRET_KEY, and Stripe error message preservation.
- Added route-level validation coverage for POST /api/payments.
- Added an env-gated Stripe test-mode smoke test that only runs with RUN_STRIPE_SMOKE_TEST=1 and a sk_test_ STRIPE_SECRET_KEY.

## Verification
- npm test -w apps/api (8 passed, 1 smoke skipped without test Stripe credentials)
- npm test (8 passed, 1 smoke skipped without test Stripe credentials)
- npm run build
- git diff --check
