### PR TITLE
Add original technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Clockwork Mercy
+
+The build begins with borrowed light,
+A quiet pulse through copper lanes;
+It asks the tests to speak outright,
+Then names the fault before it wanes.
+
+A function learns to leave a trace,
+A log keeps watch where humans sleep;
+Small signals gather into place,
+And patient loops remember deep.
+
+No magic hides behind the screen,
+Just careful hands and honest code;
+A cleaner path through what has been,
+A kinder map for what is owed.
+
+So ship the fix with steady breath,
+Let review turn doubt to trust;
+The best machines are shaped by depth,
+And made more human when they must.


### PR DESCRIPTION
## Summary
- Adds an original four-stanza technical poem in `POEM.md`.

## Creative decision
I chose a compact lyrical form about tests, logs, review, and humane engineering so the poem feels specific to a software project rather than generic filler.

Closes #76