### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^16.12.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,58 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("STRIPE_SECRET_KEY is required to create payment intents");
+  }
+
+  stripeClient ??= new Stripe(process.env.STRIPE_SECRET_KEY);
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || currency.trim() === "") {
+    throw new Error("currency must be a non-empty string");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: payload.metadata
   };
+}
+
+export async function createPaymentIntent(payload) {
+  const { amount, currency, metadata } = validatePaymentPayload(payload);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error?.type?.startsWith("Stripe")) {
+      throw new Error(error.message);
+    }
+    throw error;
+  }
+}
+
+export function __setStripeClientForTest(client) {
+  stripeClient = client;
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createPaymentIntent, __setStripeClientForTest } from "../services/paymentService.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test.afterEach(() => {
+  __setStripeClientForTest(undefined);
+  delete process.env.STRIPE_SECRET_KEY;
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_example";
+  const calls = [];
+
+  __setStripeClientForTest({
+    paymentIntents: {
+      async create(payload) {
+        calls.push(payload);
+        return {
+          id: "pi_123",
+          client_secret: "pi_123_secret_456"
+        };
+      }
+    }
+  });
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: { jobId: "job_1" }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { jobId: "job_1" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_123",
+    clientSecret: "pi_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_example";
+  let stripePayload;
+
+  __setStripeClientForTest({
+    paymentIntents: {
+      async create(payload) {
+        stripePayload = payload;
+        return { id: "pi_123", client_secret: "secret" };
+      }
+    }
+  });
+
+  await createPaymentIntent({ amount: 100 });
+
+  assert.equal(stripePayload.currency, "usd");
+});
+
+test("createPaymentIntent validates amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }),
+    /amount must be a positive integer/
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_example";
+  __setStripeClientForTest({
+    paymentIntents: {
+      async create() {
+        const error = new Error("Your card was declined.");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100 }),
+    /Your card was declined\./
+  );
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100 }),
+    /STRIPE_SECRET_KEY is required/
+  );
+});
+
+test("POST /api/payments returns Stripe payment data", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_example";
+  __setStripeClientForTest({
+    paymentIntents: {
+      async create() {
+        return { id: "pi_route", client_secret: "pi_route_secret" };
+      }
+    }
+  });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.paymentId, "pi_route");
+    assert.equal(payload.data.clientSecret, "pi_route_secret");
+  });
+});
+
+test("createPaymentIntent live Stripe smoke test", { skip: process.env.STRIPE_LIVE_SMOKE !== "1" }, async () => {
+  const result = await createPaymentIntent({ amount: 100, currency: "usd" });
+  assert.match(result.paymentId, /^pi_/);
+  assert.equal(typeof result.clientSecret, "string");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^16.12.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaced the fake `pay_${Date.now()}` payment stub with Stripe PaymentIntent creation through the Stripe Node SDK
- Validates `amount` as a positive integer, defaults/lowercases `currency`, and supports optional metadata
- Returns `paymentId` and `clientSecret` from the real Stripe response while preserving Stripe error messages
- Added mocked service + POST `/api/payments` route coverage plus a guarded live smoke test (`STRIPE_LIVE_SMOKE=1`)
- Fixed the API test script to run test files via glob under Node 22

## Demo / verification
- `npm test -w apps/api`
- `git diff --check`

Result: 7 passing tests, 1 skipped guarded live Stripe smoke test.

Short demo artifact: the test output exercises the mocked Stripe PaymentIntent path, validation failures, default currency, Stripe error preservation, env-key guard, POST `/api/payments` response, and existing health endpoint test.