### PR TITLE
Implement Stripe PaymentIntent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -2,5 +2,16 @@ import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json({
+        success: false,
+        message: error.message
+      });
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,129 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+
+const STRIPE_API_VERSION = "2026-02-25.clover";
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
+}
+
+let stripeClient;
+let stripeClientFactory = createStripeClient;
+
+function createStripeClient(secretKey) {
+  return new Stripe(secretKey, {
+    apiVersion: STRIPE_API_VERSION
+  });
+}
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentProviderError("STRIPE_SECRET_KEY is required to create payment intents.");
+  }
+
+  stripeClient = stripeClientFactory(secretKey);
+  return stripeClient;
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentValidationError("Payment amount is required and must be a positive integer.");
+  }
+
+  return amount;
+}
+
+function validateCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return "usd";
+  }
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError("Payment currency must be a three-letter ISO currency code.");
+  }
+
+  return currency.toLowerCase();
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (metadata === null || Array.isArray(metadata) || typeof metadata !== "object") {
+    throw new PaymentValidationError("Payment metadata must be an object when provided.");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === null || value === undefined || typeof value === "object") {
+        throw new PaymentValidationError("Payment metadata values must be strings, numbers, or booleans.");
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function isStripeError(error) {
+  return typeof error?.type === "string" && error.type.startsWith("Stripe");
+}
+
+export function setStripeClientFactoryForTests(factory) {
+  stripeClient = undefined;
+  stripeClientFactory = factory;
+}
+
+export function resetStripeClientForTests() {
+  stripeClient = undefined;
+  stripeClientFactory = createStripeClient;
+}
+
+export async function createPaymentIntent(payload = {}) {
+  const amount = validateAmount(payload.amount);
+  const currency = validateCurrency(payload.currency);
+  const metadata = validateMetadata(payload.metadata);
+  const params = { amount, currency };
+
+  if (metadata) {
+    params.metadata = metadata;
+  }
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create(params);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentValidationError || error instanceof PaymentProviderError) {
+      throw error;
+    }
+
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(error.message, { cause: error });
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentController.test.js
+++ b/apps/api/src/tests/paymentController.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  resetStripeClientForTests,
+  setStripeClientFactoryForTests
+} from "../services/paymentService.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test.afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  resetStripeClientForTests();
+});
+
+test("POST /api/payments returns PaymentIntent details", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeClientFactoryForTests(() => ({
+    paymentIntents: {
+      create: async () => ({
+        id: "pi_route_123",
+        client_secret: "pi_route_123_secret"
+      })
+    }
+  }));
+
+  const server = await listen(createApp());
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: 1200 })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.paymentId, "pi_route_123");
+  assert.equal(payload.data.clientSecret, "pi_route_123_secret");
+  assert.equal(payload.data.currency, "usd");
+
+  await close(server);
+});
+
+test("POST /api/payments returns validation errors as 400", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: 0 })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Payment amount is required and must be a positive integer."
+  });
+
+  await close(server);
+});

--- a/apps/api/src/tests/paymentService.smoke.test.js
+++ b/apps/api/src/tests/paymentService.smoke.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent can create a Stripe test-mode PaymentIntent", { skip: !process.env.RUN_STRIPE_SMOKE_TEST }, async () => {
+  assert.match(
+    process.env.STRIPE_SECRET_KEY ?? "",
+    /^sk_test_/,
+    "RUN_STRIPE_SMOKE_TEST requires a Stripe test-mode secret key."
+  );
+
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: {
+      source: "api-smoke-test"
+    }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.+_secret_.+/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  resetStripeClientForTests,
+  setStripeClientFactoryForTests
+} from "../services/paymentService.js";
+
+test.afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated payload", async () => {
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeClientFactoryForTests((secretKey) => {
+    assert.equal(secretKey, "sk_test_mock");
+
+    return {
+      paymentIntents: {
+        create: async (params) => {
+          calls.push(params);
+          return {
+            id: "pi_mock_123",
+            client_secret: "pi_mock_123_secret_456"
+          };
+        }
+      }
+    };
+  });
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: {
+      jobId: 42,
+      urgent: true
+    }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        jobId: "42",
+        urgent: "true"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mock_123",
+    clientSecret: "pi_mock_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeClientFactoryForTests(() => ({
+    paymentIntents: {
+      create: async (params) => {
+        calls.push(params);
+        return {
+          id: "pi_default_currency",
+          client_secret: "pi_default_currency_secret"
+        };
+      }
+    }
+  }));
+
+  await createPaymentIntent({ amount: 1 });
+
+  assert.deepEqual(calls, [{ amount: 1, currency: "usd" }]);
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  let called = false;
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeClientFactoryForTests(() => ({
+    paymentIntents: {
+      create: async () => {
+        called = true;
+      }
+    }
+  }));
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 10.5 }),
+    /positive integer/
+  );
+  assert.equal(called, false);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeClientFactoryForTests(() => ({
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined.");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  }));
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 500 }),
+    (error) => error.name === "PaymentProviderError" && error.message === "Your card was declined."
+  );
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 500 }),
+    /STRIPE_SECRET_KEY is required/
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

Fixes #1

## Summary
- replace the timestamp-based payment stub with Stripe `paymentIntents.create()` using `STRIPE_SECRET_KEY`
- validate `amount`, normalize/default `currency`, and validate optional metadata before calling Stripe
- return Stripe `id` as `paymentId` and `client_secret` as `clientSecret`
- preserve Stripe API error messages through a provider error and return validation/provider errors from the payment route
- add mocked service tests, route tests, and an opt-in Stripe test-mode smoke test

## Verification
- `npm test` — 8 passed, 1 skipped guarded Stripe smoke test
- `npm run build` — root script prints package-specific build guidance
- `npm run lint` — root script reports no lint configured
- `git diff --check`

## Smoke test
The live Stripe smoke test is intentionally skipped by default so CI does not need secrets. It can be run with:

```bash
RUN_STRIPE_SMOKE_TEST=1 STRIPE_SECRET_KEY=sk_test_... npm test -w apps/api
```

## Demo note
This is a backend-only payment service change. I do not have a Stripe test key in this environment, so the PR demo is the mocked API/service test run plus the guarded live smoke-test path above rather than a live provider charge.