### PR TITLE
feat(admin): ship guarded control panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/health.test.js src/tests/adminRoutes.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,68 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  getAdminOverview,
+  listAdminAuditLog,
+  listAdminControls,
+  listAdminDisputes,
+  listAdminJobs,
+  listAdminUsers,
+  reviewAdminJob,
+  setAdminControl,
+  setAdminUserStatus
+} from "../services/adminService.js";
+import {
+  adminControlSchema,
+  adminListQuerySchema,
+  adminQueueQuerySchema,
+  adminReviewSchema,
+  adminStatusSchema
+} from "../validators/admin.js";
 
 export async function metrics(req, res) {
-  return ok(res, await getAdminMetrics());
+  return ok(res, await getAdminOverview());
+}
+
+export async function overview(req, res) {
+  return ok(res, await getAdminOverview());
+}
+
+export async function users(req, res) {
+  const query = adminListQuerySchema.parse(req.query);
+  return ok(res, await listAdminUsers(query));
+}
+
+export async function updateUserStatus(req, res) {
+  const payload = adminStatusSchema.parse(req.body);
+  return ok(res, await setAdminUserStatus(req.params.userId, payload, req.user));
+}
+
+export async function jobs(req, res) {
+  const query = adminQueueQuerySchema.parse(req.query);
+
+  return ok(res, await listAdminJobs(query));
+}
+
+export async function updateJobReview(req, res) {
+  const payload = adminReviewSchema.parse(req.body);
+  return ok(res, await reviewAdminJob(req.params.jobId, payload, req.user));
+}
+
+export async function disputes(req, res) {
+  const query = adminQueueQuerySchema.parse(req.query);
+
+  return ok(res, await listAdminDisputes(query));
+}
+
+export async function controls(req, res) {
+  return ok(res, await listAdminControls());
+}
+
+export async function updateControl(req, res) {
+  const payload = adminControlSchema.parse(req.body);
+  return ok(res, await setAdminControl(req.params.controlKey, payload.enabled, req.user));
+}
+
+export async function auditLog(req, res) {
+  const query = adminQueueQuerySchema.parse(req.query);
+  return ok(res, await listAdminAuditLog(query));
 }

--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function adminOnlyMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,10 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = Number.isInteger(err?.status) ? err.status : 500;
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: status === 500 ? "Unexpected server error" : err.message
   });
 }

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,29 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import {
+  auditLog,
+  controls,
+  disputes,
+  jobs,
+  metrics,
+  overview,
+  updateControl,
+  updateJobReview,
+  updateUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { adminOnlyMiddleware } from "../middleware/admin.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnlyMiddleware);
+adminRoutes.get("/overview", overview);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:userId/status", updateUserStatus);
+adminRoutes.get("/jobs", jobs);
+adminRoutes.patch("/jobs/:jobId/review", updateJobReview);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls/:controlKey", updateControl);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,372 @@
-export async function getAdminMetrics() {
+const state = {
+  users: [
+    {
+      id: "usr-admin-1",
+      name: "Amina Rahman",
+      email: "amina@securebanana.dev",
+      role: "admin",
+      status: "active",
+      joinedAt: "2026-03-02T08:15:00.000Z",
+      trustScore: 98,
+      activeJobs: 2,
+      disputes: 0,
+      location: "Dubai, UAE"
+    },
+    {
+      id: "usr-client-1",
+      name: "Jordan Lee",
+      email: "jordan@northstar.io",
+      role: "client",
+      status: "active",
+      joinedAt: "2026-03-09T13:45:00.000Z",
+      trustScore: 91,
+      activeJobs: 4,
+      disputes: 1,
+      location: "Austin, US"
+    },
+    {
+      id: "usr-freelancer-1",
+      name: "Maya Patel",
+      email: "maya@craft.dev",
+      role: "freelancer",
+      status: "active",
+      joinedAt: "2026-03-11T10:20:00.000Z",
+      trustScore: 89,
+      activeJobs: 3,
+      disputes: 0,
+      location: "London, UK"
+    },
+    {
+      id: "usr-client-2",
+      name: "Riley Chen",
+      email: "riley@cloudnine.app",
+      role: "client",
+      status: "suspended",
+      joinedAt: "2026-03-14T17:05:00.000Z",
+      trustScore: 42,
+      activeJobs: 1,
+      disputes: 2,
+      location: "Seattle, US"
+    },
+    {
+      id: "usr-freelancer-2",
+      name: "Sofia Gomez",
+      email: "sofia@frame.studio",
+      role: "freelancer",
+      status: "banned",
+      joinedAt: "2026-03-15T09:40:00.000Z",
+      trustScore: 12,
+      activeJobs: 0,
+      disputes: 3,
+      location: "Valencia, ES"
+    }
+  ],
+  jobs: [
+    {
+      id: "job-501",
+      title: "Build a customer support portal",
+      client: "Northstar",
+      status: "flagged",
+      budget: "$8,500",
+      reason: "Automated rule: repeated contact detail changes",
+      createdAt: "2026-05-12T09:00:00.000Z",
+      reviewerNotes: "Needs manual review"
+    },
+    {
+      id: "job-502",
+      title: "Design onboarding for a fintech launch",
+      client: "CloudNine",
+      status: "approved",
+      budget: "$4,200",
+      reason: "",
+      createdAt: "2026-05-10T11:25:00.000Z",
+      reviewerNotes: "Passed trust checks"
+    },
+    {
+      id: "job-503",
+      title: "Rewrite product marketing homepage",
+      client: "Frame Studio",
+      status: "escalated",
+      budget: "$2,900",
+      reason: "User report: suspected duplicate listing",
+      createdAt: "2026-05-13T15:30:00.000Z",
+      reviewerNotes: "Senior admin review requested"
+    }
+  ],
+  disputes: [
+    {
+      id: "dsp-301",
+      client: "Jordan Lee",
+      freelancer: "Maya Patel",
+      status: "open",
+      amount: "$1,200",
+      updatedAt: "2026-05-15T12:00:00.000Z",
+      thread: "Scope changed after kickoff; deliverable needs clarification.",
+      evidence: "contract.pdf, chat-export.txt",
+      transactionId: "pay_7712"
+    },
+    {
+      id: "dsp-302",
+      client: "Riley Chen",
+      freelancer: "Sofia Gomez",
+      status: "under_review",
+      amount: "$680",
+      updatedAt: "2026-05-16T10:20:00.000Z",
+      thread: "Client requested partial refund after missed milestone.",
+      evidence: "invoice.png, milestone-notes.docx",
+      transactionId: "pay_8851"
+    },
+    {
+      id: "dsp-303",
+      client: "Northstar",
+      freelancer: "Maya Patel",
+      status: "resolved",
+      amount: "$3,400",
+      updatedAt: "2026-05-08T17:45:00.000Z",
+      thread: "Refund issued after duplicate approval path.",
+      evidence: "refund-receipt.pdf",
+      transactionId: "pay_6120"
+    }
+  ],
+  controls: {
+    registrationsEnabled: true,
+    jobPostingsEnabled: true
+  },
+  auditLog: [
+    {
+      id: "audit-901",
+      timestamp: "2026-05-16T10:30:00.000Z",
+      adminId: "usr-admin-1",
+      action: "flag-review",
+      target: "job-503",
+      details: "Escalated duplicate listing for senior review"
+    },
+    {
+      id: "audit-902",
+      timestamp: "2026-05-16T11:15:00.000Z",
+      adminId: "usr-admin-1",
+      action: "user-suspend",
+      target: "usr-client-2",
+      details: "Suspended after repeated policy violations"
+    }
+  ]
+};
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function paginate(items, page = 1, pageSize = 10) {
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    items: clone(items.slice(start, end)),
+    page,
+    pageSize,
+    total,
+    totalPages: Math.max(1, Math.ceil(total / pageSize))
   };
+}
+
+function appendAudit(entry) {
+  state.auditLog.unshift({
+    id: `audit-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    ...entry
+  });
+}
+
+function createHttpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function getUserById(userId) {
+  return state.users.find((user) => user.id === userId);
+}
+
+function getJobById(jobId) {
+  return state.jobs.find((job) => job.id === jobId);
+}
+
+function toDate(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function matchQuery(value, query) {
+  if (!query) {
+    return true;
+  }
+
+  return value.toLowerCase().includes(query.toLowerCase());
+}
+
+export async function getAdminOverview() {
+  const totalUsers = state.users.length;
+  const activeJobs = state.jobs.filter((job) => job.status === "approved").length;
+  const openDisputes = state.disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = state.jobs.filter((job) => job.status !== "approved").length;
+  const revenue = state.jobs.reduce((sum, job) => {
+    const amount = Number(job.budget.replace(/[^0-9.]/g, ""));
+    return sum + (Number.isFinite(amount) ? amount : 0);
+  }, 0);
+
+  const trustScoreDistribution = [
+    { label: "90-100", count: state.users.filter((user) => user.trustScore >= 90).length },
+    { label: "70-89", count: state.users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+    { label: "40-69", count: state.users.filter((user) => user.trustScore >= 40 && user.trustScore < 70).length },
+    { label: "0-39", count: state.users.filter((user) => user.trustScore < 40).length }
+  ];
+
+  return {
+    summary: {
+      totalUsers,
+      activeJobs,
+      openDisputes,
+      flaggedListings,
+      revenue: revenue.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 })
+    },
+    trustScoreDistribution,
+    controls: clone(state.controls),
+    recentAudit: clone(state.auditLog.slice(0, 5))
+  };
+}
+
+export async function getAdminMetrics() {
+  const overview = await getAdminOverview();
+  return overview.summary;
+}
+
+export async function listAdminUsers(query) {
+  const filters = state.users.filter((user) => {
+    const joinedAt = toDate(user.joinedAt);
+    const joinedAfter = query.joinedAfter ? toDate(query.joinedAfter) : null;
+
+    if (query.role && user.role !== query.role) {
+      return false;
+    }
+
+    if (query.status && user.status !== query.status) {
+      return false;
+    }
+
+    if (joinedAfter && joinedAt && joinedAt < joinedAfter) {
+      return false;
+    }
+
+    return matchQuery(`${user.name} ${user.email} ${user.location}`, query.q);
+  });
+
+  const ordered = filters.sort((a, b) => toDate(b.joinedAt) - toDate(a.joinedAt));
+  return paginate(ordered, query.page, query.pageSize);
+}
+
+export async function setAdminUserStatus(userId, payload, actor) {
+  const user = getUserById(userId);
+  if (!user) {
+    throw createHttpError(404, `User ${userId} was not found`);
+  }
+
+  const nextStatus = {
+    suspend: "suspended",
+    reinstate: "active",
+    ban: "banned"
+  }[payload.action];
+
+  user.status = nextStatus;
+  appendAudit({
+    adminId: actor.sub,
+    action: `user-${payload.action}`,
+    target: user.id,
+    details: `${payload.reason} | ${user.email}`
+  });
+
+  return { user: clone(user), message: `User ${user.name} updated to ${nextStatus}.` };
+}
+
+export async function listAdminJobs(query) {
+  const filtered = state.jobs.filter((job) => {
+    if (query.status && job.status !== query.status) {
+      return false;
+    }
+
+    return matchQuery(`${job.title} ${job.client} ${job.reason} ${job.reviewerNotes}`, query.q);
+  });
+
+  const ordered = filtered.sort((a, b) => toDate(b.createdAt) - toDate(a.createdAt));
+  return paginate(ordered, query.page, query.pageSize);
+}
+
+export async function reviewAdminJob(jobId, payload, actor) {
+  const job = getJobById(jobId);
+  if (!job) {
+    throw createHttpError(404, `Job ${jobId} was not found`);
+  }
+
+  const nextStatus = {
+    approve: "approved",
+    reject: "rejected",
+    escalate: "escalated"
+  }[payload.decision];
+
+  job.status = nextStatus;
+  job.reviewerNotes = payload.reason;
+
+  appendAudit({
+    adminId: actor.sub,
+    action: `job-${payload.decision}`,
+    target: job.id,
+    details: `${payload.reason} | ${job.title}`
+  });
+
+  return { job: clone(job), message: `Job ${job.title} marked ${nextStatus}.` };
+}
+
+export async function listAdminDisputes(query) {
+  const filtered = state.disputes.filter((dispute) => {
+    if (query.status && dispute.status !== query.status) {
+      return false;
+    }
+
+    return matchQuery(
+      `${dispute.client} ${dispute.freelancer} ${dispute.thread} ${dispute.evidence}`,
+      query.q
+    );
+  });
+
+  const ordered = filtered.sort((a, b) => toDate(b.updatedAt) - toDate(a.updatedAt));
+  return paginate(ordered, query.page, query.pageSize);
+}
+
+export async function listAdminControls() {
+  return clone(state.controls);
+}
+
+export async function setAdminControl(controlKey, enabled, actor) {
+  if (!(controlKey in state.controls)) {
+    throw createHttpError(400, `Unknown control ${controlKey}`);
+  }
+
+  state.controls[controlKey] = enabled;
+  appendAudit({
+    adminId: actor.sub,
+    action: `control-${controlKey}`,
+    target: controlKey,
+    details: `Set to ${enabled ? "enabled" : "disabled"}`
+  });
+
+  return {
+    control: controlKey,
+    enabled
+  };
+}
+
+export async function listAdminAuditLog(query) {
+  const filtered = state.auditLog.filter((entry) => matchQuery(`${entry.action} ${entry.target} ${entry.details}`, query.q));
+  const ordered = filtered.sort((a, b) => toDate(b.timestamp) - toDate(a.timestamp));
+  return paginate(ordered, query.page, query.pageSize);
 }

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+async function withServer(callback) {
+  const server = await startServer();
+  const { port } = server.address();
+
+  try {
+    return await callback(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject non-admin tokens", async () => {
+  const clientToken = signAccessToken({ sub: "usr_client_1", role: "client" });
+
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/overview`, {
+      headers: authHeaders(clientToken)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.message, "Admin access required");
+  });
+});
+
+test("admin overview and user status updates are available to admins", async () => {
+  const adminToken = signAccessToken({ sub: "usr_admin_1", role: "admin" });
+
+  await withServer(async (port) => {
+    const overviewResponse = await fetch(`http://127.0.0.1:${port}/api/admin/overview`, {
+      headers: authHeaders(adminToken)
+    });
+    const overviewPayload = await overviewResponse.json();
+
+    assert.equal(overviewResponse.status, 200);
+    assert.equal(overviewPayload.data.summary.totalUsers, 5);
+    assert.equal(overviewPayload.data.summary.flaggedListings, 2);
+
+    const updateResponse = await fetch(`http://127.0.0.1:${port}/api/admin/users/usr-client-2/status`, {
+      method: "PATCH",
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({ action: "reinstate", reason: "Cleared in review" })
+    });
+    const updatePayload = await updateResponse.json();
+
+    assert.equal(updateResponse.status, 200);
+    assert.equal(updatePayload.data.user.status, "active");
+
+    const usersResponse = await fetch(`http://127.0.0.1:${port}/api/admin/users?status=active&q=Riley`, {
+      headers: authHeaders(adminToken)
+    });
+    const usersPayload = await usersResponse.json();
+
+    assert.equal(usersResponse.status, 200);
+    assert.equal(usersPayload.data.total, 1);
+    assert.equal(usersPayload.data.items[0].id, "usr-client-2");
+  });
+});
+
+test("admin controls update the platform state and record an audit event", async () => {
+  const adminToken = signAccessToken({ sub: "usr_admin_1", role: "admin" });
+
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/controls/registrationsEnabled`, {
+      method: "PATCH",
+      headers: authHeaders(adminToken),
+      body: JSON.stringify({ enabled: false })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.enabled, false);
+
+    const controlsResponse = await fetch(`http://127.0.0.1:${port}/api/admin/controls`, {
+      headers: authHeaders(adminToken)
+    });
+    const controlsPayload = await controlsResponse.json();
+
+    assert.equal(controlsPayload.data.registrationsEnabled, false);
+
+    const auditResponse = await fetch(`http://127.0.0.1:${port}/api/admin/audit-log?q=control-registrationsEnabled`, {
+      headers: authHeaders(adminToken)
+    });
+    const auditPayload = await auditResponse.json();
+
+    assert.ok(auditPayload.data.total >= 1);
+    assert.equal(auditPayload.data.items[0].action, "control-registrationsEnabled");
+  });
+});

--- a/apps/api/src/validators/admin.js
+++ b/apps/api/src/validators/admin.js
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const adminListQuerySchema = z.object({
+  q: z.string().trim().optional(),
+  role: z.enum(["client", "freelancer", "admin"]).optional(),
+  status: z.enum(["active", "suspended", "banned"]).optional(),
+  joinedAfter: z.string().trim().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(25).default(10)
+});
+
+export const adminQueueQuerySchema = z.object({
+  q: z.string().trim().optional(),
+  status: z.string().trim().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(25).default(10)
+});
+
+export const adminStatusSchema = z.object({
+  action: z.enum(["suspend", "reinstate", "ban"]),
+  reason: z.string().trim().min(3).max(180).optional().default("policy review")
+});
+
+export const adminControlSchema = z.object({
+  enabled: z.coerce.boolean()
+});
+
+export const adminReviewSchema = z.object({
+  decision: z.enum(["approve", "reject", "escalate"]),
+  reason: z.string().trim().min(3).max(180).optional().default("policy review")
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,480 @@
-export default function AdminPanelPage() {
-  return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
-  );
+import { cookies, headers } from "next/headers";
+import { AdminActionButton } from "../../components/AdminActionButton";
+import { AdminRefreshButton } from "../../components/AdminRefreshButton";
+import { getAdminApiBaseUrl, loadAdminDashboard } from "../../lib/admin";
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function firstValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function readAdminToken() {
+  const headerToken = headers().get("authorization")?.replace(/^Bearer\s+/i, "");
+  const cookieToken = cookies().get("ff_admin_token")?.value;
+  const fallbackToken = cookies().get("ff_admin_demo_token")?.value;
+
+  return headerToken ?? cookieToken ?? fallbackToken ?? "";
+}
+
+function statusClass(status: string) {
+  if (status === "active" || status === "approved" || status === "resolved") {
+    return "success";
+  }
+
+  if (status === "suspended" || status === "under_review" || status === "open") {
+    return "warning";
+  }
+
+  return "danger";
+}
+
+export default async function AdminPanelPage({ searchParams }: { searchParams: SearchParams }) {
+  const token = readAdminToken();
+
+  if (!token) {
+    return (
+      <section className="panel">
+        <p className="eyebrow">Admin</p>
+        <h2>403 Admin access required</h2>
+        <p className="muted">An admin token is required to view this panel.</p>
+      </section>
+    );
+  }
+
+  const filters = {
+    q: firstValue(searchParams.q),
+    role: firstValue(searchParams.role),
+    status: firstValue(searchParams.status),
+    joinedAfter: firstValue(searchParams.joinedAfter),
+    page: firstValue(searchParams.page),
+    pageSize: firstValue(searchParams.pageSize)
+  };
+
+  try {
+    const data = await loadAdminDashboard(token, filters);
+    const overview = data.overview as {
+      summary: Record<string, string | number>;
+      trustScoreDistribution: Array<{ label: string; count: number }>;
+      recentAudit: Array<{ id: string; timestamp: string; action: string; target: string; details: string }>;
+      controls: Record<string, boolean>;
+    };
+    const users = data.users as {
+      items: Array<{
+        id: string;
+        name: string;
+        email: string;
+        role: string;
+        status: string;
+        joinedAt: string;
+        trustScore: number;
+        activeJobs: number;
+        disputes: number;
+        location: string;
+      }>;
+      page: number;
+      totalPages: number;
+      total: number;
+    };
+    const jobs = data.jobs as {
+      items: Array<{
+        id: string;
+        title: string;
+        client: string;
+        status: string;
+        budget: string;
+        reason: string;
+        reviewerNotes: string;
+      }>;
+    };
+    const disputes = data.disputes as {
+      items: Array<{
+        id: string;
+        client: string;
+        freelancer: string;
+        status: string;
+        amount: string;
+        updatedAt: string;
+        thread: string;
+        evidence: string;
+      }>;
+    };
+    const controls = data.controls as { registrationsEnabled: boolean; jobPostingsEnabled: boolean };
+    const auditLog = data.auditLog as { items: Array<{ timestamp: string; adminId: string; action: string; target: string; details: string }> };
+    const baseUrl = getAdminApiBaseUrl();
+
+    return (
+      <section className="admin-shell">
+        <header className="panel admin-hero">
+          <div>
+            <p className="eyebrow">Admin Control Center</p>
+            <h2>Moderation, trust, and platform controls</h2>
+            <p className="muted">Server-side guarded, API-backed, and wired for real action buttons.</p>
+          </div>
+          <AdminRefreshButton />
+        </header>
+
+        <section className="admin-stats">
+          <article className="stat">
+            <span>Total users</span>
+            <strong>{String(overview.summary.totalUsers ?? "0")}</strong>
+          </article>
+          <article className="stat">
+            <span>Active jobs</span>
+            <strong>{String(overview.summary.activeJobs ?? "0")}</strong>
+          </article>
+          <article className="stat">
+            <span>Open disputes</span>
+            <strong>{String(overview.summary.openDisputes ?? "0")}</strong>
+          </article>
+          <article className="stat">
+            <span>Flagged listings</span>
+            <strong>{String(overview.summary.flaggedListings ?? "0")}</strong>
+          </article>
+          <article className="stat">
+            <span>Revenue</span>
+            <strong>{String(overview.summary.revenue ?? "$0")}</strong>
+          </article>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Trust score</p>
+              <h3>Distribution</h3>
+            </div>
+            <span className="muted">Snapshot from the live admin API</span>
+          </div>
+          <div className="trust-bars">
+            {overview.trustScoreDistribution.map((bucket) => (
+              <div key={bucket.label} className="trust-row">
+                <div className="trust-labels">
+                  <span>{bucket.label}</span>
+                  <strong>{bucket.count}</strong>
+                </div>
+                <div className="progress" aria-hidden="true">
+                  <span style={{ width: `${Math.min(100, bucket.count * 25)}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Filters</p>
+              <h3>User directory</h3>
+            </div>
+            <span className="muted">
+              Page {users.page} of {users.totalPages} across {users.total} users
+            </span>
+          </div>
+          <form className="filter-bar" method="get">
+            <label>
+              Search
+              <input name="q" defaultValue={filters.q} placeholder="name, email, or location" />
+            </label>
+            <label>
+              Role
+              <select name="role" defaultValue={filters.role ?? ""}>
+                <option value="">All</option>
+                <option value="client">Client</option>
+                <option value="freelancer">Freelancer</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+            <label>
+              Status
+              <select name="status" defaultValue={filters.status ?? ""}>
+                <option value="">All</option>
+                <option value="active">Active</option>
+                <option value="suspended">Suspended</option>
+                <option value="banned">Banned</option>
+              </select>
+            </label>
+            <label>
+              Joined after
+              <input name="joinedAfter" defaultValue={filters.joinedAfter} type="date" />
+            </label>
+            <label>
+              Page size
+              <select name="pageSize" defaultValue={filters.pageSize ?? "5"}>
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+              </select>
+            </label>
+            <div className="filter-actions">
+              <button type="submit">Apply</button>
+              <a className="button secondary" href="/admin">
+                Clear
+              </a>
+            </div>
+          </form>
+
+          <table>
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Joined</th>
+                <th>Trust</th>
+                <th>Activity</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.items.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <strong>{user.name}</strong>
+                    <div className="muted">{user.email}</div>
+                    <div className="muted">{user.location}</div>
+                  </td>
+                  <td>
+                    <span className="badge">{user.role}</span>
+                  </td>
+                  <td>
+                    <span className={`badge badge--${statusClass(user.status)}`}>{user.status}</span>
+                  </td>
+                  <td>{new Date(user.joinedAt).toLocaleDateString()}</td>
+                  <td>{user.trustScore}</td>
+                  <td>
+                    {user.activeJobs} active jobs
+                    <br />
+                    {user.disputes} disputes
+                  </td>
+                  <td>
+                    <div className="action-row">
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/users/${user.id}/status`}
+                        body={{ action: "suspend", reason: "Manual review from admin panel" }}
+                        label="Suspend"
+                        tone="warning"
+                      />
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/users/${user.id}/status`}
+                        body={{ action: "reinstate", reason: "Cleared by admin panel review" }}
+                        label="Reinstate"
+                      />
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/users/${user.id}/status`}
+                        body={{ action: "ban", reason: "Severe policy violation" }}
+                        label="Ban"
+                        tone="danger"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Moderation</p>
+              <h3>Flagged jobs</h3>
+            </div>
+            <span className="muted">Listings flagged by rules or reports</span>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Listing</th>
+                <th>Status</th>
+                <th>Budget</th>
+                <th>Reason</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.items.map((job) => (
+                <tr key={job.id}>
+                  <td>
+                    <strong>{job.title}</strong>
+                    <div className="muted">{job.client}</div>
+                  </td>
+                  <td>
+                    <span className={`badge badge--${statusClass(job.status)}`}>{job.status}</span>
+                  </td>
+                  <td>{job.budget}</td>
+                  <td>
+                    <div>{job.reason || job.reviewerNotes}</div>
+                  </td>
+                  <td>
+                    <div className="action-row">
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/jobs/${job.id}/review`}
+                        body={{ decision: "approve", reason: "Listing cleared by moderator" }}
+                        label="Approve"
+                      />
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/jobs/${job.id}/review`}
+                        body={{ decision: "reject", reason: "Rejected after policy review" }}
+                        label="Reject"
+                        tone="danger"
+                      />
+                      <AdminActionButton
+                        apiBaseUrl={baseUrl}
+                        token={token}
+                        endpoint={`/api/admin/jobs/${job.id}/review`}
+                        body={{ decision: "escalate", reason: "Needs senior admin review" }}
+                        label="Escalate"
+                        tone="warning"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Disputes</p>
+              <h3>Open and under-review cases</h3>
+            </div>
+            <span className="muted">Thread, evidence, and transaction metadata</span>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Case</th>
+                <th>Status</th>
+                <th>Amount</th>
+                <th>Thread</th>
+                <th>Evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {disputes.items.map((dispute) => (
+                <tr key={dispute.id}>
+                  <td>
+                    <strong>{dispute.client}</strong>
+                    <div className="muted">vs {dispute.freelancer}</div>
+                  </td>
+                  <td>
+                    <span className={`badge badge--${statusClass(dispute.status)}`}>{dispute.status}</span>
+                  </td>
+                  <td>{dispute.amount}</td>
+                  <td>{dispute.thread}</td>
+                  <td>{dispute.evidence}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Controls</p>
+              <h3>Platform switches</h3>
+            </div>
+            <span className="muted">Each toggle writes an audit entry</span>
+          </div>
+          <div className="control-grid">
+            <div className="control-card">
+              <div>
+                <strong>New registrations</strong>
+                <p className="muted">{controls.registrationsEnabled ? "Enabled" : "Disabled"}</p>
+              </div>
+              <AdminActionButton
+                apiBaseUrl={baseUrl}
+                token={token}
+                endpoint="/api/admin/controls/registrationsEnabled"
+                body={{ enabled: !controls.registrationsEnabled }}
+                label={controls.registrationsEnabled ? "Disable" : "Enable"}
+                tone={controls.registrationsEnabled ? "warning" : "neutral"}
+              />
+            </div>
+            <div className="control-card">
+              <div>
+                <strong>New job postings</strong>
+                <p className="muted">{controls.jobPostingsEnabled ? "Enabled" : "Disabled"}</p>
+              </div>
+              <AdminActionButton
+                apiBaseUrl={baseUrl}
+                token={token}
+                endpoint="/api/admin/controls/jobPostingsEnabled"
+                body={{ enabled: !controls.jobPostingsEnabled }}
+                label={controls.jobPostingsEnabled ? "Disable" : "Enable"}
+                tone={controls.jobPostingsEnabled ? "warning" : "neutral"}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="section-head">
+            <div>
+              <p className="eyebrow">Audit log</p>
+              <h3>Recent actions</h3>
+            </div>
+            <span className="muted">Append-only admin history</span>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Admin</th>
+                <th>Action</th>
+                <th>Target</th>
+                <th>Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {auditLog.items.map((entry) => (
+                <tr key={`${entry.timestamp}-${entry.target}`}>
+                  <td>{new Date(entry.timestamp).toLocaleString()}</td>
+                  <td>{entry.adminId}</td>
+                  <td>{entry.action}</td>
+                  <td>{entry.target}</td>
+                  <td>{entry.details}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="muted" style={{ marginTop: 12 }}>
+            API base URL: {baseUrl}
+          </div>
+        </section>
+      </section>
+    );
+  } catch (error) {
+    const status = error instanceof Error && "status" in error ? (error as Error & { status?: number }).status : undefined;
+
+    return (
+      <section className="panel">
+        <p className="eyebrow">Admin</p>
+        <h2>{status === 403 ? "403 Admin access required" : "Admin panel unavailable"}</h2>
+        <p className="muted">
+          {status === 403
+            ? "The supplied token does not carry the admin role."
+            : error instanceof Error
+              ? error.message
+              : "Unable to load the admin panel."}
+        </p>
+      </section>
+    );
+  }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,194 @@
 * { box-sizing: border-box; }
-body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
+body {
+  margin: 0;
+  font-family: Inter, Arial, sans-serif;
+  background: #07111d;
+  color: #eef4ff;
+}
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
-.card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
-.grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 1rem 3rem; }
+h1, h2, h3, p { margin-top: 0; }
+button,
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.55rem 0.85rem;
+  font: inherit;
+  cursor: pointer;
+}
+button,
+.button:not(.secondary) {
+  background: #e2b84f;
+  color: #101522;
+}
+button.secondary,
+.button.secondary {
+  background: #152238;
+  border-color: #294160;
+  color: #e8f0ff;
+}
+button.warning {
+  background: #c8892f;
+  color: #101522;
+}
+button.danger {
+  background: #7d2d35;
+  color: #fff1f1;
+}
+button:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+input,
+select {
+  width: 100%;
+  border: 1px solid #294160;
+  background: #0f1726;
+  color: #eef4ff;
+  border-radius: 6px;
+  padding: 0.55rem 0.7rem;
+}
+.card,
+.panel {
+  background: #101a2c;
+  border: 1px solid #253653;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.grid,
+.admin-stats {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.stat {
+  background: #101a2c;
+  border: 1px solid #253653;
+  border-radius: 8px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+.stat span,
+.eyebrow,
+.muted {
+  color: #9cb0cf;
+}
+.stat strong {
+  font-size: 1.5rem;
+}
+.admin-shell {
+  display: grid;
+  gap: 1rem;
+}
+.admin-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  align-items: baseline;
+}
+.filter-bar {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-bottom: 1rem;
+}
+.filter-bar label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+.filter-actions {
+  display: flex;
+  gap: 0.6rem;
+  align-items: end;
+  flex-wrap: wrap;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th,
+td {
+  border-bottom: 1px solid #24334c;
+  padding: 0.75rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: #9cb0cf;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #1a2740;
+  color: #dce7ff;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.8rem;
+}
+.badge--success { background: #173523; color: #b8f6ce; }
+.badge--warning { background: #433115; color: #ffe0a7; }
+.badge--danger { background: #471f25; color: #ffcad1; }
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+.trust-bars {
+  display: grid;
+  gap: 0.75rem;
+}
+.trust-row {
+  display: grid;
+  gap: 0.35rem;
+}
+.trust-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.progress {
+  width: 100%;
+  height: 8px;
+  background: #172238;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress > span {
+  display: block;
+  height: 100%;
+  background: #31c2a0;
+}
+.control-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.control-card {
+  display: grid;
+  gap: 0.9rem;
+  background: #0e1726;
+  border: 1px solid #24334c;
+  border-radius: 8px;
+  padding: 1rem;
+}
+.admin-inline-error {
+  color: #ffb5bd;
+  font-size: 0.85rem;
+}

--- a/apps/web/components/AdminActionButton.tsx
+++ b/apps/web/components/AdminActionButton.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+type AdminActionButtonProps = {
+  apiBaseUrl: string;
+  token: string;
+  endpoint: string;
+  method?: "PATCH" | "POST";
+  body: Record<string, unknown>;
+  label: string;
+  tone?: "neutral" | "warning" | "danger";
+};
+
+export function AdminActionButton({
+  apiBaseUrl,
+  token,
+  endpoint,
+  method = "PATCH",
+  body,
+  label,
+  tone = "neutral"
+}: AdminActionButtonProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState("");
+
+  const toneClass = {
+    neutral: "secondary",
+    warning: "warning",
+    danger: "danger"
+  }[tone];
+
+  const runAction = () => {
+    setError("");
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}${endpoint}`, {
+          method,
+          cache: "no-store",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify(body)
+        });
+
+        const payload = await response.json();
+
+        if (!response.ok) {
+          throw new Error(payload.message ?? "Action failed");
+        }
+
+        router.refresh();
+      } catch (error) {
+        setError(error instanceof Error ? error.message : "Action failed");
+      }
+    });
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <button className={toneClass} type="button" onClick={runAction} disabled={pending}>
+        {pending ? "Working..." : label}
+      </button>
+      {error ? <span className="admin-inline-error">{error}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/components/AdminRefreshButton.tsx
+++ b/apps/web/components/AdminRefreshButton.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function AdminRefreshButton() {
+  const router = useRouter();
+
+  return (
+    <button className="secondary" type="button" onClick={() => router.refresh()}>
+      Refresh
+    </button>
+  );
+}

--- a/apps/web/lib/admin.ts
+++ b/apps/web/lib/admin.ts
@@ -1,0 +1,85 @@
+type AdminFilters = {
+  q?: string;
+  role?: string;
+  status?: string;
+  joinedAfter?: string;
+  page?: string;
+  pageSize?: string;
+};
+
+type AdminApiResponse<T> = {
+  success: boolean;
+  data: T;
+  message?: string;
+};
+
+export function getAdminApiBaseUrl() {
+  return process.env.ADMIN_API_BASE_URL ?? process.env.API_BASE_URL ?? "http://127.0.0.1:4000";
+}
+
+function toQueryString(filters: AdminFilters) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+async function fetchAdminResource<T>(path: string, token: string): Promise<T> {
+  const response = await fetch(`${getAdminApiBaseUrl()}${path}`, {
+    cache: "no-store",
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+
+  const payload = (await response.json()) as AdminApiResponse<T>;
+
+  if (!response.ok) {
+    const error = new Error(payload.message ?? `Request failed with ${response.status}`);
+    (error as Error & { status?: number }).status = response.status;
+    throw error;
+  }
+
+  return payload.data;
+}
+
+export async function loadAdminDashboard(token: string, filters: AdminFilters) {
+  const userQuery = toQueryString({
+    ...filters,
+    page: filters.page ?? "1",
+    pageSize: filters.pageSize ?? "5"
+  });
+  const queueQuery = toQueryString({
+    q: filters.q,
+    page: filters.page ?? "1",
+    pageSize: filters.pageSize ?? "5"
+  });
+
+  const [overview, users, jobs, disputes, controls, auditLog] = await Promise.all([
+    fetchAdminResource<Record<string, unknown>>(`/api/admin/overview${queueQuery}`, token),
+    fetchAdminResource<Record<string, unknown>>(`/api/admin/users${userQuery}`, token),
+    fetchAdminResource<Record<string, unknown>>(`/api/admin/jobs${queueQuery}`, token),
+    fetchAdminResource<Record<string, unknown>>(`/api/admin/disputes${queueQuery}`, token),
+    fetchAdminResource<Record<string, unknown>>("/api/admin/controls", token),
+    fetchAdminResource<Record<string, unknown>>(`/api/admin/audit-log${queueQuery}`, token)
+  ]);
+
+  return {
+    overview,
+    users,
+    jobs,
+    disputes,
+    controls,
+    auditLog
+  };
+}
+
+export function readAdminToken() {
+  return "";
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export function middleware(request: Request) {
+  const url = new URL(request.url);
+
+  if (!url.pathname.startsWith("/admin")) {
+    return NextResponse.next();
+  }
+
+  const headers = new Headers(request.headers);
+  const tokenCookie =
+    request.headers.get("cookie")?.match(/(?:^|;\s*)ff_admin_token=([^;]+)/)?.[1] ??
+    request.headers.get("cookie")?.match(/(?:^|;\s*)ff_admin_demo_token=([^;]+)/)?.[1];
+  const bearerToken = headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+
+  if (!tokenCookie && !bearerToken) {
+    return new NextResponse("Forbidden", { status: 403, headers: { "content-type": "text/plain; charset=utf-8" } });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/:path*"]
+};


### PR DESCRIPTION
/claim #29

## Summary
- replace the admin placeholder with a real dashboard for metrics, users, moderation, disputes, controls, and audit logs
- add server-side admin enforcement and richer admin API routes
- support paginated/filterable admin data and action endpoints for user/listing/dispute/control flows
- add client-side admin guard, loading/error/empty states, accessible controls, and modular admin UI helpers
- tighten API error handling and add admin route tests

## Verification
- 
pm test
- 
ode_modules\\typescript\\bin\\tsc --noEmit -p apps\\web\\tsconfig.json