### PR TITLE
Add quiet ledger poem (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Quiet Ledger
+
+The brief arrives in measured lines,
+a scope, a rate, a name.
+Two strangers turn their careful signs
+toward work that has a frame.
+
+A proposal crosses into view,
+not loud, but built to stand.
+It names the task, the risk, the due,
+and waits for one clear hand.
+
+The patch is small, the proof is plain,
+the tests report their light.
+Each passing check reduces strain
+and makes the contract bright.
+
+Reviewers read the trace with care,
+then mark the claim as done.
+The payout leaves a balanced square:
+trust earned by everyone.
+
+So FreelanceFlow keeps time between
+the promise and the paid,
+where honest work can still be seen
+after the merge is made.


### PR DESCRIPTION
/claim #76

## Summary
Add `POEM.md` at the project root with an original five-stanza poem written for this project.

## Creative Note
I chose a quiet ledger form because it maps the FreelanceFlow bounty workflow from scoped promise to proof, review, merge, and payout while staying distinct from the existing security-research, marketplace, protocol, relay, release-room, garden, and receipt-themed poem submissions.

## Acceptance Criteria
- [x] Original poem written specifically for this project
- [x] Minimum 3 stanzas; this submission has 5 stanzas
- [x] Submitted as `POEM.md` in the project root
- [x] PR includes a one-line note on the creative decision

## Validation
- `wc -l POEM.md` -> 26 lines
- `git diff --check` passed

Refs #76
