### PR TITLE
Add marketplace trust poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Ledger at Dawn
+
+The board wakes first, before the bids arrive,
+with empty cards arranged in quiet rows;
+a client writes the work they need alive,
+and trusts a stranger only by what shows.
+
+A profile gathers proof in measured light:
+one shipped repair, one message answered clean,
+one proposal shaped to fit the job just right,
+not loud, but clear enough to stand between.
+
+The escrow holds its breath beneath the page,
+a promise locked until the work is done;
+reviewers turn the diff from doubt to gauge,
+and mark the task as earned, not merely won.
+
+By evening, dashboards settle into green:
+the invoice sent, the rating left with care;
+a marketplace is more than screens between,
+it is a way to make the risk feel fair.


### PR DESCRIPTION
Closes #76

/claim #76

Creative note: I used a restrained four-stanza marketplace poem because FreelanceFlow is built around trust between strangers, so the poem follows the path from posted work to proposal, escrow, review, invoice, and a fairer handoff between clients and freelancers.

Validation:
- Added `POEM.md` at the project root.
- Confirmed the poem has four stanzas, exceeding the three-stanza minimum.
- Kept the PR scoped to the single requested markdown file.