### PR TITLE
Add functional admin panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,92 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail } from "../utils/response.js";
+import {
+  decideModerationItem,
+  getAdminMetrics,
+  getAdminUserProfile,
+  getDisputeDetails,
+  getPlatformControls,
+  listAdminUsers,
+  listAuditLog,
+  listDisputes,
+  listModerationQueue,
+  ruleOnDispute,
+  updateAdminUserStatus,
+  updatePlatformControl
+} from "../services/adminService.js";
+
+function serviceError(res, error) {
+  return fail(res, error.message ?? "Admin request failed", error.status ?? 400);
+}
 
 export async function metrics(req, res) {
-  return ok(res, await getAdminMetrics());
+  return ok(res, await getAdminMetrics(req.user));
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function userProfile(req, res) {
+  try {
+    return ok(res, await getAdminUserProfile(req.params.userId));
+  } catch (error) {
+    return serviceError(res, error);
+  }
+}
+
+export async function userStatus(req, res) {
+  try {
+    return ok(res, await updateAdminUserStatus(req.user, req.params.userId, req.body));
+  } catch (error) {
+    return serviceError(res, error);
+  }
+}
+
+export async function moderation(req, res) {
+  return ok(res, await listModerationQueue(req.query));
+}
+
+export async function moderationDecision(req, res) {
+  try {
+    return ok(res, await decideModerationItem(req.user, req.params.itemId, req.body));
+  } catch (error) {
+    return serviceError(res, error);
+  }
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function disputeDetails(req, res) {
+  try {
+    return ok(res, await getDisputeDetails(req.params.disputeId));
+  } catch (error) {
+    return serviceError(res, error);
+  }
+}
+
+export async function disputeRuling(req, res) {
+  try {
+    return ok(res, await ruleOnDispute(req.user, req.params.disputeId, req.body));
+  } catch (error) {
+    return serviceError(res, error);
+  }
+}
+
+export async function audit(req, res) {
+  return ok(res, await listAuditLog(req.query));
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function controlUpdate(req, res) {
+  try {
+    return ok(res, await updatePlatformControl(req.user, req.params.controlKey, req.body));
+  } catch (error) {
+    return serviceError(res, error);
+  }
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,34 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  audit,
+  controlUpdate,
+  controls,
+  disputeDetails,
+  disputeRuling,
+  disputes,
+  metrics,
+  moderation,
+  moderationDecision,
+  userProfile,
+  userStatus,
+  users
+} from "../controllers/adminController.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
+adminRoutes.get("/overview", metrics);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.get("/users/:userId", userProfile);
+adminRoutes.patch("/users/:userId/status", userStatus);
+adminRoutes.get("/moderation", moderation);
+adminRoutes.post("/moderation/:itemId/decision", moderationDecision);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.get("/disputes/:disputeId", disputeDetails);
+adminRoutes.post("/disputes/:disputeId/ruling", disputeRuling);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls/:controlKey", controlUpdate);
+adminRoutes.get("/audit", audit);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,557 @@
-export async function getAdminMetrics() {
-  return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+const users = [
+  {
+    id: "usr_admin_001",
+    name: "Avery Admin",
+    email: "avery.admin@freelanceflow.test",
+    role: "admin",
+    status: "active",
+    joinedAt: "2026-04-20T10:15:00.000Z",
+    trustScore: 96,
+    activeJobs: [],
+    disputeHistory: []
+  },
+  {
+    id: "usr_client_101",
+    name: "Nora Client",
+    email: "nora.client@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-05-02T12:00:00.000Z",
+    trustScore: 84,
+    activeJobs: ["job_101", "job_103"],
+    disputeHistory: ["dsp_501"]
+  },
+  {
+    id: "usr_free_205",
+    name: "Mika Freelancer",
+    email: "mika.dev@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-05-04T09:30:00.000Z",
+    trustScore: 91,
+    activeJobs: ["job_101"],
+    disputeHistory: []
+  },
+  {
+    id: "usr_free_218",
+    name: "Rae Design",
+    email: "rae.design@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-05-09T15:45:00.000Z",
+    trustScore: 42,
+    activeJobs: [],
+    disputeHistory: ["dsp_502"]
+  },
+  {
+    id: "usr_client_122",
+    name: "Sol Client",
+    email: "sol.client@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-05-14T18:05:00.000Z",
+    trustScore: 73,
+    activeJobs: ["job_104"],
+    disputeHistory: []
+  }
+];
+
+const jobs = [
+  {
+    id: "job_101",
+    title: "Build an AI customer support widget",
+    posterId: "usr_client_101",
+    status: "active",
+    budget: 1500,
+    flagged: false,
+    reports: 0
+  },
+  {
+    id: "job_102",
+    title: "Clone a competitor website exactly",
+    posterId: "usr_client_101",
+    status: "flagged",
+    budget: 650,
+    flagged: true,
+    reports: 4
+  },
+  {
+    id: "job_103",
+    title: "Migrate legacy API to Node.js",
+    posterId: "usr_client_101",
+    status: "active",
+    budget: 2800,
+    flagged: false,
+    reports: 0
+  },
+  {
+    id: "job_104",
+    title: "Design SaaS onboarding flows",
+    posterId: "usr_client_122",
+    status: "flagged",
+    budget: 900,
+    flagged: true,
+    reports: 2
+  }
+];
+
+const moderationQueue = [
+  {
+    id: "mod_701",
+    jobId: "job_102",
+    title: "Clone a competitor website exactly",
+    posterId: "usr_client_101",
+    reason: "Potential intellectual-property violation",
+    status: "pending",
+    severity: "high",
+    reportedAt: "2026-05-16T12:20:00.000Z"
+  },
+  {
+    id: "mod_702",
+    jobId: "job_104",
+    title: "Design SaaS onboarding flows",
+    posterId: "usr_client_122",
+    reason: "Budget mismatch reported by freelancer",
+    status: "pending",
+    severity: "medium",
+    reportedAt: "2026-05-16T16:40:00.000Z"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_501",
+    clientId: "usr_client_101",
+    freelancerId: "usr_free_205",
+    jobId: "job_101",
+    amount: 1500,
+    status: "open",
+    openedAt: "2026-05-15T08:10:00.000Z",
+    transactionId: "txn_9001",
+    thread: [
+      { authorId: "usr_client_101", message: "Milestone build is incomplete.", createdAt: "2026-05-15T08:10:00.000Z" },
+      { authorId: "usr_free_205", message: "The latest deployment includes the requested flow.", createdAt: "2026-05-15T09:00:00.000Z" }
+    ],
+    evidence: [
+      { type: "url", label: "Preview deployment", value: "https://preview.freelanceflow.test/job_101" }
+    ]
+  },
+  {
+    id: "dsp_502",
+    clientId: "usr_client_122",
+    freelancerId: "usr_free_218",
+    jobId: "job_104",
+    amount: 900,
+    status: "under_review",
+    openedAt: "2026-05-16T11:25:00.000Z",
+    transactionId: "txn_9002",
+    thread: [
+      { authorId: "usr_free_218", message: "Scope changed after work started.", createdAt: "2026-05-16T11:25:00.000Z" }
+    ],
+    evidence: [
+      { type: "file", label: "Original scope PDF", value: "scope-job-104.pdf" }
+    ]
+  }
+];
+
+const notifications = [];
+const auditLog = [
+  {
+    id: "aud_001",
+    adminId: "usr_admin_001",
+    action: "admin.metrics.viewed",
+    targetType: "dashboard",
+    targetId: "admin",
+    details: "Seed audit entry for dashboard verification",
+    createdAt: "2026-05-16T10:00:00.000Z"
+  }
+];
+
+const platformControls = {
+  registrations: {
+    key: "registrations",
+    label: "New user registrations",
+    enabled: true,
+    updatedAt: "2026-05-15T10:00:00.000Z",
+    updatedBy: "usr_admin_001"
+  },
+  jobPostings: {
+    key: "jobPostings",
+    label: "New job postings",
+    enabled: true,
+    updatedAt: "2026-05-15T10:00:00.000Z",
+    updatedBy: "usr_admin_001"
+  }
+};
+
+function now() {
+  return new Date().toISOString();
+}
+
+function getAdminId(admin) {
+  return admin?.sub ?? admin?.id ?? "unknown-admin";
+}
+
+function appendAudit(admin, action, targetType, targetId, details) {
+  const entry = {
+    id: `aud_${String(auditLog.length + 1).padStart(3, "0")}`,
+    adminId: getAdminId(admin),
+    action,
+    targetType,
+    targetId,
+    details,
+    createdAt: now()
   };
+  auditLog.push(entry);
+  return entry;
+}
+
+function toPositiveInteger(value, fallback, max = 100) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.min(parsed, max);
+}
+
+function paginate(items, query = {}) {
+  const page = toPositiveInteger(query.page, 1, 1000);
+  const pageSize = toPositiveInteger(query.pageSize, 10, 50);
+  const total = items.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const start = (page - 1) * pageSize;
+
+  return {
+    items: items.slice(start, start + pageSize),
+    page,
+    pageSize,
+    total,
+    totalPages
+  };
+}
+
+function textMatches(value, search) {
+  return String(value ?? "").toLowerCase().includes(search.toLowerCase());
+}
+
+function dateBoundary(value, boundary) {
+  if (!value) return null;
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(value);
+  const normalized = dateOnly ? `${value}T${boundary === "end" ? "23:59:59.999" : "00:00:00.000"}Z` : value;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function requireKnownUser(userId) {
+  const user = users.find((candidate) => candidate.id === userId);
+  if (!user) {
+    const error = new Error("User not found");
+    error.status = 404;
+    throw error;
+  }
+  return user;
+}
+
+function requireQueueItem(itemId) {
+  const item = moderationQueue.find((candidate) => candidate.id === itemId);
+  if (!item) {
+    const error = new Error("Moderation item not found");
+    error.status = 404;
+    throw error;
+  }
+  return item;
+}
+
+function requireDispute(disputeId) {
+  const dispute = disputes.find((candidate) => candidate.id === disputeId);
+  if (!dispute) {
+    const error = new Error("Dispute not found");
+    error.status = 404;
+    throw error;
+  }
+  return dispute;
+}
+
+function buildTrustDistribution() {
+  const buckets = [
+    { label: "0-49", min: 0, max: 49, count: 0 },
+    { label: "50-69", min: 50, max: 69, count: 0 },
+    { label: "70-89", min: 70, max: 89, count: 0 },
+    { label: "90-100", min: 90, max: 100, count: 0 }
+  ];
+
+  for (const user of users) {
+    const bucket = buckets.find((candidate) => user.trustScore >= candidate.min && user.trustScore <= candidate.max);
+    if (bucket) bucket.count += 1;
+  }
+
+  return buckets.map(({ label, count }) => ({ label, count }));
+}
+
+export async function getAdminMetrics(admin) {
+  const data = {
+    totalUsers: users.length,
+    activeJobs: jobs.filter((job) => job.status === "active").length,
+    openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+    flaggedListings: moderationQueue.filter((item) => item.status === "pending").length,
+    revenueCurrentPeriod: jobs.reduce((sum, job) => sum + job.budget, 0),
+    trustDistribution: buildTrustDistribution(),
+    controls: Object.values(platformControls)
+  };
+
+  appendAudit(admin, "admin.metrics.viewed", "dashboard", "admin", "Viewed admin dashboard metrics");
+  return data;
+}
+
+export async function listAdminUsers(query = {}) {
+  let results = [...users].sort((a, b) => b.joinedAt.localeCompare(a.joinedAt));
+  const { search, role, status, joinedAfter, joinedBefore } = query;
+
+  if (search) {
+    results = results.filter((user) => textMatches(user.name, search) || textMatches(user.email, search) || textMatches(user.id, search));
+  }
+  if (role) {
+    results = results.filter((user) => user.role === role);
+  }
+  if (status) {
+    results = results.filter((user) => user.status === status);
+  }
+  if (joinedAfter) {
+    const lowerBound = dateBoundary(joinedAfter, "start");
+    if (lowerBound) results = results.filter((user) => user.joinedAt >= lowerBound);
+  }
+  if (joinedBefore) {
+    const upperBound = dateBoundary(joinedBefore, "end");
+    if (upperBound) results = results.filter((user) => user.joinedAt <= upperBound);
+  }
+
+  return paginate(results, query);
+}
+
+export async function getAdminUserProfile(userId) {
+  const user = requireKnownUser(userId);
+  return {
+    ...user,
+    activeJobs: jobs.filter((job) => user.activeJobs.includes(job.id)),
+    disputeHistory: disputes.filter((dispute) => user.disputeHistory.includes(dispute.id))
+  };
+}
+
+export async function updateAdminUserStatus(admin, userId, payload = {}) {
+  const allowedStatuses = new Set(["active", "suspended", "banned"]);
+  const status = payload.status;
+  if (!allowedStatuses.has(status)) {
+    const error = new Error("Status must be active, suspended, or banned");
+    error.status = 400;
+    throw error;
+  }
+
+  const user = requireKnownUser(userId);
+  const previousStatus = user.status;
+  user.status = status;
+  user.statusReason = payload.reason ?? "";
+  user.updatedAt = now();
+
+  const audit = appendAudit(
+    admin,
+    `admin.user.${status}`,
+    "user",
+    user.id,
+    `Changed user status from ${previousStatus} to ${status}${payload.reason ? `: ${payload.reason}` : ""}`
+  );
+
+  return { user, audit };
+}
+
+export async function listModerationQueue(query = {}) {
+  let results = [...moderationQueue].sort((a, b) => b.reportedAt.localeCompare(a.reportedAt));
+  if (query.status) {
+    results = results.filter((item) => item.status === query.status);
+  }
+  if (query.severity) {
+    results = results.filter((item) => item.severity === query.severity);
+  }
+  return paginate(results, query);
+}
+
+export async function decideModerationItem(admin, itemId, payload = {}) {
+  const allowedDecisions = new Set(["approve", "reject", "escalate"]);
+  if (!allowedDecisions.has(payload.decision)) {
+    const error = new Error("Decision must be approve, reject, or escalate");
+    error.status = 400;
+    throw error;
+  }
+
+  const item = requireQueueItem(itemId);
+  const job = jobs.find((candidate) => candidate.id === item.jobId);
+  item.status = payload.decision === "approve" ? "approved" : payload.decision === "reject" ? "rejected" : "escalated";
+  item.resolutionReason = payload.reason ?? "";
+  item.resolvedAt = now();
+  item.resolvedBy = getAdminId(admin);
+
+  if (job) {
+    job.status = item.status === "approved" ? "active" : item.status;
+    job.flagged = item.status === "escalated";
+  }
+
+  let notification = null;
+  if (payload.decision === "reject") {
+    notification = {
+      id: `ntf_${String(notifications.length + 1).padStart(3, "0")}`,
+      userId: item.posterId,
+      type: "listing_rejected",
+      message: `Your listing "${item.title}" was rejected${payload.reason ? `: ${payload.reason}` : "."}`,
+      createdAt: now()
+    };
+    notifications.push(notification);
+  }
+
+  const audit = appendAudit(
+    admin,
+    `admin.moderation.${payload.decision}`,
+    "moderation",
+    item.id,
+    `${payload.decision} listing ${item.jobId}${payload.reason ? `: ${payload.reason}` : ""}`
+  );
+
+  return { item, job, notification, audit };
+}
+
+export async function listDisputes(query = {}) {
+  let results = [...disputes].sort((a, b) => b.openedAt.localeCompare(a.openedAt));
+  if (query.status) {
+    results = results.filter((dispute) => dispute.status === query.status);
+  }
+  return paginate(results, query);
+}
+
+export async function getDisputeDetails(disputeId) {
+  const dispute = requireDispute(disputeId);
+  return {
+    ...dispute,
+    client: requireKnownUser(dispute.clientId),
+    freelancer: requireKnownUser(dispute.freelancerId),
+    job: jobs.find((candidate) => candidate.id === dispute.jobId)
+  };
+}
+
+export async function ruleOnDispute(admin, disputeId, payload = {}) {
+  const allowedRulings = new Set(["client", "freelancer", "refund", "escalate"]);
+  if (!allowedRulings.has(payload.ruling)) {
+    const error = new Error("Ruling must be client, freelancer, refund, or escalate");
+    error.status = 400;
+    throw error;
+  }
+
+  const dispute = requireDispute(disputeId);
+  dispute.status = payload.ruling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = payload.ruling;
+  dispute.rulingReason = payload.reason ?? "";
+  dispute.resolvedAt = payload.ruling === "escalate" ? undefined : now();
+  dispute.reviewedBy = getAdminId(admin);
+  dispute.financialAction = payload.ruling === "refund" ? { type: "refund", amount: dispute.amount, transactionId: dispute.transactionId } : null;
+
+  notifications.push(
+    {
+      id: `ntf_${String(notifications.length + 1).padStart(3, "0")}`,
+      userId: dispute.clientId,
+      type: "dispute_ruling",
+      message: `Dispute ${dispute.id} updated: ${payload.ruling}`,
+      createdAt: now()
+    },
+    {
+      id: `ntf_${String(notifications.length + 1).padStart(3, "0")}`,
+      userId: dispute.freelancerId,
+      type: "dispute_ruling",
+      message: `Dispute ${dispute.id} updated: ${payload.ruling}`,
+      createdAt: now()
+    }
+  );
+
+  const audit = appendAudit(
+    admin,
+    `admin.dispute.${payload.ruling}`,
+    "dispute",
+    dispute.id,
+    `${payload.ruling} ruling${payload.reason ? `: ${payload.reason}` : ""}`
+  );
+
+  return { dispute, audit };
+}
+
+export async function listAuditLog(query = {}) {
+  let results = [...auditLog].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  if (query.adminId) {
+    results = results.filter((entry) => entry.adminId === query.adminId);
+  }
+  if (query.action) {
+    results = results.filter((entry) => entry.action === query.action || entry.action.startsWith(`${query.action}.`));
+  }
+  if (query.from) {
+    const lowerBound = dateBoundary(query.from, "start");
+    if (lowerBound) results = results.filter((entry) => entry.createdAt >= lowerBound);
+  }
+  if (query.to) {
+    const upperBound = dateBoundary(query.to, "end");
+    if (upperBound) results = results.filter((entry) => entry.createdAt <= upperBound);
+  }
+  return paginate(results, query);
+}
+
+export async function getPlatformControls() {
+  return Object.values(platformControls);
+}
+
+export async function updatePlatformControl(admin, controlKey, payload = {}) {
+  const control = platformControls[controlKey];
+  if (!control) {
+    const error = new Error("Platform control not found");
+    error.status = 404;
+    throw error;
+  }
+  if (typeof payload.enabled !== "boolean") {
+    const error = new Error("enabled must be a boolean");
+    error.status = 400;
+    throw error;
+  }
+  if (!payload.confirmed) {
+    const error = new Error("Confirmation is required before changing a platform control");
+    error.status = 400;
+    throw error;
+  }
+
+  const previousValue = control.enabled;
+  control.enabled = payload.enabled;
+  control.updatedAt = now();
+  control.updatedBy = getAdminId(admin);
+
+  const audit = appendAudit(
+    admin,
+    "admin.control.updated",
+    "platform_control",
+    control.key,
+    `Changed ${control.label} from ${previousValue ? "enabled" : "disabled"} to ${control.enabled ? "enabled" : "disabled"}`
+  );
+
+  return { control, audit };
+}
+
+export function __resetAdminStateForTests() {
+  users.find((user) => user.id === "usr_free_218").status = "suspended";
+  const mod = moderationQueue.find((item) => item.id === "mod_701");
+  mod.status = "pending";
+  mod.resolutionReason = "";
+  mod.resolvedAt = undefined;
+  mod.resolvedBy = undefined;
+  const dispute = disputes.find((item) => item.id === "dsp_501");
+  dispute.status = "open";
+  dispute.ruling = undefined;
+  dispute.rulingReason = "";
+  dispute.resolvedAt = undefined;
+  dispute.reviewedBy = undefined;
+  dispute.financialAction = null;
+  platformControls.registrations.enabled = true;
+  platformControls.jobPostings.enabled = true;
+  notifications.length = 0;
+  auditLog.splice(1);
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+import { __resetAdminStateForTests } from "../services/adminService.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders(role = "admin") {
+  return {
+    authorization: `Bearer ${signAccessToken({ sub: `usr_${role}`, role })}`,
+    "content-type": "application/json"
+  };
+}
+
+test("admin routes reject missing and non-admin credentials", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/admin/overview`);
+    assert.equal(missing.status, 401);
+
+    const client = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: authHeaders("client")
+    });
+    const payload = await client.json();
+
+    assert.equal(client.status, 403);
+    assert.equal(payload.message, "Forbidden: admin role required");
+  });
+});
+
+test("admin overview returns metrics and trust distribution", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: authHeaders()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.totalUsers, 5);
+    assert.equal(payload.data.flaggedListings, 2);
+    assert.deepEqual(
+      payload.data.trustDistribution.map((bucket) => bucket.label),
+      ["0-49", "50-69", "70-89", "90-100"]
+    );
+  });
+});
+
+test("admin users endpoint filters and paginates server-side", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users?role=freelancer&status=suspended&page=1&pageSize=1`, {
+      headers: authHeaders()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.pageSize, 1);
+    assert.equal(payload.data.total, 1);
+    assert.equal(payload.data.items.length, 1);
+    assert.equal(payload.data.items[0].role, "freelancer");
+    assert.equal(payload.data.items[0].status, "suspended");
+  });
+});
+
+test("admin can inspect a user profile with jobs and disputes", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users/usr_client_101`, {
+      headers: authHeaders()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.id, "usr_client_101");
+    assert.equal(payload.data.activeJobs.length, 2);
+    assert.equal(payload.data.disputeHistory[0].id, "dsp_501");
+  });
+});
+
+test("admin can change user status and audit the action", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users/usr_free_218/status`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ status: "banned", reason: "Repeated policy violations" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.user.status, "banned");
+    assert.equal(payload.data.audit.action, "admin.user.banned");
+
+    const audit = await fetch(`${baseUrl}/api/admin/audit?action=admin.user`, {
+      headers: authHeaders()
+    });
+    const auditPayload = await audit.json();
+    assert.equal(audit.status, 200);
+    assert.equal(auditPayload.data.items[0].targetId, "usr_free_218");
+  });
+});
+
+test("admin moderation rejection notifies poster and records audit entry", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/moderation/mod_701/decision`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ decision: "reject", reason: "Copies another platform" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.item.status, "rejected");
+    assert.equal(payload.data.notification.type, "listing_rejected");
+    assert.equal(payload.data.audit.action, "admin.moderation.reject");
+  });
+});
+
+test("admin can inspect dispute evidence and issue a refund ruling", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const details = await fetch(`${baseUrl}/api/admin/disputes/dsp_501`, {
+      headers: authHeaders()
+    });
+    const detailsPayload = await details.json();
+
+    assert.equal(details.status, 200);
+    assert.equal(detailsPayload.data.transactionId, "txn_9001");
+    assert.equal(detailsPayload.data.thread.length, 2);
+    assert.equal(detailsPayload.data.evidence[0].label, "Preview deployment");
+
+    const response = await fetch(`${baseUrl}/api/admin/disputes/dsp_501/ruling`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ ruling: "refund", reason: "Milestone not delivered" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.dispute.status, "resolved");
+    assert.equal(payload.data.dispute.financialAction.type, "refund");
+    assert.equal(payload.data.audit.action, "admin.dispute.refund");
+  });
+});
+
+test("platform controls require confirmation and append audit entries", async () => {
+  __resetAdminStateForTests();
+  await withServer(async (baseUrl) => {
+    const denied = await fetch(`${baseUrl}/api/admin/controls/registrations`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ enabled: false })
+    });
+    assert.equal(denied.status, 400);
+
+    const response = await fetch(`${baseUrl}/api/admin/controls/registrations`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ enabled: false, confirmed: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.control.enabled, false);
+    assert.equal(payload.data.audit.action, "admin.control.updated");
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,776 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+const PAGE_SIZE = 5;
+
+type PageResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+type AdminOverview = {
+  totalUsers: number;
+  activeJobs: number;
+  openDisputes: number;
+  flaggedListings: number;
+  revenueCurrentPeriod: number;
+  trustDistribution: { label: string; count: number }[];
+  controls: PlatformControl[];
+};
+
+type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  joinedAt: string;
+  trustScore: number;
+};
+
+type JobSummary = {
+  id: string;
+  title: string;
+  status: string;
+  budget: number;
+};
+
+type UserProfile = AdminUser & {
+  activeJobs: JobSummary[];
+  disputeHistory: Dispute[];
+};
+
+type ModerationItem = {
+  id: string;
+  jobId: string;
+  title: string;
+  reason: string;
+  status: string;
+  severity: string;
+  reportedAt: string;
+};
+
+type Dispute = {
+  id: string;
+  jobId: string;
+  status: string;
+  amount: number;
+  transactionId: string;
+  openedAt: string;
+};
+
+type DisputeDetails = Dispute & {
+  client: AdminUser;
+  freelancer: AdminUser;
+  job?: JobSummary;
+  thread: { authorId: string; message: string; createdAt: string }[];
+  evidence: { type: string; label: string; value: string }[];
+};
+
+type PlatformControl = {
+  key: string;
+  label: string;
+  enabled: boolean;
+  updatedAt: string;
+  updatedBy: string;
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  details: string;
+  createdAt: string;
+};
+
+type RefreshOptions = Partial<{
+  usersPage: number;
+  moderationPage: number;
+  disputesPage: number;
+  auditPage: number;
+}>;
+
+const tabs = ["Users", "Moderation", "Disputes", "Audit"];
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(new Date(value));
+}
+
+function statusClass(status: string) {
+  return `status status-${status.replace(/_/g, "-")}`;
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
 export default function AdminPanelPage() {
+  const [token, setToken] = useState("");
+  const [activeTab, setActiveTab] = useState("Users");
+  const [overview, setOverview] = useState<AdminOverview | null>(null);
+  const [users, setUsers] = useState<PageResult<AdminUser> | null>(null);
+  const [moderation, setModeration] = useState<PageResult<ModerationItem> | null>(null);
+  const [disputes, setDisputes] = useState<PageResult<Dispute> | null>(null);
+  const [audit, setAudit] = useState<PageResult<AuditEntry> | null>(null);
+  const [selectedUser, setSelectedUser] = useState<UserProfile | null>(null);
+  const [selectedDispute, setSelectedDispute] = useState<DisputeDetails | null>(null);
+  const [userSearch, setUserSearch] = useState("");
+  const [userRole, setUserRole] = useState("");
+  const [userStatus, setUserStatus] = useState("");
+  const [joinedAfter, setJoinedAfter] = useState("");
+  const [joinedBefore, setJoinedBefore] = useState("");
+  const [auditAdmin, setAuditAdmin] = useState("");
+  const [auditAction, setAuditAction] = useState("");
+  const [auditFrom, setAuditFrom] = useState("");
+  const [auditTo, setAuditTo] = useState("");
+  const [usersPage, setUsersPage] = useState(1);
+  const [moderationPage, setModerationPage] = useState(1);
+  const [disputesPage, setDisputesPage] = useState(1);
+  const [auditPage, setAuditPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  const headers = useMemo(
+    () => ({
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`
+    }),
+    [token]
+  );
+
+  useEffect(() => {
+    const savedToken = window.localStorage.getItem("adminToken") ?? "";
+    setToken(savedToken);
+  }, []);
+
+  async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers ?? {})
+      }
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload.success) {
+      throw new Error(payload.message ?? "Admin request failed");
+    }
+    return payload.data;
+  }
+
+  async function refresh(options: RefreshOptions = {}) {
+    if (!token) {
+      setMessage("Admin API token required.");
+      return;
+    }
+
+    const nextUsersPage = options.usersPage ?? usersPage;
+    const nextModerationPage = options.moderationPage ?? moderationPage;
+    const nextDisputesPage = options.disputesPage ?? disputesPage;
+    const nextAuditPage = options.auditPage ?? auditPage;
+
+    setLoading(true);
+    setMessage("");
+
+    try {
+      const userQuery = new URLSearchParams({ page: String(nextUsersPage), pageSize: String(PAGE_SIZE) });
+      if (userSearch) userQuery.set("search", userSearch);
+      if (userRole) userQuery.set("role", userRole);
+      if (userStatus) userQuery.set("status", userStatus);
+      if (joinedAfter) userQuery.set("joinedAfter", joinedAfter);
+      if (joinedBefore) userQuery.set("joinedBefore", joinedBefore);
+
+      const auditQuery = new URLSearchParams({ page: String(nextAuditPage), pageSize: String(PAGE_SIZE) });
+      if (auditAdmin) auditQuery.set("adminId", auditAdmin);
+      if (auditAction) auditQuery.set("action", auditAction);
+      if (auditFrom) auditQuery.set("from", auditFrom);
+      if (auditTo) auditQuery.set("to", auditTo);
+
+      const [overviewData, usersData, moderationData, disputesData, auditData] = await Promise.all([
+        request<AdminOverview>("/api/admin/overview"),
+        request<PageResult<AdminUser>>(`/api/admin/users?${userQuery.toString()}`),
+        request<PageResult<ModerationItem>>(
+          `/api/admin/moderation?page=${nextModerationPage}&pageSize=${PAGE_SIZE}&status=pending`
+        ),
+        request<PageResult<Dispute>>(`/api/admin/disputes?page=${nextDisputesPage}&pageSize=${PAGE_SIZE}`),
+        request<PageResult<AuditEntry>>(`/api/admin/audit?${auditQuery.toString()}`)
+      ]);
+
+      setOverview(overviewData);
+      setUsers(usersData);
+      setModeration(moderationData);
+      setDisputes(disputesData);
+      setAudit(auditData);
+      setUsersPage(nextUsersPage);
+      setModerationPage(nextModerationPage);
+      setDisputesPage(nextDisputesPage);
+      setAuditPage(nextAuditPage);
+      setMessage("Admin data refreshed.");
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to load admin data."));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (token) {
+      refresh();
+    }
+  }, [token]);
+
+  function saveToken() {
+    window.localStorage.setItem("adminToken", token);
+    document.cookie = `ff_access_token=${token}; path=/; SameSite=Lax`;
+    setMessage("Admin token saved.");
+  }
+
+  async function updateUserStatus(userId: string, status: string) {
+    try {
+      await request(`/api/admin/users/${userId}/status`, {
+        method: "PATCH",
+        body: JSON.stringify({ status, reason: "Admin panel action" })
+      });
+      if (selectedUser?.id === userId) {
+        setSelectedUser(null);
+      }
+      await refresh();
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to update user."));
+    }
+  }
+
+  async function decideModeration(itemId: string, decision: string) {
+    try {
+      await request(`/api/admin/moderation/${itemId}/decision`, {
+        method: "POST",
+        body: JSON.stringify({ decision, reason: "Reviewed from admin panel" })
+      });
+      await refresh();
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to update moderation item."));
+    }
+  }
+
+  async function ruleDispute(disputeId: string, ruling: string) {
+    try {
+      await request(`/api/admin/disputes/${disputeId}/ruling`, {
+        method: "POST",
+        body: JSON.stringify({ ruling, reason: "Reviewed from admin panel" })
+      });
+      if (selectedDispute?.id === disputeId) {
+        await viewDispute(disputeId);
+      }
+      await refresh();
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to rule on dispute."));
+    }
+  }
+
+  async function toggleControl(control: PlatformControl) {
+    const confirmed = window.confirm(`Confirm ${control.enabled ? "disabling" : "enabling"} ${control.label}?`);
+    if (!confirmed) return;
+
+    try {
+      await request(`/api/admin/controls/${control.key}`, {
+        method: "PATCH",
+        body: JSON.stringify({ enabled: !control.enabled, confirmed: true })
+      });
+      await refresh();
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to update platform control."));
+    }
+  }
+
+  async function viewUser(userId: string) {
+    try {
+      const profile = await request<UserProfile>(`/api/admin/users/${userId}`);
+      setSelectedUser(profile);
+      setActiveTab("Users");
+      setMessage(`Loaded ${profile.name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to load user profile."));
+    }
+  }
+
+  async function viewDispute(disputeId: string) {
+    try {
+      const details = await request<DisputeDetails>(`/api/admin/disputes/${disputeId}`);
+      setSelectedDispute(details);
+      setActiveTab("Disputes");
+      setMessage(`Loaded dispute ${details.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error, "Unable to load dispute details."));
+    }
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell">
+      <div className="admin-header">
+        <div>
+          <p className="eyebrow">Operations</p>
+          <h2>Admin Panel</h2>
+        </div>
+        <button type="button" onClick={() => refresh()} disabled={loading} aria-label="Refresh admin data">
+          {loading ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      <div className="admin-auth">
+        <label htmlFor="admin-token">Admin API token</label>
+        <input
+          id="admin-token"
+          type="password"
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          placeholder="Bearer token value"
+        />
+        <button type="button" onClick={saveToken}>
+          Save
+        </button>
+      </div>
+
+      {message ? (
+        <p className={message.includes("Unable") || message.includes("required") || message.includes("failed") ? "alert alert-error" : "alert"}>
+          {message}
+        </p>
+      ) : null}
+
+      {overview ? (
+        <>
+          <div className="metric-grid">
+            <Metric label="Total users" value={overview.totalUsers.toLocaleString()} />
+            <Metric label="Active jobs" value={overview.activeJobs.toLocaleString()} />
+            <Metric label="Open disputes" value={overview.openDisputes.toLocaleString()} />
+            <Metric label="Flagged listings" value={overview.flaggedListings.toLocaleString()} />
+            <Metric label="Revenue" value={`$${overview.revenueCurrentPeriod.toLocaleString()}`} />
+          </div>
+
+          <div className="admin-layout">
+            <section className="panel">
+              <div className="panel-title">
+                <h3>Trust distribution</h3>
+              </div>
+              <div className="trust-chart" aria-label="Trust score distribution chart">
+                {overview.trustDistribution.map((bucket) => (
+                  <div key={bucket.label} className="trust-row">
+                    <span>{bucket.label}</span>
+                    <div>
+                      <i style={{ width: `${Math.max(8, bucket.count * 24)}%` }} />
+                    </div>
+                    <strong>{bucket.count}</strong>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="panel">
+              <div className="panel-title">
+                <h3>Platform controls</h3>
+              </div>
+              <div className="control-list">
+                {overview.controls.map((control) => (
+                  <div className="control-row" key={control.key}>
+                    <div>
+                      <strong>{control.label}</strong>
+                      <span>
+                        {control.enabled ? "Enabled" : "Disabled"} by {control.updatedBy} at {formatDate(control.updatedAt)}
+                      </span>
+                    </div>
+                    <button type="button" onClick={() => toggleControl(control)} aria-label={`Toggle ${control.label}`}>
+                      {control.enabled ? "Disable" : "Enable"}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <div className="tabs" role="tablist" aria-label="Admin sections">
+            {tabs.map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                className={activeTab === tab ? "active" : ""}
+                onClick={() => setActiveTab(tab)}
+                role="tab"
+                aria-selected={activeTab === tab}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+
+          {activeTab === "Users" ? (
+            <section className="panel">
+              <div className="panel-title">
+                <h3>User management</h3>
+                <div className="filters">
+                  <input
+                    value={userSearch}
+                    onChange={(event) => setUserSearch(event.target.value)}
+                    placeholder="Search users"
+                    aria-label="Search users"
+                  />
+                  <select value={userRole} onChange={(event) => setUserRole(event.target.value)} aria-label="Filter users by role">
+                    <option value="">All roles</option>
+                    <option value="client">Client</option>
+                    <option value="freelancer">Freelancer</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                  <select value={userStatus} onChange={(event) => setUserStatus(event.target.value)} aria-label="Filter users by status">
+                    <option value="">All statuses</option>
+                    <option value="active">Active</option>
+                    <option value="suspended">Suspended</option>
+                    <option value="banned">Banned</option>
+                  </select>
+                  <input
+                    type="date"
+                    value={joinedAfter}
+                    onChange={(event) => setJoinedAfter(event.target.value)}
+                    aria-label="Joined after"
+                  />
+                  <input
+                    type="date"
+                    value={joinedBefore}
+                    onChange={(event) => setJoinedBefore(event.target.value)}
+                    aria-label="Joined before"
+                  />
+                  <button type="button" onClick={() => refresh({ usersPage: 1 })}>
+                    Apply
+                  </button>
+                </div>
+              </div>
+              <DataTable
+                emptyLabel="No users match the current filters."
+                headers={["User", "Role", "Status", "Trust", "Joined", "Actions"]}
+                rows={(users?.items ?? []).map((user) => [
+                  <span key="user">
+                    <strong>{user.name}</strong>
+                    <small>{user.email}</small>
+                  </span>,
+                  user.role,
+                  <span key="status" className={statusClass(user.status)}>
+                    {user.status}
+                  </span>,
+                  user.trustScore,
+                  formatDate(user.joinedAt),
+                  <div className="row-actions" key="actions">
+                    <button type="button" onClick={() => viewUser(user.id)}>
+                      View
+                    </button>
+                    <button type="button" onClick={() => updateUserStatus(user.id, "suspended")}>
+                      Suspend
+                    </button>
+                    <button type="button" onClick={() => updateUserStatus(user.id, "active")}>
+                      Reinstate
+                    </button>
+                    <button type="button" onClick={() => updateUserStatus(user.id, "banned")}>
+                      Ban
+                    </button>
+                  </div>
+                ])}
+              />
+              <Pagination result={users} onPageChange={(page) => refresh({ usersPage: page })} />
+              {selectedUser ? <UserDetails user={selectedUser} /> : null}
+            </section>
+          ) : null}
+
+          {activeTab === "Moderation" ? (
+            <section className="panel">
+              <div className="panel-title">
+                <h3>Listing moderation</h3>
+              </div>
+              <DataTable
+                emptyLabel="No pending moderation items."
+                headers={["Listing", "Reason", "Severity", "Reported", "Actions"]}
+                rows={(moderation?.items ?? []).map((item) => [
+                  <span key="listing">
+                    <strong>{item.title}</strong>
+                    <small>{item.jobId}</small>
+                  </span>,
+                  item.reason,
+                  <span key="severity" className={statusClass(item.severity)}>
+                    {item.severity}
+                  </span>,
+                  formatDate(item.reportedAt),
+                  <div className="row-actions" key="actions">
+                    <button type="button" onClick={() => decideModeration(item.id, "approve")}>
+                      Approve
+                    </button>
+                    <button type="button" onClick={() => decideModeration(item.id, "reject")}>
+                      Reject
+                    </button>
+                    <button type="button" onClick={() => decideModeration(item.id, "escalate")}>
+                      Escalate
+                    </button>
+                  </div>
+                ])}
+              />
+              <Pagination result={moderation} onPageChange={(page) => refresh({ moderationPage: page })} />
+            </section>
+          ) : null}
+
+          {activeTab === "Disputes" ? (
+            <section className="panel">
+              <div className="panel-title">
+                <h3>Dispute resolution</h3>
+              </div>
+              <DataTable
+                emptyLabel="No disputes to review."
+                headers={["Dispute", "Status", "Transaction", "Opened", "Actions"]}
+                rows={(disputes?.items ?? []).map((dispute) => [
+                  <span key="dispute">
+                    <strong>{dispute.id}</strong>
+                    <small>
+                      {dispute.jobId} / ${dispute.amount}
+                    </small>
+                  </span>,
+                  <span key="status" className={statusClass(dispute.status)}>
+                    {dispute.status}
+                  </span>,
+                  dispute.transactionId,
+                  formatDate(dispute.openedAt),
+                  <div className="row-actions" key="actions">
+                    <button type="button" onClick={() => viewDispute(dispute.id)}>
+                      View
+                    </button>
+                    <button type="button" onClick={() => ruleDispute(dispute.id, "client")}>
+                      Client
+                    </button>
+                    <button type="button" onClick={() => ruleDispute(dispute.id, "freelancer")}>
+                      Freelancer
+                    </button>
+                    <button type="button" onClick={() => ruleDispute(dispute.id, "refund")}>
+                      Refund
+                    </button>
+                    <button type="button" onClick={() => ruleDispute(dispute.id, "escalate")}>
+                      Escalate
+                    </button>
+                  </div>
+                ])}
+              />
+              <Pagination result={disputes} onPageChange={(page) => refresh({ disputesPage: page })} />
+              {selectedDispute ? <DisputeDetailsPanel dispute={selectedDispute} /> : null}
+            </section>
+          ) : null}
+
+          {activeTab === "Audit" ? (
+            <section className="panel">
+              <div className="panel-title">
+                <h3>Audit log</h3>
+                <div className="filters">
+                  <input
+                    value={auditAdmin}
+                    onChange={(event) => setAuditAdmin(event.target.value)}
+                    placeholder="Admin ID"
+                    aria-label="Filter audit by admin ID"
+                  />
+                  <input
+                    value={auditAction}
+                    onChange={(event) => setAuditAction(event.target.value)}
+                    placeholder="Action prefix"
+                    aria-label="Filter audit by action"
+                  />
+                  <input type="date" value={auditFrom} onChange={(event) => setAuditFrom(event.target.value)} aria-label="Audit from date" />
+                  <input type="date" value={auditTo} onChange={(event) => setAuditTo(event.target.value)} aria-label="Audit to date" />
+                  <button type="button" onClick={() => refresh({ auditPage: 1 })}>
+                    Apply
+                  </button>
+                </div>
+              </div>
+              <DataTable
+                emptyLabel="No audit entries found."
+                headers={["Action", "Target", "Admin", "Details", "Time"]}
+                rows={(audit?.items ?? []).map((entry) => [
+                  entry.action,
+                  `${entry.targetType}:${entry.targetId}`,
+                  entry.adminId,
+                  entry.details,
+                  formatDate(entry.createdAt)
+                ])}
+              />
+              <Pagination result={audit} onPageChange={(page) => refresh({ auditPage: page })} />
+            </section>
+          ) : null}
+        </>
+      ) : (
+        <section className="panel empty-state">
+          <h3>Admin data is locked</h3>
+          <p>Save an admin token and refresh to load the dashboard.</p>
+        </section>
+      )}
     </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <article className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function Pagination<T>({ result, onPageChange }: { result: PageResult<T> | null; onPageChange: (page: number) => void }) {
+  if (!result) return null;
+
+  return (
+    <div className="pagination" aria-label="Table pagination">
+      <span>
+        Page {result.page} of {result.totalPages} ({result.total} total)
+      </span>
+      <div>
+        <button type="button" onClick={() => onPageChange(result.page - 1)} disabled={result.page <= 1}>
+          Previous
+        </button>
+        <button type="button" onClick={() => onPageChange(result.page + 1)} disabled={result.page >= result.totalPages}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function UserDetails({ user }: { user: UserProfile }) {
+  return (
+    <section className="detail-panel" aria-label="Selected user profile">
+      <div className="panel-title">
+        <h3>{user.name}</h3>
+        <span className={statusClass(user.status)}>{user.status}</span>
+      </div>
+      <div className="detail-grid">
+        <Detail label="Email" value={user.email} />
+        <Detail label="Role" value={user.role} />
+        <Detail label="Trust score" value={String(user.trustScore)} />
+        <Detail label="Joined" value={formatDate(user.joinedAt)} />
+      </div>
+      <div className="detail-columns">
+        <div>
+          <h4>Active jobs</h4>
+          <DetailList
+            emptyLabel="No active jobs."
+            items={user.activeJobs.map((job) => `${job.title} (${job.status}, $${job.budget})`)}
+          />
+        </div>
+        <div>
+          <h4>Dispute history</h4>
+          <DetailList
+            emptyLabel="No disputes."
+            items={user.disputeHistory.map((dispute) => `${dispute.id}: ${dispute.status} / $${dispute.amount}`)}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DisputeDetailsPanel({ dispute }: { dispute: DisputeDetails }) {
+  return (
+    <section className="detail-panel" aria-label="Selected dispute details">
+      <div className="panel-title">
+        <h3>{dispute.id}</h3>
+        <span className={statusClass(dispute.status)}>{dispute.status}</span>
+      </div>
+      <div className="detail-grid">
+        <Detail label="Client" value={`${dispute.client.name} (${dispute.client.email})`} />
+        <Detail label="Freelancer" value={`${dispute.freelancer.name} (${dispute.freelancer.email})`} />
+        <Detail label="Transaction" value={dispute.transactionId} />
+        <Detail label="Amount" value={`$${dispute.amount}`} />
+        <Detail label="Job" value={dispute.job?.title ?? dispute.jobId} />
+        <Detail label="Opened" value={formatDate(dispute.openedAt)} />
+      </div>
+      <div className="detail-columns">
+        <div>
+          <h4>Thread</h4>
+          <DetailList
+            emptyLabel="No thread messages."
+            items={dispute.thread.map((message) => `${formatDate(message.createdAt)} ${message.authorId}: ${message.message}`)}
+          />
+        </div>
+        <div>
+          <h4>Evidence</h4>
+          <DetailList
+            emptyLabel="No evidence attached."
+            items={dispute.evidence.map((item) => `${item.label} (${item.type}): ${item.value}`)}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="detail-item">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function DetailList({ items, emptyLabel }: { items: string[]; emptyLabel: string }) {
+  if (items.length === 0) {
+    return <p className="empty-state">{emptyLabel}</p>;
+  }
+
+  return (
+    <ul className="detail-list">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function DataTable({
+  headers,
+  rows,
+  emptyLabel
+}: {
+  headers: string[];
+  rows: (React.ReactNode | string | number)[][];
+  emptyLabel: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="empty-state">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} scope="col">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.map((cell, cellIndex) => (
+                <td key={cellIndex}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,81 @@
 * { box-sizing: border-box; }
-body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: #111318; color: #f5f7fb; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
-.card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+button, input, select { font: inherit; }
+button { border: 0; border-radius: 6px; background: #2563eb; color: white; cursor: pointer; padding: 0.58rem 0.8rem; }
+button:hover { background: #1d4ed8; }
+button:disabled { cursor: not-allowed; opacity: 0.62; }
+input, select { min-height: 2.4rem; border: 1px solid #343945; border-radius: 6px; background: #171a21; color: #f5f7fb; padding: 0.5rem 0.7rem; }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 1rem; }
+.card { background: #191d25; border: 1px solid #303642; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.admin-shell { display: grid; gap: 1rem; }
+.admin-header, .panel-title, .admin-auth, .control-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.admin-header h2 { margin: 0.2rem 0 0; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.eyebrow { margin: 0; color: #9aa4b2; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.admin-auth { flex-wrap: wrap; padding: 1rem; border: 1px solid #303642; border-radius: 8px; background: #191d25; }
+.admin-auth label { color: #cbd5e1; font-weight: 700; }
+.admin-auth input { flex: 1 1 320px; }
+.alert { margin: 0; border: 1px solid #315b43; border-radius: 8px; background: #143322; color: #a7f3d0; padding: 0.85rem 1rem; }
+.alert-error { border-color: #7f1d1d; background: #3a1518; color: #fecaca; }
+.metric-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 0.8rem; }
+.metric-card, .panel { border: 1px solid #303642; border-radius: 8px; background: #191d25; }
+.metric-card { min-height: 7rem; display: grid; align-content: space-between; padding: 1rem; }
+.metric-card span, .control-row span, td small { color: #9aa4b2; }
+.metric-card strong { font-size: 1.65rem; }
+.admin-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.panel { padding: 1rem; overflow: hidden; }
+.panel-title { margin-bottom: 0.8rem; }
+.panel-title h3 { margin: 0; font-size: 1.05rem; }
+.trust-chart { display: grid; gap: 0.75rem; }
+.trust-row { display: grid; grid-template-columns: 4.5rem 1fr 2rem; align-items: center; gap: 0.75rem; }
+.trust-row div { height: 0.7rem; overflow: hidden; border-radius: 999px; background: #262b36; }
+.trust-row i { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #22c55e, #38bdf8); }
+.control-list { display: grid; gap: 0.75rem; }
+.control-row { border: 1px solid #303642; border-radius: 8px; padding: 0.85rem; background: #151820; }
+.control-row div, td span { display: grid; gap: 0.22rem; }
+.tabs { display: flex; gap: 0.5rem; flex-wrap: wrap; border-bottom: 1px solid #303642; padding-bottom: 0.6rem; }
+.tabs button { background: #232936; color: #d7deea; }
+.tabs button.active { background: #eab308; color: #1c1917; }
+.filters { display: flex; gap: 0.5rem; flex-wrap: wrap; justify-content: flex-end; }
+.filters input, .filters select { min-width: 9.5rem; }
+.table-scroll { width: 100%; overflow-x: auto; }
+table { width: 100%; min-width: 760px; border-collapse: collapse; }
+th, td { border-bottom: 1px solid #303642; padding: 0.8rem 0.7rem; text-align: left; vertical-align: middle; }
+th { color: #cbd5e1; font-size: 0.76rem; letter-spacing: 0.05em; text-transform: uppercase; }
+td { color: #edf2f7; }
+.row-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.row-actions button { background: #2f3746; padding: 0.42rem 0.55rem; }
+.row-actions button:hover { background: #475569; }
+.status { display: inline-block; width: fit-content; border-radius: 999px; padding: 0.2rem 0.55rem; font-size: 0.78rem; font-weight: 700; background: #29313d; color: #dbeafe; text-transform: capitalize; }
+.status-active, .status-approved, .status-low { background: #123524; color: #bbf7d0; }
+.status-pending, .status-under-review, .status-medium, .status-suspended { background: #3f3214; color: #fde68a; }
+.status-banned, .status-rejected, .status-high { background: #401a1a; color: #fecaca; }
+.status-escalated { background: #2d2447; color: #ddd6fe; }
+.empty-state { color: #a8b3c2; margin: 0; }
+.pagination { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 0.85rem; color: #a8b3c2; }
+.pagination div { display: flex; gap: 0.5rem; }
+.detail-panel { margin-top: 1rem; border: 1px solid #3a4352; border-radius: 8px; background: #151922; padding: 1rem; }
+.detail-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
+.detail-item { border: 1px solid #303642; border-radius: 8px; background: #11151d; padding: 0.75rem; }
+.detail-item span { display: block; margin-bottom: 0.25rem; color: #9aa4b2; font-size: 0.76rem; text-transform: uppercase; }
+.detail-item strong { overflow-wrap: anywhere; }
+.detail-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.detail-columns h4 { margin: 0 0 0.5rem; color: #d7deea; }
+.detail-list { margin: 0; padding-left: 1.2rem; color: #d7deea; }
+.detail-list li + li { margin-top: 0.35rem; }
+
+@media (max-width: 900px) {
+  .metric-grid, .admin-layout { grid-template-columns: 1fr 1fr; }
+  .admin-header, .panel-title { align-items: flex-start; flex-direction: column; }
+  .filters { justify-content: flex-start; }
+}
+
+@media (max-width: 620px) {
+  main { padding: 1rem 0.75rem; }
+  .metric-grid, .admin-layout, .detail-columns { grid-template-columns: 1fr; }
+  .admin-auth { align-items: stretch; flex-direction: column; }
+  .admin-auth input, .admin-auth button { width: 100%; }
+  .pagination { align-items: flex-start; flex-direction: column; }
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+function readJwtRole(token?: string) {
+  if (!token) return "";
+  const payload = token.split(".")[1];
+  if (!payload) return "";
+
+  try {
+    const padded = payload.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(payload.length / 4) * 4, "=");
+    return JSON.parse(atob(padded)).role ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function proxy(request: NextRequest) {
+  const roleCookie = request.cookies.get("ff_role")?.value;
+  const token = request.cookies.get("ff_access_token")?.value;
+  const role = roleCookie || readJwtRole(token);
+
+  if (role === "admin") {
+    return NextResponse.next();
+  }
+
+  const forbiddenUrl = new URL("/settings", request.url);
+  forbiddenUrl.searchParams.set("error", "403");
+  return NextResponse.redirect(forbiddenUrl);
+}
+
+export const config = {
+  matcher: ["/admin/:path*"]
+};


### PR DESCRIPTION
/claim #29

## Summary
- Replaced the placeholder admin page with a guarded operations panel covering metrics, trust distribution, users, moderation, disputes, platform controls, and audit logs.
- Added server-side admin authorization to every `/api/admin/*` route and implemented paginated/filterable admin endpoints.
- Added admin actions for user suspension/reinstatement/bans, listing moderation decisions, dispute rulings/refunds/escalation, control toggles with confirmation, notifications, and append-only audit entries.
- Added detail views for user profiles, active jobs, dispute history, dispute thread/evidence, and transaction data.

## Validation
- `npm test`
- `npm run build -w apps/web`
- `node --check apps/api/src/services/adminService.js apps/api/src/controllers/adminController.js apps/api/src/routes/adminRoutes.js apps/api/src/middleware/auth.js apps/api/src/tests/admin.test.js`
- `git diff --check`

## Demo walkthrough
1. Start the API and web app locally.
2. Use an admin JWT containing `role: "admin"` as `ff_access_token`, then open `/admin`.
3. Refresh the dashboard, filter users/audit logs, view a user profile, moderate a flagged listing, inspect a dispute, issue a ruling/refund, and toggle platform controls.
4. Confirm each action appears in the audit log.

## Notes
- Non-admin requests are redirected from `/admin` and rejected by the API with `403`.
- This implementation is scoped to the repository's current mock/in-memory service architecture.
- AI assistance was used to implement and validate this PR.
