### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^16.12.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,13 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.statusCode) {
+    return res.status(err.statusCode).json({
+      success: false,
+      message: err.message
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,130 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+    this.statusCode = 500;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+    this.cause = cause;
+  }
+}
+
+export function configureStripeClient(client) {
+  stripeClient = client;
+}
+
+export function resetStripeClient() {
+  stripeClient = undefined;
+}
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY ?? env.stripeSecretKey;
+  if (!secretKey) {
+    throw new PaymentConfigurationError("STRIPE_SECRET_KEY is required to create payments");
+  }
+
+  stripeClient = new Stripe(secretKey);
+  return stripeClient;
+}
+
+function validateMetadata(metadata) {
+  if (metadata == null) {
+    return undefined;
+  }
+
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentValidationError("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (!key || typeof key !== "string") {
+        throw new PaymentValidationError("metadata keys must be non-empty strings");
+      }
+
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw new PaymentValidationError("metadata values must be strings, numbers, or booleans");
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function validatePayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentValidationError("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentValidationError("amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError("currency must be a three-letter ISO currency code");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: validateMetadata(payload.metadata)
   };
+}
+
+function isStripeError(error) {
+  return typeof error?.type === "string" && error.type.startsWith("Stripe");
+}
+
+export async function createPaymentIntent(payload) {
+  const payment = validatePayload(payload);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create({
+      amount: payment.amount,
+      currency: payment.currency,
+      ...(payment.metadata ? { metadata: payment.metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentValidationError || error instanceof PaymentConfigurationError) {
+      throw error;
+    }
+
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(`Stripe payment failed: ${error.message}`, error);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  configureStripeClient,
+  createPaymentIntent,
+  PaymentProviderError,
+  PaymentValidationError,
+  resetStripeClient
+} from "../services/paymentService.js";
+
+test.afterEach(() => {
+  resetStripeClient();
+});
+
+function mockStripeClient(createPaymentIntentImpl) {
+  return {
+    paymentIntents: {
+      create: createPaymentIntentImpl
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent and maps the response", async () => {
+  const calls = [];
+  configureStripeClient(
+    mockStripeClient(async (params) => {
+      calls.push(params);
+      return {
+        id: "pi_test_123",
+        client_secret: "pi_test_123_secret_abc",
+        amount: params.amount,
+        currency: params.currency
+      };
+    })
+  );
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    metadata: { jobId: "job_123", urgent: true, attempt: 2 }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        jobId: "job_123",
+        urgent: "true",
+        attempt: "2"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+
+  resetStripeClient();
+});
+
+test("createPaymentIntent normalizes provided currency", async () => {
+  const calls = [];
+  configureStripeClient(
+    mockStripeClient(async (params) => {
+      calls.push(params);
+      return {
+        id: "pi_eur",
+        client_secret: "pi_eur_secret",
+        amount: params.amount,
+        currency: params.currency
+      };
+    })
+  );
+
+  await createPaymentIntent({ amount: 1099, currency: "EUR" });
+
+  assert.equal(calls[0].currency, "eur");
+});
+
+test("createPaymentIntent validates amount before calling Stripe", async () => {
+  let called = false;
+  configureStripeClient(
+    mockStripeClient(async () => {
+      called = true;
+    })
+  );
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "amount must be a positive integer in the smallest currency unit"
+  );
+
+  assert.equal(called, false);
+});
+
+test("createPaymentIntent validates currency and metadata shape", async () => {
+  configureStripeClient(mockStripeClient(async () => ({})));
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, currency: "US" }),
+    /currency must be a three-letter ISO currency code/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, metadata: ["not", "metadata"] }),
+    /metadata must be an object/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, metadata: { nested: { id: 1 } } }),
+    /metadata values must be strings, numbers, or booleans/
+  );
+
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  configureStripeClient(
+    mockStripeClient(async () => {
+      const error = new Error("Your card was declined");
+      error.type = "StripeCardError";
+      throw error;
+    })
+  );
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }),
+    (error) =>
+      error instanceof PaymentProviderError &&
+      error.message === "Stripe payment failed: Your card was declined" &&
+      error.cause?.message === "Your card was declined"
+  );
+});
+
+test("POST /api/payments returns the Stripe client secret", async () => {
+  configureStripeClient(
+    mockStripeClient(async (params) => ({
+      id: "pi_route",
+      client_secret: "pi_route_secret",
+      amount: params.amount,
+      currency: params.currency
+    }))
+  );
+
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: 4500, currency: "usd" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.paymentId, "pi_route");
+  assert.equal(payload.data.clientSecret, "pi_route_secret");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test(
+  "guarded Stripe smoke test creates a real test-mode PaymentIntent",
+  { skip: process.env.RUN_STRIPE_SMOKE_TEST !== "1" || !process.env.STRIPE_SECRET_KEY },
+  async () => {
+    resetStripeClient();
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { source: "securebanana-bounty-smoke" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^16.12.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2052,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2140,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- replace the timestamp-based payment stub with Stripe Node SDK PaymentIntent creation using STRIPE_SECRET_KEY
- validate amount, currency, and supported metadata before calling Stripe
- map Stripe id/client_secret into the API response and surface validation/provider errors with HTTP status codes
- add mocked node:test coverage for service behavior and POST /api/payments, plus an opt-in live Stripe smoke test

## Demo / verification
- The route test boots the Express app, POSTs to `/api/payments`, and verifies that the mocked Stripe PaymentIntent id and client secret are returned.
- The live Stripe smoke test is intentionally skipped unless `RUN_STRIPE_SMOKE_TEST=1` and `STRIPE_SECRET_KEY` are set, so CI does not require secrets.

## Validation
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `node --check apps/api/src/middleware/errorHandler.js`
- `git diff --check`
- `npm run test -w apps/api`
- `npm test`

/claim #1