### PR TITLE
Implement Stripe PaymentIntent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,31 @@
+import Stripe from "stripe";
+import { z } from "zod";
+import { env } from "../config/env.js";
+
+const paymentIntentSchema = z.object({
+  amount: z.number().int().positive(),
+  currency: z.string().trim().min(3).max(3).default("usd")
+});
+
 export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+  const { amount, currency } = paymentIntentSchema.parse(payload);
+
+  if (!env.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create Stripe PaymentIntents");
+  }
+
+  const stripe = new Stripe(env.stripeSecretKey);
+  const paymentIntent = await stripe.paymentIntents.create({
+    amount,
+    currency: currency.toLowerCase(),
+    automatic_payment_methods: { enabled: true }
+  });
+
   return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    id: paymentIntent.id,
+    amount: paymentIntent.amount,
+    currency: paymentIntent.currency,
+    clientSecret: paymentIntent.client_secret,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+const originalStripeSecretKey = process.env.STRIPE_SECRET_KEY;
+
+test.afterEach(() => {
+  if (originalStripeSecretKey === undefined) {
+    delete process.env.STRIPE_SECRET_KEY;
+  } else {
+    process.env.STRIPE_SECRET_KEY = originalStripeSecretKey;
+  }
+});
+
+test("createPaymentIntent requires integer positive amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 12.5, currency: "usd" }),
+    /Expected integer/
+  );
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY", async () => {
+  delete process.env.STRIPE_SECRET_KEY;
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 5000, currency: "usd" }),
+    /STRIPE_SECRET_KEY is required/
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Fixes #1

## Summary
- add Stripe SDK dependency to the API workspace
- validate positive integer amount + 3-letter currency before creating a PaymentIntent
- require STRIPE_SECRET_KEY instead of returning a mock payment payload
- return Stripe PaymentIntent id, amount, currency, clientSecret, provider
- fix API test command glob and add payment validation/env tests

## Test
- npm test -w apps/api
