### PR TITLE
Add original bounty workflow poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Warranty Ledger
+
+Before a bid becomes a promise,
+scope is written down in light;
+each line a small, deliberate border
+between the possible and the right.
+
+A proof arrives with quiet footsteps,
+not a boast and not a flare;
+just steps to reproduce the weather
+that made the hidden fault appear.
+
+The reviewer reads like someone building
+a bridge from doubt to earned release;
+tests turn rumor into signal,
+and patched code settles into peace.
+
+Then payout closes like a handshake,
+not the ending, but the trace:
+work made visible, risk made smaller,
+trust recorded in its place.


### PR DESCRIPTION
/claim #76

## Summary
- Add an original poem as `POEM.md` in the repository root.
- Keep the change scoped to the single requested Markdown file.

## Creative Decision
I used a warranty-ledger theme because this project centers on trusted freelance/bounty workflows: scope, proof, review, and payout. The poem uses four concise quatrains so each stanza maps to one checkpoint in that workflow.

## Validation
- `git diff --check HEAD~1 HEAD` passed.
- `POEM.md` has 4 stanzas, exceeding the 3-stanza minimum.
- I attempted `npm test`, but the root test script recursively re-invoked `npm run test -w apps/api` with accumulating workspace arguments and failed before running useful tests; this PR only adds Markdown content.

Closes #76