### PR TITLE
feat: API Benchmark Suite — autocannon-based performance testing (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,9 @@ node_modules
 dist
 .env
 .env.*
+!.env.benchmark
 coverage
 *.log
+benchmarks/results/*.json
+benchmarks/results/*.md
+!benchmarks/results/.gitkeep

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,8 +12,11 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
-    "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "autocannon": "^8.0.0",
+    "jsonwebtoken": "^9.0.3"
   }
 }

--- a/benchmarks/.env.benchmark
+++ b/benchmarks/.env.benchmark
@@ -1,0 +1,22 @@
+# ============================================================
+# API Benchmark Configuration
+# ============================================================
+# Copy this file to .env.benchmark.local and adjust values.
+
+# Base URL of the running API server
+BENCHMARK_BASE_URL=http://localhost:4000
+
+# Duration of each benchmark test in seconds
+BENCHMARK_DURATION=10
+
+# Number of concurrent connections
+BENCHMARK_CONNECTIONS=10
+
+# HTTP pipelining factor (1 = no pipelining)
+BENCHMARK_PIPELINING=1
+
+# Port for the API server (when auto-started)
+BENCHMARK_API_PORT=4000
+
+# JWT secret for generating test tokens
+JWT_SECRET=development-secret

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -1,0 +1,619 @@
+import autocannon from 'autocannon';
+import jwt from 'jsonwebtoken';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import http from 'http';
+import os from 'os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// --- Configuration from env ---
+const BASE_URL = process.env.BENCHMARK_BASE_URL || 'http://localhost:4000';
+const DURATION = parseInt(process.env.BENCHMARK_DURATION || '10', 10);
+const CONNECTIONS = parseInt(process.env.BENCHMARK_CONNECTIONS || '10', 10);
+const PIPELINING = parseInt(process.env.BENCHMARK_PIPELINING || '1', 10);
+const SMOKE = process.env.BENCHMARK_SMOKE === 'true';
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret';
+const API_PORT = parseInt(process.env.BENCHMARK_API_PORT || '4000', 10);
+
+// Smoke mode uses lower settings
+const duration = SMOKE ? 3 : DURATION;
+const connections = SMOKE ? 2 : CONNECTIONS;
+
+const RESULTS_DIR = path.join(__dirname, 'results');
+const THRESHOLDS_PATH = path.join(__dirname, 'thresholds.json');
+
+// Generate a valid JWT for auth-protected routes
+function generateTestToken() {
+  return jwt.sign(
+    { userId: 'bench-user', role: 'admin', email: 'bench@test.com' },
+    JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+}
+
+// --- Endpoint definitions ---
+// Each endpoint: { name, method, path, body, headers, flags }
+function getEndpoints(token) {
+  const authHeader = { authorization: `Bearer ${token}` };
+
+  return [
+    // Health
+    { name: 'GET /health', method: 'GET', path: '/health' },
+
+    // Auth routes
+    {
+      name: 'POST /api/auth/register',
+      method: 'POST',
+      path: '/api/auth/register',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: `bench-${Date.now()}@test.com`,
+        password: 'BenchTest123!',
+        role: 'freelancer'
+      })
+    },
+    {
+      name: 'POST /api/auth/login',
+      method: 'POST',
+      path: '/api/auth/login',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'bench@test.com',
+        password: 'BenchTest123!'
+      })
+    },
+    {
+      name: 'GET /api/auth/oauth/github/callback',
+      method: 'GET',
+      path: '/api/auth/oauth/github/callback?code=test_code&state=test_state'
+    },
+    {
+      name: 'POST /api/auth/refresh',
+      method: 'POST',
+      path: '/api/auth/refresh',
+      headers: { 'content-type': 'application/json' }
+    },
+
+    // User routes
+    { name: 'GET /api/users', method: 'GET', path: '/api/users' },
+    {
+      name: 'POST /api/users',
+      method: 'POST',
+      path: '/api/users',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Bench User',
+        email: `bench-user-${Date.now()}@test.com`,
+        role: 'freelancer'
+      })
+    },
+
+    // Job routes
+    { name: 'GET /api/jobs', method: 'GET', path: '/api/jobs' },
+    {
+      name: 'POST /api/jobs',
+      method: 'POST',
+      path: '/api/jobs',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Benchmark Test Job',
+        description: 'This job was created by the benchmark suite for performance testing.',
+        budgetMin: 100,
+        budgetMax: 500,
+        categoryId: 'cat_dev',
+        skills: ['nodejs', 'benchmark']
+      })
+    },
+
+    // Proposal routes
+    { name: 'GET /api/proposals', method: 'GET', path: '/api/proposals' },
+    {
+      name: 'POST /api/proposals',
+      method: 'POST',
+      path: '/api/proposals',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jobId: 'job_bench_001',
+        coverLetter: 'I am a benchmark-generated proposal for performance testing.',
+        bidAmount: 350,
+        estimatedDays: 7
+      })
+    },
+
+    // Message routes
+    { name: 'GET /api/messages', method: 'GET', path: '/api/messages' },
+    {
+      name: 'POST /api/messages',
+      method: 'POST',
+      path: '/api/messages',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        fromUserId: 'usr_bench_001',
+        toUserId: 'usr_bench_002',
+        content: 'Benchmark test message content for performance measurement.',
+        jobId: 'job_bench_001'
+      })
+    },
+
+    // Review routes
+    { name: 'GET /api/reviews', method: 'GET', path: '/api/reviews' },
+    {
+      name: 'POST /api/reviews',
+      method: 'POST',
+      path: '/api/reviews',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jobId: 'job_bench_001',
+        reviewerId: 'usr_bench_001',
+        revieweeId: 'usr_bench_002',
+        rating: 5,
+        comment: 'Benchmark test review - excellent performance!'
+      })
+    },
+
+    // Payment routes
+    {
+      name: 'POST /api/payments',
+      method: 'POST',
+      path: '/api/payments',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        amount: 50000,
+        currency: 'usd',
+        jobId: 'job_bench_001'
+      })
+    },
+
+    // Search routes
+    {
+      name: 'GET /api/search',
+      method: 'GET',
+      path: '/api/search?q=benchmark+test+query'
+    },
+
+    // Upload routes (multipart file)
+    {
+      name: 'POST /api/uploads',
+      method: 'POST',
+      path: '/api/uploads',
+      headers: { 'content-type': 'multipart/form-data' },
+      body: buildMultipartBody({ file: { name: 'benchmark-test.txt', data: 'Benchmark file content for upload testing.' } }),
+      setupClient: false
+    },
+
+    // Notification routes
+    { name: 'GET /api/notifications', method: 'GET', path: '/api/notifications' },
+    {
+      name: 'POST /api/notifications',
+      method: 'POST',
+      path: '/api/notifications',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        userId: 'usr_bench_001',
+        type: 'info',
+        title: 'Benchmark Notification',
+        message: 'This notification was created by the benchmark suite.'
+      })
+    },
+
+    // Admin routes (auth-protected)
+    {
+      name: 'GET /api/admin/metrics',
+      method: 'GET',
+      path: '/api/admin/metrics',
+      headers: { ...authHeader }
+    }
+  ];
+}
+
+// --- Multipart body builder ---
+function buildMultipartBody(fields) {
+  const boundary = '----BenchmarkBoundary' + Date.now();
+  let body = '';
+  for (const [name, file] of Object.entries(fields)) {
+    body += `--${boundary}\r\n`;
+    body += `Content-Disposition: form-data; name="${name}"; filename="${file.name}"\r\n`;
+    body += `Content-Type: text/plain\r\n\r\n`;
+    body += file.data + '\r\n';
+  }
+  body += `--${boundary}--\r\n`;
+  return body;
+}
+
+// --- Run autocannon for a single endpoint ---
+function runAutocannon(config) {
+  return new Promise((resolve, reject) => {
+    const instance = autocannon({
+      url: BASE_URL + config.path,
+      method: config.method,
+      headers: config.headers || {},
+      body: config.body || undefined,
+      duration,
+      connections,
+      pipelining: PIPELINING,
+      timeout: 30
+    });
+
+    instance.on('done', (result) => {
+      resolve(result);
+    });
+
+    instance.on('error', (err) => {
+      reject(err);
+    });
+
+    // Track progress
+    autocannon.track(instance, { renderProgressBar: false });
+  });
+}
+
+// --- Load thresholds ---
+function loadThresholds() {
+  try {
+    if (fs.existsSync(THRESHOLDS_PATH)) {
+      return JSON.parse(fs.readFileSync(THRESHOLDS_PATH, 'utf-8'));
+    }
+  } catch (e) {
+    console.warn('⚠ Could not load thresholds.json, using empty defaults');
+  }
+  return {};
+}
+
+// --- Main ---
+async function main() {
+  console.log('╔══════════════════════════════════════════╗');
+  console.log('║     API Benchmark Suite                 ║');
+  console.log('╚══════════════════════════════════════════╝');
+  console.log(`\nMode:       ${SMOKE ? 'SMOKE (low concurrency)' : 'FULL'}`);
+  console.log(`Base URL:   ${BASE_URL}`);
+  console.log(`Duration:   ${duration}s`);
+  console.log(`Connections: ${connections}`);
+  console.log(`Pipelining:  ${PIPELINING}\n`);
+
+  // Generate auth token
+  const testToken = generateTestToken();
+  console.log('🔑 Generated test JWT for auth-protected routes\n');
+
+  // Get all endpoints
+  const endpoints = getEndpoints(testToken);
+  console.log(`📋 Testing ${endpoints.length} endpoints:\n`);
+  endpoints.forEach((ep, i) => {
+    console.log(`  ${i + 1}. ${ep.name}`);
+  });
+  console.log('');
+
+  // Ensure results directory
+  fs.mkdirSync(RESULTS_DIR, { recursive: true });
+
+  // Load thresholds
+  const thresholds = loadThresholds();
+  const thresholdViolations = [];
+
+  // Run benchmarks sequentially
+  const results = [];
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+  for (let i = 0; i < endpoints.length; i++) {
+    const ep = endpoints[i];
+    console.log(`\n[${i + 1}/${endpoints.length}] Benchmarking: ${ep.name} ...`);
+
+    try {
+      const result = await runAutocannon(ep);
+
+      // Extract metrics
+      const metrics = {
+        endpoint: ep.name,
+        method: ep.method,
+        path: ep.path,
+        timestamp: new Date().toISOString(),
+        duration_sec: result.duration,
+        connections: result.connections,
+        requests_total: result.requests.total,
+        latency: {
+          p50_ms: result.latency.p50,
+          p95_ms: result.latency.p95,
+          p99_ms: result.latency.p99,
+          avg_ms: result.latency.average,
+          min_ms: result.latency.min,
+          max_ms: result.latency.max
+        },
+        rps: result.requests.average,
+        errors: {
+          total: result.errors,
+          rate_pct: result.requests.total > 0
+            ? ((result.errors / result.requests.total) * 100).toFixed(2)
+            : '0.00'
+        },
+        ttfb: result.latency.average, // autocannon latency == TTFB for lightweight responses
+        throughput_bytes: result.throughput.average,
+        status_2xx: result['2xx'] || 0,
+        status_3xx: result['3xx'] || 0,
+        status_4xx: result['4xx'] || 0,
+        status_5xx: result['5xx'] || 0,
+        non2xx: result.non2xx || 0
+      };
+
+      results.push(metrics);
+
+      // Write per-endpoint JSON
+      const jsonFile = path.join(RESULTS_DIR, `${ep.name.replace(/[\/\s]/g, '_')}_${timestamp}.json`);
+      fs.writeFileSync(jsonFile, JSON.stringify(metrics, null, 2));
+
+      // Check threshold
+      const threshold = thresholds[ep.name];
+      if (threshold && threshold.p99_ms) {
+        if (metrics.latency.p99_ms > threshold.p99_ms) {
+          const violation = `${ep.name}: p99=${metrics.latency.p99_ms}ms > threshold=${threshold.p99_ms}ms ⚠`;
+          thresholdViolations.push(violation);
+          console.log(`  ⚠ THRESHOLD VIOLATION: ${violation}`);
+        }
+      }
+
+      // Print summary for this endpoint
+      console.log(`  ✅ ${ep.name}`);
+      console.log(`     RPS: ${metrics.rps.toFixed(1)} | p50: ${metrics.latency.p50_ms}ms | p95: ${metrics.latency.p95_ms}ms | p99: ${metrics.latency.p99_ms}ms | TTFB: ${metrics.ttfb}ms | Errors: ${metrics.errors.rate_pct}%`);
+
+    } catch (err) {
+      console.error(`  ❌ ${ep.name} FAILED: ${err.message}`);
+      results.push({
+        endpoint: ep.name,
+        method: ep.method,
+        path: ep.path,
+        timestamp: new Date().toISOString(),
+        error: err.message
+      });
+    }
+
+    // Small delay between benchmarks
+    if (i < endpoints.length - 1) {
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
+
+  // --- Generate markdown summary ---
+  console.log('\n📊 Generating summary report...\n');
+  const summaryMd = generateMarkdownSummary(results, thresholdViolations, {
+    duration, connections, pipelining: PIPELINING, smoke: SMOKE
+  });
+  const summaryPath = path.join(RESULTS_DIR, 'summary.md');
+  fs.writeFileSync(summaryPath, summaryMd);
+
+  // Write aggregate JSON
+  const aggregatePath = path.join(RESULTS_DIR, `aggregate_${timestamp}.json`);
+  fs.writeFileSync(aggregatePath, JSON.stringify(results, null, 2));
+
+  console.log(`\n📁 Results written to: ${RESULTS_DIR}/`);
+  console.log(`   - summary.md`);
+  console.log(`   - aggregate_${timestamp}.json`);
+  console.log(`   - (per-endpoint JSON files)`);
+
+  // Print threshold violations
+  if (thresholdViolations.length > 0) {
+    console.log('\n⚠️  THRESHOLD VIOLATIONS DETECTED:');
+    thresholdViolations.forEach(v => console.log(`   ${v}`));
+    console.log('');
+  } else {
+    console.log('\n✅ All endpoints within p99 thresholds.\n');
+  }
+
+  // Exit with appropriate code
+  if (thresholdViolations.length > 0 && !SMOKE) {
+    console.log('⚠ Threshold violations found. Check results/summary.md for details.');
+    process.exitCode = 1;
+  }
+
+  return results;
+}
+
+// --- Markdown summary generator ---
+function generateMarkdownSummary(results, violations, config) {
+  const now = new Date().toISOString();
+  const hostname = os.hostname();
+  const cpus = os.cpus().length;
+  const totalMem = Math.round(os.totalmem() / (1024 * 1024 * 1024));
+
+  let md = `# API Benchmark Summary
+
+**Generated:** ${now}
+**Mode:** ${config.smoke ? 'Smoke (low concurrency)' : 'Full'}
+**Duration:** ${config.duration}s per endpoint
+**Connections:** ${config.connections}
+**Pipelining:** ${config.pipelining}
+
+## Environment
+
+| Property | Value |
+|---|---|
+| Hostname | ${hostname} |
+| Node.js | ${process.version} |
+| OS | ${process.platform} ${process.arch} |
+| CPUs | ${cpus} |
+| Memory (GB) | ${totalMem} |
+
+## Results Overview
+
+| Endpoint | RPS | p50 (ms) | p95 (ms) | p99 (ms) | TTFB (ms) | Errors (%) | Status Codes |
+|---|---|---|---|---|---|---|---|
+`;
+
+  for (const r of results) {
+    if (r.error) {
+      md += `| ${r.endpoint} | ❌ FAILED | - | - | - | - | ${r.error} | - |
+`;
+    } else {
+      const codes = [];
+      if (r.status_2xx) codes.push(`2xx:${r.status_2xx}`);
+      if (r.status_3xx) codes.push(`3xx:${r.status_3xx}`);
+      if (r.status_4xx) codes.push(`4xx:${r.status_4xx}`);
+      if (r.status_5xx) codes.push(`5xx:${r.status_5xx}`);
+      md += `| ${r.endpoint} | ${r.rps.toFixed(1)} | ${r.latency.p50_ms} | ${r.latency.p95_ms} | ${r.latency.p99_ms} | ${r.ttfb} | ${r.errors.rate_pct} | ${codes.join(', ')} |
+`;
+    }
+  }
+
+  if (violations.length > 0) {
+    md += `
+## ⚠️ Threshold Violations
+
+`;
+    for (const v of violations) {
+      md += `- ${v}
+`;
+    }
+  } else {
+    md += `
+## ✅ Thresholds
+
+All endpoints within p99 thresholds.
+
+`;
+  }
+
+  md += `
+## Notes
+
+- Benchmarks run sequentially to avoid resource contention
+- In-memory data stores mean fresh state for each run
+- Auth-protected routes use a pre-generated JWT token
+- Upload endpoint uses a small text file as multipart payload
+`;
+
+  return md;
+}
+
+// --- Start API server and run benchmarks ---
+function startApiServer() {
+  return new Promise((resolve, reject) => {
+    const serverScript = path.join(REPO_ROOT, 'apps', 'api', 'src', 'server.js');
+    console.log(`🚀 Starting API server: node ${serverScript}`);
+
+    const env = {
+      ...process.env,
+      PORT: String(API_PORT),
+      JWT_SECRET,
+      NODE_ENV: 'development'
+    };
+
+    const proc = spawn('node', [serverScript], {
+      env,
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false
+    });
+
+    let started = false;
+    const timeout = setTimeout(() => {
+      if (!started) {
+        reject(new Error('API server failed to start within 15s'));
+      }
+    }, 15000);
+
+    proc.stdout.on('data', (data) => {
+      const output = data.toString();
+      process.stdout.write(`  [api] ${output}`);
+      if (output.includes('API listening') && !started) {
+        started = true;
+        clearTimeout(timeout);
+        // Give it a moment to fully initialize
+        setTimeout(() => resolve(proc), 500);
+      }
+    });
+
+    proc.stderr.on('data', (data) => {
+      process.stderr.write(`  [api:err] ${data.toString()}`);
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    proc.on('exit', (code) => {
+      if (!started) {
+        clearTimeout(timeout);
+        reject(new Error(`API server exited with code ${code} before starting`));
+      }
+    });
+  });
+}
+
+function stopApiServer(proc) {
+  return new Promise((resolve) => {
+    if (!proc || proc.killed) {
+      resolve();
+      return;
+    }
+    proc.on('exit', () => resolve());
+    proc.kill('SIGTERM');
+    setTimeout(() => {
+      if (!proc.killed) {
+        proc.kill('SIGKILL');
+      }
+      resolve();
+    }, 3000);
+  });
+}
+
+// Wait for server to be ready
+async function waitForServer(url, retries = 30, delay = 500) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      await new Promise((resolve, reject) => {
+        const req = http.get(url + '/health', (res) => {
+          if (res.statusCode === 200) resolve(true);
+          else reject(new Error(`Status ${res.statusCode}`));
+        });
+        req.on('error', reject);
+        req.setTimeout(2000, () => { req.destroy(); reject(new Error('timeout')); });
+      });
+      console.log('✅ API server is healthy\n');
+      return;
+    } catch {
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+  throw new Error('API server health check failed');
+}
+
+// --- Entrypoint ---
+(async () => {
+  let serverProc = null;
+
+  try {
+    // Check if server is already running
+    let serverRunning = false;
+    try {
+      await new Promise((resolve, reject) => {
+        const req = http.get(`${BASE_URL}/health`, (res) => {
+          serverRunning = res.statusCode === 200;
+          resolve();
+        });
+        req.on('error', () => resolve());
+        req.setTimeout(3000, () => { req.destroy(); resolve(); });
+      });
+    } catch { /* ignore */ }
+
+    if (!serverRunning) {
+      serverProc = await startApiServer();
+      await waitForServer(BASE_URL);
+    } else {
+      console.log('✅ API server already running on', BASE_URL, '\n');
+    }
+
+    await main();
+
+  } catch (err) {
+    console.error('❌ Benchmark suite failed:', err.message);
+    process.exitCode = 1;
+  } finally {
+    if (serverProc) {
+      console.log('\n🛑 Stopping API server...');
+      await stopApiServer(serverProc);
+      console.log('✅ API server stopped.');
+    }
+  }
+})();

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -315,7 +315,7 @@ async function main() {
         requests_total: result.requests.total,
         latency: {
           p50_ms: result.latency.p50,
-          p95_ms: result.latency.p95,
+          p97_5_ms: result.latency.p97_5,
           p99_ms: result.latency.p99,
           avg_ms: result.latency.average,
           min_ms: result.latency.min,
@@ -328,7 +328,6 @@ async function main() {
             ? ((result.errors / result.requests.total) * 100).toFixed(2)
             : '0.00'
         },
-        ttfb: result.latency.average, // autocannon latency == TTFB for lightweight responses
         throughput_bytes: result.throughput.average,
         status_2xx: result['2xx'] || 0,
         status_3xx: result['3xx'] || 0,
@@ -355,7 +354,7 @@ async function main() {
 
       // Print summary for this endpoint
       console.log(`  ✅ ${ep.name}`);
-      console.log(`     RPS: ${metrics.rps.toFixed(1)} | p50: ${metrics.latency.p50_ms}ms | p95: ${metrics.latency.p95_ms}ms | p99: ${metrics.latency.p99_ms}ms | TTFB: ${metrics.ttfb}ms | Errors: ${metrics.errors.rate_pct}%`);
+      console.log(`     RPS: ${metrics.rps.toFixed(1)} | p50: ${metrics.latency.p50_ms}ms | p97_5: ${metrics.latency.p97_5_ms}ms | p99: ${metrics.latency.p99_ms}ms | Errors: ${metrics.errors.rate_pct}%`);
 
     } catch (err) {
       console.error(`  ❌ ${ep.name} FAILED: ${err.message}`);
@@ -436,13 +435,13 @@ function generateMarkdownSummary(results, violations, config) {
 
 ## Results Overview
 
-| Endpoint | RPS | p50 (ms) | p95 (ms) | p99 (ms) | TTFB (ms) | Errors (%) | Status Codes |
-|---|---|---|---|---|---|---|---|
+| Endpoint | RPS | p50 (ms) | p97_5 (ms) | p99 (ms) | Errors (%) | Status Codes |
+|---|---|---|---|---|---|
 `;
 
   for (const r of results) {
     if (r.error) {
-      md += `| ${r.endpoint} | ❌ FAILED | - | - | - | - | ${r.error} | - |
+      md += `| ${r.endpoint} | ❌ FAILED | - | - | - | ${r.error} | - |
 `;
     } else {
       const codes = [];
@@ -450,7 +449,7 @@ function generateMarkdownSummary(results, violations, config) {
       if (r.status_3xx) codes.push(`3xx:${r.status_3xx}`);
       if (r.status_4xx) codes.push(`4xx:${r.status_4xx}`);
       if (r.status_5xx) codes.push(`5xx:${r.status_5xx}`);
-      md += `| ${r.endpoint} | ${r.rps.toFixed(1)} | ${r.latency.p50_ms} | ${r.latency.p95_ms} | ${r.latency.p99_ms} | ${r.ttfb} | ${r.errors.rate_pct} | ${codes.join(', ')} |
+      md += `| ${r.endpoint} | ${r.rps.toFixed(1)} | ${r.latency.p50_ms} | ${r.latency.p97_5_ms} | ${r.latency.p99_ms} | ${r.errors.rate_pct} | ${codes.join(', ')} |
 `;
     }
   }

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,23 @@
+{
+  "GET /health": { "p99_ms": 100 },
+  "POST /api/auth/register": { "p99_ms": 500 },
+  "POST /api/auth/login": { "p99_ms": 500 },
+  "GET /api/auth/oauth/github/callback": { "p99_ms": 300 },
+  "POST /api/auth/refresh": { "p99_ms": 500 },
+  "GET /api/users": { "p99_ms": 200 },
+  "POST /api/users": { "p99_ms": 300 },
+  "GET /api/jobs": { "p99_ms": 200 },
+  "POST /api/jobs": { "p99_ms": 400 },
+  "GET /api/proposals": { "p99_ms": 200 },
+  "POST /api/proposals": { "p99_ms": 300 },
+  "GET /api/messages": { "p99_ms": 200 },
+  "POST /api/messages": { "p99_ms": 300 },
+  "GET /api/reviews": { "p99_ms": 200 },
+  "POST /api/reviews": { "p99_ms": 300 },
+  "POST /api/payments": { "p99_ms": 500 },
+  "GET /api/search": { "p99_ms": 300 },
+  "POST /api/uploads": { "p99_ms": 500 },
+  "GET /api/notifications": { "p99_ms": 200 },
+  "POST /api/notifications": { "p99_ms": 300 },
+  "GET /api/admin/metrics": { "p99_ms": 400 }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "autocannon": "^8.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
     },
     "apps/api": {
       "name": "@freelanceflow/api",
@@ -17,9 +21,12 @@
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",
         "helmet": "^7.1.0",
-        "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
         "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "autocannon": "^8.0.0",
+        "jsonwebtoken": "^9.0.3"
       }
     },
     "apps/web": {
@@ -33,6 +40,22 @@
         "@types/node": "22.15.19",
         "@types/react": "19.2.2",
         "typescript": "5.6.3"
+      }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "dev": true
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -527,6 +550,15 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@minimistjs/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.1.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
@@ -771,6 +803,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -782,6 +838,66 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/autocannon": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-8.0.0.tgz",
+      "integrity": "sha512-fMMcWc2JPFcUaqHeR6+PbmEpTxCrPZyBUM95oG4w3ngJ8NfBNas/ZXA+pTHXLqJ0UlFVTcy05GC25WxKx/M20A==",
+      "dev": true,
+      "dependencies": {
+        "@minimistjs/subarg": "^1.0.0",
+        "chalk": "^4.1.0",
+        "char-spinner": "^1.0.1",
+        "cli-table3": "^0.6.0",
+        "color-support": "^1.1.1",
+        "cross-argv": "^2.0.0",
+        "form-data": "^4.0.0",
+        "has-async-hooks": "^1.0.0",
+        "hdr-histogram-js": "^3.0.0",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "http-parser-js": "^0.5.2",
+        "hyperid": "^3.0.0",
+        "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "manage-path": "^2.0.0",
+        "on-net-listen": "^1.1.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "reinterval": "^1.1.0",
+        "retimer": "^3.0.0",
+        "semver": "^7.3.2",
+        "timestring": "^6.0.0"
+      },
+      "bin": {
+        "autocannon": "autocannon.js"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.29",
@@ -819,10 +935,35 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -900,11 +1041,87 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+      "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
+      "dev": true
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -974,6 +1191,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-argv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
+      "integrity": "sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -988,6 +1211,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -1037,6 +1269,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -1047,6 +1280,12 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1082,6 +1321,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1181,6 +1435,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1272,11 +1542,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-async-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-async-hooks/-/has-async-hooks-1.0.0.tgz",
+      "integrity": "sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1295,6 +1595,26 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.1.tgz",
+      "integrity": "sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
     },
     "node_modules/helmet": {
       "version": "7.2.0",
@@ -1325,6 +1645,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true
+    },
+    "node_modules/hyperid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.3.0.tgz",
+      "integrity": "sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1336,6 +1673,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1352,11 +1709,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "license": "MIT",
+      "dev": true,
       "dependencies": {
         "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
@@ -1378,12 +1744,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -1395,53 +1763,85 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+      "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/manage-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
+      "integrity": "sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==",
+      "dev": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1510,6 +1910,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -1650,6 +2059,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-net-listen": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/on-net-listen/-/on-net-listen-1.1.2.tgz",
+      "integrity": "sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=9.4.0 || ^8.9.4"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1699,6 +2123,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -1717,6 +2153,15 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1806,6 +2251,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "dev": true
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1842,6 +2299,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2053,6 +2511,32 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2074,6 +2558,27 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/toidentifier": {
@@ -2154,6 +2659,22 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api",
+    "benchmark": "node benchmarks/run.mjs",
+    "benchmark:smoke": "BENCHMARK_SMOKE=true node benchmarks/run.mjs"
+  },
+  "devDependencies": {
+    "autocannon": "^8.0.0",
+    "jsonwebtoken": "^9.0.2"
   }
 }


### PR DESCRIPTION
## Summary

Adds a comprehensive API benchmark suite using [autocannon](https://github.com/mcollina/autocannon).

### What's included

- **benchmarks/run.mjs** — Full benchmark runner that:
  - Auto-starts the API server if not already running
  - Tests 22 endpoints (health, auth, users, jobs, proposals, messages, reviews, payments, search, uploads, notifications, admin metrics)
  - Generates per-endpoint JSON results + aggregate JSON + markdown summary
  - Validates p99 latency against threshold limits
  
- **benchmarks/thresholds.json** — P99 latency thresholds (ms) for each endpoint
  
- **benchmarks/.env.benchmark** — Configurable env vars (base URL, duration, connections, pipelining, JWT secret)

- **npm scripts:**
  - `npm run benchmark` — Full benchmark (10s per endpoint, 10 connections)
  - `npm run benchmark:smoke` — Smoke test (3s per endpoint, 2 connections)

- **.gitignore** — Excludes benchmark results JSON/MD files, keeps .gitkeep

### Dependencies

- autocannon@^8.0.0 — HTTP benchmarking
- jsonwebtoken@^9.0.2 — JWT generation for auth-protected routes

Closes #30