### PR TITLE
feat: API benchmark suite (#30)

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,214 @@
+// API Benchmark Suite — k6 script
+// Run: k6 run --vus 10 --duration 30s benchmark.js
+//
+// Environment variables:
+//   BASE_URL  - API base URL (default: http://localhost:3000)
+//   TOKEN     - Auth token for protected routes (optional)
+
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+
+// Custom metrics
+const rps = new Rate('requests_per_second');
+const errorRate = new Rate('error_rate');
+const p50 = new Trend('latency_p50');
+const p95 = new Trend('latency_p95');
+const p99 = new Trend('latency_p99');
+const ttfb = new Trend('ttfb');
+const totalRequests = new Counter('total_requests');
+const successRequests = new Counter('success_requests');
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const AUTH_TOKEN = __ENV.TOKEN || '';
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 5 },   // Ramp up
+    { duration: '20s', target: 10 },   // Steady
+    { duration: '10s', target: 0 },    // Ramp down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],  // 95% under 2s
+    error_rate: ['rate<0.10'],           // <10% errors
+  },
+};
+
+function recordMetrics(name, response) {
+  const duration = response.timings.duration;
+  p50.add(duration);
+  p95.add(duration);
+  p99.add(duration);
+  ttfb.add(response.timings.waiting);
+  totalRequests.add(1);
+  rps.add(1);
+
+  if (response.status >= 200 && response.status < 500) {
+    successRequests.add(1);
+  } else {
+    errorRate.add(1);
+  }
+}
+
+function authHeaders() {
+  return AUTH_TOKEN
+    ? { headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' } }
+    : { headers: { 'Content-Type': 'application/json' } };
+}
+
+export default function () {
+  // === Public Endpoints ===
+  group('Health Check', () => {
+    const res = http.get(`${BASE_URL}/health`);
+    check(res, { 'health is 200': (r) => r.status === 200 });
+    recordMetrics('health', res);
+  });
+
+  group('Auth - Register', () => {
+    const payload = JSON.stringify({
+      email: `benchmark_${Date.now()}@test.com`,
+      password: 'Benchmark123!',
+      name: 'Benchmark User',
+    });
+    const res = http.post(`${BASE_URL}/api/auth/register`, payload, authHeaders());
+    check(res, { 'register is 200/201': (r) => r.status === 201 || r.status === 200 });
+    recordMetrics('auth_register', res);
+  });
+
+  group('Auth - Login', () => {
+    const payload = JSON.stringify({
+      email: `benchmark_${Date.now()}@test.com`,
+      password: 'Benchmark123!',
+    });
+    const res = http.post(`${BASE_URL}/api/auth/login`, payload, authHeaders());
+    check(res, { 'login is 200': (r) => r.status === 200 });
+    recordMetrics('auth_login', res);
+  });
+
+  group('Auth - Token Refresh', () => {
+    const res = http.post(`${BASE_URL}/api/auth/refresh`, '{}', authHeaders());
+    check(res, { 'refresh responded' : (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('auth_refresh', res);
+  });
+
+  // === Read Endpoints (GET) ===
+  group('Users - List', () => {
+    const res = http.get(`${BASE_URL}/api/users`, authHeaders());
+    check(res, { 'users list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('users_list', res);
+  });
+
+  group('Jobs - List', () => {
+    const res = http.get(`${BASE_URL}/api/jobs`, authHeaders());
+    check(res, { 'jobs list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('jobs_list', res);
+  });
+
+  group('Proposals - List', () => {
+    const res = http.get(`${BASE_URL}/api/proposals`, authHeaders());
+    check(res, { 'proposals list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('proposals_list', res);
+  });
+
+  group('Reviews - List', () => {
+    const res = http.get(`${BASE_URL}/api/reviews`, authHeaders());
+    check(res, { 'reviews list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('reviews_list', res);
+  });
+
+  group('Messages - List', () => {
+    const res = http.get(`${BASE_URL}/api/messages`, authHeaders());
+    check(res, { 'messages list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('messages_list', res);
+  });
+
+  group('Notifications - List', () => {
+    const res = http.get(`${BASE_URL}/api/notifications`, authHeaders());
+    check(res, { 'notifications list responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('notifications_list', res);
+  });
+
+  group('Search', () => {
+    const res = http.get(`${BASE_URL}/api/search?q=developer&limit=10`, authHeaders());
+    check(res, { 'search responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('search', res);
+  });
+
+  // === Write Endpoints (POST) ===
+  group('Jobs - Create', () => {
+    const payload = JSON.stringify({
+      title: 'Benchmark Job - Senior Developer',
+      description: 'A test job created during API benchmarking to measure performance under load.',
+      budget: 5000,
+      category: 'Engineering',
+      skills: ['TypeScript', 'React', 'Node.js'],
+    });
+    const res = http.post(`${BASE_URL}/api/jobs`, payload, authHeaders());
+    check(res, { 'job creation responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('jobs_create', res);
+  });
+
+  group('Proposals - Create', () => {
+    const payload = JSON.stringify({
+      jobId: 'benchmark-job-id',
+      coverLetter: 'I am an experienced developer interested in this position.',
+      proposedRate: 100,
+    });
+    const res = http.post(`${BASE_URL}/api/proposals`, payload, authHeaders());
+    check(res, { 'proposal creation responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('proposals_create', res);
+  });
+
+  group('Payments - Create', () => {
+    const payload = JSON.stringify({
+      amount: 1000,
+      currency: 'USD',
+      description: 'Benchmark payment',
+    });
+    const res = http.post(`${BASE_URL}/api/payments`, payload, authHeaders());
+    check(res, { 'payment creation responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('payments_create', res);
+  });
+
+  group('Reviews - Create', () => {
+    const payload = JSON.stringify({
+      targetUserId: 'benchmark-user-id',
+      rating: 5,
+      comment: 'Excellent work!',
+    });
+    const res = http.post(`${BASE_URL}/api/reviews`, payload, authHeaders());
+    check(res, { 'review creation responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('reviews_create', res);
+  });
+
+  group('Messages - Send', () => {
+    const payload = JSON.stringify({
+      recipientId: 'benchmark-recipient-id',
+      subject: 'Benchmark Message',
+      body: 'This is a test message generated during benchmarking.',
+    });
+    const res = http.post(`${BASE_URL}/api/messages`, payload, authHeaders());
+    check(res, { 'message send responded': (r) => r.status >= 200 && r.status < 500 });
+    recordMetrics('messages_send', res);
+  });
+
+  // === Admin Endpoints (Protected) ===
+  if (AUTH_TOKEN) {
+    group('Admin - Metrics', () => {
+      const res = http.get(`${BASE_URL}/api/admin/metrics`, {
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+      });
+      check(res, { 'admin metrics responded': (r) => r.status >= 200 && r.status < 500 });
+      recordMetrics('admin_metrics', res);
+    });
+  }
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    'stdout': textSummary(data, { indent: '  ', enableColors: true }),
+    'benchmark-report.json': JSON.stringify(data, null, 2),
+  };
+}

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+API Benchmark Suite - Python (httpx) Alternative
+Run when k6 is not available.
+
+Usage:
+    pip install httpx
+    python3 benchmark.py
+    python3 benchmark.py --base-url http://localhost:3000 --token YOUR_TOKEN
+    python3 benchmark.py --vus 5 --duration 30
+"""
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+import time
+import httpx
+from datetime import datetime
+
+BASE_URL = "http://localhost:3000"
+AUTH_TOKEN = ""
+
+# Test endpoints configuration
+ENDPOINTS = [
+    # (name, method, path, payload)
+    ("health", "GET", "/health", None, False),
+    ("auth_register", "POST", "/api/auth/register",
+     lambda: {"email": f"bench_{int(time.time()*1000)}@test.com", "password": "Bench123!", "name": "Bench User"}, False),
+    ("auth_login", "POST", "/api/auth/login",
+     lambda: {"email": f"bench_{int(time.time()*1000)}@test.com", "password": "Bench123!"}, False),
+    ("users_list", "GET", "/api/users", None, True),
+    ("jobs_list", "GET", "/api/jobs", None, True),
+    ("proposals_list", "GET", "/api/proposals", None, True),
+    ("reviews_list", "GET", "/api/reviews", None, True),
+    ("messages_list", "GET", "/api/messages", None, True),
+    ("notifications_list", "GET", "/api/notifications", None, True),
+    ("search", "GET", "/api/search?q=developer&limit=10", None, True),
+    ("jobs_create", "POST", "/api/jobs",
+     {"title": "Bench Senior Dev", "description": "Test job", "budget": 5000, "skills": ["Python"]}, True),
+    ("proposals_create", "POST", "/api/proposals",
+     {"jobId": "test-id", "coverLetter": "I can help!", "proposedRate": 100}, True),
+    ("payments_create", "POST", "/api/payments",
+     {"amount": 500, "currency": "USD", "description": "Test"}, True),
+    ("reviews_create", "POST", "/api/reviews",
+     {"targetUserId": "user-id", "rating": 5, "comment": "Great!"}, True),
+    ("messages_send", "POST", "/api/messages",
+     {"recipientId": "user-id", "subject": "Hi", "body": "Test message"}, True),
+    ("admin_metrics", "GET", "/api/admin/metrics", None, True),
+]
+
+if AUTH_TOKEN:
+    ENDPOINTS.append(("admin_metrics", "GET", "/api/admin/metrics", None, True))
+
+
+class Stats:
+    def __init__(self):
+        self.latencies = []
+        self.errors = 0
+        self.total = 0
+    
+    def add(self, latency_ms, success=True):
+        self.latencies.append(latency_ms)
+        self.total += 1
+        if not success:
+            self.errors += 1
+    
+    @property
+    def p50(self):
+        return sorted(self.latencies)[len(self.latencies) // 2] if self.latencies else 0
+    
+    @property
+    def p95(self):
+        if not self.latencies:
+            return 0
+        sorted_lat = sorted(self.latencies)
+        idx = int(len(sorted_lat) * 0.95)
+        return sorted_lat[min(idx, len(sorted_lat)-1)]
+    
+    @property
+    def p99(self):
+        if not self.latencies:
+            return 0
+        sorted_lat = sorted(self.latencies)
+        idx = int(len(sorted_lat) * 0.99)
+        return sorted_lat[min(idx, len(sorted_lat)-1)]
+    
+    @property
+    def avg(self):
+        return statistics.mean(self.latencies) if self.latencies else 0
+    
+    @property
+    def error_rate(self):
+        return (self.errors / self.total * 100) if self.total else 0
+
+
+async def run_benchmark(base_url: str, vus: int, duration: int):
+    """Run benchmark with virtual users for specified duration."""
+    all_stats = {}
+    
+    async def worker(worker_id):
+        async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+            end_time = time.time() + duration
+            while time.time() < end_time:
+                for name, method, path, payload_factory, needs_auth in ENDPOINTS:
+                    if time.time() >= end_time:
+                        break
+                    
+                    headers = {"Content-Type": "application/json"}
+                    if needs_auth and AUTH_TOKEN:
+                        headers["Authorization"] = f"Bearer {AUTH_TOKEN}"
+                    
+                    payload = payload_factory() if callable(payload_factory) else payload_factory
+                    
+                    try:
+                        start = time.time()
+                        if method == "GET":
+                            resp = await client.get(path, headers=headers)
+                        else:
+                            resp = await client.post(path, json=payload, headers=headers)
+                        latency = (time.time() - start) * 1000
+                        
+                        if name not in all_stats:
+                            all_stats[name] = Stats()
+                        all_stats[name].add(latency, resp.status < 500)
+                    except Exception:
+                        if name not in all_stats:
+                            all_stats[name] = Stats()
+                        all_stats[name].add(9999, False)
+    
+    workers = [worker(i) for i in range(vus)]
+    await asyncio.gather(*workers)
+    return all_stats
+
+
+def print_report(stats: dict, duration: int):
+    """Print formatted benchmark report."""
+    total_req = sum(s.total for s in stats.values())
+    total_err = sum(s.errors for s in stats.values())
+    overall_rps = total_req / duration if duration > 0 else 0
+    
+    print()
+    print("╔══════════════════════════════════════════════════════════════════════╗")
+    print(f"║  API Benchmark Report                     {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}  ║")
+    print(f"║  Total requests: {total_req:<6d} | Errors: {total_err:<5d} | RPS: {overall_rps:.1f}    ║")
+    print("╠══════════════════════════════════════════════════════════════════════╣")
+    print(f"║  {'Endpoint':25s} {'P50(ms)':>8s} {'P95(ms)':>8s} {'P99(ms)':>8s} {'Err%':>6s} {'Req':>6s} ║")
+    print("╠══════════════════════════════════════════════════════════════════════╣")
+    
+    for name in sorted(stats.keys()):
+        s = stats[name]
+        color = ""
+        reset = ""
+        if s.p95 < 500:
+            color = "\033[32m"  # green
+        elif s.p95 < 2000:
+            color = "\033[33m"  # yellow
+        else:
+            color = "\033[31m"  # red
+        reset = "\033[0m"
+        
+        print(f"║ {color}{name:25s} {s.p50:>7.0f}ms {s.p95:>7.0f}ms {s.p99:>7.0f}ms "
+              f"{s.error_rate:>5.1f}% {s.total:>5d}{reset} ║")
+    
+    print("╚══════════════════════════════════════════════════════════════════════╝")
+    print()
+    
+    # Summary
+    if total_req > 0:
+        print(f"📊 Summary:")
+        print(f"   Total requests: {total_req}")
+        print(f"   Errors: {total_err} ({total_err/total_req*100:.1f}%)")
+        print(f"   Throughput: {overall_rps:.1f} req/s")
+        print(f"   Duration: {duration}s with multi VUs")
+        print()
+        
+        # Bottleneck detection
+        slow = [(n, s) for n, s in stats.items() if s.p95 > 2000]
+        if slow:
+            print(f"⚠️  Bottlenecks detected (P95 > 2s):")
+            for name, s in sorted(slow, key=lambda x: -x[1].p95):
+                print(f"   🔴 {name}: P95={s.p95:.0f}ms, AVG={s.avg:.0f}ms, errors={s.error_rate:.1f}%")
+        else:
+            print(f"✅ No significant bottlenecks detected (all P95 < 2s)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="API Benchmark Suite")
+    parser.add_argument("--base-url", default=BASE_URL, help="API base URL")
+    parser.add_argument("--token", default="", help="Auth token for protected routes")
+    parser.add_argument("--vus", type=int, default=5, help="Virtual users (default: 5)")
+    parser.add_argument("--duration", type=int, default=20, help="Duration in seconds (default: 20)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON report")
+    args = parser.parse_args()
+    
+    global BASE_URL, AUTH_TOKEN
+    BASE_URL = args.base_url
+    AUTH_TOKEN = args.token
+    
+    print(f"🚀 API Benchmark Suite")
+    print(f"   Target: {BASE_URL}")
+    print(f"   Virtual Users: {args.vus}")
+    print(f"   Duration: {args.duration}s")
+    print(f"   Auth: {'Yes' if AUTH_TOKEN else 'No'}")
+    print(f"   Endpoints: {len(ENDPOINTS)}")
+    print()
+    print(f"Running benchmark...")
+    
+    stats = asyncio.run(run_benchmark(BASE_URL, args.vus, args.duration))
+    
+    if args.json:
+        report = {}
+        for name, s in stats.items():
+            report[name] = {
+                "p50_ms": round(s.p50, 1),
+                "p95_ms": round(s.p95, 1),
+                "p99_ms": round(s.p99, 1),
+                "avg_ms": round(s.avg, 1),
+                "error_rate_pct": round(s.error_rate, 1),
+                "total_requests": s.total,
+                "errors": s.errors,
+            }
+        report["_meta"] = {
+            "target": BASE_URL,
+            "vus": args.vus,
+            "duration": args.duration,
+            "total_requests": sum(s.total for s in stats.values()),
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+        print(json.dumps(report, indent=2))
+    else:
+        print_report(stats, args.duration)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add comprehensive API benchmark suite for all /api/ endpoints.

Includes:
- k6 script (benchmark.js) — primary benchmark tool with staged load
- Python alternative (benchmark.py) — for environments without k6
- p50, p95, p99 latency tracking per endpoint
- Error rate monitoring
- TTFB measurement
- Per-endpoint reporting with bottleneck detection
- JSON output for CI integration

Closes #30