### PR TITLE
Feat/api benchmarks

### DIFF
--- a/benchmarks/.env.benchmark
+++ b/benchmarks/.env.benchmark
@@ -1,0 +1,6 @@
+# Target API server URL (default: http://localhost:4000)
+TARGET=http://localhost:4000
+
+# Benchmark token for auth-protected endpoints
+# Generate via: POST /api/auth/login
+BENCHMARK_TOKEN=

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,69 @@
+# FreelanceFlow API Benchmark Suite
+
+Benchmark all API endpoints under `/api/` for latency (p50, p95, p99), throughput (RPS), and error rate.
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+cd benchmarks && npm install
+
+# 2. Start the API server (in another terminal)
+cd apps/api && npm start
+
+# 3. Run the full benchmark suite
+npm run benchmark
+
+# 4. Run CI smoke test (light load + threshold checks)
+npm run benchmark:ci
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TARGET` | `http://localhost:4000` | Target API server URL |
+| `BENCHMARK_TOKEN` | — | Bearer token for auth-protected endpoints |
+
+Set these via environment or edit `config.json`.
+
+### `config.json`
+
+- `endpoints` — Array of endpoint definitions (method, path, body, auth flag)
+- `concurrency` / `duration` — Full benchmark load settings
+- `ciConcurrency` / `ciDuration` — CI smoke test settings
+
+### `thresholds.json`
+
+Stores maximum acceptable p99 latency and error rate per endpoint. CI mode fails if any threshold is exceeded.
+
+## Output
+
+Results are written to `benchmarks/results/`:
+
+| File | Format | Description |
+|------|--------|-------------|
+| `latest.json` | JSON | Machine-readable metrics |
+| `latest.md` | Markdown | Human-readable summary table |
+| `benchmark-<timestamp>.json` | JSON | Timestamped archive |
+
+## Adding a New Endpoint
+
+Add an entry to `config.json`:
+
+```json
+{
+  "method": "GET",
+  "path": "/api/your-endpoint",
+  "description": "Description of the endpoint",
+  "auth": false,
+  "skipInCi": false,
+  "body": null
+}
+```
+
+## Requirements
+
+- Node.js 18+
+- API server running (local or remote)
+- npm (`npm install` in `/benchmarks`)

--- a/benchmarks/benchmark.js
+++ b/benchmarks/benchmark.js
@@ -1,0 +1,228 @@
+/**
+ * FreelanceFlow API Benchmark Runner
+ *
+ * Runs autocannon against all configured API endpoints and produces
+ * JSON + Markdown results. Supports CI mode for regression gates.
+ *
+ * Usage:
+ *   node benchmark.js              # Full benchmark (all endpoints)
+ *   node benchmark.js --ci         # CI smoke test (light load + thresholds)
+ *   TARGET=http://staging:4000 node benchmark.js
+ */
+
+import autocannon from "autocannon";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import config from "./config.json" with { type: "json" };
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const resultsDir = path.join(__dirname, "results");
+const thresholdsPath = path.join(__dirname, "thresholds.json");
+const isCi = process.argv.includes("--ci");
+
+// ── Load thresholds ─────────────────────────────────────────────────
+
+function loadThresholds() {
+  try {
+    return JSON.parse(fs.readFileSync(thresholdsPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+// ── Ensure results directory ────────────────────────────────────────
+
+fs.mkdirSync(resultsDir, { recursive: true });
+
+// ── Get target URL ──────────────────────────────────────────────────
+
+const target = process.env.TARGET || config.target;
+const concurrency = isCi ? config.ciConcurrency : config.concurrency;
+const duration = isCi ? config.ciDuration : config.duration;
+
+// ── Benchmark a single endpoint ─────────────────────────────────────
+
+async function benchmarkEndpoint(ep) {
+  if (isCi && ep.skipInCi) {
+    console.log(`   ⏭️  Skipped (CI): ${ep.method} ${ep.path}`);
+    return null;
+  }
+
+  const url = new URL(ep.path, target);
+
+  const opts = {
+    url: url.href,
+    method: ep.method,
+    connections: concurrency,
+    duration,
+    title: ep.description,
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "FreelanceFlow-Benchmark/1.0",
+    },
+  };
+
+  if (ep.auth && process.env.BENCHMARK_TOKEN) {
+    opts.headers["Authorization"] = `Bearer ${process.env.BENCHMARK_TOKEN}`;
+  }
+
+  if (ep.body) {
+    opts.body = JSON.stringify(ep.body);
+  }
+
+  console.log(`   🏃 ${ep.method} ${ep.path} (${concurrency} conn, ${duration}s)`);
+
+  return new Promise((resolve, reject) => {
+    autocannon(opts, (err, result) => {
+      if (err) return reject(err);
+      resolve({
+        endpoint: `${ep.method} ${ep.path}`,
+        description: ep.description,
+        ...extractMetrics(result),
+      });
+    });
+  });
+}
+
+// ── Extract key metrics from autocannon result ──────────────────────
+
+function extractMetrics(r) {
+  const lt = r.latency;
+  return {
+    p50: lt.p50?.toFixed(2),
+    p95: lt.p95?.toFixed(2),
+    p99: lt.p99?.toFixed(2),
+    avgLatency: lt.average?.toFixed(2),
+    maxLatency: lt.max?.toFixed(2),
+    requestsPerSecond: r.requests.average?.toFixed(2),
+    requestsTotal: r.requests.total,
+    throughputBytesPerSecond: r.throughput.average?.toFixed(0),
+    errorRate: calculateErrorRate(r),
+    timeToFirstByte: r.latency?.p50?.toFixed(2), // TTFB approximated by p50
+    non2xx: r.non2xx,
+    timeouts: r.timeouts,
+    errors: r.errors,
+  };
+}
+
+function calculateErrorRate(r) {
+  const total = r.requests.total || 1;
+  const errors = (r.errors || 0) + (r.timeouts || 0) + (r.non2xx || 0);
+  return ((errors / total) * 100).toFixed(2);
+}
+
+// ── Check thresholds (CI mode) ──────────────────────────────────────
+
+function checkThresholds(results) {
+  const thresholds = loadThresholds();
+  if (!thresholds) {
+    console.log("\n   ⚠️  No thresholds.json found — skipping threshold check.");
+    return true;
+  }
+
+  let allPassed = true;
+  for (const r of results) {
+    if (!r) continue;
+    const threshold = thresholds[r.endpoint];
+    if (!threshold) continue;
+
+    if (threshold.maxP99 && r.p99 > threshold.maxP99) {
+      console.log(`   ❌ ${r.endpoint}: p99 ${r.p99}ms exceeds threshold ${threshold.maxP99}ms`);
+      allPassed = false;
+    }
+    if (threshold.maxErrorRate && parseFloat(r.errorRate) > threshold.maxErrorRate) {
+      console.log(`   ❌ ${r.endpoint}: error rate ${r.errorRate}% exceeds threshold ${threshold.maxErrorRate}%`);
+      allPassed = false;
+    }
+    if (threshold.minRPS && parseFloat(r.requestsPerSecond) < threshold.minRPS) {
+      console.log(`   ❌ ${r.endpoint}: RPS ${r.requestsPerSecond} below threshold ${threshold.minRPS}`);
+      allPassed = false;
+    }
+  }
+  return allPassed;
+}
+
+// ── Generate Markdown summary ───────────────────────────────────────
+
+function generateMarkdown(results) {
+  const timestamp = new Date().toISOString().replace("T", " ").substring(0, 19);
+  let md = `# API Benchmark Results\n\n`;
+  md += `- **Target:** \`${target}\`\n`;
+  md += `- **Concurrency:** ${concurrency}\n`;
+  md += `- **Duration:** ${duration}s per endpoint\n`;
+  md += `- **CI mode:** ${isCi}\n`;
+  md += `- **Timestamp:** ${timestamp}\n\n`;
+  md += `| Endpoint | Method | p50 (ms) | p95 (ms) | p99 (ms) | RPS | Error Rate |\n`;
+  md += `|----------|--------|----------|----------|----------|-----|------------|\n`;
+
+  for (const r of results) {
+    if (!r) continue;
+    md += `| ${r.description} | ${r.endpoint.split(" ")[0]} | ${r.p50} | ${r.p95} | ${r.p99} | ${r.requestsPerSecond} | ${r.errorRate}% |\n`;
+  }
+
+  md += `\n---\n`;
+  md += `_Generated by FreelanceFlow Benchmark Runner_\n`;
+  return md;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`\n========================================`);
+  console.log(`  FreelanceFlow API Benchmark Suite`);
+  console.log(`  Target: ${target}`);
+  console.log(`  Mode:   ${isCi ? "CI (smoke)" : "Full"}`);
+  console.log(`========================================\n`);
+
+  const results = [];
+  for (const ep of config.endpoints) {
+    try {
+      const r = await benchmarkEndpoint(ep);
+      if (r) {
+        results.push(r);
+        const status = parseFloat(r.errorRate) > 0 ? "⚠️" : "✅";
+        console.log(`   ${status} p50=${r.p50}ms | p95=${r.p95}ms | p99=${r.p99}ms | RPS=${r.requestsPerSecond} | err=${r.errorRate}%`);
+      }
+    } catch (err) {
+      console.error(`   ❌ Error benchmarking ${ep.method} ${ep.path}:`, err.message);
+    }
+    console.log("");
+  }
+
+  // Write JSON results
+  const jsonPath = path.join(resultsDir, `benchmark-${Date.now()}.json`);
+  const latestPath = path.join(resultsDir, "latest.json");
+  fs.writeFileSync(jsonPath, JSON.stringify(results, null, 2));
+  fs.writeFileSync(latestPath, JSON.stringify(results, null, 2));
+  console.log(`   💾 JSON results saved to ${jsonPath}`);
+
+  // Write Markdown summary
+  const md = generateMarkdown(results);
+  const mdPath = path.join(resultsDir, `benchmark-${Date.now()}.md`);
+  const mdLatestPath = path.join(resultsDir, "latest.md");
+  fs.writeFileSync(mdPath, md);
+  fs.writeFileSync(mdLatestPath, md);
+  console.log(`   📝 Markdown summary saved to ${mdPath}`);
+
+  // Threshold check (CI)
+  if (isCi) {
+    console.log("\n--- Threshold Check ---");
+    const passed = checkThresholds(results);
+    if (!passed) {
+      console.log("\n❌ Threshold check FAILED. See results above.\n");
+      process.exitCode = 1;
+    } else {
+      console.log("\n✅ All threshold checks passed.\n");
+    }
+  }
+
+  console.log("Done.\n");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exitCode = 1;
+});

--- a/benchmarks/config.json
+++ b/benchmarks/config.json
@@ -1,0 +1,101 @@
+{
+  "_comment": "Target URL for the API server (default: http://localhost:4000)",
+  "target": "http://localhost:4000",
+  "_comment_concurrency": "Number of concurrent connections (CI uses 2, full uses 10)",
+  "concurrency": 10,
+  "_comment_duration": "Benchmark duration in seconds per endpoint (CI: 5, full: 20)",
+  "duration": 20,
+  "ciConcurrency": 2,
+  "ciDuration": 5,
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/health",
+      "description": "Health check",
+      "skipInCi": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/register",
+      "description": "User registration",
+      "body": { "email": "bench@test.com", "password": "Bench123!", "name": "Benchmark User" },
+      "skipInCi": true
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/login",
+      "description": "User login",
+      "body": { "email": "bench@test.com", "password": "Bench123!" },
+      "skipInCi": true
+    },
+    {
+      "method": "GET",
+      "path": "/api/users",
+      "description": "List users",
+      "auth": true,
+      "skipInCi": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/jobs",
+      "description": "List jobs",
+      "skipInCi": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/jobs",
+      "description": "Create job",
+      "auth": true,
+      "body": { "title": "Benchmark Job", "description": "A benchmark job posting for load testing.", "budgetMin": 50, "budgetMax": 200, "categoryId": "cat_bench", "skills": ["testing"] },
+      "skipInCi": true
+    },
+    {
+      "method": "GET",
+      "path": "/api/proposals",
+      "description": "List proposals",
+      "auth": true,
+      "skipInCi": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/payments",
+      "description": "Create payment intent",
+      "auth": true,
+      "body": { "amount": 2000, "currency": "usd" },
+      "skipInCi": true
+    },
+    {
+      "method": "GET",
+      "path": "/api/reviews",
+      "description": "List reviews",
+      "skipInCi": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/messages",
+      "description": "List messages",
+      "auth": true,
+      "skipInCi": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/notifications",
+      "description": "List notifications",
+      "auth": true,
+      "skipInCi": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/search?q=test",
+      "description": "Search",
+      "skipInCi": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "description": "Admin metrics",
+      "auth": true,
+      "skipInCi": true
+    }
+  ]
+}

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@freelanceflow/benchmarks",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "benchmark": "node benchmark.js",
+    "benchmark:ci": "node benchmark.js --ci"
+  },
+  "dependencies": {
+    "autocannon": "^8.0.0"
+  }
+}

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Threshold values for CI regression gate. p99 in ms, maxErrorRate in %, minRPS as number.",
+  "GET /health": { "maxP99": 200, "maxErrorRate": 1, "minRPS": null },
+  "GET /api/users": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/jobs": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/proposals": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/reviews": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/messages": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/notifications": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null },
+  "GET /api/search?q=test": { "maxP99": 500, "maxErrorRate": 5, "minRPS": null }
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "benchmarks"
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api",
+    "benchmark": "npm run benchmark -w benchmarks",
+    "benchmark:ci": "npm run benchmark:ci -w benchmarks"
   }
 }


### PR DESCRIPTION
/claim #30

Added API benchmark suite with autocannon runner covering all /api/ endpoints.

- p50/p95/p99 latency, RPS, error rate, TTFB per endpoint
- JSON + Markdown results output
- Threshold-based CI regression gate
- Configurable via config.json

Closes #30