### PR TITLE
Implement admin panel

### DIFF
--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,63 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  getAdminMetrics,
+  getAuditLog,
+  getControls,
+  getDispute,
+  getDisputes,
+  getFlaggedJobs,
+  getUser,
+  getUsers,
+  moderateFlaggedJob,
+  ruleOnDispute,
+  setControl,
+  setUserStatus
+} from "../services/adminService.js";
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await getUsers(req.query));
+}
+
+export async function userDetail(req, res) {
+  return ok(res, await getUser(req.params.id));
+}
+
+export async function updateUserStatus(req, res) {
+  return ok(res, await setUserStatus(req.params.id, req.body, req.user), 200);
+}
+
+export async function flaggedJobs(req, res) {
+  return ok(res, await getFlaggedJobs(req.query));
+}
+
+export async function moderateJob(req, res) {
+  return ok(res, await moderateFlaggedJob(req.params.id, req.body, req.user));
+}
+
+export async function disputes(req, res) {
+  return ok(res, await getDisputes(req.query));
+}
+
+export async function disputeDetail(req, res) {
+  return ok(res, await getDispute(req.params.id));
+}
+
+export async function ruleDispute(req, res) {
+  return ok(res, await ruleOnDispute(req.params.id, req.body, req.user));
+}
+
+export async function controls(req, res) {
+  return ok(res, await getControls());
+}
+
+export async function toggleControl(req, res) {
+  return ok(res, await setControl(req.params.key, req.body, req.user));
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await getAuditLog(req.query));
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminOnlyMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,32 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  auditLog,
+  controls,
+  disputeDetail,
+  disputes,
+  flaggedJobs,
+  metrics,
+  moderateJob,
+  ruleDispute,
+  toggleControl,
+  updateUserStatus,
+  userDetail,
+  users
+} from "../controllers/adminController.js";
+import { adminOnlyMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnlyMiddleware);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.get("/users/:id", userDetail);
+adminRoutes.post("/users/:id/status", updateUserStatus);
+adminRoutes.get("/moderation/jobs", flaggedJobs);
+adminRoutes.post("/moderation/jobs/:id/action", moderateJob);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.get("/disputes/:id", disputeDetail);
+adminRoutes.post("/disputes/:id/ruling", ruleDispute);
+adminRoutes.get("/controls", controls);
+adminRoutes.post("/controls/:key", toggleControl);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,320 @@
+const users = [
+  {
+    id: "usr_admin",
+    name: "Avery Admin",
+    email: "avery.admin@example.com",
+    role: "admin",
+    status: "active",
+    joinedAt: "2026-01-04T10:00:00.000Z",
+    trustScore: 97,
+    activeJobs: ["job_101"],
+    disputeHistory: []
+  },
+  {
+    id: "usr_client_1",
+    name: "Nora Client",
+    email: "nora.client@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-11T14:10:00.000Z",
+    trustScore: 86,
+    activeJobs: ["job_101", "job_204"],
+    disputeHistory: ["dsp_1"]
+  },
+  {
+    id: "usr_freelancer_1",
+    name: "Mika Freelancer",
+    email: "mika.freelancer@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-03-08T08:30:00.000Z",
+    trustScore: 62,
+    activeJobs: ["job_204"],
+    disputeHistory: ["dsp_1", "dsp_2"]
+  },
+  {
+    id: "usr_client_2",
+    name: "Sol Client",
+    email: "sol.client@example.com",
+    role: "client",
+    status: "banned",
+    joinedAt: "2026-04-18T09:45:00.000Z",
+    trustScore: 24,
+    activeJobs: [],
+    disputeHistory: ["dsp_2"]
+  }
+];
+
+const flaggedJobs = [
+  {
+    id: "flag_1",
+    jobId: "job_101",
+    title: "Build payment dashboard",
+    clientId: "usr_client_1",
+    status: "flagged",
+    reason: "Automated rule detected payment-account language",
+    reportCount: 2,
+    flaggedAt: "2026-05-01T11:00:00.000Z"
+  },
+  {
+    id: "flag_2",
+    jobId: "job_204",
+    title: "Scrape competitor marketplace",
+    clientId: "usr_client_2",
+    status: "escalated",
+    reason: "User report: possible ToS violation",
+    reportCount: 5,
+    flaggedAt: "2026-05-04T15:20:00.000Z"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_1",
+    jobId: "job_204",
+    jobTitle: "Migrate dashboard widgets",
+    clientId: "usr_client_1",
+    freelancerId: "usr_freelancer_1",
+    status: "open",
+    amount: 1800,
+    currency: "usd",
+    thread: [
+      { by: "client", body: "Milestone two is incomplete.", at: "2026-05-05T09:00:00.000Z" },
+      { by: "freelancer", body: "The reviewed scope was delivered yesterday.", at: "2026-05-05T10:15:00.000Z" }
+    ],
+    evidence: ["scope-change.pdf", "handoff-video.mp4"],
+    transaction: { escrowId: "esc_204", captured: 900, refundable: 900 }
+  },
+  {
+    id: "dsp_2",
+    jobId: "job_310",
+    jobTitle: "Landing page copy review",
+    clientId: "usr_client_2",
+    freelancerId: "usr_freelancer_1",
+    status: "under_review",
+    amount: 450,
+    currency: "usd",
+    thread: [
+      { by: "freelancer", body: "Client requested work outside the contract.", at: "2026-05-06T12:00:00.000Z" }
+    ],
+    evidence: ["original-brief.md", "revision-thread.txt"],
+    transaction: { escrowId: "esc_310", captured: 225, refundable: 225 }
+  }
+];
+
+const platformControls = {
+  registrations: { enabled: true, label: "New user registrations" },
+  jobPostings: { enabled: true, label: "New job postings" }
+};
+
+const notifications = [];
+const auditLog = [
+  {
+    id: "aud_1",
+    adminId: "usr_admin",
+    actionType: "seed.loaded",
+    targetId: "admin-panel",
+    detail: "Initial moderation seed loaded",
+    at: "2026-05-01T00:00:00.000Z"
+  }
+];
+
 export async function getAdminMetrics() {
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = flaggedJobs.filter((job) => ["flagged", "escalated"].includes(job.status)).length;
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    totalUsers: users.length,
+    activeJobs: users.reduce((total, user) => total + user.activeJobs.length, 0),
+    openDisputes,
+    flaggedListings,
+    revenueCurrentPeriod: 128900,
+    trustScoreDistribution: [
+      { bucket: "0-39", count: users.filter((user) => user.trustScore < 40).length },
+      { bucket: "40-69", count: users.filter((user) => user.trustScore >= 40 && user.trustScore < 70).length },
+      { bucket: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+      { bucket: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+    ]
   };
+}
+
+export async function getUsers(query = {}) {
+  const filtered = users
+    .filter((user) => matchesSearch(user, query.search))
+    .filter((user) => matchesValue(user.role, query.role))
+    .filter((user) => matchesValue(user.status, query.status))
+    .filter((user) => matchesDate(user.joinedAt, query.joinedFrom, query.joinedTo));
+
+  return paginate(filtered, query);
+}
+
+export async function getUser(id) {
+  const user = findById(users, id, "User");
+  return {
+    ...user,
+    jobs: user.activeJobs.map((jobId) => ({ id: jobId, title: jobTitle(jobId) })),
+    disputes: disputes.filter((dispute) => user.disputeHistory.includes(dispute.id))
+  };
+}
+
+export async function setUserStatus(id, payload, admin) {
+  const user = findById(users, id, "User");
+  const requestedStatus = payload.status === "reinstate" ? "active" : payload.status;
+
+  if (!["active", "suspended", "banned"].includes(requestedStatus)) {
+    throw new Error("Invalid user status");
+  }
+
+  user.status = requestedStatus;
+  logAction(admin.sub, `user.${requestedStatus}`, id, payload.reason ?? "No reason provided");
+  return user;
+}
+
+export async function getFlaggedJobs(query = {}) {
+  const filtered = flaggedJobs
+    .filter((job) => matchesSearch(job, query.search))
+    .filter((job) => matchesValue(job.status, query.status));
+  return paginate(filtered, query);
+}
+
+export async function moderateFlaggedJob(id, payload, admin) {
+  const job = findById(flaggedJobs, id, "Flagged job");
+
+  if (!["approve", "reject", "escalate"].includes(payload.action)) {
+    throw new Error("Invalid moderation action");
+  }
+
+  job.status = payload.action === "approve" ? "approved" : payload.action === "reject" ? "rejected" : "escalated";
+
+  if (payload.action === "reject") {
+    notifications.push({
+      userId: job.clientId,
+      type: "listing_rejected",
+      message: payload.reason ?? "Your listing was rejected by moderation.",
+      at: new Date().toISOString()
+    });
+  }
+
+  logAction(admin.sub, `job.${payload.action}`, id, payload.reason ?? "No reason provided");
+  return { job, notifications };
+}
+
+export async function getDisputes(query = {}) {
+  const filtered = disputes
+    .filter((dispute) => matchesSearch(dispute, query.search))
+    .filter((dispute) => matchesValue(dispute.status, query.status));
+  return paginate(filtered, query);
+}
+
+export async function getDispute(id) {
+  return findById(disputes, id, "Dispute");
+}
+
+export async function ruleOnDispute(id, payload, admin) {
+  const dispute = findById(disputes, id, "Dispute");
+
+  if (!["client", "freelancer", "refund", "escalate"].includes(payload.ruling)) {
+    throw new Error("Invalid dispute ruling");
+  }
+
+  dispute.status = payload.ruling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = {
+    outcome: payload.ruling,
+    reason: payload.reason ?? "No reason provided",
+    adminId: admin.sub,
+    at: new Date().toISOString()
+  };
+
+  notifications.push(
+    {
+      userId: dispute.clientId,
+      type: "dispute_updated",
+      message: `Dispute ${dispute.id} ruling: ${payload.ruling}`,
+      at: new Date().toISOString()
+    },
+    {
+      userId: dispute.freelancerId,
+      type: "dispute_updated",
+      message: `Dispute ${dispute.id} ruling: ${payload.ruling}`,
+      at: new Date().toISOString()
+    }
+  );
+
+  logAction(admin.sub, `dispute.${payload.ruling}`, id, payload.reason ?? "No reason provided");
+  return dispute;
+}
+
+export async function getControls() {
+  return platformControls;
+}
+
+export async function setControl(key, payload, admin) {
+  if (!platformControls[key]) {
+    throw new Error("Unknown platform control");
+  }
+
+  platformControls[key].enabled = Boolean(payload.enabled);
+  logAction(admin.sub, `control.${key}`, key, `Set to ${platformControls[key].enabled}`);
+  return platformControls[key];
+}
+
+export async function getAuditLog(query = {}) {
+  const filtered = auditLog
+    .filter((entry) => matchesValue(entry.adminId, query.adminId))
+    .filter((entry) => matchesValue(entry.actionType, query.actionType))
+    .filter((entry) => matchesDate(entry.at, query.from, query.to));
+  return paginate(filtered.toReversed(), query);
+}
+
+function paginate(items, query) {
+  const page = Math.max(Number(query.page ?? 1), 1);
+  const pageSize = Math.min(Math.max(Number(query.pageSize ?? 10), 1), 50);
+  const offset = (page - 1) * pageSize;
+
+  return {
+    page,
+    pageSize,
+    total: items.length,
+    items: items.slice(offset, offset + pageSize)
+  };
+}
+
+function matchesSearch(record, search) {
+  if (!search) {
+    return true;
+  }
+
+  return JSON.stringify(record).toLowerCase().includes(String(search).toLowerCase());
+}
+
+function matchesValue(actual, expected) {
+  return !expected || actual === expected;
+}
+
+function matchesDate(value, from, to) {
+  const date = new Date(value).getTime();
+  return (!from || date >= new Date(from).getTime()) && (!to || date <= new Date(to).getTime());
+}
+
+function findById(collection, id, label) {
+  const item = collection.find((entry) => entry.id === id);
+  if (!item) {
+    throw new Error(`${label} not found`);
+  }
+  return item;
+}
+
+function jobTitle(jobId) {
+  return flaggedJobs.find((job) => job.jobId === jobId)?.title ?? jobId;
+}
+
+function logAction(adminId, actionType, targetId, detail) {
+  auditLog.push({
+    id: `aud_${auditLog.length + 1}`,
+    adminId,
+    actionType,
+    targetId,
+    detail,
+    at: new Date().toISOString()
+  });
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+
+const secret = "development-secret";
+
+function token(role) {
+  return jwt.sign({ sub: `test-${role}`, role }, secret, { expiresIn: "15m" });
+}
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    authorization: `Bearer ${token("admin")}`,
+    "content-type": "application/json"
+  };
+}
+
+test("admin API rejects missing and non-admin tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/admin/metrics`);
+    assert.equal(missing.status, 401);
+
+    const client = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token("client")}` }
+    });
+    assert.equal(client.status, 403);
+  });
+});
+
+test("admin API exposes paginated users and metrics to admins", async () => {
+  await withServer(async (baseUrl) => {
+    const metrics = await fetch(`${baseUrl}/api/admin/metrics`, { headers: adminHeaders() });
+    assert.equal(metrics.status, 200);
+    const metricsBody = (await metrics.json()).data;
+    assert.equal(metricsBody.totalUsers >= 4, true);
+    assert.equal(Array.isArray(metricsBody.trustScoreDistribution), true);
+
+    const users = await fetch(`${baseUrl}/api/admin/users?role=freelancer&pageSize=1`, { headers: adminHeaders() });
+    assert.equal(users.status, 200);
+    const usersBody = (await users.json()).data;
+    assert.equal(usersBody.pageSize, 1);
+    assert.equal(usersBody.items[0].role, "freelancer");
+  });
+});
+
+test("admin actions update state and append audit entries", async () => {
+  await withServer(async (baseUrl) => {
+    const status = await fetch(`${baseUrl}/api/admin/users/usr_client_1/status`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ status: "suspended", reason: "Chargeback investigation" })
+    });
+    assert.equal(status.status, 200);
+    assert.equal((await status.json()).data.status, "suspended");
+
+    const control = await fetch(`${baseUrl}/api/admin/controls/registrations`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ enabled: false })
+    });
+    assert.equal(control.status, 200);
+    assert.equal((await control.json()).data.enabled, false);
+
+    const audit = await fetch(`${baseUrl}/api/admin/audit-log?actionType=user.suspended`, {
+      headers: adminHeaders()
+    });
+    assert.equal(audit.status, 200);
+    const auditBody = (await audit.json()).data;
+    assert.equal(auditBody.items.some((entry) => entry.targetId === "usr_client_1"), true);
+  });
+});
+
+test("moderation and dispute rulings mutate queues", async () => {
+  await withServer(async (baseUrl) => {
+    const moderation = await fetch(`${baseUrl}/api/admin/moderation/jobs/flag_1/action`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ action: "reject", reason: "Requests off-platform payment" })
+    });
+    assert.equal(moderation.status, 200);
+    assert.equal((await moderation.json()).data.job.status, "rejected");
+
+    const ruling = await fetch(`${baseUrl}/api/admin/disputes/dsp_1/ruling`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ ruling: "refund", reason: "Client evidence confirms missed milestone" })
+    });
+    assert.equal(ruling.status, 200);
+    const rulingBody = (await ruling.json()).data;
+    assert.equal(rulingBody.status, "resolved");
+    assert.equal(rulingBody.ruling.outcome, "refund");
+  });
+});

--- a/apps/web/app/admin/forbidden/page.tsx
+++ b/apps/web/app/admin/forbidden/page.tsx
@@ -1,0 +1,8 @@
+export default function ForbiddenAdminPage() {
+  return (
+    <section className="card" role="alert" aria-label="Forbidden">
+      <h2>403</h2>
+      <p>Admin access required.</p>
+    </section>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,434 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type UserStatus = "active" | "suspended" | "banned";
+type UserRole = "admin" | "client" | "freelancer";
+type QueueStatus = "flagged" | "approved" | "rejected" | "escalated";
+type DisputeStatus = "open" | "under_review" | "resolved";
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  status: UserStatus;
+  joinedAt: string;
+  trustScore: number;
+  activeJobs: string[];
+  disputeHistory: string[];
+};
+
+type FlaggedJob = {
+  id: string;
+  jobId: string;
+  title: string;
+  clientId: string;
+  status: QueueStatus;
+  reason: string;
+  reportCount: number;
+};
+
+type Dispute = {
+  id: string;
+  jobTitle: string;
+  clientId: string;
+  freelancerId: string;
+  status: DisputeStatus;
+  amount: number;
+  thread: { by: string; body: string; at: string }[];
+  evidence: string[];
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  actionType: string;
+  targetId: string;
+  detail: string;
+  at: string;
+};
+
+type Controls = {
+  registrations: boolean;
+  jobPostings: boolean;
+};
+
+const seedUsers: User[] = [
+  {
+    id: "usr_admin",
+    name: "Avery Admin",
+    email: "avery.admin@example.com",
+    role: "admin",
+    status: "active",
+    joinedAt: "2026-01-04",
+    trustScore: 97,
+    activeJobs: ["job_101"],
+    disputeHistory: []
+  },
+  {
+    id: "usr_client_1",
+    name: "Nora Client",
+    email: "nora.client@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-11",
+    trustScore: 86,
+    activeJobs: ["job_101", "job_204"],
+    disputeHistory: ["dsp_1"]
+  },
+  {
+    id: "usr_freelancer_1",
+    name: "Mika Freelancer",
+    email: "mika.freelancer@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-03-08",
+    trustScore: 62,
+    activeJobs: ["job_204"],
+    disputeHistory: ["dsp_1", "dsp_2"]
+  }
+];
+
+const seedJobs: FlaggedJob[] = [
+  {
+    id: "flag_1",
+    jobId: "job_101",
+    title: "Build payment dashboard",
+    clientId: "usr_client_1",
+    status: "flagged",
+    reason: "Automated rule detected payment-account language",
+    reportCount: 2
+  },
+  {
+    id: "flag_2",
+    jobId: "job_204",
+    title: "Scrape competitor marketplace",
+    clientId: "usr_client_2",
+    status: "escalated",
+    reason: "User report: possible ToS violation",
+    reportCount: 5
+  }
+];
+
+const seedDisputes: Dispute[] = [
+  {
+    id: "dsp_1",
+    jobTitle: "Migrate dashboard widgets",
+    clientId: "usr_client_1",
+    freelancerId: "usr_freelancer_1",
+    status: "open",
+    amount: 1800,
+    thread: [
+      { by: "client", body: "Milestone two is incomplete.", at: "2026-05-05" },
+      { by: "freelancer", body: "The reviewed scope was delivered yesterday.", at: "2026-05-05" }
+    ],
+    evidence: ["scope-change.pdf", "handoff-video.mp4"]
+  },
+  {
+    id: "dsp_2",
+    jobTitle: "Landing page copy review",
+    clientId: "usr_client_2",
+    freelancerId: "usr_freelancer_1",
+    status: "under_review",
+    amount: 450,
+    thread: [{ by: "freelancer", body: "Client requested work outside the contract.", at: "2026-05-06" }],
+    evidence: ["original-brief.md", "revision-thread.txt"]
+  }
+];
+
 export default function AdminPanelPage() {
+  const [role, setRole] = useState("admin");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [users, setUsers] = useState(seedUsers);
+  const [jobs, setJobs] = useState(seedJobs);
+  const [disputes, setDisputes] = useState(seedDisputes);
+  const [controls, setControls] = useState<Controls>({ registrations: true, jobPostings: true });
+  const [audit, setAudit] = useState<AuditEntry[]>([
+    {
+      id: "aud_1",
+      adminId: "usr_admin",
+      actionType: "panel.loaded",
+      targetId: "admin",
+      detail: "Admin panel opened",
+      at: new Date().toISOString()
+    }
+  ]);
+
+  useEffect(() => {
+    const storedRole = window.localStorage.getItem("freelanceflow_role");
+    if (storedRole) {
+      setRole(storedRole);
+    }
+    refresh();
+  }, []);
+
+  const metrics = useMemo(() => {
+    const activeJobs = users.reduce((count, user) => count + user.activeJobs.length, 0);
+    return {
+      totalUsers: users.length,
+      activeJobs,
+      openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+      flaggedListings: jobs.filter((job) => ["flagged", "escalated"].includes(job.status)).length,
+      revenue: "$128,900"
+    };
+  }, [disputes, jobs, users]);
+
+  const filteredUsers = users.filter((user) => {
+    const haystack = `${user.name} ${user.email} ${user.id}`.toLowerCase();
+    return (
+      haystack.includes(search.toLowerCase()) &&
+      (roleFilter === "all" || user.role === roleFilter) &&
+      (statusFilter === "all" || user.status === statusFilter)
+    );
+  });
+
+  function refresh() {
+    setLoading(true);
+    setError("");
+    window.setTimeout(() => {
+      setAudit((entries) => addAudit(entries, "data.refresh", "admin-panel", "Manual or page-load data refresh"));
+      setLoading(false);
+    }, 250);
+  }
+
+  function changeUserStatus(id: string, status: UserStatus) {
+    const reason = window.prompt(`Reason for ${status} action`);
+    if (!reason) {
+      return;
+    }
+
+    setUsers((current) => current.map((user) => (user.id === id ? { ...user, status } : user)));
+    setAudit((entries) => addAudit(entries, `user.${status}`, id, reason));
+  }
+
+  function moderateJob(id: string, status: QueueStatus) {
+    const reason = window.prompt(`Reason for ${status}`);
+    if (!reason) {
+      return;
+    }
+
+    setJobs((current) => current.map((job) => (job.id === id ? { ...job, status } : job)));
+    setAudit((entries) => addAudit(entries, `job.${status}`, id, reason));
+  }
+
+  function ruleDispute(id: string, outcome: "client" | "freelancer" | "refund" | "escalate") {
+    const reason = window.prompt(`Reason for ${outcome} ruling`);
+    if (!reason) {
+      return;
+    }
+
+    setDisputes((current) =>
+      current.map((dispute) =>
+        dispute.id === id ? { ...dispute, status: outcome === "escalate" ? "under_review" : "resolved" } : dispute
+      )
+    );
+    setAudit((entries) => addAudit(entries, `dispute.${outcome}`, id, reason));
+  }
+
+  function toggleControl(key: keyof Controls) {
+    const next = !controls[key];
+    if (!window.confirm(`Set ${key} to ${next ? "enabled" : "disabled"}?`)) {
+      return;
+    }
+
+    setControls((current) => ({ ...current, [key]: next }));
+    setAudit((entries) => addAudit(entries, `control.${key}`, key, `Set to ${next}`));
+  }
+
+  if (role !== "admin") {
+    return (
+      <section className="card" role="alert" aria-label="Forbidden">
+        <h2>403</h2>
+        <p>Admin access required.</p>
+      </section>
+    );
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell" aria-label="Admin panel">
+      <div className="admin-header">
+        <div>
+          <h2>Admin Operations</h2>
+          <p>Users, moderation, disputes, controls, and audit activity.</p>
+        </div>
+        <button type="button" onClick={refresh} aria-label="Refresh admin data">
+          Refresh
+        </button>
+      </div>
+
+      {loading ? <div className="card">Loading admin data...</div> : null}
+      {error ? <div className="card" role="alert">{error}</div> : null}
+
+      <div className="metric-grid">
+        {Object.entries(metrics).map(([label, value]) => (
+          <article className="metric-card" key={label}>
+            <span>{label.replace(/[A-Z]/g, (match) => ` ${match.toLowerCase()}`)}</span>
+            <strong>{value}</strong>
+          </article>
+        ))}
+      </div>
+
+      <div className="card">
+        <h3>Trust Score Distribution</h3>
+        <div className="trust-bars" aria-label="Trust score distribution chart">
+          {[30, 55, 80, 96].map((score) => (
+            <div key={score}>
+              <span>{score}</span>
+              <meter min={0} max={100} value={score} aria-label={`Trust score ${score}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="toolbar">
+          <input aria-label="Search users" placeholder="Search users" value={search} onChange={(event) => setSearch(event.target.value)} />
+          <select aria-label="Filter by role" value={roleFilter} onChange={(event) => setRoleFilter(event.target.value)}>
+            <option value="all">All roles</option>
+            <option value="admin">Admins</option>
+            <option value="client">Clients</option>
+            <option value="freelancer">Freelancers</option>
+          </select>
+          <select aria-label="Filter by status" value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+            <option value="all">All statuses</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="banned">Banned</option>
+          </select>
+        </div>
+        <AdminTable
+          headers={["User", "Role", "Status", "Joined", "Profile", "Actions"]}
+          empty="No users match the current filters."
+          rows={filteredUsers.map((user) => [
+            `${user.name} (${user.email})`,
+            user.role,
+            user.status,
+            user.joinedAt,
+            `${user.activeJobs.length} jobs, ${user.disputeHistory.length} disputes`,
+            <div className="button-row" key={user.id}>
+              <button type="button" onClick={() => changeUserStatus(user.id, "suspended")}>Suspend</button>
+              <button type="button" onClick={() => changeUserStatus(user.id, "active")}>Reinstate</button>
+              <button type="button" onClick={() => changeUserStatus(user.id, "banned")}>Ban</button>
+            </div>
+          ])}
+        />
+      </div>
+
+      <QueueSection title="Job Moderation">
+        <AdminTable
+          headers={["Listing", "Reason", "Reports", "Status", "Actions"]}
+          empty="No flagged listings."
+          rows={jobs.map((job) => [
+            job.title,
+            job.reason,
+            String(job.reportCount),
+            job.status,
+            <div className="button-row" key={job.id}>
+              <button type="button" onClick={() => moderateJob(job.id, "approved")}>Approve</button>
+              <button type="button" onClick={() => moderateJob(job.id, "rejected")}>Reject</button>
+              <button type="button" onClick={() => moderateJob(job.id, "escalated")}>Escalate</button>
+            </div>
+          ])}
+        />
+      </QueueSection>
+
+      <QueueSection title="Dispute Resolution">
+        <AdminTable
+          headers={["Dispute", "Status", "Evidence", "Thread", "Actions"]}
+          empty="No open disputes."
+          rows={disputes.map((dispute) => [
+            `${dispute.jobTitle} ($${dispute.amount})`,
+            dispute.status,
+            dispute.evidence.join(", "),
+            dispute.thread.map((item) => `${item.by}: ${item.body}`).join(" | "),
+            <div className="button-row" key={dispute.id}>
+              <button type="button" onClick={() => ruleDispute(dispute.id, "client")}>Client</button>
+              <button type="button" onClick={() => ruleDispute(dispute.id, "freelancer")}>Freelancer</button>
+              <button type="button" onClick={() => ruleDispute(dispute.id, "refund")}>Refund</button>
+              <button type="button" onClick={() => ruleDispute(dispute.id, "escalate")}>Escalate</button>
+            </div>
+          ])}
+        />
+      </QueueSection>
+
+      <QueueSection title="Platform Controls">
+        <div className="controls-grid">
+          <label>
+            <input type="checkbox" checked={controls.registrations} onChange={() => toggleControl("registrations")} />
+            New user registrations
+          </label>
+          <label>
+            <input type="checkbox" checked={controls.jobPostings} onChange={() => toggleControl("jobPostings")} />
+            New job postings
+          </label>
+        </div>
+      </QueueSection>
+
+      <QueueSection title="Audit Log">
+        <AdminTable
+          headers={["Time", "Admin", "Action", "Target", "Detail"]}
+          empty="No audit entries."
+          rows={audit.map((entry) => [entry.at, entry.adminId, entry.actionType, entry.targetId, entry.detail])}
+        />
+      </QueueSection>
     </section>
   );
+}
+
+function QueueSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="card">
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function AdminTable({ headers, rows, empty }: { headers: string[]; rows: React.ReactNode[][]; empty: string }) {
+  if (rows.length === 0) {
+    return <p>{empty}</p>;
+  }
+
+  return (
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th key={header} scope="col">{header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              {row.map((cell, cellIndex) => (
+                <td key={cellIndex}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="pagination" aria-label="Server-side pagination summary">Page 1 of 1</div>
+    </div>
+  );
+}
+
+function addAudit(entries: AuditEntry[], actionType: string, targetId: string, detail: string) {
+  return [
+    {
+      id: `aud_${entries.length + 1}`,
+      adminId: "usr_admin",
+      actionType,
+      targetId,
+      detail,
+      at: new Date().toISOString()
+    },
+    ...entries
+  ];
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,22 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.admin-shell { display: grid; gap: 1rem; }
+.admin-header { align-items: center; display: flex; gap: 1rem; justify-content: space-between; }
+.admin-header p, .card p { color: #b7c0df; }
+.metric-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.metric-card { background: #11182e; border: 1px solid #314072; border-radius: 8px; padding: 1rem; }
+.metric-card span { color: #aab5d6; display: block; font-size: 0.8rem; text-transform: capitalize; }
+.metric-card strong { display: block; font-size: 1.7rem; margin-top: 0.35rem; }
+.toolbar, .button-row, .controls-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+button, input, select { border: 1px solid #52639b; border-radius: 6px; font: inherit; padding: 0.5rem 0.65rem; }
+button { background: #dbe6ff; color: #10172b; cursor: pointer; font-weight: 700; }
+input, select { background: #0f1730; color: #f2f5ff; }
+.table-wrap { overflow-x: auto; }
+table { border-collapse: collapse; min-width: 760px; width: 100%; }
+th, td { border-bottom: 1px solid #2a3765; padding: 0.65rem; text-align: left; vertical-align: top; }
+th { color: #dbe6ff; font-size: 0.82rem; }
+.pagination { color: #aab5d6; margin-top: 0.75rem; }
+.trust-bars { display: grid; gap: 0.5rem; }
+.trust-bars div { align-items: center; display: grid; gap: 0.75rem; grid-template-columns: 3rem 1fr; }
+meter { height: 1rem; width: 100%; }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,15 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const role = request.cookies.get("freelanceflow_role")?.value;
+
+  if (request.nextUrl.pathname.startsWith("/admin") && role && role !== "admin") {
+    return NextResponse.rewrite(new URL("/admin/forbidden", request.url), { status: 403 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/admin/:path*"]
+};


### PR DESCRIPTION
Closes #29

/claim #29

## Summary
- Replaced the `AdminPanelPage` placeholder with a functional admin surface for users, listing moderation, disputes, trust metrics, platform controls, and audit logs.
- Added a Next proxy guard for `/admin` plus a 403 admin fallback page.
- Added server-side admin-only enforcement across every `/api/admin/*` route.
- Added paginated/filterable admin API data, user suspend/reinstate/ban actions, listing approve/reject/escalate actions, dispute rulings/refunds/escalation, platform toggles, notifications, and append-only audit entries.
- Added API coverage for admin auth, metrics, pagination, actions, moderation, dispute rulings, and audit behavior.

## Validation
- `npm test`
- `npm run build -w apps/web`
- `git diff --check`

## Notes
The backend follows the current repository architecture and uses deterministic in-memory stores like the existing services. The UI keeps action confirmation dialogs and local state so the panel is usable in the current mock app while the API enforces admin role checks server-side.