### PR TITLE
Add original technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Between Green Checks
+
+At half past one, the build lights blink,
+small moons above a borrowed desk.
+A branch leans out across the dark,
+asking only to be read.
+
+Someone has swept the logs again,
+folded the warnings into rows,
+left comments plain as kitchen notes:
+try this, this breaks, this now goes.
+
+The work is rarely trumpet-shaped.
+It sounds more like a quiet key,
+turned once inside a stubborn lock
+so other hands can enter free.
+
+By morning, nothing wears a crown.
+The diff is small, the thread is clean.
+Yet in that narrow strip of green,
+a hundred future hours are seen.

--- a/POEM.md
+++ b/POEM.md
@@ -1,21 +1,26 @@
-# Between Green Checks
+# Milestones in the Flow
 
-At half past one, the build lights blink,
-small moons above a borrowed desk.
-A branch leans out across the dark,
-asking only to be read.
+FreelanceFlow opens with a posted need,
+a job card bright against the morning glass;
+scope, budget, skill tags, dates agreed,
+so scattered talent knows which doors to pass.
 
-Someone has swept the logs again,
-folded the warnings into rows,
-left comments plain as kitchen notes:
-try this, this breaks, this now goes.
+A freelancer answers with a proposal,
+not thunder, just a plan drawn close and clear;
+the client reads the path from task to handoff,
+and risk grows smaller when intent is near.
 
-The work is rarely trumpet-shaped.
-It sounds more like a quiet key,
-turned once inside a stubborn lock
-so other hands can enter free.
+Messages keep the work from turning vague,
+each note a rail beneath the moving day;
+milestones mark the proof behind the pledge,
+and dashboards show where every promise stays.
 
-By morning, nothing wears a crown.
-The diff is small, the thread is clean.
-Yet in that narrow strip of green,
-a hundred future hours are seen.
+When payments wait behind the service layer,
+they carry trust without a louder claim;
+reviews return the human weight of work,
+not just a score, but memory with a name.
+
+Admins watch the quiet health of routes,
+notifications surface what must be known;
+a marketplace is strongest when its flow
+lets careful strangers build as if at home.


### PR DESCRIPTION
/claim #76

## Summary
- Reworked `POEM.md` into an original five-stanza poem written specifically for FreelanceFlow.
- Kept the change scoped to the requested root-level Markdown file.
- Anchored the poem in the project's actual marketplace language: jobs, proposals, messages, dashboards, payments, reviews, admins, notifications, and marketplace flow.

## Creative decision
I chose a milestone-flow theme because FreelanceFlow connects clients and freelancers through scoped jobs, clear proposals, communication, payment trust, reviews, and operational visibility.

## Acceptance checklist
- [x] Original poem written for this project specifically
- [x] At least 3 stanzas: 5 poem stanzas
- [x] Submitted as `POEM.md` in the project root
- [x] PR description includes a one-line creative decision

## Validation
- Windows: custom acceptance validation passed (`POEM.md` present, 5 stanzas, 147 words, 10 project-specific terms).
- Windows: `git diff --check` completed with no whitespace errors.
- Windows: `node --test apps/api/src/tests/health.test.js` passed.
- WSL Ubuntu-26.04: custom acceptance validation passed (`POEM.md` present, 5 stanzas, 147 words, 10 project-specific terms).
- WSL Ubuntu-26.04: `node --test apps/api/src/tests/health.test.js` passed.

## Demo
This is a Markdown-only content change; the rendered root `POEM.md` is the demo artifact.