### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    const status = Number.isInteger(error?.statusCode) ? error.statusCode : 500;
+    const message = error instanceof Error ? error.message : "Payment creation failed";
+    return fail(res, message, status);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,103 @@
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export function setStripeClientForTests(client) {
+  stripeClient = client;
+}
+
+export function resetStripeClientForTests() {
+  stripeClient = undefined;
+}
+
 export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+  const paymentPayload = validatePaymentPayload(payload);
+  const stripe = getStripeClient();
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(paymentPayload);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Stripe payment intent creation failed";
+    throw createPaymentError(message, 502, error);
+  }
+}
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  if (!env.stripeSecretKey) {
+    throw createPaymentError("STRIPE_SECRET_KEY is required to create a Stripe PaymentIntent", 503);
+  }
+
+  stripeClient = new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw createPaymentError("Payment payload must be an object", 400);
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw createPaymentError(
+      "payload.amount must be a positive integer in the smallest currency unit",
+      400
+    );
+  }
+
+  const currency = payload.currency ?? "usd";
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw createPaymentError("payload.currency must be a three-letter ISO currency code", 400);
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: normalizeMetadata(payload.metadata)
   };
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined) {
+    return {};
+  }
+
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw createPaymentError("payload.metadata must be an object when provided", 400);
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === undefined || value === null) {
+        throw createPaymentError(`payload.metadata.${key} must not be null or undefined`, 400);
+      }
+
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw createPaymentError(
+          `payload.metadata.${key} must be a string, number, or boolean`,
+          400
+        );
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function createPaymentError(message, statusCode, cause) {
+  const error = cause ? new Error(message, { cause }) : new Error(message);
+  error.statusCode = statusCode;
+  return error;
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,288 @@
+import test, { afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import {
+  createPaymentIntent,
+  resetStripeClientForTests,
+  setStripeClientForTests
+} from "../services/paymentService.js";
+
+function createStripeMock(handler) {
+  return {
+    paymentIntents: {
+      create: handler
+    }
+  };
+}
+
+afterEach(() => {
+  resetStripeClientForTests();
+});
+
+async function withApiServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createPaymentIntent validates and maps a Stripe PaymentIntent", async () => {
+  const calls = [];
+
+  setStripeClientForTests(
+    createStripeMock(async (payload) => {
+      calls.push(payload);
+      return {
+        id: "pi_test_123",
+        client_secret: "pi_test_123_secret_abc",
+        amount: payload.amount,
+        currency: payload.currency
+      };
+    })
+  );
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    metadata: {
+      jobId: "job_123",
+      retry: false,
+      attempt: 2
+    }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        jobId: "job_123",
+        retry: "false",
+        attempt: "2"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent normalizes explicit currency before the Stripe call", async () => {
+  let stripePayload;
+
+  setStripeClientForTests(
+    createStripeMock(async (payload) => {
+      stripePayload = payload;
+      return {
+        id: "pi_test_eur",
+        client_secret: "secret",
+        amount: payload.amount,
+        currency: payload.currency
+      };
+    })
+  );
+
+  await createPaymentIntent({ amount: 900, currency: "EUR" });
+
+  assert.equal(stripePayload.currency, "eur");
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent rejects invalid amount before calling Stripe", async () => {
+  let called = false;
+
+  setStripeClientForTests(
+    createStripeMock(async () => {
+      called = true;
+      throw new Error("should not be called");
+    })
+  );
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 0 }),
+    /payload.amount must be a positive integer/
+  );
+  assert.equal(called, false);
+
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent rejects invalid currency before calling Stripe", async () => {
+  let called = false;
+
+  setStripeClientForTests(
+    createStripeMock(async () => {
+      called = true;
+      throw new Error("should not be called");
+    })
+  );
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 1000, currency: "usdollars" }),
+    /payload.currency must be a three-letter ISO currency code/
+  );
+  assert.equal(called, false);
+
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent rejects invalid metadata before calling Stripe", async () => {
+  let called = false;
+
+  setStripeClientForTests(
+    createStripeMock(async () => {
+      called = true;
+      throw new Error("should not be called");
+    })
+  );
+
+  await assert.rejects(
+    createPaymentIntent({
+      amount: 1000,
+      metadata: {
+        nested: { bad: true }
+      }
+    }),
+    /payload.metadata.nested must be a string, number, or boolean/
+  );
+  assert.equal(called, false);
+
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  setStripeClientForTests(
+    createStripeMock(async () => {
+      const error = new Error("Your card was declined.");
+      error.type = "StripeCardError";
+      throw error;
+    })
+  );
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 1000, currency: "usd" }),
+    /Your card was declined./
+  );
+
+  resetStripeClientForTests();
+});
+
+test("POST /api/payments returns mapped Stripe PaymentIntent data", async () => {
+  setStripeClientForTests(
+    createStripeMock(async (payload) => ({
+      id: "pi_route_123",
+      client_secret: "pi_route_123_secret_abc",
+      amount: payload.amount,
+      currency: payload.currency
+    }))
+  );
+
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1200, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        paymentId: "pi_route_123",
+        clientSecret: "pi_route_123_secret_abc",
+        amount: 1200,
+        currency: "usd",
+        provider: "stripe"
+      }
+    });
+  });
+
+  resetStripeClientForTests();
+});
+
+test("POST /api/payments returns validation errors before calling Stripe", async () => {
+  let called = false;
+
+  setStripeClientForTests(
+    createStripeMock(async () => {
+      called = true;
+      throw new Error("should not be called");
+    })
+  );
+
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -1 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "payload.amount must be a positive integer in the smallest currency unit"
+    });
+  });
+
+  assert.equal(called, false);
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY when no client is injected", async () => {
+  const originalStripeSecretKey = env.stripeSecretKey;
+
+  resetStripeClientForTests();
+  env.stripeSecretKey = "";
+
+  try {
+    await assert.rejects(
+      createPaymentIntent({ amount: 1000, currency: "usd" }),
+      /STRIPE_SECRET_KEY is required/
+    );
+  } finally {
+    env.stripeSecretKey = originalStripeSecretKey;
+  }
+});
+
+test(
+  "createPaymentIntent can create a live Stripe test-mode PaymentIntent",
+  { skip: process.env.RUN_STRIPE_SMOKE !== "1" || !process.env.STRIPE_SECRET_KEY },
+  async () => {
+    resetStripeClientForTests();
+
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: {
+        source: "freelanceflow-smoke-test"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /_secret_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaced the timestamp payment stub with a real Stripe PaymentIntent call from the Stripe Node SDK.
- Added `STRIPE_SECRET_KEY` based client initialization with test injection support for mocked unit tests.
- Validates amount, currency, and metadata before any Stripe API call.
- Returns `paymentId` from `paymentIntent.id` and `clientSecret` from `paymentIntent.client_secret`.
- Preserves Stripe error messages and returns clear API errors from `POST /api/payments`.
- Fixed the API test script so `npm test` runs the actual `*.test.js` files.

## Testing
- `npm install stripe -w apps/api`
- `npm test`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `git diff --check`

`npm test` result: 10 passing, 1 skipped. The skipped test is the guarded live Stripe smoke test, which only runs when `RUN_STRIPE_SMOKE=1` and `STRIPE_SECRET_KEY` are provided.