### PR TITLE
Add technical poem for FreelanceFlow project

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,72 @@
+# FreelanceFlow
+
+```
+// A technical poem about building a marketplace
+// Theme: The architecture of connection
+```
+
+## I. The Stack
+
+In `apps/web`, the Next.js renders dreams—
+landing pages where freelancers beam,
+job listings scroll like endless streams,
+each card a promise, pixel-perfect schemes.
+
+The App Router maps each `/` route,
+from `/jobs` to `/profile`, `/billing` too,
+React components compose like notes
+in a symphony the browser knew.
+
+## II. The Engine
+
+`apps/api` hums with Express veins,
+RESTful whispers through the lanes:
+`POST /auth/register`—a new account blooms,
+`GET /jobs/:id`—detail fills the rooms.
+
+Controllers delegate to services thin,
+Zod schemas validate each sin,
+Stripe placeholders hold the door
+for payments waiting at the core.
+
+## III. The Schema
+
+`packages/db` with Prisma writes
+the models—Users, Jobs in lines,
+Proposals, Reviews, Messages, Skills,
+each relation stitching digital wills.
+
+The schema is the constitution here:
+every freelancer, every frontier,
+typed and enforced, no column unclear,
+data flowing without fear.
+
+## IV. The Monorepo
+
+Four packages bound in workspace root,
+npm links like invisible thread,
+each package contributes its fruit
+to the whole—none left for dead.
+
+`packages/ui` shares what eyes should see:
+buttons, cards, components free,
+imported by both you and me,
+a design system unity.
+
+## V. The Freelancer
+
+Behind each job post beats a pulse—
+a client typing at midnight's hush,
+a freelancer sharpening every result,
+building trust in code and rush.
+
+FreelanceFlow is where they meet:
+proposals sent, contracts complete,
+reviews earned through honest heat,
+the marketplace on open street.
+
+```
+// Written for SecureBananaLabs/bug-bounty
+// Author: piaopiao78
+// Date: 2026-05-18
+```


### PR DESCRIPTION
/claim #76

## Creative Decision

I chose to write this poem in the style of a **code commentary** — treating the project's architecture itself as the subject matter. Each stanza mirrors one of the four packages in the monorepo (`apps/web`, `apps/api`, `packages/db`, `packages/ui`), with a fifth stanza tying them together through the human element of freelancing. The poem uses technical terminology (routes, controllers, schemas, npm links) as poetic devices, blending the language of software engineering with traditional verse structure.

## Checklist

- [x] Poem is original and written for this project specifically
- [x] Minimum 3 stanzas (5 stanzas total)
- [x] Submitted as `POEM.md` in the project root
- [x] PR description includes a one-line note on the creative decision