### PR TITLE
feat: implement Stripe payment intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+- `STRIPE_SECRET_KEY` — Stripe secret key used by `apps/api` to create PaymentIntents.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  const message = statusCode === 500 ? "Unexpected server error" : err.message;
+  if (statusCode >= 500) {
+    console.error("Unhandled API error:", err);
+  }
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,113 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+const DEFAULT_CURRENCY = "usd";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
+}
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return DEFAULT_CURRENCY;
+  }
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentValidationError("currency must be a three-letter ISO currency code");
+  }
+
+  return currency.toLowerCase();
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined || metadata === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(metadata) || typeof metadata !== "object") {
+    throw new PaymentValidationError("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === null || value === undefined || typeof value === "object") {
+        throw new PaymentValidationError("metadata values must be strings, numbers, or booleans");
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+export function buildPaymentIntentParams(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentValidationError("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentValidationError("amount is required and must be a positive integer");
+  }
+
+  const params = {
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: normalizeCurrency(payload.currency)
   };
+
+  const metadata = normalizeMetadata(payload.metadata);
+  if (metadata) {
+    params.metadata = metadata;
+  }
+
+  return params;
+}
+
+export function createStripeClient(secretKey = env.stripeSecretKey) {
+  if (!secretKey) {
+    throw new PaymentProviderError("STRIPE_SECRET_KEY is required to create payment intents");
+  }
+
+  return new Stripe(secretKey);
+}
+
+function getStripeClient() {
+  stripeClient ??= createStripeClient();
+  return stripeClient;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const params = buildPaymentIntentParams(payload);
+  const client = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await client.paymentIntents.create(params);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? params.amount,
+      currency: paymentIntent.currency ?? params.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentValidationError || error instanceof PaymentProviderError) {
+      throw error;
+    }
+
+    const message = error?.message ?? "Stripe payment intent creation failed";
+    throw new PaymentProviderError(`Stripe payment intent creation failed: ${message}`);
+  }
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid amounts with a descriptive error", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: "1000" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "amount is required and must be a positive integer"
+    });
+  });
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPaymentIntentParams,
+  createPaymentIntent,
+  createStripeClient,
+  PaymentProviderError,
+  PaymentValidationError
+} from "../services/paymentService.js";
+
+test("buildPaymentIntentParams validates amount and defaults currency", () => {
+  assert.deepEqual(buildPaymentIntentParams({ amount: 2500 }), {
+    amount: 2500,
+    currency: "usd"
+  });
+
+  assert.throws(
+    () => buildPaymentIntentParams({ amount: 0 }),
+    /amount is required and must be a positive integer/
+  );
+  assert.throws(
+    () => buildPaymentIntentParams({ amount: 12.5 }),
+    /amount is required and must be a positive integer/
+  );
+});
+
+test("buildPaymentIntentParams normalizes currency and metadata", () => {
+  assert.deepEqual(
+    buildPaymentIntentParams({
+      amount: 1099,
+      currency: "EUR",
+      metadata: {
+        jobId: "job_123",
+        escrow: true,
+        milestone: 2
+      }
+    }),
+    {
+      amount: 1099,
+      currency: "eur",
+      metadata: {
+        jobId: "job_123",
+        escrow: "true",
+        milestone: "2"
+      }
+    }
+  );
+
+  assert.throws(
+    () => buildPaymentIntentParams({ amount: 1099, currency: "EURO" }),
+    /currency must be a three-letter ISO currency code/
+  );
+  assert.throws(
+    () => buildPaymentIntentParams({ amount: 1099, metadata: { nested: {} } }),
+    /metadata values must be strings, numbers, or booleans/
+  );
+});
+
+test("createPaymentIntent calls Stripe with validated params and maps response", async () => {
+  const calls = [];
+  const stripeClient = {
+    paymentIntents: {
+      create: async (params) => {
+        calls.push(params);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_456",
+          amount: params.amount,
+          currency: params.currency
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent(
+    { amount: 1999, currency: "USD", metadata: { invoiceId: "inv_1" } },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 1999,
+      currency: "usd",
+      metadata: { invoiceId: "inv_1" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 1999,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined.");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  };
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 1000 }, { stripeClient }),
+    (error) => {
+      assert.ok(error instanceof PaymentProviderError);
+      assert.equal(error.statusCode, 502);
+      assert.match(error.message, /Your card was declined\./);
+      return true;
+    }
+  );
+});
+
+test("createStripeClient requires STRIPE_SECRET_KEY", () => {
+  assert.throws(() => createStripeClient(""), {
+    name: "PaymentProviderError",
+    message: "STRIPE_SECRET_KEY is required to create payment intents"
+  });
+});
+
+test(
+  "createPaymentIntent creates a live Stripe test PaymentIntent when enabled",
+  {
+    skip:
+      process.env.RUN_STRIPE_SMOKE !== "1" || !process.env.STRIPE_SECRET_KEY
+        ? "Set RUN_STRIPE_SMOKE=1 and STRIPE_SECRET_KEY to run the live Stripe smoke test"
+        : false
+  },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { source: "securebanana-smoke-test" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /_secret_/);
+  }
+);
+
+test("createPaymentIntent rethrows validation errors without calling Stripe", async () => {
+  let called = false;
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        called = true;
+      }
+    }
+  };
+
+  await assert.rejects(
+    createPaymentIntent({ amount: -1 }, { stripeClient }),
+    PaymentValidationError
+  );
+  assert.equal(called, false);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Proposed Changes

- Replaced the timestamp-based payment stub with Stripe PaymentIntent creation through the Stripe Node.js SDK.
- Initialized Stripe from `STRIPE_SECRET_KEY` via the API env config, with no hardcoded keys.
- Added validation for required positive-integer `amount`, normalized three-letter `currency`, and Stripe-safe metadata values.
- Mapped Stripe `id` and `client_secret` to `paymentId` and `clientSecret`.
- Preserved Stripe provider error messages through API-safe errors.
- Updated the payment controller/error middleware so validation/provider errors reach callers as meaningful responses.
- Added mocked service tests plus a guarded live Stripe smoke test that only runs with `RUN_STRIPE_SMOKE=1` and `STRIPE_SECRET_KEY`.

## Proof

```bash
npm test
```

Result:

```text
8 passed, 1 skipped, 0 failed
```

The skipped test is the live Stripe smoke test. It is intentionally opt-in so CI and local runs do not require Stripe credentials.
