### PR TITLE
Add project poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,16 @@
+# Marketplace Canticle
+
+A client writes a need in plain TypeScript light,
+a job card opens like a window in the stack;
+profiles answer softly through the search page night,
+and proposals learn the shortest honest track.
+
+Behind the screen, the routes keep careful time:
+a token refreshed, a message sent, a fee prepared;
+controllers pass the work in layered rhyme,
+so every promise knows where it is shared.
+
+FreelanceFlow, your ledger is not only pay;
+it is trust compiled from small reviewed designs:
+a marketplace where builders find their way,
+and clean code turns uncertain work to signs.


### PR DESCRIPTION
Closes #76

Creative decision: I used a marketplace-as-canticle tone to connect FreelanceFlow’s job, proposal, auth, messaging, and payment layers into one original 3-stanza poem.

Validation: `npm test` attempted, but the existing repo script fails because `apps/api/src/tests` is missing; this PR only adds `POEM.md`.