### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^17.7.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error.statusCode) {
+      return fail(res, error.message, error.statusCode);
+    }
+
+    return next(error);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,115 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+    this.statusCode = 500;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, cause) {
+    super(message, { cause });
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
+}
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentConfigurationError(
+      "STRIPE_SECRET_KEY is required to create payment intents"
+    );
+  }
+
+  stripeClient ??= new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (!metadata || Array.isArray(metadata) || typeof metadata !== "object") {
+    throw new PaymentValidationError("metadata must be an object if provided");
+  }
+
+  const entries = Object.entries(metadata)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => {
+      if (!key.trim()) {
+        throw new PaymentValidationError("metadata keys must not be empty");
+      }
+
+      return [key, String(value)];
+    });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function buildPaymentIntentParams(payload = {}) {
+  if (!payload || Array.isArray(payload) || typeof payload !== "object") {
+    throw new PaymentValidationError("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentValidationError(
+      "amount is required and must be a positive integer in the smallest currency unit"
+    );
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency.trim())) {
+    throw new PaymentValidationError(
+      "currency must be a three-letter ISO currency code"
+    );
+  }
+
+  const metadata = normalizeMetadata(payload.metadata);
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.trim().toLowerCase(),
+    ...(metadata ? { metadata } : {})
   };
+}
+
+function wrapStripeError(error) {
+  if (error?.type?.startsWith("Stripe")) {
+    throw new PaymentProviderError(error.message, error);
+  }
+
+  throw error;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const params = buildPaymentIntentParams(payload);
+  const client = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await client.paymentIntents.create(params);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? params.amount,
+      currency: paymentIntent.currency ?? params.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    wrapStripeError(error);
+  }
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments returns validation errors with a useful message", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -10 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /positive integer/);
+  });
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  PaymentConfigurationError,
+  PaymentProviderError,
+  PaymentValidationError
+} from "../services/paymentService.js";
+
+function createMockStripeClient(responseOrError, calls = []) {
+  return {
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+
+        if (responseOrError instanceof Error) {
+          throw responseOrError;
+        }
+
+        return responseOrError;
+      }
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated defaults", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(
+    {
+      id: "pi_test_123",
+      client_secret: "pi_test_123_secret_abc",
+      amount: 1250,
+      currency: "usd"
+    },
+    calls
+  );
+
+  const result = await createPaymentIntent(
+    {
+      amount: 1250,
+      metadata: {
+        jobId: 42,
+        milestoneId: "m_1",
+        emptyValue: null
+      }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 1250,
+      currency: "usd",
+      metadata: {
+        jobId: "42",
+        milestoneId: "m_1"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 1250,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent normalizes explicit currency before calling Stripe", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(
+    {
+      id: "pi_test_eur",
+      client_secret: "pi_test_eur_secret",
+      amount: 5000,
+      currency: "eur"
+    },
+    calls
+  );
+
+  await createPaymentIntent({ amount: 5000, currency: " EUR " }, { stripeClient });
+
+  assert.deepEqual(calls, [{ amount: 5000, currency: "eur" }]);
+});
+
+test("createPaymentIntent rejects missing or invalid amounts before Stripe is called", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient({}, calls);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    PaymentValidationError
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 12.34 }, { stripeClient }),
+    /positive integer/
+  );
+
+  assert.deepEqual(calls, []);
+});
+
+test("createPaymentIntent rejects invalid payload and metadata shapes", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient({}, calls);
+
+  await assert.rejects(
+    () => createPaymentIntent(null, { stripeClient }),
+    /payload must be an object/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 500, metadata: [] }, { stripeClient }),
+    /metadata must be an object/
+  );
+  await assert.rejects(
+    () =>
+      createPaymentIntent(
+        {
+          amount: 500,
+          metadata: {
+            " ": "invalid"
+          }
+        },
+        { stripeClient }
+      ),
+    /metadata keys must not be empty/
+  );
+
+  assert.deepEqual(calls, []);
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  const stripeError = new Error("Your card was declined");
+  stripeError.type = "StripeCardError";
+  const stripeClient = createMockStripeClient(stripeError);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1500 }, { stripeClient }),
+    (error) =>
+      error instanceof PaymentProviderError &&
+      error.message === "Your card was declined" &&
+      error.cause === stripeError
+  );
+});
+
+test("createPaymentIntent reports missing Stripe configuration after validation", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100 }),
+    PaymentConfigurationError
+  );
+});

--- a/apps/api/src/tests/paymentStripeSmoke.test.js
+++ b/apps/api/src/tests/paymentStripeSmoke.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+const canRunStripeSmoke =
+  process.env.STRIPE_SMOKE_TEST === "1" && process.env.STRIPE_SECRET_KEY;
+
+test(
+  "creates a real Stripe test-mode PaymentIntent when explicitly enabled",
+  { skip: canRunStripeSmoke ? false : "set STRIPE_SMOKE_TEST=1 and STRIPE_SECRET_KEY to run" },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: {
+        source: "securebanana-smoke-test"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_.+_secret_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^17.7.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary

Implements the Stripe PaymentIntent flow for the payment service.

- Replaces the mock `pay_${Date.now()}` payment id with Stripe's Node SDK.
- Reads the Stripe secret key from `STRIPE_SECRET_KEY`.
- Validates payment payloads before contacting Stripe.
- Defaults currency to `usd` and normalizes explicit three-letter currency codes.
- Supports Stripe metadata after filtering nullish values and converting values to strings.
- Returns the Stripe `paymentId`, `clientSecret`, amount, currency, and provider.
- Maps validation, configuration, and Stripe provider failures to useful API responses.

## Verification

- `npm test -w apps/api`
- `git diff --check`

## Demo

- Short demo video: https://github.com/yang-agoni/bug-bounty/releases/download/pr20-demo-20260517/securebanana-pr20-demo.mp4

The real Stripe smoke test is included but intentionally skipped by default. It runs only with:

```bash
STRIPE_SMOKE_TEST=1 STRIPE_SECRET_KEY=sk_test_... npm test -w apps/api
```

## Notes

The smoke test should be run only with a Stripe test-mode key. No secret key is committed.

Closes #1
