### PR TITLE
Add handshake protocol poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Handshake Protocol
+
+A request leaves port with its headers clean:
+budget, deadline, and context in tow;
+FreelanceFlow gives the packet a screen
+so useful work knows where to go.
+
+A profile signs with artifacts,
+commits, messages, receipts that hold;
+not charm, but verifiable facts,
+keeps the channel honest and bold.
+
+Escrow becomes the round-trip ACK,
+funds wait steady while milestones load;
+each delivered diff comes safely back,
+and both sides read the same green code.
+
+When payout clears and reviews remain,
+the route is cached for another day;
+trust is a protocol tested by strain,
+and every fair job strengthens the way.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the project root.
- Wrote an original four-stanza poem for the FreelanceFlow project context.

## Creative note
I used a network-handshake/protocol theme because FreelanceFlow routes scoped work through verified identity, escrow, delivery, review, and payout.

## Demo
Short demo GIF: https://github.com/growthstudioworks/bug-bounty/releases/download/securebanana-pr133-demo-20260518-0122/securebanana-pr133-demo.gif

The demo previews the submitted `POEM.md` change and validation points: root-level file placement, original four-stanza poem, single Markdown-only change, and `/claim #76` linkage.

## Validation
- Confirmed `POEM.md` has four stanzas, exceeding the three-stanza minimum.
- Kept the change scoped to the single requested Markdown file.