### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^18.5.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
 import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentIntent, PaymentValidationError } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      return res.status(400).json({ error: error.message });
+    }
+
+    return res.status(502).json({ error: error.message });
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,87 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+  }
+}
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new PaymentValidationError("STRIPE_SECRET_KEY is required");
+  }
+
+  stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY);
+  return stripeClient;
+}
+
+export function setStripeClientForTests(client) {
+  stripeClient = client;
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentValidationError("amount must be a positive integer in the smallest currency unit");
+  }
+
+  return amount;
+}
+
+function validateCurrency(currency) {
+  if (currency === undefined) {
+    return "usd";
+  }
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError("currency must be a three-letter currency code");
+  }
+
+  return currency.toLowerCase();
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (metadata === null || Array.isArray(metadata) || typeof metadata !== "object") {
+    throw new PaymentValidationError("metadata must be an object when provided");
+  }
+
+  return metadata;
+}
+
+export async function createPaymentIntent(payload = {}) {
+  const amount = validateAmount(payload.amount);
+  const currency = validateCurrency(payload.currency);
+  const metadata = validateMetadata(payload.metadata);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      throw error;
+    }
+
+    throw new Error(error.message || "Stripe payment intent creation failed");
+  }
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { setStripeClientForTests } from "../services/paymentService.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments returns Stripe client secret", async () => {
+  setStripeClientForTests({
+    paymentIntents: {
+      async create() {
+        return {
+          id: "pi_route_123",
+          client_secret: "pi_route_123_secret"
+        };
+      }
+    }
+  });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1999 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.paymentId, "pi_route_123");
+    assert.equal(payload.data.clientSecret, "pi_route_123_secret");
+  });
+});
+
+test("POST /api/payments returns 400 for invalid amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -1 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "amount must be a positive integer in the smallest currency unit");
+  });
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  PaymentValidationError,
+  setStripeClientForTests
+} from "../services/paymentService.js";
+
+test("createPaymentIntent creates a Stripe payment intent", async () => {
+  const calls = [];
+
+  setStripeClientForTests({
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_456"
+        };
+      }
+    }
+  });
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: { orderId: "order_123" }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { orderId: "order_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+
+  setStripeClientForTests({
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+        return {
+          id: "pi_test_default",
+          client_secret: "pi_test_default_secret"
+        };
+      }
+    }
+  });
+
+  await createPaymentIntent({ amount: 1000 });
+
+  assert.equal(calls[0].currency, "usd");
+});
+
+test("createPaymentIntent rejects invalid amounts", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 0 }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "amount must be a positive integer in the smallest currency unit"
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  setStripeClientForTests({
+    paymentIntents: {
+      async create() {
+        throw new Error("Your card was declined.");
+      }
+    }
+  });
+
+  await assert.rejects(createPaymentIntent({ amount: 1000 }), /Your card was declined\./);
+});

--- a/apps/api/src/tests/paymentSmoke.test.js
+++ b/apps/api/src/tests/paymentSmoke.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, setStripeClientForTests } from "../services/paymentService.js";
+
+test("creates a real Stripe test-mode payment intent when explicitly enabled", { skip: process.env.RUN_STRIPE_SMOKE_TEST !== "1" }, async () => {
+  setStripeClientForTests(undefined);
+
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smoke: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^18.5.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,8 +743,9 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1107,6 +1109,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1706,6 +1709,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -1776,6 +1780,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1785,6 +1790,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2053,6 +2059,26 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmmirror.com/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2154,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Closes #1

/claim #1

## Summary
- Replaces the fake `pay_${Date.now()}` payment id with a real Stripe PaymentIntent call
- Reads Stripe from `STRIPE_SECRET_KEY`, with no hardcoded keys
- Validates amount, currency, and metadata before touching Stripe
- Returns `paymentId` and `clientSecret` from the Stripe response
- Preserves Stripe error messages and maps validation failures to 400 responses
- Adds service tests, payment route tests, and a guarded live Stripe smoke test

## Verification
- `npm test -w apps/api`
- `npm test`
- `git diff --check`

The live Stripe smoke test is included but skipped by default. It only runs when `RUN_STRIPE_SMOKE_TEST=1` and `STRIPE_SECRET_KEY` are set, so CI does not need a secret.