### PR TITLE
Add original technical poem (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Receipt of Repair
+
+The trace arrives with rain still in its name,
+a small red line where confidence went thin.
+We pin the failing step beside the claim,
+then ask the test to tell us where to begin.
+
+A patch is not a promise in disguise.
+It earns its light through fixtures, logs, and proof.
+Each passing check is one more honest size
+of measured trust beneath a changing roof.
+
+The reviewer reads the margin, not the noise,
+and weighs the diff by what it leaves intact.
+No flourish needs to raise its louder voice
+when careful work can stand beside the fact.
+
+At merge, the record closes like a note:
+reported, reproduced, repaired, and known.
+The payout is the receipt the system wrote
+for risk made smaller than it was alone.
+
+So keep the evidence plain, the pathway clear,
+the fix as lean as daylight on the screen.
+Good work leaves little drama in its rear,
+just cleaner code, and proof of where it has been.


### PR DESCRIPTION
/claim #76

## Summary
- Add `POEM.md` at the project root.
- Include an original five-stanza poem written for this bug-bounty project.

## Creative note
I chose a compact "receipt of repair" form because it maps the bounty workflow from report to proof to review to payout while staying distinct from the existing security-research and marketplace-themed poem submissions.

## Acceptance checklist
- Original poem written specifically for this project
- More than 3 stanzas
- Submitted as `POEM.md` in the project root
- Creative decision noted above

## Validation
- `wc -l POEM.md` -> 26 lines
- `git diff --cached --check` passed before commit