### PR TITLE
Implement Stripe payment intent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "stripe": "^17.5.0"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,55 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClientFactory = (secretKey) => new Stripe(secretKey);
+
+export function setStripeClientFactory(factory) {
+  stripeClientFactory = factory;
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("Payment amount must be a positive integer in the smallest currency unit.");
+  }
+}
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") return "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("Payment currency must be a three-letter ISO currency code.");
+  }
+  return currency.toLowerCase();
+}
+
+function createStripeClient() {
+  if (!env.stripeSecretKey) throw new Error("STRIPE_SECRET_KEY is required to create a payment intent.");
+  return stripeClientFactory(env.stripeSecretKey);
+}
+
+function normalizeStripeError(error) {
+  if (error?.type?.startsWith("Stripe")) throw new Error(error.message);
+  throw error;
+}
+
+export async function createPaymentIntent(payload = {}) {
+  validateAmount(payload.amount);
+  const currency = normalizeCurrency(payload.currency);
+
+  try {
+    const paymentIntent = await createStripeClient().paymentIntents.create({
+      amount: payload.amount,
+      currency,
+      metadata: payload.metadata ?? {}
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    normalizeStripeError(error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.STRIPE_SECRET_KEY = "sk_test_unit";
+
+const { createPaymentIntent, setStripeClientFactory } = await import("../services/paymentService.js");
+
+let createArgs;
+setStripeClientFactory((secretKey) => {
+  assert.equal(secretKey, "sk_test_unit");
+  return {
+    paymentIntents: {
+      create: async (args) => {
+        createArgs = args;
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_456",
+          amount: args.amount,
+          currency: args.currency
+        };
+      }
+    }
+  };
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent and maps identifiers", async () => {
+  const result = await createPaymentIntent({ amount: 2500, currency: "USD" });
+  assert.deepEqual(createArgs, { amount: 2500, currency: "usd", metadata: {} });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent validates amount", async () => {
+  await assert.rejects(() => createPaymentIntent({ amount: 0 }), /positive integer/);
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  await createPaymentIntent({ amount: 100 });
+  assert.equal(createArgs.currency, "usd");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^17.5.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- implement Stripe PaymentIntent creation in `createPaymentIntent`
- validate amount/currency inputs and default currency to `usd`
- return Stripe identifiers/client secret for the API layer
- add unit coverage with an injected Stripe client factory (no real Stripe call in tests)

## Test
- `npm test --workspace apps/api`

Fixes #1