### PR TITLE
Add original FreelanceFlow poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Quiet Terms of Flow
+
+At midnight, a brief comes cleanly scoped,
+no promise padded, no hidden clause.
+A profile answers with measured proof,
+and both sides name the work before applause.
+
+The message thread keeps context close,
+not noise, but record, timestamp, trace.
+A proposal travels with its edges shown:
+amount, deadline, risk, and place.
+
+Escrow is a held breath, not a wall;
+it gives the maker room to build.
+The client sees the milestone stand,
+the invoice waits until trust is filled.
+
+Review is not a verdict thrown;
+it is a mirror with receipts.
+A fix, a note, a test rerun,
+and confidence returns in careful beats.
+
+Then payout moves through quiet rails,
+not luck, not pressure, not a plea.
+FreelanceFlow does its truest work
+when fair exchange can simply be.


### PR DESCRIPTION
/claim #76

## Summary
- Adds `POEM.md` at the repository root.
- Provides an original five-stanza poem written specifically around FreelanceFlow marketplace trust, scope, escrow, review, and payout.

## Creative decision
I used a quiet night-watch tone to frame FreelanceFlow as calm infrastructure for fair work: scoped briefs, preserved context, escrow, review, and payout without turning the poem into a generic security anthem.

## Verification
- Confirmed `POEM.md` is in the project root.
- Confirmed the poem has 5 stanzas, exceeding the 3-stanza minimum.
- Ran `git diff --check` successfully.

## Demo
Markdown-only content change; the PR diff/rendered `POEM.md` preview is the demo artifact for review.