### PR TITLE
docs: add project-specific technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# FreelanceFlow: A Technical Poem
+
+In app-router dawn, a landing page unfurls,  
+Where gigs and profiles orbit rendered worlds;  
+A dashboard hums with bids and bright intent,  
+While messages thread the client’s milestone spent.
+
+The API wakes—auth tokens, refresh streams,  
+Controllers route the ledger of our dreams;  
+Services compose the contracts, clean and light,  
+And Zod keeps sentry through the server night.
+
+Prisma maps the tables, steady, true—  
+Users, jobs, reviews, and payments in the queue;  
+Uploads find their bins, notifications chime,  
+And rate limits keep the market in its time.
+
+Shared UI keeps the palette in one tune,  
+Components trade their props like harvests in June;  
+From web to api, packages align,  
+A monorepo’s pulse, a freelance flow by design.


### PR DESCRIPTION
## Summary
Adds an original technical poem as POEM.md per issue #76.

## Testing
Not applicable (documentation-only change).

## Creative Decision (one line)
I chose a monorepo-inspired theme to mirror the repo’s full-stack flow from UI to API to database.

Closes #76