### PR TITLE
Add original project poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,16 @@
+# Ledger of Small Bridges
+
+A marketplace wakes where quiet profiles glow,  
+Each name a lantern in the morning feed;  
+A client brings a problem wrapped in hope,  
+A maker answers with a useful deed.
+
+Between the brief, the bid, the signed proposal,  
+Trust learns to travel line by careful line;  
+Messages become a scaffold for the work,  
+And shared intent turns scattered hours into design.
+
+Payments close the circle, reviews leave a map,  
+Notifications ring like bells across the stream;  
+FreelanceFlow keeps the bridge from task to talent,  
+Where honest craft can meet an honest dream.


### PR DESCRIPTION
Adds `POEM.md` for bounty #76.

Creative decision: I used a bridge/ledger metaphor to match FreelanceFlow’s role connecting clients, makers, messages, payments, and reviews.

Validation: `npm test -- --runInBand` currently fails because `apps/api/src/tests` is missing in the upstream checkout (`MODULE_NOT_FOUND`), unrelated to this docs-only poem change.

Closes #76