### PR TITLE
feat: implement Stripe PaymentIntent with client_secret (Bounty #1)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,35 @@
+import Stripe from 'stripe';
+
+// Initialize Stripe with the secret key from environment
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+  apiVersion: '2023-10-16',
+});
+
 export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+  try {
+    // Convert amount to cents (assuming payload.amount is in dollars)
+    const amountInCents = Math.round(payload.amount * 100);
+    
+    // Create a PaymentIntent
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: amountInCents,
+      currency: payload.currency ?? 'usd',
+      automatic_payment_methods: {
+        enabled: true,
+      },
+    });
+
+    // Return the required object
+    return {
+      paymentId: paymentIntent.id,
+      amount: payload.amount, // Keep original amount in dollars
+      currency: payload.currency ?? 'usd',
+      provider: 'stripe',
+      client_secret: paymentIntent.client_secret,
+    };
+  } catch (error) {
+    // Handle Stripe errors
+    console.error('Stripe error:', error);
+    throw new Error(`Payment processing failed: ${error.message}`);
+  }
 }


### PR DESCRIPTION
## Summary
- Integrated Stripe Node.js SDK to create a real PaymentIntent
- Returns paymentId, amount, currency, provider: 'stripe', and client_secret
- Handles Stripe errors and throws meaningful messages
- Converts amount to cents as required by Stripe

## Changes
- Modified `apps/api/src/services/paymentService.js` to use Stripe SDK
- Added Stripe as a dependency (already installed via npm install stripe)

## Test Plan
- Verified the function syntax with `node -c`
- Manual review of the implementation

Closes #1