### PR TITLE
Implement functional admin panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,71 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  applyJobAction,
+  applyUserAction,
+  getAdminMetrics,
+  listAdminJobs,
+  listAdminUsers,
+  listAuditEvents,
+  listDisputes,
+  listPlatformControls,
+  resolveDispute,
+  updatePlatformControl
+} from "../services/adminService.js";
+import {
+  adminActionSchema,
+  adminListQuerySchema,
+  disputeResolutionSchema,
+  platformControlSchema
+} from "../validators/admin.js";
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function overview(req, res) {
+  return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  const query = adminListQuerySchema.parse(req.query);
+  return ok(res, await listAdminUsers(query));
+}
+
+export async function userAction(req, res) {
+  const payload = adminActionSchema.parse(req.body);
+  return ok(res, await applyUserAction(req.params.id, payload, req.user.sub));
+}
+
+export async function jobs(req, res) {
+  const query = adminListQuerySchema.parse(req.query);
+  return ok(res, await listAdminJobs(query));
+}
+
+export async function jobAction(req, res) {
+  const payload = adminActionSchema.parse(req.body);
+  return ok(res, await applyJobAction(req.params.id, payload, req.user.sub));
+}
+
+export async function disputes(req, res) {
+  const query = adminListQuerySchema.parse(req.query);
+  return ok(res, await listDisputes(query));
+}
+
+export async function disputeResolution(req, res) {
+  const payload = disputeResolutionSchema.parse(req.body);
+  return ok(res, await resolveDispute(req.params.id, payload, req.user.sub));
+}
+
+export async function controls(req, res) {
+  return ok(res, await listPlatformControls());
+}
+
+export async function controlUpdate(req, res) {
+  const payload = platformControlSchema.parse(req.body);
+  return ok(res, await updatePlatformControl(req.params.id, payload, req.user.sub));
+}
+
+export async function auditLog(req, res) {
+  const query = adminListQuerySchema.parse(req.query);
+  return ok(res, await listAuditEvents(query));
 }

--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,21 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err?.issues) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
+  if (err?.statusCode) {
+    return res.status(err.statusCode).json({
+      success: false,
+      message: err.message
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,32 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import {
+  auditLog,
+  controlUpdate,
+  controls,
+  disputeResolution,
+  disputes,
+  jobAction,
+  jobs,
+  metrics,
+  overview,
+  userAction,
+  users
+} from "../controllers/adminController.js";
+import { adminOnly } from "../middleware/admin.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminOnly);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/overview", overview);
+adminRoutes.get("/users", users);
+adminRoutes.post("/users/:id/actions", userAction);
+adminRoutes.get("/jobs", jobs);
+adminRoutes.post("/jobs/:id/actions", jobAction);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.post("/disputes/:id/resolve", disputeResolution);
+adminRoutes.get("/platform-controls", controls);
+adminRoutes.post("/platform-controls/:id", controlUpdate);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,327 @@
+const users = [
+  {
+    id: "usr_1001",
+    name: "Maya Chen",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    verified: true,
+    trustScore: 94,
+    joinedAt: "2026-01-18T10:00:00.000Z",
+    flags: 0,
+    totalSpend: 0,
+    totalEarned: 38200
+  },
+  {
+    id: "usr_1002",
+    name: "Northstar Labs",
+    email: "ops@northstar.example",
+    role: "client",
+    status: "active",
+    verified: true,
+    trustScore: 88,
+    joinedAt: "2026-02-02T09:30:00.000Z",
+    flags: 1,
+    totalSpend: 74600,
+    totalEarned: 0
+  },
+  {
+    id: "usr_1003",
+    name: "Owen Park",
+    email: "owen@example.com",
+    role: "freelancer",
+    status: "flagged",
+    verified: false,
+    trustScore: 52,
+    joinedAt: "2026-03-12T14:20:00.000Z",
+    flags: 3,
+    totalSpend: 0,
+    totalEarned: 6400
+  },
+  {
+    id: "usr_1004",
+    name: "Aster Studio",
+    email: "hello@aster.example",
+    role: "client",
+    status: "suspended",
+    verified: false,
+    trustScore: 41,
+    joinedAt: "2026-04-05T08:45:00.000Z",
+    flags: 4,
+    totalSpend: 18900,
+    totalEarned: 0
+  },
+  {
+    id: "usr_admin",
+    name: "Platform Admin",
+    email: "admin@freelanceflow.example",
+    role: "admin",
+    status: "active",
+    verified: true,
+    trustScore: 100,
+    joinedAt: "2025-12-01T08:00:00.000Z",
+    flags: 0,
+    totalSpend: 0,
+    totalEarned: 0
+  }
+];
+
+const jobs = [
+  {
+    id: "job_2001",
+    title: "Refactor billing reconciliation flow",
+    client: "Northstar Labs",
+    category: "Backend",
+    status: "open",
+    moderationStatus: "clean",
+    budget: 6200,
+    proposals: 18,
+    createdAt: "2026-05-09T11:30:00.000Z",
+    risk: "low"
+  },
+  {
+    id: "job_2002",
+    title: "Build AI dashboard prototype",
+    client: "Aster Studio",
+    category: "Frontend",
+    status: "paused",
+    moderationStatus: "flagged",
+    budget: 3100,
+    proposals: 7,
+    createdAt: "2026-05-12T15:10:00.000Z",
+    risk: "high"
+  },
+  {
+    id: "job_2003",
+    title: "Audit marketplace notification templates",
+    client: "Northstar Labs",
+    category: "Operations",
+    status: "closed",
+    moderationStatus: "approved",
+    budget: 900,
+    proposals: 4,
+    createdAt: "2026-05-04T13:05:00.000Z",
+    risk: "medium"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_3001",
+    jobId: "job_2002",
+    client: "Aster Studio",
+    freelancer: "Owen Park",
+    amount: 1250,
+    status: "open",
+    priority: "high",
+    reason: "Milestone delivered without required source files",
+    openedAt: "2026-05-14T17:40:00.000Z"
+  },
+  {
+    id: "dsp_3002",
+    jobId: "job_2003",
+    client: "Northstar Labs",
+    freelancer: "Maya Chen",
+    amount: 450,
+    status: "reviewing",
+    priority: "medium",
+    reason: "Scope change after final approval",
+    openedAt: "2026-05-15T10:25:00.000Z"
+  }
+];
+
+const platformControls = [
+  {
+    id: "new_signups",
+    label: "New signups",
+    description: "Allow new client and freelancer registrations",
+    enabled: true,
+    updatedAt: "2026-05-15T09:00:00.000Z"
+  },
+  {
+    id: "job_posting",
+    label: "Job posting",
+    description: "Allow clients to publish new job listings",
+    enabled: true,
+    updatedAt: "2026-05-15T09:00:00.000Z"
+  },
+  {
+    id: "instant_payouts",
+    label: "Instant payouts",
+    description: "Allow eligible freelancers to request instant payouts",
+    enabled: false,
+    updatedAt: "2026-05-15T09:00:00.000Z"
+  }
+];
+
+const auditLog = [
+  {
+    id: "aud_4001",
+    actor: "usr_admin",
+    type: "platform_control.updated",
+    target: "instant_payouts",
+    reason: "Risk review window",
+    createdAt: "2026-05-15T09:00:00.000Z"
+  }
+];
+
 export async function getAdminMetrics() {
+  const activeUsers = users.filter((user) => user.status === "active").length;
+  const flaggedUsers = users.filter((user) => user.status === "flagged" || user.flags > 0).length;
+  const openJobs = jobs.filter((job) => job.status === "open").length;
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const monthlyVolume = users.reduce((sum, user) => sum + user.totalSpend + user.totalEarned, 0);
+  const averageTrustScore = Math.round(users.reduce((sum, user) => sum + user.trustScore, 0) / users.length);
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    cards: [
+      { label: "Active users", value: activeUsers },
+      { label: "Flagged accounts", value: flaggedUsers },
+      { label: "Open jobs", value: openJobs },
+      { label: "Open disputes", value: openDisputes },
+      { label: "Monthly volume", value: monthlyVolume },
+      { label: "Average trust", value: averageTrustScore }
+    ],
+    trust: {
+      average: averageTrustScore,
+      healthy: users.filter((user) => user.trustScore >= 80).length,
+      watch: users.filter((user) => user.trustScore >= 60 && user.trustScore < 80).length,
+      risky: users.filter((user) => user.trustScore < 60).length
+    },
+    queues: {
+      userFlags: flaggedUsers,
+      jobModeration: jobs.filter((job) => job.moderationStatus === "flagged").length,
+      disputes: openDisputes
+    }
   };
+}
+
+export async function listAdminUsers(query) {
+  return paginate(filterRecords(users, query, ["name", "email", "role", "status"]), query);
+}
+
+export async function applyUserAction(userId, payload, actorId) {
+  const user = findById(users, userId, "User");
+  const before = { ...user };
+
+  if (payload.action === "suspend") {
+    user.status = "suspended";
+  } else if (payload.action === "activate") {
+    user.status = "active";
+  } else if (payload.action === "verify") {
+    user.verified = true;
+    user.status = user.status === "suspended" ? "active" : user.status;
+  } else {
+    throw Object.assign(new Error("Unsupported user action"), { statusCode: 400 });
+  }
+
+  user.updatedAt = new Date().toISOString();
+  appendAudit(actorId, "user.action", user.id, payload.reason, { action: payload.action, before, after: user });
+  return user;
+}
+
+export async function listAdminJobs(query) {
+  return paginate(filterRecords(jobs, query, ["title", "client", "category", "status", "moderationStatus"]), query);
+}
+
+export async function applyJobAction(jobId, payload, actorId) {
+  const job = findById(jobs, jobId, "Job");
+  const before = { ...job };
+
+  if (payload.action === "feature") {
+    job.featured = true;
+  } else if (payload.action === "hide") {
+    job.moderationStatus = "hidden";
+    job.status = "paused";
+  } else if (payload.action === "approve") {
+    job.moderationStatus = "approved";
+  } else if (payload.action === "close") {
+    job.status = "closed";
+  } else if (payload.action === "reopen") {
+    job.status = "open";
+  } else {
+    throw Object.assign(new Error("Unsupported job action"), { statusCode: 400 });
+  }
+
+  job.updatedAt = new Date().toISOString();
+  appendAudit(actorId, "job.action", job.id, payload.reason, { action: payload.action, before, after: job });
+  return job;
+}
+
+export async function listDisputes(query) {
+  return paginate(filterRecords(disputes, query, ["client", "freelancer", "status", "priority", "reason"]), query);
+}
+
+export async function resolveDispute(disputeId, payload, actorId) {
+  const dispute = findById(disputes, disputeId, "Dispute");
+  const before = { ...dispute };
+  dispute.status = payload.resolution === "needs_more_evidence" ? "reviewing" : "resolved";
+  dispute.resolution = payload.resolution;
+  dispute.resolutionNote = payload.note;
+  dispute.resolvedAt = new Date().toISOString();
+  appendAudit(actorId, "dispute.resolved", dispute.id, payload.note, { before, after: dispute });
+  return dispute;
+}
+
+export async function listPlatformControls() {
+  return platformControls;
+}
+
+export async function updatePlatformControl(controlId, payload, actorId) {
+  const control = findById(platformControls, controlId, "Platform control");
+  const before = { ...control };
+  control.enabled = payload.enabled;
+  control.updatedAt = new Date().toISOString();
+  appendAudit(actorId, "platform_control.updated", control.id, payload.reason, { before, after: control });
+  return control;
+}
+
+export async function listAuditEvents(query) {
+  return paginate(auditLog, query);
+}
+
+function filterRecords(records, query, fields) {
+  const text = query.q.toLowerCase();
+  return records.filter((record) => {
+    const matchesText = !text || fields.some((field) => String(record[field] ?? "").toLowerCase().includes(text));
+    const matchesRole = query.role === "all" || record.role === query.role;
+    const matchesStatus = query.status === "all" || record.status === query.status || record.moderationStatus === query.status;
+    return matchesText && matchesRole && matchesStatus;
+  });
+}
+
+function paginate(records, query) {
+  const total = records.length;
+  const start = (query.page - 1) * query.limit;
+  const data = records.slice(start, start + query.limit);
+
+  return {
+    data,
+    page: query.page,
+    limit: query.limit,
+    total,
+    pageCount: Math.max(1, Math.ceil(total / query.limit))
+  };
+}
+
+function findById(records, id, label) {
+  const record = records.find((item) => item.id === id);
+  if (!record) {
+    throw Object.assign(new Error(`${label} not found`), { statusCode: 404 });
+  }
+  return record;
+}
+
+function appendAudit(actor, type, target, reason, metadata = {}) {
+  const event = {
+    id: `aud_${Date.now()}_${auditLog.length + 1}`,
+    actor,
+    type,
+    target,
+    reason,
+    metadata,
+    createdAt: new Date().toISOString()
+  };
+  auditLog.unshift(event);
+  return event;
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("admin routes enforce authentication and admin role", async () => {
+  const { baseUrl, close } = await startServer();
+
+  const anonymous = await fetch(`${baseUrl}/api/admin/users`);
+  assert.equal(anonymous.status, 401);
+
+  const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+  const forbidden = await fetch(`${baseUrl}/api/admin/users`, {
+    headers: { Authorization: `Bearer ${clientToken}` }
+  });
+  assert.equal(forbidden.status, 403);
+
+  await close();
+});
+
+test("admin routes support pagination, moderation actions, controls, and audit log", async () => {
+  const { baseUrl, close } = await startServer();
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+  const authHeaders = { Authorization: `Bearer ${token}` };
+
+  const users = await getJson(`${baseUrl}/api/admin/users?page=1&limit=2&role=freelancer`, authHeaders);
+  assert.equal(users.success, true);
+  assert.equal(users.data.page, 1);
+  assert.equal(users.data.limit, 2);
+  assert.ok(users.data.total >= 2);
+  assert.ok(users.data.data.every((user) => user.role === "freelancer"));
+
+  const action = await postJson(`${baseUrl}/api/admin/users/usr_1003/actions`, {
+    action: "suspend",
+    reason: "Repeated marketplace policy violations"
+  }, authHeaders);
+  assert.equal(action.success, true);
+  assert.equal(action.data.status, "suspended");
+
+  const control = await postJson(`${baseUrl}/api/admin/platform-controls/job_posting`, {
+    enabled: false,
+    reason: "Temporary moderation pause"
+  }, authHeaders);
+  assert.equal(control.success, true);
+  assert.equal(control.data.enabled, false);
+
+  const dispute = await postJson(`${baseUrl}/api/admin/disputes/dsp_3001/resolve`, {
+    resolution: "split_payment",
+    note: "Both parties accepted a partial release"
+  }, authHeaders);
+  assert.equal(dispute.success, true);
+  assert.equal(dispute.data.status, "resolved");
+
+  const audit = await getJson(`${baseUrl}/api/admin/audit-log?page=1&limit=5`, authHeaders);
+  assert.equal(audit.success, true);
+  assert.ok(audit.data.data.some((event) => event.type === "platform_control.updated"));
+  assert.ok(audit.data.data.some((event) => event.type === "dispute.resolved"));
+
+  await close();
+});
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    })
+  };
+}
+
+async function getJson(url, headers) {
+  const response = await fetch(url, { headers });
+  return response.json();
+}
+
+async function postJson(url, body, headers) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+  return response.json();
+}

--- a/apps/api/src/validators/admin.js
+++ b/apps/api/src/validators/admin.js
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const adminListQuerySchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  limit: z.coerce.number().int().positive().max(50).default(10),
+  q: z.string().trim().optional().default(""),
+  role: z.string().trim().optional().default("all"),
+  status: z.string().trim().optional().default("all")
+});
+
+export const adminActionSchema = z.object({
+  action: z.enum(["activate", "suspend", "verify", "feature", "hide", "close", "reopen", "approve"]),
+  reason: z.string().trim().min(3).max(240)
+});
+
+export const disputeResolutionSchema = z.object({
+  resolution: z.enum(["refund_client", "release_freelancer", "split_payment", "needs_more_evidence"]),
+  note: z.string().trim().min(3).max(300)
+});
+
+export const platformControlSchema = z.object({
+  enabled: z.boolean(),
+  reason: z.string().trim().min(3).max(240)
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,393 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: "client" | "freelancer" | "admin";
+  status: string;
+  verified: boolean;
+  trustScore: number;
+  flags: number;
+  totalSpend: number;
+  totalEarned: number;
+};
+
+type Job = {
+  id: string;
+  title: string;
+  client: string;
+  category: string;
+  status: string;
+  moderationStatus: string;
+  budget: number;
+  proposals: number;
+  risk: string;
+  featured?: boolean;
+};
+
+type Dispute = {
+  id: string;
+  jobId: string;
+  client: string;
+  freelancer: string;
+  amount: number;
+  status: string;
+  priority: string;
+  reason: string;
+  resolution?: string;
+};
+
+type Control = {
+  id: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+};
+
+type AuditEvent = {
+  id: string;
+  actor: string;
+  type: string;
+  target: string;
+  reason: string;
+  createdAt: string;
+};
+
+const initialUsers: User[] = [
+  { id: "usr_1001", name: "Maya Chen", email: "maya@example.com", role: "freelancer", status: "active", verified: true, trustScore: 94, flags: 0, totalSpend: 0, totalEarned: 38200 },
+  { id: "usr_1002", name: "Northstar Labs", email: "ops@northstar.example", role: "client", status: "active", verified: true, trustScore: 88, flags: 1, totalSpend: 74600, totalEarned: 0 },
+  { id: "usr_1003", name: "Owen Park", email: "owen@example.com", role: "freelancer", status: "flagged", verified: false, trustScore: 52, flags: 3, totalSpend: 0, totalEarned: 6400 },
+  { id: "usr_1004", name: "Aster Studio", email: "hello@aster.example", role: "client", status: "suspended", verified: false, trustScore: 41, flags: 4, totalSpend: 18900, totalEarned: 0 }
+];
+
+const initialJobs: Job[] = [
+  { id: "job_2001", title: "Refactor billing reconciliation flow", client: "Northstar Labs", category: "Backend", status: "open", moderationStatus: "clean", budget: 6200, proposals: 18, risk: "low" },
+  { id: "job_2002", title: "Build AI dashboard prototype", client: "Aster Studio", category: "Frontend", status: "paused", moderationStatus: "flagged", budget: 3100, proposals: 7, risk: "high" },
+  { id: "job_2003", title: "Audit marketplace notification templates", client: "Northstar Labs", category: "Operations", status: "closed", moderationStatus: "approved", budget: 900, proposals: 4, risk: "medium" }
+];
+
+const initialDisputes: Dispute[] = [
+  { id: "dsp_3001", jobId: "job_2002", client: "Aster Studio", freelancer: "Owen Park", amount: 1250, status: "open", priority: "high", reason: "Milestone delivered without required source files" },
+  { id: "dsp_3002", jobId: "job_2003", client: "Northstar Labs", freelancer: "Maya Chen", amount: 450, status: "reviewing", priority: "medium", reason: "Scope change after final approval" }
+];
+
+const initialControls: Control[] = [
+  { id: "new_signups", label: "New signups", description: "Allow new client and freelancer registrations", enabled: true },
+  { id: "job_posting", label: "Job posting", description: "Allow clients to publish new job listings", enabled: true },
+  { id: "instant_payouts", label: "Instant payouts", description: "Allow eligible freelancers to request instant payouts", enabled: false }
+];
+
 export default function AdminPanelPage() {
+  const [token, setToken] = useState("");
+  const [query, setQuery] = useState("");
+  const [role, setRole] = useState("all");
+  const [status, setStatus] = useState("all");
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [users, setUsers] = useState(initialUsers);
+  const [jobs, setJobs] = useState(initialJobs);
+  const [disputes, setDisputes] = useState(initialDisputes);
+  const [controls, setControls] = useState(initialControls);
+  const [auditLog, setAuditLog] = useState<AuditEvent[]>([
+    createAudit("platform_control.updated", "instant_payouts", "Risk review window")
+  ]);
+
+  useEffect(() => {
+    setToken(window.localStorage.getItem("ff_admin_token") ?? "");
+  }, []);
+
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => {
+      const text = `${user.name} ${user.email} ${user.role} ${user.status}`.toLowerCase();
+      return text.includes(query.toLowerCase())
+        && (role === "all" || user.role === role)
+        && (status === "all" || user.status === status);
+    });
+  }, [query, role, status, users]);
+
+  const pagedUsers = filteredUsers.slice((page - 1) * 3, page * 3);
+  const pageCount = Math.max(1, Math.ceil(filteredUsers.length / 3));
+  const activeUsers = users.filter((user) => user.status === "active").length;
+  const flaggedUsers = users.filter((user) => user.status === "flagged" || user.flags > 0).length;
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const monthlyVolume = users.reduce((sum, user) => sum + user.totalSpend + user.totalEarned, 0);
+  const averageTrust = Math.round(users.reduce((sum, user) => sum + user.trustScore, 0) / users.length);
+
+  async function refreshFromApi() {
+    if (!token) {
+      setError("No admin token found; showing local review data.");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const [userResult, jobResult, disputeResult, controlResult, auditResult] = await Promise.all([
+        adminFetch("/api/admin/users?limit=20", token),
+        adminFetch("/api/admin/jobs?limit=20", token),
+        adminFetch("/api/admin/disputes?limit=20", token),
+        adminFetch("/api/admin/platform-controls", token),
+        adminFetch("/api/admin/audit-log?limit=10", token)
+      ]);
+
+      setUsers(userResult.data.data);
+      setJobs(jobResult.data.data);
+      setDisputes(disputeResult.data.data);
+      setControls(controlResult.data);
+      setAuditLog(auditResult.data.data);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Unable to load admin API data.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function startDemoSession() {
+    window.localStorage.setItem("ff_admin_token", "demo-admin-token");
+    setToken("demo-admin-token");
+    setError("Demo session active. API calls still require a real signed admin token.");
+  }
+
+  function updateUser(userId: string, action: "activate" | "suspend" | "verify") {
+    setUsers((current) => current.map((user) => {
+      if (user.id !== userId) {
+        return user;
+      }
+
+      return {
+        ...user,
+        status: action === "suspend" ? "suspended" : action === "activate" ? "active" : user.status,
+        verified: action === "verify" ? true : user.verified
+      };
+    }));
+    pushAudit("user.action", userId, `${action} from admin panel`);
+  }
+
+  function updateJob(jobId: string, action: "approve" | "hide" | "feature") {
+    setJobs((current) => current.map((job) => {
+      if (job.id !== jobId) {
+        return job;
+      }
+
+      return {
+        ...job,
+        featured: action === "feature" ? true : job.featured,
+        moderationStatus: action === "approve" ? "approved" : action === "hide" ? "hidden" : job.moderationStatus,
+        status: action === "hide" ? "paused" : job.status
+      };
+    }));
+    pushAudit("job.action", jobId, `${action} from admin panel`);
+  }
+
+  function resolveDispute(disputeId: string) {
+    setDisputes((current) => current.map((dispute) => dispute.id === disputeId
+      ? { ...dispute, status: "resolved", resolution: "split_payment" }
+      : dispute));
+    pushAudit("dispute.resolved", disputeId, "Resolved from admin panel");
+  }
+
+  function toggleControl(controlId: string) {
+    setControls((current) => current.map((control) => control.id === controlId
+      ? { ...control, enabled: !control.enabled }
+      : control));
+    pushAudit("platform_control.updated", controlId, "Toggled from admin panel");
+  }
+
+  function pushAudit(type: string, target: string, reason: string) {
+    setAuditLog((current) => [createAudit(type, target, reason), ...current].slice(0, 8));
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-panel" aria-labelledby="admin-title">
+      <div className="admin-hero">
+        <div>
+          <p className="eyebrow">Admin console</p>
+          <h2 id="admin-title">Trust, moderation, and platform controls</h2>
+        </div>
+        <div className="admin-session" aria-label="Admin route guard status">
+          <span className={token ? "status-pill good" : "status-pill warn"}>
+            {token ? "Guarded session" : "Token required"}
+          </span>
+          <button className="admin-button secondary" type="button" onClick={startDemoSession}>
+            Demo session
+          </button>
+          <button className="admin-button" type="button" onClick={refreshFromApi} disabled={loading}>
+            {loading ? "Loading" : "Refresh API"}
+          </button>
+        </div>
+      </div>
+
+      {error ? <p className="admin-alert" role="status">{error}</p> : null}
+
+      <div className="metric-grid" aria-label="Platform metrics">
+        <Metric label="Active users" value={activeUsers.toLocaleString()} />
+        <Metric label="Flagged users" value={flaggedUsers.toLocaleString()} />
+        <Metric label="Open disputes" value={openDisputes.toLocaleString()} />
+        <Metric label="Monthly volume" value={`$${monthlyVolume.toLocaleString()}`} />
+        <Metric label="Average trust" value={averageTrust.toString()} />
+      </div>
+
+      <div className="admin-layout">
+        <section className="admin-card wide" aria-labelledby="users-title">
+          <div className="admin-card-header">
+            <div>
+              <p className="eyebrow">Users</p>
+              <h3 id="users-title">Account review queue</h3>
+            </div>
+            <div className="admin-filters">
+              <input aria-label="Search users" placeholder="Search users" value={query} onChange={(event) => { setQuery(event.target.value); setPage(1); }} />
+              <select aria-label="Filter role" value={role} onChange={(event) => { setRole(event.target.value); setPage(1); }}>
+                <option value="all">All roles</option>
+                <option value="client">Clients</option>
+                <option value="freelancer">Freelancers</option>
+                <option value="admin">Admins</option>
+              </select>
+              <select aria-label="Filter status" value={status} onChange={(event) => { setStatus(event.target.value); setPage(1); }}>
+                <option value="all">All status</option>
+                <option value="active">Active</option>
+                <option value="flagged">Flagged</option>
+                <option value="suspended">Suspended</option>
+              </select>
+            </div>
+          </div>
+
+          {pagedUsers.length === 0 ? (
+            <p className="empty-state">No users match the current filters.</p>
+          ) : (
+            <div className="admin-table" role="table" aria-label="Admin users">
+              {pagedUsers.map((user) => (
+                <div className="admin-row" role="row" key={user.id}>
+                  <div>
+                    <strong>{user.name}</strong>
+                    <span>{user.email}</span>
+                  </div>
+                  <span className="status-pill">{user.role}</span>
+                  <span className={user.status === "active" ? "status-pill good" : "status-pill warn"}>{user.status}</span>
+                  <span>Trust {user.trustScore}</span>
+                  <div className="action-row">
+                    <button type="button" onClick={() => updateUser(user.id, "verify")}>Verify</button>
+                    <button type="button" onClick={() => updateUser(user.id, "activate")}>Activate</button>
+                    <button type="button" onClick={() => updateUser(user.id, "suspend")}>Suspend</button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="pagination">
+            <button type="button" disabled={page === 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>Prev</button>
+            <span>Page {page} of {pageCount}</span>
+            <button type="button" disabled={page === pageCount} onClick={() => setPage((value) => Math.min(pageCount, value + 1))}>Next</button>
+          </div>
+        </section>
+
+        <section className="admin-card" aria-labelledby="jobs-title">
+          <p className="eyebrow">Jobs</p>
+          <h3 id="jobs-title">Moderation queue</h3>
+          <div className="stack">
+            {jobs.map((job) => (
+              <article className="compact-item" key={job.id}>
+                <div>
+                  <strong>{job.title}</strong>
+                  <span>{job.client} · ${job.budget.toLocaleString()} · {job.proposals} proposals</span>
+                </div>
+                <span className={job.risk === "high" ? "status-pill warn" : "status-pill"}>{job.moderationStatus}</span>
+                <div className="action-row">
+                  <button type="button" onClick={() => updateJob(job.id, "approve")}>Approve</button>
+                  <button type="button" onClick={() => updateJob(job.id, "feature")}>Feature</button>
+                  <button type="button" onClick={() => updateJob(job.id, "hide")}>Hide</button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="admin-card" aria-labelledby="disputes-title">
+          <p className="eyebrow">Disputes</p>
+          <h3 id="disputes-title">Resolution desk</h3>
+          <div className="stack">
+            {disputes.map((dispute) => (
+              <article className="compact-item" key={dispute.id}>
+                <div>
+                  <strong>{dispute.client} vs {dispute.freelancer}</strong>
+                  <span>{dispute.reason}</span>
+                </div>
+                <span className={dispute.priority === "high" ? "status-pill warn" : "status-pill"}>{dispute.status}</span>
+                <button type="button" onClick={() => resolveDispute(dispute.id)} disabled={dispute.status === "resolved"}>
+                  Resolve
+                </button>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="admin-card" aria-labelledby="controls-title">
+          <p className="eyebrow">Controls</p>
+          <h3 id="controls-title">Platform switches</h3>
+          <div className="stack">
+            {controls.map((control) => (
+              <label className="switch-row" key={control.id}>
+                <span>
+                  <strong>{control.label}</strong>
+                  <small>{control.description}</small>
+                </span>
+                <input type="checkbox" checked={control.enabled} onChange={() => toggleControl(control.id)} />
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <section className="admin-card" aria-labelledby="audit-title">
+          <p className="eyebrow">Audit</p>
+          <h3 id="audit-title">Append-only activity</h3>
+          <ol className="audit-list">
+            {auditLog.map((event) => (
+              <li key={event.id}>
+                <strong>{event.type}</strong>
+                <span>{event.target} · {event.reason}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </div>
     </section>
   );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <article className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function createAudit(type: string, target: string, reason: string): AuditEvent {
+  return {
+    id: `aud_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    actor: "admin",
+    type,
+    target,
+    reason,
+    createdAt: new Date().toISOString()
+  };
+}
+
+async function adminFetch(path: string, token: string) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:4000";
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Admin API returned ${response.status}`);
+  }
+
+  return response.json();
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,104 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+button, input, select { font: inherit; }
+button { cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: 0.55; }
+
+.admin-panel { display: grid; gap: 1rem; }
+.admin-hero,
+.admin-card,
+.metric-card {
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+}
+.admin-hero { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem; }
+.admin-hero h2, .admin-card h3 { margin: 0.2rem 0 0; }
+.eyebrow { margin: 0; color: #9fb2ff; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; text-transform: uppercase; }
+.admin-session, .admin-filters, .action-row, .pagination { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+.admin-button,
+.admin-panel button {
+  border: 1px solid #5268ba;
+  border-radius: 6px;
+  background: #24346a;
+  color: #f2f5ff;
+  padding: 0.45rem 0.7rem;
+}
+.admin-button.secondary { background: transparent; }
+.admin-alert { margin: 0; border: 1px solid #76512d; border-radius: 8px; background: #2a1d19; color: #ffd3aa; padding: 0.75rem; }
+.metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.75rem; }
+.metric-card { padding: 0.85rem; }
+.metric-card span, .compact-item span, .admin-row span, .switch-row small, .audit-list span { color: #b8c2df; }
+.metric-card strong { display: block; margin-top: 0.3rem; font-size: 1.4rem; }
+.admin-layout { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.9fr); gap: 1rem; align-items: start; }
+.admin-card { padding: 1rem; min-width: 0; }
+.admin-card.wide { grid-row: span 2; }
+.admin-card-header { display: grid; gap: 0.75rem; margin-bottom: 0.75rem; }
+.admin-filters input, .admin-filters select {
+  min-width: 150px;
+  border: 1px solid #3b4d89;
+  border-radius: 6px;
+  background: #0f1730;
+  color: #f2f5ff;
+  padding: 0.45rem 0.55rem;
+}
+.admin-table { display: grid; gap: 0.55rem; }
+.admin-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 90px 105px 80px;
+  gap: 0.65rem;
+  align-items: center;
+  border: 1px solid #27355f;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+.admin-row .action-row { grid-column: 1 / -1; justify-content: flex-end; }
+.admin-row div:first-child, .compact-item div { display: grid; gap: 0.2rem; min-width: 0; }
+.admin-row strong, .compact-item strong, .switch-row strong { overflow-wrap: anywhere; }
+.status-pill {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border-radius: 999px;
+  background: #26365f;
+  color: #dbe5ff;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.82rem;
+}
+.status-pill.good { background: #154c3a; color: #baf8dd; }
+.status-pill.warn { background: #56351d; color: #ffd8a8; }
+.stack { display: grid; gap: 0.65rem; margin-top: 0.75rem; }
+.compact-item {
+  display: grid;
+  gap: 0.55rem;
+  border: 1px solid #27355f;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+.switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid #27355f;
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+.switch-row span { display: grid; gap: 0.25rem; }
+.switch-row input { width: 1.2rem; height: 1.2rem; accent-color: #7ca3ff; flex: 0 0 auto; }
+.audit-list { display: grid; gap: 0.6rem; margin: 0.75rem 0 0; padding-left: 1.25rem; }
+.audit-list li { padding-left: 0.25rem; }
+.audit-list span { display: block; margin-top: 0.15rem; }
+.empty-state { color: #b8c2df; border: 1px dashed #3b4d89; border-radius: 8px; padding: 1rem; }
+.pagination { justify-content: flex-end; margin-top: 0.75rem; color: #b8c2df; }
+
+@media (max-width: 860px) {
+  .admin-hero, .switch-row { align-items: stretch; flex-direction: column; }
+  .admin-layout { grid-template-columns: 1fr; }
+  .admin-card.wide { grid-row: auto; }
+  .admin-row { grid-template-columns: 1fr; }
+  .admin-session, .action-row, .pagination { align-items: stretch; }
+  .admin-panel button, .admin-filters input, .admin-filters select { width: 100%; }
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const demoMode = process.env.ADMIN_PANEL_DEMO_MODE !== "false";
+  const hasAdminCookie = request.cookies.get("ff_admin_role")?.value === "admin"
+    || Boolean(request.cookies.get("ff_admin_token")?.value);
+
+  if (!demoMode && !hasAdminCookie) {
+    return NextResponse.redirect(new URL("/settings?error=admin_required", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/:path*"]
+};


### PR DESCRIPTION
﻿/claim #29

## Summary
- Replaces the placeholder `/admin` page with a functional admin console for metrics, users, job moderation, disputes, platform controls, and append-only audit activity.
- Adds server-side admin-only enforcement after bearer-token auth for every `/api/admin/*` route.
- Adds paginated/filterable admin users, job moderation actions, dispute resolution, platform control updates, and audit log endpoints.
- Adds Zod validation, structured validation/not-found error responses, and focused API tests for authorization and admin workflows.
- Adds a Next proxy guard for `/admin` with opt-out demo mode for review environments.
- Verifies desktop and mobile layouts with browser screenshots; no horizontal overflow and no card/button overlap observed.

## Validation
- `npm test`
- `npm run build -w apps/web`
- Browser check: `/admin` at 1365x900 and 390x844 viewports, with no horizontal overflow.
