### PR TITLE
Add original marketplace poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# A Clearer Handoff
+
+A brief arrives with edges still unclear,
+some half-lit need beneath a careful name.
+The work begins when both sides learn to hear
+the quiet shape inside the public claim.
+
+A profile holds its record like a lamp,
+not loud, but steady where the doubts collect.
+Each proof of craft, each measured time and stamp,
+turns risk into a thing both can inspect.
+
+The escrow waits without a flourish there,
+a patient hinge between the yes and done.
+It keeps the promise level in the air
+until the tested work can face the sun.
+
+Then notes are closed, the invoice finds its line,
+and trust is not a speech, but what remains:
+a cleaner path from talent into sign,
+a market tuned by outcomes, not refrains.


### PR DESCRIPTION
Closes #76

/claim #76

Creative note: I used a restrained four-stanza marketplace poem because FreelanceFlow is built around the handoff from uncertain request to verified work, so the form follows trust becoming concrete through profile evidence, escrow, review, and settlement.

Validation:
- Added `POEM.md` at the project root.
- Confirmed the poem has four stanzas, exceeding the three-stanza minimum.
- Ran `git diff --check` with no whitespace errors.
- Kept the PR scoped to the single requested markdown file.