### PR TITLE
feat: add original technical poem "The Freelancer's Stack"

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,70 @@
+# The Freelancer's Stack
+
+*An original poem for the FreelanceFlow platform*
+
+---
+
+## I. The Request
+
+A job appears at midnight, clean and bright,
+A client posts their vision to the board —
+A system built to handle load and light,
+Each endpoint sharp, each schema well-explored.
+
+The freelancer reads the spec with careful eyes,
+Parses the requirements line by line,
+Then types a proposal, measured, wise:
+*"I'll build this well. The architecture's mine."*
+
+---
+
+## II. The Build
+
+The terminal hums, the editor glows,
+Controllers wired to services below,
+Each route a promise that the system knows —
+Auth guards the gate, the middleware in flow.
+
+A schema grows in Prisma, field by field,
+Users and jobs and proposals aligned,
+The database a fortress, strong and sealed,
+The API a bridge for every mind.
+
+Tests run green. The logs are clean and still.
+A pull request opens — diff is tight.
+The reviewer nods: *"Good work. Merge at will."*
+The pipeline passes. Everything is right.
+
+---
+
+## III. The Delivery
+
+The client sees the dashboard come alive,
+Job listings bloom, proposals fill the queue,
+The platform breathes — it's ready to survive
+The weight of every freelancer's debut.
+
+No placeholder remains, no TODO stands,
+The payment gateway hums with Stripe's precision,
+The work is done by careful, steady hands —
+A system built on trust and clear decision.
+
+---
+
+## IV. The Silence After
+
+When all is merged and all the tickets close,
+The freelancer logs off into the night,
+The platform runs — nobody really knows
+How much it took to get the architecture right.
+
+But somewhere in the code, a comment stays,
+A function named with care, a test that holds —
+The quiet proof of all those working days,
+A story that the version history tells.
+
+---
+
+*Theme: The lifecycle of a freelance project — from first proposal to final merge.
+Form: Four-stanza ballad structure, mirroring the four phases of software delivery.
+Written specifically for the FreelanceFlow monorepo.*


### PR DESCRIPTION
/claim #76

## What I made
"The Freelancer's Stack" — a 4-stanza ballad tracing the full lifecycle of a freelance project: proposal → build → delivery → silence after merge.

## Creative decision
Form: ballad structure with 4 stanzas mirroring the 4 phases of software delivery. Theme chosen specifically for the FreelanceFlow monorepo — every stanza references real parts of the codebase (Prisma, controllers, Stripe, auth).

## File
`POEM.md` in project root, minimum 4 stanzas.