### PR TITLE
Add trust relay poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Trust Relay
+
+The report arrives as a packet of rain,
+small, exact, and easy to miss.
+A failing step blinks under glass,
+asking the runner to witness this.
+
+The test turns quiet doubt into shape,
+red at first, then green with proof.
+Each assertion holds the doorframe square,
+each log marks truth beneath the roof.
+
+The reviewer walks the changed lines twice,
+not hunting blame, but clearing air.
+A fix is only finished work
+when someone else can find it fair.
+
+Then escrow hums in the final light,
+a ledger closing clean and plain.
+Trust is not a promise made,
+but work that passes through the chain.


### PR DESCRIPTION
/claim #76

Adds `POEM.md`, an original four-stanza poem about bug reports, tests, review, and escrow moving through a trust relay; I chose this tone because it matches the project workflow without duplicating the existing security-hunt submissions.

Validation:
- Original poem written for this project
- 4 stanzas
- Submitted as POEM.md in the project root