### PR TITLE
Implement secure Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return fail(res, error.message ?? "Payment intent creation failed", error.statusCode ?? 500);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,77 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+let stripeFactory = (secretKey) => new Stripe(secretKey);
+
+export class PaymentServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+  }
+}
+
+export function setStripeFactoryForTests(factory) {
+  stripeFactory = factory ?? ((secretKey) => new Stripe(secretKey));
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentServiceError("Payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentServiceError(
+      "Payment amount is required and must be a positive integer in the smallest currency unit"
+    );
+  }
+
+  const currency = (payload.currency ?? "usd").toLowerCase();
+  if (!/^[a-z]{3}$/.test(currency)) {
+    throw new PaymentServiceError("Payment currency must be a three-letter ISO currency code");
+  }
+
+  if (
+    payload.metadata !== undefined &&
+    (!payload.metadata || typeof payload.metadata !== "object" || Array.isArray(payload.metadata))
+  ) {
+    throw new PaymentServiceError("Payment metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency,
+    metadata: payload.metadata
   };
+}
+
+export async function createPaymentIntent(payload) {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY environment variable is required", 500);
+  }
+
+  const payment = validatePaymentPayload(payload);
+  const stripe = stripeFactory(secretKey);
+  const createPayload = {
+    amount: payment.amount,
+    currency: payment.currency
+  };
+
+  if (payment.metadata) {
+    createPayload.metadata = payment.metadata;
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(createPayload);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: payment.amount,
+      currency: payment.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw new PaymentServiceError(error.message ?? "Stripe payment intent creation failed", 502);
+  }
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { setStripeFactoryForTests } from "../services/paymentService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test.afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  setStripeFactoryForTests();
+});
+
+test("POST /api/payments returns Stripe client secret and payment id", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeFactoryForTests(() => ({
+    paymentIntents: {
+      create: async () => ({
+        id: "pi_route_123",
+        client_secret: "pi_route_123_secret_456"
+      })
+    }
+  }));
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1500 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.paymentId, "pi_route_123");
+    assert.equal(payload.data.clientSecret, "pi_route_123_secret_456");
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments surfaces validation errors", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -1 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /amount is required/);
+  });
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  PaymentServiceError,
+  setStripeFactoryForTests
+} from "../services/paymentService.js";
+
+function withStripeMock(assertions) {
+  const calls = [];
+  const paymentIntents = {
+    create: async (payload) => {
+      calls.push(payload);
+      return {
+        id: "pi_test_123",
+        client_secret: "pi_test_123_secret_456"
+      };
+    }
+  };
+
+  setStripeFactoryForTests((secretKey) => {
+    assertions.secretKey = secretKey;
+    return { paymentIntents };
+  });
+
+  return calls;
+}
+
+test.afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  setStripeFactoryForTests();
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated input", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const assertions = {};
+  const calls = withStripeMock(assertions);
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "EUR",
+    metadata: { jobId: "job_123" }
+  });
+
+  assert.equal(assertions.secretKey, "sk_test_mock");
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "eur",
+      metadata: { jobId: "job_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 2500,
+    currency: "eur",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const assertions = {};
+  const calls = withStripeMock(assertions);
+
+  await createPaymentIntent({ amount: 1000 });
+
+  assert.deepEqual(calls, [{ amount: 1000, currency: "usd" }]);
+});
+
+test("createPaymentIntent rejects missing or invalid amounts", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+
+  await assert.rejects(
+    () => createPaymentIntent({ currency: "usd" }),
+    /amount is required and must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0, currency: "usd" }),
+    /amount is required and must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10.5, currency: "usd" }),
+    /amount is required and must be a positive integer/
+  );
+});
+
+test("createPaymentIntent rejects invalid currency and metadata", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "us" }),
+    /currency must be a three-letter ISO currency code/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: [] }),
+    /metadata must be an object/
+  );
+});
+
+test("createPaymentIntent requires STRIPE_SECRET_KEY before contacting Stripe", async () => {
+  let contactedStripe = false;
+  setStripeFactoryForTests(() => {
+    contactedStripe = true;
+    return { paymentIntents: { create: async () => ({}) } };
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usd" }),
+    (error) => {
+      assert.equal(error instanceof PaymentServiceError, true);
+      assert.equal(error.statusCode, 500);
+      assert.match(error.message, /STRIPE_SECRET_KEY/);
+      return true;
+    }
+  );
+  assert.equal(contactedStripe, false);
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  setStripeFactoryForTests(() => ({
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  }));
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usd" }),
+    (error) => {
+      assert.equal(error.statusCode, 502);
+      assert.equal(error.message, "Your card was declined");
+      return true;
+    }
+  );
+});

--- a/apps/api/src/tests/paymentSmoke.test.js
+++ b/apps/api/src/tests/paymentSmoke.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test(
+  "creates a real Stripe test-mode PaymentIntent when smoke testing is enabled",
+  { skip: !process.env.RUN_STRIPE_SMOKE || !process.env.STRIPE_SECRET_KEY },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: Number(process.env.STRIPE_SMOKE_AMOUNT ?? 100),
+      currency: process.env.STRIPE_SMOKE_CURRENCY ?? "usd",
+      metadata: {
+        smoke: "true",
+        source: "freelanceflow-api-test"
+      }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_.*_secret_/);
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,8 +743,9 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1107,6 +1109,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1706,6 +1709,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -1776,6 +1780,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1785,6 +1790,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2053,6 +2059,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2151,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Closes #1

/claim #1

## Summary
- Replaces the timestamp-based payment stub with Stripe PaymentIntent creation through the Stripe Node.js SDK.
- Initializes Stripe from `STRIPE_SECRET_KEY`, validates amount/currency/metadata before the provider call, and maps Stripe `id`/`client_secret` to `paymentId`/`clientSecret`.
- Adds mocked service and route coverage plus a guarded live Stripe smoke test that only runs when `RUN_STRIPE_SMOKE=1` and `STRIPE_SECRET_KEY` are set.

## Acceptance Criteria Coverage
- `stripe` dependency installed in `apps/api`.
- `STRIPE_SECRET_KEY` required; no hardcoded keys.
- `amount` must be a positive integer in smallest currency unit.
- `currency` defaults to `usd` and is normalized to lowercase.
- Calls `stripe.paymentIntents.create({ amount, currency, ...metadata })`.
- Returns `paymentId` and `clientSecret`; removed `pay_${Date.now()}` stub ids.
- Preserves Stripe API error messages through `PaymentServiceError`.
- Unit tests mock Stripe and assert exact PaymentIntent arguments.
- Smoke test is guarded by env flags for real Stripe test-mode execution.

## Validation
- `npm.cmd run test -w apps/api` -> 9 passed, 1 skipped smoke test
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `node --check apps/api/src/tests/paymentRoutes.test.js`
- `git diff --check`