### PR TITLE
Implement Stripe PaymentIntent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  createPaymentIntent,
+  PaymentProviderError,
+  PaymentValidationError
+} from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      return fail(res, error.message, 400);
+    }
+
+    if (error instanceof PaymentProviderError) {
+      return fail(res, error.message, 502);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,115 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+import Stripe from "stripe";
+
+const DEFAULT_CURRENCY = "usd";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, cause) {
+    super(message, { cause });
+    this.name = "PaymentProviderError";
+  }
+}
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentValidationError("STRIPE_SECRET_KEY is required to create a payment intent.");
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(secretKey);
+  }
+
+  return stripeClient;
+}
+
+function normalizeAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentValidationError(
+      "amount is required and must be a positive integer in the smallest currency unit."
+    );
+  }
+
+  return amount;
+}
+
+function normalizeCurrency(currency = DEFAULT_CURRENCY) {
+  if (typeof currency !== "string" || currency.trim().length !== 3) {
+    throw new PaymentValidationError("currency must be a three-letter ISO currency code.");
+  }
+
+  return currency.trim().toLowerCase();
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentValidationError("metadata must be an object when provided.");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === null || value === undefined || typeof value === "object") {
+        throw new PaymentValidationError(`metadata.${key} must be a string, number, or boolean.`);
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function buildPaymentIntentParams(payload = {}) {
+  const params = {
+    amount: normalizeAmount(payload.amount),
+    currency: normalizeCurrency(payload.currency)
   };
+
+  const metadata = normalizeMetadata(payload.metadata);
+  if (metadata) {
+    params.metadata = metadata;
+  }
+
+  return params;
+}
+
+function isStripeError(error) {
+  return typeof error?.type === "string" && error.type.startsWith("Stripe");
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const params = buildPaymentIntentParams(payload);
+  const stripe = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(params);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(error.message, error);
+    }
+
+    throw error;
+  }
+}
+
+export function resetStripeClientForTests() {
+  stripeClient = undefined;
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,177 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  createPaymentIntent,
+  PaymentProviderError,
+  PaymentValidationError,
+  resetStripeClientForTests
+} from "../services/paymentService.js";
+
+function createMockStripeClient(responseOverrides = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    client: {
+      paymentIntents: {
+        create: async (params) => {
+          calls.push(params);
+
+          return {
+            id: "pi_test_123",
+            client_secret: "pi_test_123_secret_abc",
+            amount: params.amount,
+            currency: params.currency,
+            ...responseOverrides
+          };
+        }
+      }
+    }
+  };
+}
+
+test("createPaymentIntent calls Stripe with validated payload and returns client secret", async () => {
+  const stripe = createMockStripeClient();
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: {
+        proposalId: 42,
+        sandbox: true
+      }
+    },
+    { stripeClient: stripe.client }
+  );
+
+  assert.deepEqual(stripe.calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        proposalId: "42",
+        sandbox: "true"
+      }
+    }
+  ]);
+
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const stripe = createMockStripeClient();
+
+  await createPaymentIntent({ amount: 1000 }, { stripeClient: stripe.client });
+
+  assert.deepEqual(stripe.calls, [{ amount: 1000, currency: "usd" }]);
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  const stripe = createMockStripeClient();
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient: stripe.client }),
+    PaymentValidationError
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent rejects invalid metadata before calling Stripe", async () => {
+  const stripe = createMockStripeClient();
+
+  await assert.rejects(
+    () =>
+      createPaymentIntent(
+        {
+          amount: 1000,
+          metadata: { nested: { unsupported: true } }
+        },
+        { stripeClient: stripe.client }
+      ),
+    /metadata\.nested must be a string, number, or boolean/
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Your card was declined.");
+  stripeError.type = "StripeCardError";
+
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        throw stripeError;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }, { stripeClient }),
+    (error) =>
+      error instanceof PaymentProviderError &&
+      error.message === "Your card was declined." &&
+      error.cause === stripeError
+  );
+});
+
+test("POST /api/payments returns a validation response for invalid payloads", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: -1 })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.match(payload.message, /positive integer/);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+const skipStripeSmoke =
+  process.env.STRIPE_PAYMENT_SMOKE_TEST === "1" && process.env.STRIPE_SECRET_KEY
+    ? false
+    : "Set STRIPE_PAYMENT_SMOKE_TEST=1 and STRIPE_SECRET_KEY to run the live Stripe smoke test.";
+
+test(
+  "createPaymentIntent can create a real Stripe test-mode PaymentIntent",
+  { skip: skipStripeSmoke },
+  async () => {
+    resetStripeClientForTests();
+
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: {
+        source: "payment-service-smoke"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.ok(result.clientSecret);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- replace the timestamp payment stub with Stripe SDK PaymentIntent creation from `STRIPE_SECRET_KEY`
- validate `amount`, default/normalize `currency`, and coerce supported metadata before the Stripe API call
- return `paymentId` and `clientSecret` from the Stripe response while preserving Stripe error messages
- add mocked service coverage, API validation coverage, and an opt-in live Stripe smoke test

## Verification
- `npm test`

Live smoke test can be run with `STRIPE_PAYMENT_SMOKE_TEST=1 STRIPE_SECRET_KEY=... npm test -w apps/api`.

## Payout
Payment method: Algora bounty-platform payout to GitHub user @jamilahmadzai for claim #1.


