### PR TITLE
feat: add original poem for FreelanceFlow project

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,23 @@
+# POEM.md
+
+## The Freelancer's Compass
+
+*In bytes and logic, dreams take flight,*  
+*Through endless loops of day and night.*  
+*A bid is placed, a job is found,*  
+*Where skills and purpose both are bound.*
+
+*The clock ticks on, the cursor blinks,*  
+*A freelancer thinks, connects, and links.*  
+*From coffee steam to moonlight glow,*  
+*A craft refined, a code to grow.*
+
+*Each pull request, a bridge they weave,*  
+*With every line, they dare believe*  
+*That pixels, text, and API calls*  
+*Can build the walls where freedom falls.*
+
+*No corner office, no nine-to-five,*  
+*In this marketplace, they feel alive.*  
+*The FreelanceFlow — a digital sea,*  
+*Where work meets worth, and souls are free.*


### PR DESCRIPTION
/claim #76

Added original 4-stanza poem "The Freelancer's Compass" for the FreelanceFlow project.

Creative decision: Rhyming quatrains mapping the freelance journey from bid to delivery — reflects the full lifecycle within the platform.

Closes #76