### PR TITLE
Add milestone clock poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Milestone Clock
+
+The client sets a scope at dawn,
+not loud, but line by line;
+a brief becomes a bounded room
+with dates the work can sign.
+
+The freelancer weighs the task,
+then prices time and risk;
+a proposal lands with measured proof,
+not promise dressed as mist.
+
+Escrow holds the middle ground,
+steady while commits arrive;
+messages keep the record clear
+so both sides stay aligned.
+
+Review turns output into trust,
+the final note is paid;
+FreelanceFlow keeps the path in view
+from first ask to work well made.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the project root.
- The poem has four stanzas and was written specifically around FreelanceFlow's proposal, escrow, delivery, review, and payout flow.

## Creative note
I chose a milestone-clock theme because the marketplace turns uncertain work into timed checkpoints: scoped ask, priced proposal, escrowed delivery, review, and payout.

## Validation
- `git diff --check` -> passed
- `(Get-Content -Path POEM.md).Count` -> 21 lines
- Manual check: original poem, 4 stanzas, project-specific, submitted as `POEM.md`.

AI-assisted with OpenAI Codex; acceptance criteria verified before submission.