### PR TITLE
Add differential tide poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Tide Table for a Patch
+
+At dawn the failing test comes in,
+a red mark on the harbor wall;
+it names the place the proof grew thin,
+then waits for us to hear the call.
+
+We chart the inputs, byte by byte,
+through fixtures shaped like quiet piers;
+each assertion trims the night,
+each diff makes small the larger fears.
+
+The runner hums its steady note,
+no drama, just the facts made plain;
+a branch can float, a claim can vote,
+but only checked work leaves the rain.
+
+By dusk the reviewer reads the tide,
+the risk recedes, the logs are clear;
+we merge the patch with scope and pride,
+and leave a safer channel here.


### PR DESCRIPTION
/claim #76

Adds `POEM.md`, an original four-stanza poem about using tests, fixtures, assertions, and review to turn uncertainty into safer releases; I chose the tide-table metaphor because it fits the bug-bounty workflow while staying distinct from existing relay, symphony, and release-room submissions.

Validation:
- Original poem written for this project
- 4 stanzas
- Submitted as `POEM.md` in the project root
- Scope limited to one Markdown file

Closes #76