### PR TITLE
Implement protected admin operations panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,97 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  getAdminMetrics,
+  getPlatformControls,
+  getUserProfile,
+  listAuditLog,
+  listDisputes,
+  listModerationQueue,
+  listNotifications,
+  listUsers,
+  resolveListing,
+  ruleOnDispute,
+  updatePlatformControl,
+  updateUserStatus
+} from "../services/adminService.js";
+
+function adminId(req) {
+  return req.user?.sub ?? req.user?.id ?? "unknown_admin";
+}
+
+function handleAdminError(res, error) {
+  return fail(res, error.message ?? "Admin action failed", error.status ?? 500);
+}
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await listUsers(req.query));
+}
+
+export async function userProfile(req, res) {
+  try {
+    return ok(res, await getUserProfile(req.params.userId));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function changeUserStatus(req, res) {
+  try {
+    return ok(res, await updateUserStatus(adminId(req), req.params.userId, req.body.status));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function moderationQueue(req, res) {
+  return ok(res, await listModerationQueue(req.query));
+}
+
+export async function moderateListing(req, res) {
+  try {
+    return ok(
+      res,
+      await resolveListing(adminId(req), req.params.jobId, req.body.action, req.body.reason)
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function disputeRuling(req, res) {
+  try {
+    return ok(
+      res,
+      await ruleOnDispute(adminId(req), req.params.disputeId, req.body.ruling, req.body.note)
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function changeControl(req, res) {
+  try {
+    return ok(res, await updatePlatformControl(adminId(req), req.params.key, req.body.enabled));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await listAuditLog(req.query));
+}
+
+export async function notifications(req, res) {
+  return ok(res, await listNotifications());
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,12 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminOnly(req, res, next) {
+  const role = String(req.user?.role ?? "").toUpperCase();
+  if (role !== "ADMIN") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,33 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  auditLog,
+  changeControl,
+  changeUserStatus,
+  controls,
+  disputeRuling,
+  disputes,
+  metrics,
+  moderateListing,
+  moderationQueue,
+  notifications,
+  userProfile,
+  users
+} from "../controllers/adminController.js";
+import { adminOnly, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnly);
+
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.get("/users/:userId", userProfile);
+adminRoutes.patch("/users/:userId/status", changeUserStatus);
+adminRoutes.get("/moderation/jobs", moderationQueue);
+adminRoutes.post("/moderation/jobs/:jobId", moderateListing);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.post("/disputes/:disputeId/ruling", disputeRuling);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls/:key", changeControl);
+adminRoutes.get("/audit-log", auditLog);
+adminRoutes.get("/notifications", notifications);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,457 @@
-export async function getAdminMetrics() {
+const users = [
+  {
+    id: "usr_client_01",
+    email: "ana.client@example.com",
+    fullName: "Ana Client",
+    role: "CLIENT",
+    status: "ACTIVE",
+    trustScore: 92,
+    createdAt: "2026-04-02T09:12:00.000Z",
+    activeJobs: ["job_101"],
+    disputes: ["dis_1001"]
+  },
+  {
+    id: "usr_freelancer_01",
+    email: "maya.freelancer@example.com",
+    fullName: "Maya Freelancer",
+    role: "FREELANCER",
+    status: "ACTIVE",
+    trustScore: 87,
+    createdAt: "2026-04-08T12:35:00.000Z",
+    activeJobs: ["job_101", "job_103"],
+    disputes: ["dis_1001"]
+  },
+  {
+    id: "usr_client_02",
+    email: "owen.client@example.com",
+    fullName: "Owen Client",
+    role: "CLIENT",
+    status: "SUSPENDED",
+    trustScore: 54,
+    createdAt: "2026-05-01T17:20:00.000Z",
+    activeJobs: ["job_104"],
+    disputes: []
+  },
+  {
+    id: "usr_freelancer_02",
+    email: "li.freelancer@example.com",
+    fullName: "Li Freelancer",
+    role: "FREELANCER",
+    status: "BANNED",
+    trustScore: 22,
+    createdAt: "2026-05-12T08:05:00.000Z",
+    activeJobs: [],
+    disputes: ["dis_1002"]
+  },
+  {
+    id: "usr_admin_01",
+    email: "admin@example.com",
+    fullName: "Primary Admin",
+    role: "ADMIN",
+    status: "ACTIVE",
+    trustScore: 100,
+    createdAt: "2026-03-25T11:00:00.000Z",
+    activeJobs: [],
+    disputes: []
+  }
+];
+
+const jobs = [
+  {
+    id: "job_101",
+    title: "Build an AI customer support widget",
+    clientId: "usr_client_01",
+    clientName: "Ana Client",
+    status: "OPEN",
+    moderationStatus: "FLAGGED",
+    flagReason: "Automated scan detected external payment solicitation",
+    reportCount: 3,
+    budget: 1500,
+    createdAt: "2026-05-10T14:22:00.000Z"
+  },
+  {
+    id: "job_102",
+    title: "Design SaaS onboarding flows",
+    clientId: "usr_client_01",
+    clientName: "Ana Client",
+    status: "OPEN",
+    moderationStatus: "APPROVED",
+    flagReason: null,
+    reportCount: 0,
+    budget: 900,
+    createdAt: "2026-05-11T10:13:00.000Z"
+  },
+  {
+    id: "job_103",
+    title: "Migrate legacy API to Node.js",
+    clientId: "usr_client_02",
+    clientName: "Owen Client",
+    status: "IN_PROGRESS",
+    moderationStatus: "ESCALATED",
+    flagReason: "User report: unclear deliverables and suspicious milestone terms",
+    reportCount: 1,
+    budget: 2800,
+    createdAt: "2026-05-12T15:42:00.000Z"
+  },
+  {
+    id: "job_104",
+    title: "Audit smart contract payout flow",
+    clientId: "usr_client_02",
+    clientName: "Owen Client",
+    status: "DRAFT",
+    moderationStatus: "FLAGGED",
+    flagReason: "High-risk financial wording requires manual review",
+    reportCount: 2,
+    budget: 4200,
+    createdAt: "2026-05-14T07:30:00.000Z"
+  }
+];
+
+const disputes = [
+  {
+    id: "dis_1001",
+    jobId: "job_101",
+    jobTitle: "Build an AI customer support widget",
+    clientId: "usr_client_01",
+    clientName: "Ana Client",
+    freelancerId: "usr_freelancer_01",
+    freelancerName: "Maya Freelancer",
+    amount: 650,
+    status: "open",
+    openedAt: "2026-05-13T16:45:00.000Z",
+    evidence: ["Milestone brief", "Delivery screenshot", "Chat transcript"],
+    thread: [
+      { author: "Ana Client", body: "The first milestone is incomplete.", createdAt: "2026-05-13T16:45:00.000Z" },
+      { author: "Maya Freelancer", body: "The agreed widget prototype was delivered.", createdAt: "2026-05-13T17:05:00.000Z" }
+    ],
+    transaction: { paymentId: "pay_445", escrowStatus: "HELD", currency: "USD" },
+    ruling: null
+  },
+  {
+    id: "dis_1002",
+    jobId: "job_104",
+    jobTitle: "Audit smart contract payout flow",
+    clientId: "usr_client_02",
+    clientName: "Owen Client",
+    freelancerId: "usr_freelancer_02",
+    freelancerName: "Li Freelancer",
+    amount: 1200,
+    status: "under_review",
+    openedAt: "2026-05-15T09:10:00.000Z",
+    evidence: ["Escrow receipt", "Source repository link"],
+    thread: [
+      { author: "Li Freelancer", body: "Client requested extra work outside the contract.", createdAt: "2026-05-15T09:10:00.000Z" }
+    ],
+    transaction: { paymentId: "pay_472", escrowStatus: "HELD", currency: "USD" },
+    ruling: null
+  }
+];
+
+const controls = [
+  {
+    key: "registrationsEnabled",
+    label: "New user registrations",
+    enabled: true,
+    updatedAt: "2026-05-15T08:00:00.000Z",
+    updatedBy: "usr_admin_01"
+  },
+  {
+    key: "jobPostingsEnabled",
+    label: "New job postings",
+    enabled: true,
+    updatedAt: "2026-05-15T08:00:00.000Z",
+    updatedBy: "usr_admin_01"
+  }
+];
+
+const notifications = [];
+
+const auditLog = [
+  {
+    id: "aud_001",
+    adminId: "usr_admin_01",
+    actionType: "CONTROL_UPDATED",
+    targetType: "platform_control",
+    targetId: "registrationsEnabled",
+    message: "Enabled new user registrations",
+    createdAt: "2026-05-15T08:00:00.000Z"
+  }
+];
+
+function now() {
+  return new Date().toISOString();
+}
+
+function normalize(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function paginate(items, query = {}) {
+  const page = Math.max(Number(query.page ?? 1), 1);
+  const pageSize = Math.min(Math.max(Number(query.pageSize ?? 10), 1), 50);
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    items: items.slice(start, start + pageSize),
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: Math.max(Math.ceil(total / pageSize), 1)
+    }
   };
+}
+
+function appendAudit({ adminId, actionType, targetType, targetId, message }) {
+  const entry = {
+    id: `aud_${String(auditLog.length + 1).padStart(3, "0")}`,
+    adminId,
+    actionType,
+    targetType,
+    targetId,
+    message,
+    createdAt: now()
+  };
+  auditLog.push(entry);
+  return entry;
+}
+
+function createNotification(userId, title, body) {
+  const notification = {
+    id: `ntf_${String(notifications.length + 1).padStart(3, "0")}`,
+    userId,
+    title,
+    body,
+    read: false,
+    createdAt: now()
+  };
+  notifications.push(notification);
+  return notification;
+}
+
+function requireItem(item, label) {
+  if (!item) {
+    const error = new Error(`${label} not found`);
+    error.status = 404;
+    throw error;
+  }
+  return item;
+}
+
+export async function getAdminMetrics() {
+  const totalRevenue = jobs.reduce((sum, job) => sum + job.budget, 0);
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = jobs.filter((job) => ["FLAGGED", "ESCALATED"].includes(job.moderationStatus)).length;
+  const trustScoreDistribution = [
+    { label: "0-39", count: users.filter((user) => user.trustScore < 40).length },
+    { label: "40-69", count: users.filter((user) => user.trustScore >= 40 && user.trustScore < 70).length },
+    { label: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+    { label: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+  ];
+
+  return {
+    totalUsers: users.length,
+    activeJobs: jobs.filter((job) => ["OPEN", "IN_PROGRESS"].includes(job.status)).length,
+    openDisputes,
+    flaggedListings,
+    revenueCurrentPeriod: totalRevenue,
+    trustScoreDistribution,
+    refreshedAt: now()
+  };
+}
+
+export async function listUsers(query) {
+  const search = normalize(query.search);
+  const role = normalize(query.role);
+  const status = normalize(query.status);
+  const joinedFrom = query.joinedFrom ? Date.parse(query.joinedFrom) : null;
+  const joinedTo = query.joinedTo ? Date.parse(query.joinedTo) : null;
+
+  const filtered = users.filter((user) => {
+    const matchesSearch =
+      !search ||
+      normalize(user.email).includes(search) ||
+      normalize(user.fullName).includes(search) ||
+      normalize(user.id).includes(search);
+    const matchesRole = !role || normalize(user.role) === role;
+    const matchesStatus = !status || normalize(user.status) === status;
+    const joinedAt = Date.parse(user.createdAt);
+    const matchesFrom = !joinedFrom || joinedAt >= joinedFrom;
+    const matchesTo = !joinedTo || joinedAt <= joinedTo;
+
+    return matchesSearch && matchesRole && matchesStatus && matchesFrom && matchesTo;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getUserProfile(userId) {
+  const user = requireItem(users.find((candidate) => candidate.id === userId), "User");
+  return {
+    ...user,
+    activeJobs: jobs.filter((job) => user.activeJobs.includes(job.id)),
+    disputeHistory: disputes.filter((dispute) => user.disputes.includes(dispute.id))
+  };
+}
+
+export async function updateUserStatus(adminId, userId, status) {
+  const nextStatus = String(status ?? "").toUpperCase();
+  if (!["ACTIVE", "SUSPENDED", "BANNED"].includes(nextStatus)) {
+    const error = new Error("Invalid user status");
+    error.status = 400;
+    throw error;
+  }
+
+  const user = requireItem(users.find((candidate) => candidate.id === userId), "User");
+  user.status = nextStatus;
+
+  appendAudit({
+    adminId,
+    actionType: `USER_${nextStatus}`,
+    targetType: "user",
+    targetId: userId,
+    message: `Updated ${user.email} to ${nextStatus}`
+  });
+
+  return user;
+}
+
+export async function listModerationQueue(query) {
+  const status = normalize(query.status);
+  const flagged = jobs.filter((job) => {
+    if (!status) return ["FLAGGED", "ESCALATED"].includes(job.moderationStatus);
+    return normalize(job.moderationStatus) === status;
+  });
+
+  return paginate(flagged, query);
+}
+
+export async function resolveListing(adminId, jobId, action, reason) {
+  const job = requireItem(jobs.find((candidate) => candidate.id === jobId), "Job");
+  const normalizedAction = normalize(action);
+  const statusMap = {
+    approve: "APPROVED",
+    reject: "REJECTED",
+    escalate: "ESCALATED"
+  };
+  const moderationStatus = statusMap[normalizedAction];
+
+  if (!moderationStatus) {
+    const error = new Error("Invalid moderation action");
+    error.status = 400;
+    throw error;
+  }
+
+  job.moderationStatus = moderationStatus;
+  job.flagReason = reason || job.flagReason;
+
+  appendAudit({
+    adminId,
+    actionType: `LISTING_${moderationStatus}`,
+    targetType: "job",
+    targetId: jobId,
+    message: `${moderationStatus} listing ${job.title}${reason ? `: ${reason}` : ""}`
+  });
+
+  if (moderationStatus === "REJECTED") {
+    createNotification(
+      job.clientId,
+      "Your listing was rejected",
+      reason || `The listing "${job.title}" did not pass moderation.`
+    );
+  }
+
+  return job;
+}
+
+export async function listDisputes(query) {
+  const status = normalize(query.status);
+  const filtered = status ? disputes.filter((dispute) => normalize(dispute.status) === status) : disputes;
+  return paginate(filtered, query);
+}
+
+export async function ruleOnDispute(adminId, disputeId, ruling, note) {
+  const normalizedRuling = normalize(ruling);
+  if (!["client", "freelancer", "refund", "escalate"].includes(normalizedRuling)) {
+    const error = new Error("Invalid dispute ruling");
+    error.status = 400;
+    throw error;
+  }
+
+  const dispute = requireItem(disputes.find((candidate) => candidate.id === disputeId), "Dispute");
+  dispute.status = normalizedRuling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = {
+    ruling: normalizedRuling,
+    note,
+    adminId,
+    ruledAt: now()
+  };
+
+  appendAudit({
+    adminId,
+    actionType: "DISPUTE_RULED",
+    targetType: "dispute",
+    targetId: disputeId,
+    message: `Ruled ${normalizedRuling} on dispute ${disputeId}${note ? `: ${note}` : ""}`
+  });
+
+  createNotification(
+    dispute.clientId,
+    "Dispute updated",
+    `A ruling was recorded for ${dispute.jobTitle}: ${normalizedRuling}.`
+  );
+  createNotification(
+    dispute.freelancerId,
+    "Dispute updated",
+    `A ruling was recorded for ${dispute.jobTitle}: ${normalizedRuling}.`
+  );
+
+  return dispute;
+}
+
+export async function getPlatformControls() {
+  return { controls };
+}
+
+export async function updatePlatformControl(adminId, key, enabled) {
+  const control = requireItem(controls.find((candidate) => candidate.key === key), "Platform control");
+  control.enabled = Boolean(enabled);
+  control.updatedAt = now();
+  control.updatedBy = adminId;
+
+  appendAudit({
+    adminId,
+    actionType: "CONTROL_UPDATED",
+    targetType: "platform_control",
+    targetId: key,
+    message: `${control.enabled ? "Enabled" : "Disabled"} ${control.label}`
+  });
+
+  return control;
+}
+
+export async function listAuditLog(query) {
+  const admin = normalize(query.adminId);
+  const actionType = normalize(query.actionType);
+  const from = query.from ? Date.parse(query.from) : null;
+  const to = query.to ? Date.parse(query.to) : null;
+
+  const filtered = auditLog
+    .filter((entry) => {
+      const createdAt = Date.parse(entry.createdAt);
+      const matchesAdmin = !admin || normalize(entry.adminId) === admin;
+      const matchesAction = !actionType || normalize(entry.actionType) === actionType;
+      const matchesFrom = !from || createdAt >= from;
+      const matchesTo = !to || createdAt <= to;
+      return matchesAdmin && matchesAction && matchesFrom && matchesTo;
+    })
+    .slice()
+    .reverse();
+
+  return paginate(filtered, query);
+}
+
+export async function listNotifications() {
+  return { notifications: notifications.slice().reverse() };
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: "usr_admin_01", role: "ADMIN" })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+function clientHeaders() {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: "usr_client_01", role: "CLIENT" })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject authenticated non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers: clientHeaders() });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("admin metrics include required platform health summary", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers: adminHeaders() });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.totalUsers, "number");
+    assert.equal(typeof payload.data.activeJobs, "number");
+    assert.equal(typeof payload.data.openDisputes, "number");
+    assert.equal(typeof payload.data.flaggedListings, "number");
+    assert.equal(typeof payload.data.revenueCurrentPeriod, "number");
+    assert.ok(Array.isArray(payload.data.trustScoreDistribution));
+  });
+});
+
+test("admin can paginate users, change account status, and create an audit log entry", async () => {
+  await withServer(async (baseUrl) => {
+    const usersResponse = await fetch(`${baseUrl}/api/admin/users?page=1&pageSize=2&role=CLIENT`, {
+      headers: adminHeaders()
+    });
+    const usersPayload = await usersResponse.json();
+
+    assert.equal(usersResponse.status, 200);
+    assert.equal(usersPayload.data.items.length, 2);
+    assert.equal(usersPayload.data.pagination.pageSize, 2);
+
+    const statusResponse = await fetch(`${baseUrl}/api/admin/users/usr_client_01/status`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ status: "SUSPENDED" })
+    });
+    const statusPayload = await statusResponse.json();
+
+    assert.equal(statusResponse.status, 200);
+    assert.equal(statusPayload.data.status, "SUSPENDED");
+
+    const auditResponse = await fetch(`${baseUrl}/api/admin/audit-log?actionType=USER_SUSPENDED`, {
+      headers: adminHeaders()
+    });
+    const auditPayload = await auditResponse.json();
+
+    assert.equal(auditResponse.status, 200);
+    assert.equal(auditPayload.data.items[0].targetId, "usr_client_01");
+  });
+});
+
+test("rejecting a flagged listing notifies the posting user", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/moderation/jobs/job_101`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ action: "reject", reason: "External payment links are not allowed." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.moderationStatus, "REJECTED");
+
+    const notificationsResponse = await fetch(`${baseUrl}/api/admin/notifications`, {
+      headers: adminHeaders()
+    });
+    const notificationsPayload = await notificationsResponse.json();
+
+    assert.equal(notificationsResponse.status, 200);
+    const rejectionNotice = notificationsPayload.data.notifications.find((notification) =>
+      notification.body.includes("External payment links")
+    );
+
+    assert.ok(rejectionNotice);
+    assert.equal(rejectionNotice.userId, "usr_client_01");
+  });
+});
+
+test("dispute rulings update status and are written to the audit log", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/disputes/dis_1001/ruling`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ ruling: "refund", note: "Refund approved after evidence review." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.status, "resolved");
+    assert.equal(payload.data.ruling.ruling, "refund");
+
+    const auditResponse = await fetch(`${baseUrl}/api/admin/audit-log?actionType=DISPUTE_RULED`, {
+      headers: adminHeaders()
+    });
+    const auditPayload = await auditResponse.json();
+
+    assert.equal(auditResponse.status, 200);
+    assert.equal(auditPayload.data.items[0].targetId, "dis_1001");
+  });
+});

--- a/apps/web/app/admin/AdminPanelClient.tsx
+++ b/apps/web/app/admin/AdminPanelClient.tsx
@@ -1,0 +1,622 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+
+type Pagination = {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+type Metrics = {
+  totalUsers: number;
+  activeJobs: number;
+  openDisputes: number;
+  flaggedListings: number;
+  revenueCurrentPeriod: number;
+  refreshedAt: string;
+  trustScoreDistribution: Array<{ label: string; count: number }>;
+};
+
+type User = {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  status: string;
+  trustScore: number;
+  createdAt: string;
+  activeJobs?: Job[];
+  disputeHistory?: Dispute[];
+};
+
+type Job = {
+  id: string;
+  title: string;
+  clientName: string;
+  clientId: string;
+  status: string;
+  moderationStatus: string;
+  flagReason: string | null;
+  reportCount: number;
+  budget: number;
+  createdAt: string;
+};
+
+type Dispute = {
+  id: string;
+  jobTitle: string;
+  clientName: string;
+  freelancerName: string;
+  amount: number;
+  status: string;
+  evidence: string[];
+  thread: Array<{ author: string; body: string; createdAt: string }>;
+  transaction: { paymentId: string; escrowStatus: string; currency: string };
+  ruling: null | { ruling: string; note?: string; adminId: string; ruledAt: string };
+};
+
+type Control = {
+  key: string;
+  label: string;
+  enabled: boolean;
+  updatedAt: string;
+  updatedBy: string;
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  message: string;
+  createdAt: string;
+};
+
+type Paged<T> = {
+  items: T[];
+  pagination: Pagination;
+};
+
+type ApiEnvelope<T> = {
+  success: boolean;
+  data: T;
+  message?: string;
+};
+
+const userStatuses = ["ACTIVE", "SUSPENDED", "BANNED"];
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { currency: "USD", style: "currency" }).format(value);
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" }).format(new Date(value));
+}
+
+function buildQuery(params: Record<string, string | number | undefined>) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") search.set(key, String(value));
+  });
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+function StatusBadge({ value }: { value: string }) {
+  return <span className={`admin-badge admin-badge-${value.toLowerCase()}`}>{value.replaceAll("_", " ")}</span>;
+}
+
+export function AdminPanelClient({ apiBaseUrl }: { apiBaseUrl: string }) {
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [users, setUsers] = useState<Paged<User> | null>(null);
+  const [jobs, setJobs] = useState<Paged<Job> | null>(null);
+  const [disputes, setDisputes] = useState<Paged<Dispute> | null>(null);
+  const [controls, setControls] = useState<Control[]>([]);
+  const [audit, setAudit] = useState<Paged<AuditEntry> | null>(null);
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [userFilters, setUserFilters] = useState({ search: "", role: "", status: "", joinedFrom: "", joinedTo: "", page: 1 });
+  const [auditFilters, setAuditFilters] = useState({ adminId: "", actionType: "", from: "", to: "" });
+
+  const request = useCallback(
+    async <T,>(path: string, init?: RequestInit): Promise<T> => {
+      const response = await fetch(`${apiBaseUrl}${path}`, {
+        ...init,
+        headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) }
+      });
+      const payload = (await response.json()) as ApiEnvelope<T>;
+
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.message || "Admin request failed");
+      }
+
+      return payload.data;
+    },
+    [apiBaseUrl]
+  );
+
+  const loadPanel = useCallback(async () => {
+    setRefreshing(true);
+    setError("");
+
+    try {
+      const [nextMetrics, nextUsers, nextJobs, nextDisputes, nextControls, nextAudit] = await Promise.all([
+        request<Metrics>("/admin/metrics"),
+        request<Paged<User>>(`/admin/users${buildQuery({ ...userFilters, pageSize: 5 })}`),
+        request<Paged<Job>>("/admin/moderation/jobs?pageSize=5"),
+        request<Paged<Dispute>>("/admin/disputes?pageSize=5"),
+        request<{ controls: Control[] }>("/admin/controls"),
+        request<Paged<AuditEntry>>(`/admin/audit-log${buildQuery({ ...auditFilters, pageSize: 8 })}`)
+      ]);
+
+      setMetrics(nextMetrics);
+      setUsers(nextUsers);
+      setJobs(nextJobs);
+      setDisputes(nextDisputes);
+      setControls(nextControls.controls);
+      setAudit(nextAudit);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Unable to load admin panel");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [auditFilters, request, userFilters]);
+
+  useEffect(() => {
+    void loadPanel();
+  }, [loadPanel]);
+
+  async function handleUserStatus(user: User, status: string) {
+    const confirmed = window.confirm(`Change ${user.fullName}'s status to ${status}?`);
+    if (!confirmed) return;
+
+    await request<User>(`/admin/users/${user.id}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status })
+    });
+    await loadPanel();
+  }
+
+  async function handleModeration(job: Job, action: "approve" | "reject" | "escalate") {
+    const reason =
+      action === "reject"
+        ? window.prompt("Reason sent to the posting user:")
+        : window.prompt("Moderation note:");
+    if (reason === null) return;
+
+    await request<Job>(`/admin/moderation/jobs/${job.id}`, {
+      method: "POST",
+      body: JSON.stringify({ action, reason })
+    });
+    await loadPanel();
+  }
+
+  async function handleDispute(dispute: Dispute, ruling: "client" | "freelancer" | "refund" | "escalate") {
+    const note = window.prompt(`Record ruling "${ruling}" for ${dispute.id}:`);
+    if (note === null) return;
+
+    await request<Dispute>(`/admin/disputes/${dispute.id}/ruling`, {
+      method: "POST",
+      body: JSON.stringify({ ruling, note })
+    });
+    await loadPanel();
+  }
+
+  async function handleControl(control: Control) {
+    const nextValue = !control.enabled;
+    const confirmed = window.confirm(
+      `${nextValue ? "Enable" : "Disable"} ${control.label}? This action will be logged.`
+    );
+    if (!confirmed) return;
+
+    await request<Control>(`/admin/controls/${control.key}`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled: nextValue })
+    });
+    await loadPanel();
+  }
+
+  async function handleUserSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setUserFilters((current) => ({ ...current, page: 1 }));
+  }
+
+  async function viewProfile(user: User) {
+    setSelectedUser(await request<User>(`/admin/users/${user.id}`));
+  }
+
+  const emptyState = !loading && !error;
+
+  return (
+    <section className="admin-shell" aria-labelledby="admin-panel-title">
+      <div className="admin-header">
+        <div>
+          <p className="admin-eyebrow">Operations</p>
+          <h2 id="admin-panel-title">Admin Panel</h2>
+        </div>
+        <button className="admin-button" disabled={refreshing} onClick={() => void loadPanel()} type="button">
+          {refreshing ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="admin-status admin-status-error" role="alert">
+          <strong>Unable to load admin data</strong>
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading && (
+        <div className="admin-status" role="status">
+          <strong>Loading admin workspace</strong>
+          <span>Fetching metrics, moderation queues, controls, and audit entries.</span>
+        </div>
+      )}
+
+      {metrics && (
+        <div className="admin-metrics" aria-label="Trust and platform metrics">
+          {[
+            ["Total users", metrics.totalUsers],
+            ["Active jobs", metrics.activeJobs],
+            ["Open disputes", metrics.openDisputes],
+            ["Flagged listings", metrics.flaggedListings],
+            ["Current revenue", formatCurrency(metrics.revenueCurrentPeriod)]
+          ].map(([label, value]) => (
+            <article className="admin-card" key={label}>
+              <span>{label}</span>
+              <strong>{value}</strong>
+            </article>
+          ))}
+          <article className="admin-card admin-chart">
+            <span>Trust score distribution</span>
+            <div className="admin-bars" aria-label="Trust score distribution chart">
+              {metrics.trustScoreDistribution.map((item) => (
+                <div className="admin-bar-row" key={item.label}>
+                  <span>{item.label}</span>
+                  <div>
+                    <i style={{ width: `${Math.max(item.count * 24, 8)}px` }} />
+                  </div>
+                  <strong>{item.count}</strong>
+                </div>
+              ))}
+            </div>
+          </article>
+        </div>
+      )}
+
+      <div className="admin-section">
+        <div className="admin-section-title">
+          <h3>User Management</h3>
+          {users && <span>{users.pagination.total} users</span>}
+        </div>
+        <form className="admin-filter-grid" onSubmit={(event) => void handleUserSearch(event)}>
+          <label>
+            Search
+            <input
+              aria-label="Search users"
+              onChange={(event) => setUserFilters((current) => ({ ...current, search: event.target.value }))}
+              value={userFilters.search}
+            />
+          </label>
+          <label>
+            Role
+            <select
+              aria-label="Filter users by role"
+              onChange={(event) => setUserFilters((current) => ({ ...current, role: event.target.value }))}
+              value={userFilters.role}
+            >
+              <option value="">All roles</option>
+              <option value="CLIENT">Client</option>
+              <option value="FREELANCER">Freelancer</option>
+              <option value="ADMIN">Admin</option>
+            </select>
+          </label>
+          <label>
+            Status
+            <select
+              aria-label="Filter users by status"
+              onChange={(event) => setUserFilters((current) => ({ ...current, status: event.target.value }))}
+              value={userFilters.status}
+            >
+              <option value="">All statuses</option>
+              {userStatuses.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Joined from
+            <input
+              aria-label="Filter users joined from"
+              onChange={(event) => setUserFilters((current) => ({ ...current, joinedFrom: event.target.value }))}
+              type="date"
+              value={userFilters.joinedFrom}
+            />
+          </label>
+          <label>
+            Joined to
+            <input
+              aria-label="Filter users joined to"
+              onChange={(event) => setUserFilters((current) => ({ ...current, joinedTo: event.target.value }))}
+              type="date"
+              value={userFilters.joinedTo}
+            />
+          </label>
+          <button className="admin-button" type="submit">
+            Apply
+          </button>
+        </form>
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Trust</th>
+                <th>Joined</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users?.items.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <strong>{user.fullName}</strong>
+                    <span>{user.email}</span>
+                  </td>
+                  <td>{user.role}</td>
+                  <td>
+                    <StatusBadge value={user.status} />
+                  </td>
+                  <td>{user.trustScore}</td>
+                  <td>{formatDate(user.createdAt)}</td>
+                  <td>
+                    <div className="admin-actions">
+                      <button type="button" onClick={() => void viewProfile(user)}>
+                        View
+                      </button>
+                      {userStatuses.map((status) => (
+                        <button
+                          disabled={status === user.status}
+                          key={status}
+                          onClick={() => void handleUserStatus(user, status)}
+                          type="button"
+                        >
+                          {status === "ACTIVE" ? "Reinstate" : status[0] + status.slice(1).toLowerCase()}
+                        </button>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {emptyState && users?.items.length === 0 && (
+                <tr>
+                  <td colSpan={6}>No users match the current filters.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        {users && (
+          <div className="admin-pagination">
+            <button
+              disabled={users.pagination.page <= 1}
+              onClick={() => setUserFilters((current) => ({ ...current, page: current.page - 1 }))}
+              type="button"
+            >
+              Previous
+            </button>
+            <span>
+              Page {users.pagination.page} of {users.pagination.totalPages}
+            </span>
+            <button
+              disabled={users.pagination.page >= users.pagination.totalPages}
+              onClick={() => setUserFilters((current) => ({ ...current, page: current.page + 1 }))}
+              type="button"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+
+      {selectedUser && (
+        <aside className="admin-section" aria-label="Selected user profile">
+          <div className="admin-section-title">
+            <h3>{selectedUser.fullName}</h3>
+            <button onClick={() => setSelectedUser(null)} type="button">
+              Close
+            </button>
+          </div>
+          <div className="admin-detail-grid">
+            <div>
+              <strong>Active jobs</strong>
+              {selectedUser.activeJobs?.length ? (
+                selectedUser.activeJobs.map((job) => <p key={job.id}>{job.title}</p>)
+              ) : (
+                <p>No active jobs.</p>
+              )}
+            </div>
+            <div>
+              <strong>Dispute history</strong>
+              {selectedUser.disputeHistory?.length ? (
+                selectedUser.disputeHistory.map((dispute) => (
+                  <p key={dispute.id}>
+                    {dispute.id}: {dispute.status}
+                  </p>
+                ))
+              ) : (
+                <p>No dispute history.</p>
+              )}
+            </div>
+          </div>
+        </aside>
+      )}
+
+      <div className="admin-section">
+        <div className="admin-section-title">
+          <h3>Job & Listing Moderation</h3>
+          {jobs && <span>{jobs.pagination.total} flagged listings</span>}
+        </div>
+        <div className="admin-list">
+          {jobs?.items.map((job) => (
+            <article className="admin-row-card" key={job.id}>
+              <div>
+                <strong>{job.title}</strong>
+                <span>
+                  {job.clientName} - {job.reportCount} reports - {formatCurrency(job.budget)}
+                </span>
+                <p>{job.flagReason}</p>
+              </div>
+              <StatusBadge value={job.moderationStatus} />
+              <div className="admin-actions">
+                <button onClick={() => void handleModeration(job, "approve")} type="button">
+                  Approve
+                </button>
+                <button onClick={() => void handleModeration(job, "reject")} type="button">
+                  Reject
+                </button>
+                <button onClick={() => void handleModeration(job, "escalate")} type="button">
+                  Escalate
+                </button>
+              </div>
+            </article>
+          ))}
+          {emptyState && jobs?.items.length === 0 && <p>No listings are waiting for moderation.</p>}
+        </div>
+      </div>
+
+      <div className="admin-section">
+        <div className="admin-section-title">
+          <h3>Dispute Resolution</h3>
+          {disputes && <span>{disputes.pagination.total} disputes</span>}
+        </div>
+        <div className="admin-list">
+          {disputes?.items.map((dispute) => (
+            <article className="admin-row-card" key={dispute.id}>
+              <div>
+                <strong>{dispute.jobTitle}</strong>
+                <span>
+                  {dispute.clientName} vs {dispute.freelancerName} - {formatCurrency(dispute.amount)}
+                </span>
+                <p>
+                  Evidence: {dispute.evidence.join(", ")}. Transaction {dispute.transaction.paymentId} is{" "}
+                  {dispute.transaction.escrowStatus}.
+                </p>
+                {dispute.thread.map((message) => (
+                  <blockquote key={`${dispute.id}-${message.createdAt}`}>
+                    {message.author}: {message.body}
+                  </blockquote>
+                ))}
+              </div>
+              <StatusBadge value={dispute.status} />
+              <div className="admin-actions">
+                <button onClick={() => void handleDispute(dispute, "client")} type="button">
+                  Client
+                </button>
+                <button onClick={() => void handleDispute(dispute, "freelancer")} type="button">
+                  Freelancer
+                </button>
+                <button onClick={() => void handleDispute(dispute, "refund")} type="button">
+                  Refund
+                </button>
+                <button onClick={() => void handleDispute(dispute, "escalate")} type="button">
+                  Escalate
+                </button>
+              </div>
+            </article>
+          ))}
+          {emptyState && disputes?.items.length === 0 && <p>No disputes match the current filter.</p>}
+        </div>
+      </div>
+
+      <div className="admin-section">
+        <div className="admin-section-title">
+          <h3>Platform Controls</h3>
+        </div>
+        <div className="admin-controls">
+          {controls.map((control) => (
+            <label className="admin-toggle" key={control.key}>
+              <span>
+                <strong>{control.label}</strong>
+                <small>
+                  Updated by {control.updatedBy} on {formatDate(control.updatedAt)}
+                </small>
+              </span>
+              <input
+                aria-label={`Toggle ${control.label}`}
+                checked={control.enabled}
+                onChange={() => void handleControl(control)}
+                type="checkbox"
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="admin-section">
+        <div className="admin-section-title">
+          <h3>Audit Log</h3>
+          {audit && <span>{audit.pagination.total} entries</span>}
+        </div>
+        <form className="admin-filter-grid" onSubmit={(event) => event.preventDefault()}>
+          <label>
+            Admin ID
+            <input
+              aria-label="Filter audit log by admin"
+              onChange={(event) => setAuditFilters((current) => ({ ...current, adminId: event.target.value }))}
+              value={auditFilters.adminId}
+            />
+          </label>
+          <label>
+            Action
+            <input
+              aria-label="Filter audit log by action type"
+              onChange={(event) => setAuditFilters((current) => ({ ...current, actionType: event.target.value }))}
+              value={auditFilters.actionType}
+            />
+          </label>
+          <label>
+            From
+            <input
+              aria-label="Filter audit log from date"
+              onChange={(event) => setAuditFilters((current) => ({ ...current, from: event.target.value }))}
+              type="date"
+              value={auditFilters.from}
+            />
+          </label>
+          <label>
+            To
+            <input
+              aria-label="Filter audit log to date"
+              onChange={(event) => setAuditFilters((current) => ({ ...current, to: event.target.value }))}
+              type="date"
+              value={auditFilters.to}
+            />
+          </label>
+        </form>
+        <div className="admin-list">
+          {audit?.items.map((entry) => (
+            <article className="admin-audit-entry" key={entry.id}>
+              <strong>{entry.actionType}</strong>
+              <span>
+                {entry.adminId} - {entry.targetType}:{entry.targetId} - {formatDate(entry.createdAt)}
+              </span>
+              <p>{entry.message}</p>
+            </article>
+          ))}
+          {emptyState && audit?.items.length === 0 && <p>No audit entries match the current filters.</p>}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/admin/api/[...path]/route.ts
+++ b/apps/web/app/admin/api/[...path]/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+const backendApiBase = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000/api";
+
+type RouteContext = {
+  params: Promise<{ path: string[] }>;
+};
+
+async function proxyAdminRequest(request: NextRequest, context: RouteContext) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("ff_access_token")?.value;
+
+  if (!token) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
+  const { path } = await context.params;
+  const target = new URL(`${backendApiBase}/${path.join("/")}`);
+  target.search = request.nextUrl.search;
+
+  const method = request.method.toUpperCase();
+  const body = method === "GET" || method === "HEAD" ? undefined : await request.text();
+
+  const response = await fetch(target, {
+    body,
+    cache: "no-store",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": request.headers.get("content-type") ?? "application/json"
+    },
+    method
+  });
+
+  const payload = await response.text();
+
+  return new NextResponse(payload, {
+    status: response.status,
+    headers: {
+      "content-type": response.headers.get("content-type") ?? "application/json"
+    }
+  });
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  return proxyAdminRequest(request, context);
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  return proxyAdminRequest(request, context);
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  return proxyAdminRequest(request, context);
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,40 @@
-export default function AdminPanelPage() {
+import { cookies } from "next/headers";
+import { AdminPanelClient } from "./AdminPanelClient";
+
+export const dynamic = "force-dynamic";
+
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000/api";
+
+function Forbidden() {
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell" aria-labelledby="admin-denied-title">
+      <div className="admin-status admin-status-error">
+        <strong id="admin-denied-title">403 admin access required</strong>
+        <span>Sign in with an administrator account before opening the operations panel.</span>
+      </div>
     </section>
   );
+}
+
+export default async function AdminPanelPage() {
+  const cookieStore = await cookies();
+  const role = cookieStore.get("ff_role")?.value?.toUpperCase();
+  const token = cookieStore.get("ff_access_token")?.value;
+
+  if (role !== "ADMIN" || !token) {
+    return <Forbidden />;
+  }
+
+  const response = await fetch(`${apiBaseUrl}/admin/metrics`, {
+    cache: "no-store",
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  }).catch(() => null);
+
+  if (!response?.ok) {
+    return <Forbidden />;
+  }
+
+  return <AdminPanelClient apiBaseUrl="/admin/api" />;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,306 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.admin-shell {
+  display: grid;
+  gap: 1rem;
+}
+
+.admin-header,
+.admin-section-title,
+.admin-pagination,
+.admin-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.admin-header,
+.admin-section-title,
+.admin-pagination {
+  justify-content: space-between;
+}
+
+.admin-eyebrow {
+  color: #7dd3fc;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+}
+
+.admin-header h2,
+.admin-section h3 {
+  margin: 0;
+}
+
+.admin-button,
+.admin-actions button,
+.admin-pagination button,
+.admin-section-title button {
+  background: #0f766e;
+  border: 1px solid #2dd4bf;
+  border-radius: 8px;
+  color: #f8fafc;
+  padding: 0.5rem 0.75rem;
+}
+
+.admin-actions {
+  flex-wrap: wrap;
+}
+
+.admin-actions button {
+  background: #1f2937;
+  border-color: #475569;
+  padding: 0.35rem 0.55rem;
+}
+
+.admin-status,
+.admin-section,
+.admin-card,
+.admin-row-card,
+.admin-audit-entry {
+  background: #111827;
+  border: 1px solid #334155;
+  border-radius: 8px;
+}
+
+.admin-status {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+}
+
+.admin-status-error {
+  background: #2a1218;
+  border-color: #be123c;
+}
+
+.admin-metrics {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.admin-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1rem;
+}
+
+.admin-card span,
+.admin-row-card span,
+.admin-audit-entry span,
+.admin-toggle small,
+.admin-table td span,
+.admin-section-title span {
+  color: #cbd5e1;
+}
+
+.admin-card strong {
+  font-size: 1.45rem;
+}
+
+.admin-chart {
+  grid-column: span 2;
+}
+
+.admin-bars,
+.admin-list,
+.admin-controls {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-bar-row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 56px 1fr 32px;
+}
+
+.admin-bar-row div {
+  background: #273449;
+  border-radius: 999px;
+  height: 8px;
+  overflow: hidden;
+}
+
+.admin-bar-row i {
+  background: #facc15;
+  display: block;
+  height: 100%;
+}
+
+.admin-section {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.admin-filter-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.admin-filter-grid label {
+  color: #cbd5e1;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.admin-filter-grid input,
+.admin-filter-grid select {
+  background: #0b1020;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  color: #f8fafc;
+  padding: 0.55rem;
+}
+
+.admin-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-table {
+  border-collapse: collapse;
+  min-width: 820px;
+  width: 100%;
+}
+
+.admin-table th,
+.admin-table td {
+  border-bottom: 1px solid #334155;
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.admin-table td:first-child {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.admin-badge {
+  border: 1px solid #475569;
+  border-radius: 999px;
+  color: #f8fafc;
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.55rem;
+  text-transform: uppercase;
+}
+
+.admin-badge-active,
+.admin-badge-approved,
+.admin-badge-resolved,
+.admin-badge-open {
+  background: #14532d;
+  border-color: #22c55e;
+}
+
+.admin-badge-suspended,
+.admin-badge-flagged,
+.admin-badge-under_review {
+  background: #713f12;
+  border-color: #f59e0b;
+}
+
+.admin-badge-banned,
+.admin-badge-rejected {
+  background: #7f1d1d;
+  border-color: #ef4444;
+}
+
+.admin-badge-escalated {
+  background: #312e81;
+  border-color: #818cf8;
+}
+
+.admin-detail-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-row-card {
+  align-items: start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr auto auto;
+  padding: 1rem;
+}
+
+.admin-row-card p,
+.admin-audit-entry p,
+.admin-detail-grid p {
+  color: #dbeafe;
+  margin: 0.35rem 0 0;
+}
+
+.admin-row-card blockquote {
+  border-left: 3px solid #0f766e;
+  color: #cbd5e1;
+  margin: 0.5rem 0 0;
+  padding-left: 0.75rem;
+}
+
+.admin-toggle {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.admin-toggle span {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.admin-toggle input {
+  height: 22px;
+  width: 44px;
+}
+
+.admin-audit-entry {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem;
+}
+
+@media (max-width: 760px) {
+  .admin-header,
+  .admin-section-title,
+  .admin-row-card,
+  .admin-toggle {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .admin-row-card {
+    display: grid;
+  }
+
+  .admin-chart {
+    grid-column: span 1;
+  }
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const role = request.cookies.get("ff_role")?.value?.toUpperCase();
+  const token = request.cookies.get("ff_access_token")?.value;
+
+  if (role !== "ADMIN" || !token) {
+    return new NextResponse(
+      "<!doctype html><title>403 admin access required</title><main style=\"align-items:center;background:#0b1020;color:#f8fafc;display:flex;font-family:Inter,Arial,sans-serif;min-height:100vh;justify-content:center;margin:0;padding:2rem\"><section style=\"background:#111827;border:1px solid #be123c;border-radius:8px;max-width:520px;padding:1.25rem\"><h1 style=\"font-size:1.5rem;margin:0 0 .5rem\">403 admin access required</h1><p style=\"color:#cbd5e1;margin:0\">Sign in with an administrator account before opening the operations panel.</p></section></main>",
+      {
+        status: 403,
+        headers: {
+          "content-type": "text/html; charset=utf-8"
+        }
+      }
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/admin/:path*"
+};

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,6 +21,25 @@ enum JobStatus {
   CANCELLED
 }
 
+enum UserStatus {
+  ACTIVE
+  SUSPENDED
+  BANNED
+}
+
+enum ModerationStatus {
+  APPROVED
+  FLAGGED
+  REJECTED
+  ESCALATED
+}
+
+enum DisputeStatus {
+  OPEN
+  UNDER_REVIEW
+  RESOLVED
+}
+
 model User {
   id             String      @id @default(cuid())
   email          String      @unique
@@ -28,6 +47,8 @@ model User {
   fullName       String
   bio            String?
   role           UserRole    @default(CLIENT)
+  status         UserStatus  @default(ACTIVE)
+  trustScore     Int         @default(100)
   isVerified     Boolean     @default(false)
   skills         Skill[]
   postedJobs     Job[]       @relation("ClientJobs")
@@ -37,6 +58,8 @@ model User {
   reviewsGiven   Review[]    @relation("Reviewer")
   reviewsGot     Review[]    @relation("Reviewee")
   notifications  Notification[]
+  clientDisputes Dispute[]   @relation("ClientDisputes")
+  freelancerDisputes Dispute[] @relation("FreelancerDisputes")
   createdAt      DateTime    @default(now())
   updatedAt      DateTime    @updatedAt
 }
@@ -48,12 +71,16 @@ model Job {
   budgetMin     Float
   budgetMax     Float
   status        JobStatus   @default(OPEN)
+  moderationStatus ModerationStatus @default(APPROVED)
+  flagReason    String?
+  reportCount   Int         @default(0)
   clientId      String
   client        User        @relation("ClientJobs", fields: [clientId], references: [id])
   categoryId    String
   category      Category    @relation(fields: [categoryId], references: [id])
   proposals     Proposal[]
   payments      Payment[]
+  disputes      Dispute[]
   createdAt     DateTime    @default(now())
   updatedAt     DateTime    @updatedAt
 }
@@ -124,4 +151,40 @@ model Notification {
   body          String
   read          Boolean     @default(false)
   createdAt     DateTime    @default(now())
+}
+
+model Dispute {
+  id            String        @id @default(cuid())
+  jobId         String
+  job           Job           @relation(fields: [jobId], references: [id])
+  clientId      String
+  client        User          @relation("ClientDisputes", fields: [clientId], references: [id])
+  freelancerId  String
+  freelancer    User          @relation("FreelancerDisputes", fields: [freelancerId], references: [id])
+  amount        Float
+  status        DisputeStatus @default(OPEN)
+  evidence      Json?
+  thread        Json?
+  transaction   Json?
+  ruling        Json?
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+}
+
+model PlatformControl {
+  key           String   @id
+  label         String
+  enabled       Boolean  @default(true)
+  updatedBy     String
+  updatedAt     DateTime @updatedAt
+}
+
+model AuditLog {
+  id            String   @id @default(cuid())
+  adminId       String
+  actionType    String
+  targetType    String
+  targetId      String
+  message       String
+  createdAt     DateTime @default(now())
 }


### PR DESCRIPTION
## Issue
Closes #29

## Summary
- Replaces the placeholder admin page with a protected operations dashboard for users, moderation, disputes, controls, metrics, and audit logs.
- Adds admin-only API routes with JWT role checks, workflow actions, notifications, and append-only audit entries.
- Adds a server-side admin proxy so access tokens stay out of rendered client HTML while the dashboard can refresh data and perform actions.
- Extends the Prisma schema with admin-friendly moderation, dispute, platform control, and audit models for future persistence.

## Acceptance criteria
- [x] Admin route is protected; non-admin/missing-token requests receive 403
- [x] Admin role is verified server-side for admin APIs
- [x] User table supports search, role/status/join-date filters, and pagination
- [x] Admin can suspend, reinstate, or ban users
- [x] Admin can view a user's active jobs and dispute history
- [x] Moderation queue supports approve, reject, and escalate actions
- [x] Rejected listings create a notification with a reason
- [x] Disputes show thread, evidence, and transaction details
- [x] Admin can rule for client, freelancer, refund, or escalation
- [x] Revenue, active jobs, disputes, trust score, and flagged listing metrics are shown
- [x] Platform controls toggle with confirmation and audit logging
- [x] Audit log is append-only and filterable by admin, action, and date
- [x] Dashboard handles initial load, manual refresh, loading states, empty states, and errors

## Validation
- npm test
- npm run build -w apps/web
- Unauthenticated /admin returns 403
- Authenticated /admin/api/admin/metrics succeeds through the server-side proxy