### PR TITLE
Add reproducible API benchmark suite

### DIFF
--- a/.github/workflows/api-benchmark-smoke.yml
+++ b/.github/workflows/api-benchmark-smoke.yml
@@ -1,0 +1,30 @@
+name: API benchmark smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/api-benchmark-smoke.yml"
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run API benchmark smoke gate
+        run: npm run benchmark:api:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 dist
 .env
 .env.*
+!benchmarks/api/.env.benchmark.example
 coverage
 *.log

--- a/benchmarks/api/.env.benchmark.example
+++ b/benchmarks/api/.env.benchmark.example
@@ -1,0 +1,11 @@
+# Optional target server. Leave blank to let the runner self-host the Express app.
+API_BENCHMARK_BASE_URL=
+
+# Default local smoke load. Increase these for staging or dedicated performance runs.
+API_BENCHMARK_REQUESTS_PER_ENDPOINT=6
+API_BENCHMARK_CONCURRENCY=2
+API_BENCHMARK_TIMEOUT_MS=10000
+
+# Report paths.
+API_BENCHMARK_JSON=benchmarks/results/api-latest.json
+API_BENCHMARK_MARKDOWN=benchmarks/results/api-latest.md

--- a/benchmarks/api/README.md
+++ b/benchmarks/api/README.md
@@ -1,0 +1,95 @@
+# API Benchmark Suite
+
+This benchmark suite exercises every current `/api/*` route in the Express API and records latency, throughput, error rate, and TTFB metrics.
+
+By default the runner starts the API app on a random local port, runs the benchmark, writes reports, and shuts the server down. You can also point it at an already running API server with `--base-url`.
+
+## Run
+
+```bash
+npm run benchmark:api
+```
+
+The default run sends a small request set to avoid tripping the API rate limiter during local smoke tests:
+
+```bash
+node benchmarks/api/benchmark.mjs --requests-per-endpoint 6 --concurrency 2
+```
+
+For a larger run against a deployed or locally tuned server:
+
+```bash
+node benchmarks/api/benchmark.mjs \
+  --base-url http://127.0.0.1:4000 \
+  --requests-per-endpoint 100 \
+  --concurrency 10 \
+  --output benchmarks/api/results/staging.json \
+  --markdown benchmarks/api/results/staging.md
+```
+
+## Covered Routes
+
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/auth/oauth/:provider/callback`
+- `POST /api/auth/refresh`
+- `GET /api/users`
+- `POST /api/users`
+- `GET /api/jobs`
+- `POST /api/jobs`
+- `GET /api/proposals`
+- `POST /api/proposals`
+- `POST /api/payments`
+- `GET /api/reviews`
+- `POST /api/reviews`
+- `GET /api/messages`
+- `POST /api/messages`
+- `GET /api/notifications`
+- `POST /api/notifications`
+- `POST /api/uploads`
+- `GET /api/search`
+- `GET /api/admin/metrics`
+
+## Metrics
+
+Each endpoint report includes:
+
+- request count
+- status-code distribution
+- error rate
+- sustained and peak requests per second
+- p50, p95, p99, and max latency
+- p50, p95, p99, and max TTFB
+- up to three sample errors for failed requests
+
+Reports are written to:
+
+- `benchmarks/results/api-latest.json`
+- `benchmarks/results/api-latest.md`
+
+## Benchmark Environment
+
+Copy the template and adjust values for staging or CI:
+
+```bash
+cp benchmarks/api/.env.benchmark.example .env.benchmark
+```
+
+The runner reads these environment variables when they are exported by your shell or CI job:
+
+- `API_BENCHMARK_BASE_URL`
+- `API_BENCHMARK_REQUESTS_PER_ENDPOINT`
+- `API_BENCHMARK_CONCURRENCY`
+- `API_BENCHMARK_TIMEOUT_MS`
+- `API_BENCHMARK_JSON`
+- `API_BENCHMARK_MARKDOWN`
+
+## Regression Gate
+
+The smoke gate compares a JSON report with `benchmarks/thresholds.json`:
+
+```bash
+npm run benchmark:api:smoke
+```
+
+The gate fails if any endpoint exceeds its p99 latency threshold or error-rate threshold.

--- a/benchmarks/api/assert-thresholds.mjs
+++ b/benchmarks/api/assert-thresholds.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+function parseArgs(argv) {
+  const options = {
+    report: "benchmarks/results/api-latest.json",
+    thresholds: "benchmarks/thresholds.json"
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const value = argv[i + 1];
+
+    if (arg === "--report") {
+      options.report = value;
+      i += 1;
+    } else if (arg === "--thresholds") {
+      options.thresholds = value;
+      i += 1;
+    } else if (arg === "--help") {
+      console.log(`Usage: node benchmarks/api/assert-thresholds.mjs [options]
+
+Options:
+  --report <path>       Benchmark JSON report. Default: benchmarks/results/api-latest.json
+  --thresholds <path>   Threshold JSON file. Default: benchmarks/thresholds.json
+`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function thresholdFor(thresholds, endpointName) {
+  return {
+    ...thresholds.defaults,
+    ...(thresholds.endpoints?.[endpointName] ?? {})
+  };
+}
+
+function mainFailures(report, thresholds) {
+  const failures = [];
+
+  for (const endpoint of report.endpoints) {
+    const threshold = thresholdFor(thresholds, endpoint.name);
+
+    if (endpoint.latencyMs.p99 > threshold.p99LatencyMs) {
+      failures.push(
+        `${endpoint.name} p99 ${endpoint.latencyMs.p99}ms exceeded ${threshold.p99LatencyMs}ms`
+      );
+    }
+
+    if (endpoint.errorRate > threshold.errorRate) {
+      failures.push(
+        `${endpoint.name} error rate ${formatPercent(endpoint.errorRate)} exceeded ${formatPercent(
+          threshold.errorRate
+        )}`
+      );
+    }
+  }
+
+  return failures;
+}
+
+function formatPercent(value) {
+  return `${Math.round(value * 10_000) / 100}%`;
+}
+
+const options = parseArgs(process.argv.slice(2));
+const report = await readJson(options.report);
+const thresholds = await readJson(options.thresholds);
+const failures = mainFailures(report, thresholds);
+
+if (failures.length > 0) {
+  console.error("Benchmark threshold failures:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Benchmark thresholds passed for ${report.endpoints.length} endpoints using ${options.thresholds}`
+);

--- a/benchmarks/api/benchmark.mjs
+++ b/benchmarks/api/benchmark.mjs
@@ -1,0 +1,557 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { createApp } from "../../apps/api/src/app.js";
+
+const DEFAULT_OPTIONS = {
+  baseUrl: process.env.API_BENCHMARK_BASE_URL ?? "",
+  concurrency: Number(process.env.API_BENCHMARK_CONCURRENCY ?? 2),
+  requestsPerEndpoint: Number(process.env.API_BENCHMARK_REQUESTS_PER_ENDPOINT ?? 6),
+  output: process.env.API_BENCHMARK_JSON ?? "benchmarks/results/api-latest.json",
+  markdown: process.env.API_BENCHMARK_MARKDOWN ?? "benchmarks/results/api-latest.md",
+  timeoutMs: Number(process.env.API_BENCHMARK_TIMEOUT_MS ?? 10_000)
+};
+
+function parseArgs(argv) {
+  const options = { ...DEFAULT_OPTIONS };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const value = argv[i + 1];
+
+    if (arg === "--base-url") {
+      options.baseUrl = value;
+      i += 1;
+    } else if (arg === "--concurrency") {
+      options.concurrency = Number(value);
+      i += 1;
+    } else if (arg === "--requests-per-endpoint") {
+      options.requestsPerEndpoint = Number(value);
+      i += 1;
+    } else if (arg === "--output") {
+      options.output = value;
+      i += 1;
+    } else if (arg === "--markdown") {
+      options.markdown = value;
+      i += 1;
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = Number(value);
+      i += 1;
+    } else if (arg === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(options.concurrency) || options.concurrency < 1) {
+    throw new Error("--concurrency must be a positive integer");
+  }
+
+  if (!Number.isInteger(options.requestsPerEndpoint) || options.requestsPerEndpoint < 1) {
+    throw new Error("--requests-per-endpoint must be a positive integer");
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`API benchmark runner
+
+Usage:
+  node benchmarks/api/benchmark.mjs [options]
+
+Options:
+  --base-url <url>                 Benchmark an already running API server.
+                                   If omitted, the runner starts the Express app on a random local port.
+  --concurrency <n>                Concurrent requests per endpoint. Default: 2
+  --requests-per-endpoint <n>      Requests to send to each endpoint. Default: 6
+  --output <path>                  JSON report path. Default: benchmarks/results/api-latest.json
+  --markdown <path>                Markdown report path. Default: benchmarks/results/api-latest.md
+  --timeout-ms <n>                 Per-request timeout. Default: 10000
+`);
+}
+
+const ENDPOINTS = [
+  {
+    name: "auth.register",
+    method: "POST",
+    path: "/api/auth/register",
+    json: ({ sequence }) => ({
+      email: `bench-register-${Date.now()}-${sequence}@example.test`,
+      password: "benchmark-pass",
+      role: "client"
+    })
+  },
+  {
+    name: "auth.login",
+    method: "POST",
+    path: "/api/auth/login",
+    json: ({ sequence }) => ({
+      email: `bench-login-${sequence}@example.test`,
+      password: "benchmark-pass"
+    })
+  },
+  {
+    name: "auth.oauthCallback",
+    method: "GET",
+    path: "/api/auth/oauth/github/callback"
+  },
+  {
+    name: "auth.refresh",
+    method: "POST",
+    path: "/api/auth/refresh"
+  },
+  {
+    name: "users.list",
+    method: "GET",
+    path: "/api/users"
+  },
+  {
+    name: "users.create",
+    method: "POST",
+    path: "/api/users",
+    json: ({ sequence }) => ({
+      email: `bench-user-${Date.now()}-${sequence}@example.test`,
+      name: "Benchmark User",
+      role: "client"
+    })
+  },
+  {
+    name: "jobs.list",
+    method: "GET",
+    path: "/api/jobs"
+  },
+  {
+    name: "jobs.create",
+    method: "POST",
+    path: "/api/jobs",
+    json: ({ sequence }) => ({
+      title: `Benchmark job ${sequence}`,
+      description: "Benchmark job used to exercise the job creation endpoint.",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "benchmark",
+      skills: ["benchmark", "api"]
+    })
+  },
+  {
+    name: "proposals.list",
+    method: "GET",
+    path: "/api/proposals"
+  },
+  {
+    name: "proposals.create",
+    method: "POST",
+    path: "/api/proposals",
+    json: ({ sequence }) => ({
+      jobId: `job_benchmark_${sequence}`,
+      freelancerId: `usr_benchmark_${sequence}`,
+      coverLetter: "Benchmark proposal payload.",
+      bidAmount: 250
+    })
+  },
+  {
+    name: "payments.create",
+    method: "POST",
+    path: "/api/payments",
+    json: ({ sequence }) => ({
+      amount: 125 + sequence,
+      currency: "usd",
+      jobId: `job_benchmark_${sequence}`
+    })
+  },
+  {
+    name: "reviews.list",
+    method: "GET",
+    path: "/api/reviews"
+  },
+  {
+    name: "reviews.create",
+    method: "POST",
+    path: "/api/reviews",
+    json: ({ sequence }) => ({
+      reviewerId: `usr_reviewer_${sequence}`,
+      revieweeId: `usr_reviewee_${sequence}`,
+      rating: 5,
+      comment: "Benchmark review payload."
+    })
+  },
+  {
+    name: "messages.list",
+    method: "GET",
+    path: "/api/messages"
+  },
+  {
+    name: "messages.create",
+    method: "POST",
+    path: "/api/messages",
+    json: ({ sequence }) => ({
+      senderId: `usr_sender_${sequence}`,
+      recipientId: `usr_recipient_${sequence}`,
+      body: "Benchmark message payload."
+    })
+  },
+  {
+    name: "notifications.list",
+    method: "GET",
+    path: "/api/notifications"
+  },
+  {
+    name: "notifications.create",
+    method: "POST",
+    path: "/api/notifications",
+    json: ({ sequence }) => ({
+      userId: `usr_notify_${sequence}`,
+      type: "benchmark",
+      message: "Benchmark notification payload."
+    })
+  },
+  {
+    name: "uploads.create",
+    method: "POST",
+    path: "/api/uploads",
+    form: ({ sequence }) => {
+      const form = new FormData();
+      form.append(
+        "file",
+        new Blob([`benchmark upload ${sequence}\n`], { type: "text/plain" }),
+        `benchmark-${sequence}.txt`
+      );
+      return form;
+    }
+  },
+  {
+    name: "search.global",
+    method: "GET",
+    path: "/api/search?q=benchmark"
+  },
+  {
+    name: "admin.metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    headers: ({ adminToken }) => ({
+      authorization: `Bearer ${adminToken}`
+    })
+  }
+];
+
+async function startSelfHostedServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolveListening, rejectListening) => {
+    server.once("listening", resolveListening);
+    server.once("error", rejectListening);
+  });
+
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()));
+      })
+  };
+}
+
+async function buildContext(baseUrl, timeoutMs) {
+  const registration = await executeRequest(
+    baseUrl,
+    {
+      name: "setup.adminToken",
+      method: "POST",
+      path: "/api/auth/register",
+      json: () => ({
+        email: `bench-admin-${Date.now()}@example.test`,
+        password: "benchmark-pass",
+        role: "admin"
+      })
+    },
+    { sequence: 0, timeoutMs }
+  );
+
+  const adminToken = registration.payload?.data?.token;
+  if (!adminToken) {
+    throw new Error("Could not create benchmark admin token");
+  }
+
+  return { adminToken, timeoutMs };
+}
+
+async function executeRequest(baseUrl, endpoint, context) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), context.timeoutMs);
+  const headers = {
+    ...(endpoint.headers?.(context) ?? {})
+  };
+
+  let body;
+  if (endpoint.json) {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify(endpoint.json(context));
+  } else if (endpoint.form) {
+    body = endpoint.form(context);
+  }
+
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(`${baseUrl}${endpoint.path}`, {
+      method: endpoint.method,
+      headers,
+      body,
+      signal: controller.signal
+    });
+    const firstByteAt = performance.now();
+    const text = await response.text();
+    const endedAt = performance.now();
+
+    let payload = null;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch {
+      payload = null;
+    }
+
+    return {
+      endpoint: endpoint.name,
+      method: endpoint.method,
+      path: endpoint.path,
+      status: response.status,
+      ok: response.status < 400,
+      ttfbMs: firstByteAt - startedAt,
+      durationMs: endedAt - startedAt,
+      bytes: Buffer.byteLength(text),
+      startedAt,
+      endedAt,
+      payload
+    };
+  } catch (error) {
+    const endedAt = performance.now();
+    return {
+      endpoint: endpoint.name,
+      method: endpoint.method,
+      path: endpoint.path,
+      status: 0,
+      ok: false,
+      error: error.name === "AbortError" ? "timeout" : error.message,
+      ttfbMs: endedAt - startedAt,
+      durationMs: endedAt - startedAt,
+      bytes: 0,
+      startedAt,
+      endedAt
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function runEndpoint(baseUrl, endpoint, context, options) {
+  const samples = [];
+  let nextSequence = 0;
+  const startedAt = performance.now();
+
+  async function worker() {
+    while (nextSequence < options.requestsPerEndpoint) {
+      const sequence = nextSequence;
+      nextSequence += 1;
+      samples.push(await executeRequest(baseUrl, endpoint, { ...context, sequence }));
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(options.concurrency, options.requestsPerEndpoint) }, () => worker())
+  );
+
+  const endedAt = performance.now();
+  return summarizeEndpoint(endpoint, samples, endedAt - startedAt);
+}
+
+function summarizeEndpoint(endpoint, samples, wallTimeMs) {
+  const durations = samples.map((sample) => sample.durationMs);
+  const ttfb = samples.map((sample) => sample.ttfbMs);
+  const failures = samples.filter((sample) => !sample.ok);
+
+  return {
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    requests: samples.length,
+    failures: failures.length,
+    errorRate: failures.length / samples.length,
+    rps: samples.length / (wallTimeMs / 1000),
+    sustainedRps: samples.length / (wallTimeMs / 1000),
+    peakRps: calculatePeakRps(samples, wallTimeMs),
+    latencyMs: {
+      p50: percentile(durations, 50),
+      p95: percentile(durations, 95),
+      p99: percentile(durations, 99),
+      max: Math.max(...durations)
+    },
+    ttfbMs: {
+      p50: percentile(ttfb, 50),
+      p95: percentile(ttfb, 95),
+      p99: percentile(ttfb, 99),
+      max: Math.max(...ttfb)
+    },
+    statuses: countBy(samples.map((sample) => sample.status)),
+    sampleErrors: failures.slice(0, 3).map((sample) => ({
+      status: sample.status,
+      error: sample.error ?? sample.payload?.message ?? "request failed"
+    }))
+  };
+}
+
+function calculatePeakRps(samples, wallTimeMs) {
+  if (wallTimeMs < 1000) {
+    return samples.length / (wallTimeMs / 1000);
+  }
+
+  const buckets = new Map();
+  const firstStart = Math.min(...samples.map((sample) => sample.startedAt));
+
+  for (const sample of samples) {
+    const bucket = Math.floor((sample.endedAt - firstStart) / 1000);
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+  }
+
+  return Math.max(...buckets.values());
+}
+
+function percentile(values, p) {
+  if (!values.length) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return round(sorted[index]);
+}
+
+function countBy(values) {
+  return values.reduce((counts, value) => {
+    counts[value] = (counts[value] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function buildSummary(results) {
+  const totalRequests = results.reduce((sum, result) => sum + result.requests, 0);
+  const totalFailures = results.reduce((sum, result) => sum + result.failures, 0);
+  const slowestP95 = [...results].sort((a, b) => b.latencyMs.p95 - a.latencyMs.p95)[0];
+  const highestErrorRate = [...results].sort((a, b) => b.errorRate - a.errorRate)[0];
+
+  return {
+    totalEndpoints: results.length,
+    totalRequests,
+    totalFailures,
+    errorRate: totalFailures / totalRequests,
+    slowestP95Endpoint: slowestP95?.name ?? null,
+    slowestP95Ms: slowestP95?.latencyMs.p95 ?? 0,
+    highestErrorRateEndpoint: highestErrorRate?.name ?? null,
+    highestErrorRate: highestErrorRate?.errorRate ?? 0
+  };
+}
+
+function renderMarkdown(report) {
+  const rows = report.endpoints
+    .map(
+      (result) =>
+        `| ${result.name} | ${result.method} | \`${result.path}\` | ${result.requests} | ${formatPercent(
+          result.errorRate
+        )} | ${round(result.sustainedRps)} | ${round(result.peakRps)} | ${result.latencyMs.p50} | ${result.latencyMs.p95} | ${
+          result.latencyMs.p99
+        } | ${result.ttfbMs.p95} |`
+    )
+    .join("\n");
+
+  return `# API Benchmark Report
+
+Generated: ${report.metadata.generatedAt}
+
+Base URL: \`${report.metadata.baseUrl}\`
+
+Requests per endpoint: ${report.metadata.requestsPerEndpoint}
+Concurrency per endpoint: ${report.metadata.concurrency}
+
+## Summary
+
+- Endpoints: ${report.summary.totalEndpoints}
+- Total requests: ${report.summary.totalRequests}
+- Total failures: ${report.summary.totalFailures}
+- Error rate: ${formatPercent(report.summary.errorRate)}
+- Slowest p95 endpoint: ${report.summary.slowestP95Endpoint} (${report.summary.slowestP95Ms} ms)
+
+## Endpoint Results
+
+| Endpoint | Method | Path | Requests | Error rate | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | p95 TTFB ms |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+${rows}
+`;
+}
+
+function formatPercent(value) {
+  return `${round(value * 100)}%`;
+}
+
+async function writeReport(path, data) {
+  const absolutePath = resolve(path);
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, data);
+  return absolutePath;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const hosted = options.baseUrl ? null : await startSelfHostedServer();
+  const baseUrl = options.baseUrl || hosted.baseUrl;
+
+  try {
+    const context = await buildContext(baseUrl, options.timeoutMs);
+    const endpoints = [];
+
+    for (const endpoint of ENDPOINTS) {
+      endpoints.push(await runEndpoint(baseUrl, endpoint, context, options));
+    }
+
+    const report = {
+      metadata: {
+        generatedAt: new Date().toISOString(),
+        baseUrl,
+        selfHosted: !options.baseUrl,
+        concurrency: options.concurrency,
+        requestsPerEndpoint: options.requestsPerEndpoint,
+        endpointCount: ENDPOINTS.length
+      },
+      summary: buildSummary(endpoints),
+      endpoints
+    };
+
+    const jsonPath = await writeReport(options.output, `${JSON.stringify(report, null, 2)}\n`);
+    const markdownPath = await writeReport(options.markdown, renderMarkdown(report));
+
+    console.log(`Wrote JSON report: ${jsonPath}`);
+    console.log(`Wrote Markdown report: ${markdownPath}`);
+    console.log(
+      `Benchmarked ${report.summary.totalEndpoints} endpoints with ${report.summary.totalRequests} requests`
+    );
+
+    if (report.summary.totalFailures > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await hosted?.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/benchmarks/results/api-latest.json
+++ b/benchmarks/results/api-latest.json
@@ -1,0 +1,562 @@
+{
+  "metadata": {
+    "generatedAt": "2026-05-19T11:30:23.177Z",
+    "baseUrl": "http://127.0.0.1:60906",
+    "selfHosted": true,
+    "concurrency": 2,
+    "requestsPerEndpoint": 6,
+    "endpointCount": 20
+  },
+  "summary": {
+    "totalEndpoints": 20,
+    "totalRequests": 120,
+    "totalFailures": 0,
+    "errorRate": 0,
+    "slowestP95Endpoint": "auth.register",
+    "slowestP95Ms": 9.93,
+    "highestErrorRateEndpoint": "auth.register",
+    "highestErrorRate": 0
+  },
+  "endpoints": [
+    {
+      "name": "auth.register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 284.3332385555875,
+      "sustainedRps": 284.3332385555875,
+      "peakRps": 284.3332385555875,
+      "latencyMs": {
+        "p50": 6.55,
+        "p95": 9.93,
+        "p99": 9.93,
+        "max": 9.925599999999974
+      },
+      "ttfbMs": {
+        "p50": 6.44,
+        "p95": 9.7,
+        "p99": 9.7,
+        "max": 9.696100000000001
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "auth.login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 671.7495717596449,
+      "sustainedRps": 671.7495717596449,
+      "peakRps": 671.7495717596449,
+      "latencyMs": {
+        "p50": 2.86,
+        "p95": 3.51,
+        "p99": 3.51,
+        "max": 3.510599999999954
+      },
+      "ttfbMs": {
+        "p50": 2.74,
+        "p95": 3.42,
+        "p99": 3.42,
+        "max": 3.4191999999999894
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "auth.oauthCallback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 937.514648666385,
+      "sustainedRps": 937.514648666385,
+      "peakRps": 937.514648666385,
+      "latencyMs": {
+        "p50": 2,
+        "p95": 2.57,
+        "p99": 2.57,
+        "max": 2.565999999999974
+      },
+      "ttfbMs": {
+        "p50": 1.92,
+        "p95": 2.41,
+        "p99": 2.41,
+        "max": 2.4144999999999754
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "auth.refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 944.4505658832924,
+      "sustainedRps": 944.4505658832924,
+      "peakRps": 944.4505658832924,
+      "latencyMs": {
+        "p50": 1.7,
+        "p95": 2.92,
+        "p99": 2.92,
+        "max": 2.9155000000000086
+      },
+      "ttfbMs": {
+        "p50": 1.64,
+        "p95": 2.82,
+        "p99": 2.82,
+        "max": 2.8238000000000056
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "users.list",
+      "method": "GET",
+      "path": "/api/users",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1499.2503748126114,
+      "sustainedRps": 1499.2503748126114,
+      "peakRps": 1499.2503748126114,
+      "latencyMs": {
+        "p50": 1.21,
+        "p95": 1.48,
+        "p99": 1.48,
+        "max": 1.4799999999999613
+      },
+      "ttfbMs": {
+        "p50": 1.16,
+        "p95": 1.43,
+        "p99": 1.43,
+        "max": 1.4302999999999884
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "users.create",
+      "method": "POST",
+      "path": "/api/users",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1069.1185117870318,
+      "sustainedRps": 1069.1185117870318,
+      "peakRps": 1069.1185117870318,
+      "latencyMs": {
+        "p50": 1.63,
+        "p95": 2.11,
+        "p99": 2.11,
+        "max": 2.109199999999987
+      },
+      "ttfbMs": {
+        "p50": 1.57,
+        "p95": 2.06,
+        "p99": 2.06,
+        "max": 2.055499999999995
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "jobs.list",
+      "method": "GET",
+      "path": "/api/jobs",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1678.9321991213444,
+      "sustainedRps": 1678.9321991213444,
+      "peakRps": 1678.9321991213444,
+      "latencyMs": {
+        "p50": 1.1,
+        "p95": 1.29,
+        "p99": 1.29,
+        "max": 1.294900000000041
+      },
+      "ttfbMs": {
+        "p50": 1.05,
+        "p95": 1.25,
+        "p99": 1.25,
+        "max": 1.2461999999999875
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "jobs.create",
+      "method": "POST",
+      "path": "/api/jobs",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 998.9511013435875,
+      "sustainedRps": 998.9511013435875,
+      "peakRps": 998.9511013435875,
+      "latencyMs": {
+        "p50": 1.76,
+        "p95": 2.27,
+        "p99": 2.27,
+        "max": 2.268699999999967
+      },
+      "ttfbMs": {
+        "p50": 1.7,
+        "p95": 2.22,
+        "p99": 2.22,
+        "max": 2.2169000000000096
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "proposals.list",
+      "method": "GET",
+      "path": "/api/proposals",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1359.8966478547602,
+      "sustainedRps": 1359.8966478547602,
+      "peakRps": 1359.8966478547602,
+      "latencyMs": {
+        "p50": 1.22,
+        "p95": 1.65,
+        "p99": 1.65,
+        "max": 1.6546999999999912
+      },
+      "ttfbMs": {
+        "p50": 1.16,
+        "p95": 1.56,
+        "p99": 1.56,
+        "max": 1.5631999999999948
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "proposals.create",
+      "method": "POST",
+      "path": "/api/proposals",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 842.1525418970905,
+      "sustainedRps": 842.1525418970905,
+      "peakRps": 842.1525418970905,
+      "latencyMs": {
+        "p50": 2.22,
+        "p95": 2.54,
+        "p99": 2.54,
+        "max": 2.542599999999993
+      },
+      "ttfbMs": {
+        "p50": 2.14,
+        "p95": 2.45,
+        "p99": 2.45,
+        "max": 2.448699999999974
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "payments.create",
+      "method": "POST",
+      "path": "/api/payments",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 808.668930939673,
+      "sustainedRps": 808.668930939673,
+      "peakRps": 808.668930939673,
+      "latencyMs": {
+        "p50": 2.28,
+        "p95": 2.83,
+        "p99": 2.83,
+        "max": 2.826599999999985
+      },
+      "ttfbMs": {
+        "p50": 2.19,
+        "p95": 2.77,
+        "p99": 2.77,
+        "max": 2.7719999999999914
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "reviews.list",
+      "method": "GET",
+      "path": "/api/reviews",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1623.0692239023901,
+      "sustainedRps": 1623.0692239023901,
+      "peakRps": 1623.0692239023901,
+      "latencyMs": {
+        "p50": 1.1,
+        "p95": 1.41,
+        "p99": 1.41,
+        "max": 1.4096000000000117
+      },
+      "ttfbMs": {
+        "p50": 1.05,
+        "p95": 1.36,
+        "p99": 1.36,
+        "max": 1.359800000000007
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "reviews.create",
+      "method": "POST",
+      "path": "/api/reviews",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1351.2296189532442,
+      "sustainedRps": 1351.2296189532442,
+      "peakRps": 1351.2296189532442,
+      "latencyMs": {
+        "p50": 1.39,
+        "p95": 1.68,
+        "p99": 1.68,
+        "max": 1.6820999999999913
+      },
+      "ttfbMs": {
+        "p50": 1.33,
+        "p95": 1.64,
+        "p99": 1.64,
+        "max": 1.6358000000000175
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "messages.list",
+      "method": "GET",
+      "path": "/api/messages",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1691.9519485646613,
+      "sustainedRps": 1691.9519485646613,
+      "peakRps": 1691.9519485646613,
+      "latencyMs": {
+        "p50": 1.09,
+        "p95": 1.27,
+        "p99": 1.27,
+        "max": 1.272100000000023
+      },
+      "ttfbMs": {
+        "p50": 1.05,
+        "p95": 1.23,
+        "p99": 1.23,
+        "max": 1.227200000000039
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "messages.create",
+      "method": "POST",
+      "path": "/api/messages",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1159.263481268233,
+      "sustainedRps": 1159.263481268233,
+      "peakRps": 1159.263481268233,
+      "latencyMs": {
+        "p50": 1.45,
+        "p95": 1.95,
+        "p99": 1.95,
+        "max": 1.949200000000019
+      },
+      "ttfbMs": {
+        "p50": 1.4,
+        "p95": 1.89,
+        "p99": 1.89,
+        "max": 1.8880000000000337
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "notifications.list",
+      "method": "GET",
+      "path": "/api/notifications",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1542.9320852727246,
+      "sustainedRps": 1542.9320852727246,
+      "peakRps": 1542.9320852727246,
+      "latencyMs": {
+        "p50": 1.22,
+        "p95": 1.4,
+        "p99": 1.4,
+        "max": 1.4003000000000156
+      },
+      "ttfbMs": {
+        "p50": 1.16,
+        "p95": 1.35,
+        "p99": 1.35,
+        "max": 1.353400000000022
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "notifications.create",
+      "method": "POST",
+      "path": "/api/notifications",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1291.1278001334101,
+      "sustainedRps": 1291.1278001334101,
+      "peakRps": 1291.1278001334101,
+      "latencyMs": {
+        "p50": 1.47,
+        "p95": 1.63,
+        "p99": 1.63,
+        "max": 1.6263999999999896
+      },
+      "ttfbMs": {
+        "p50": 1.43,
+        "p95": 1.58,
+        "p99": 1.58,
+        "max": 1.5827999999999633
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "uploads.create",
+      "method": "POST",
+      "path": "/api/uploads",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 428.75824466374644,
+      "sustainedRps": 428.75824466374644,
+      "peakRps": 428.75824466374644,
+      "latencyMs": {
+        "p50": 2.97,
+        "p95": 6.92,
+        "p99": 6.92,
+        "max": 6.916300000000035
+      },
+      "ttfbMs": {
+        "p50": 2.93,
+        "p95": 6.87,
+        "p99": 6.87,
+        "max": 6.8673
+      },
+      "statuses": {
+        "201": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "search.global",
+      "method": "GET",
+      "path": "/api/search?q=benchmark",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1338.8673182487591,
+      "sustainedRps": 1338.8673182487591,
+      "peakRps": 1338.8673182487591,
+      "latencyMs": {
+        "p50": 1.17,
+        "p95": 2.06,
+        "p99": 2.06,
+        "max": 2.0615000000000236
+      },
+      "ttfbMs": {
+        "p50": 1.11,
+        "p95": 1.98,
+        "p99": 1.98,
+        "max": 1.9816999999999894
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    },
+    {
+      "name": "admin.metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "requests": 6,
+      "failures": 0,
+      "errorRate": 0,
+      "rps": 1050.5121246607719,
+      "sustainedRps": 1050.5121246607719,
+      "peakRps": 1050.5121246607719,
+      "latencyMs": {
+        "p50": 1.49,
+        "p95": 2.71,
+        "p99": 2.71,
+        "max": 2.706899999999962
+      },
+      "ttfbMs": {
+        "p50": 1.44,
+        "p95": 2.65,
+        "p99": 2.65,
+        "max": 2.6451000000000136
+      },
+      "statuses": {
+        "200": 6
+      },
+      "sampleErrors": []
+    }
+  ]
+}

--- a/benchmarks/results/api-latest.md
+++ b/benchmarks/results/api-latest.md
@@ -1,0 +1,41 @@
+# API Benchmark Report
+
+Generated: 2026-05-19T11:30:23.177Z
+
+Base URL: `http://127.0.0.1:60906`
+
+Requests per endpoint: 6
+Concurrency per endpoint: 2
+
+## Summary
+
+- Endpoints: 20
+- Total requests: 120
+- Total failures: 0
+- Error rate: 0%
+- Slowest p95 endpoint: auth.register (9.93 ms)
+
+## Endpoint Results
+
+| Endpoint | Method | Path | Requests | Error rate | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | p95 TTFB ms |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| auth.register | POST | `/api/auth/register` | 6 | 0% | 284.33 | 284.33 | 6.55 | 9.93 | 9.93 | 9.7 |
+| auth.login | POST | `/api/auth/login` | 6 | 0% | 671.75 | 671.75 | 2.86 | 3.51 | 3.51 | 3.42 |
+| auth.oauthCallback | GET | `/api/auth/oauth/github/callback` | 6 | 0% | 937.51 | 937.51 | 2 | 2.57 | 2.57 | 2.41 |
+| auth.refresh | POST | `/api/auth/refresh` | 6 | 0% | 944.45 | 944.45 | 1.7 | 2.92 | 2.92 | 2.82 |
+| users.list | GET | `/api/users` | 6 | 0% | 1499.25 | 1499.25 | 1.21 | 1.48 | 1.48 | 1.43 |
+| users.create | POST | `/api/users` | 6 | 0% | 1069.12 | 1069.12 | 1.63 | 2.11 | 2.11 | 2.06 |
+| jobs.list | GET | `/api/jobs` | 6 | 0% | 1678.93 | 1678.93 | 1.1 | 1.29 | 1.29 | 1.25 |
+| jobs.create | POST | `/api/jobs` | 6 | 0% | 998.95 | 998.95 | 1.76 | 2.27 | 2.27 | 2.22 |
+| proposals.list | GET | `/api/proposals` | 6 | 0% | 1359.9 | 1359.9 | 1.22 | 1.65 | 1.65 | 1.56 |
+| proposals.create | POST | `/api/proposals` | 6 | 0% | 842.15 | 842.15 | 2.22 | 2.54 | 2.54 | 2.45 |
+| payments.create | POST | `/api/payments` | 6 | 0% | 808.67 | 808.67 | 2.28 | 2.83 | 2.83 | 2.77 |
+| reviews.list | GET | `/api/reviews` | 6 | 0% | 1623.07 | 1623.07 | 1.1 | 1.41 | 1.41 | 1.36 |
+| reviews.create | POST | `/api/reviews` | 6 | 0% | 1351.23 | 1351.23 | 1.39 | 1.68 | 1.68 | 1.64 |
+| messages.list | GET | `/api/messages` | 6 | 0% | 1691.95 | 1691.95 | 1.09 | 1.27 | 1.27 | 1.23 |
+| messages.create | POST | `/api/messages` | 6 | 0% | 1159.26 | 1159.26 | 1.45 | 1.95 | 1.95 | 1.89 |
+| notifications.list | GET | `/api/notifications` | 6 | 0% | 1542.93 | 1542.93 | 1.22 | 1.4 | 1.4 | 1.35 |
+| notifications.create | POST | `/api/notifications` | 6 | 0% | 1291.13 | 1291.13 | 1.47 | 1.63 | 1.63 | 1.58 |
+| uploads.create | POST | `/api/uploads` | 6 | 0% | 428.76 | 428.76 | 2.97 | 6.92 | 6.92 | 6.87 |
+| search.global | GET | `/api/search?q=benchmark` | 6 | 0% | 1338.87 | 1338.87 | 1.17 | 2.06 | 2.06 | 1.98 |
+| admin.metrics | GET | `/api/admin/metrics` | 6 | 0% | 1050.51 | 1050.51 | 1.49 | 2.71 | 2.71 | 2.65 |

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,11 @@
+{
+  "defaults": {
+    "p99LatencyMs": 250,
+    "errorRate": 0
+  },
+  "endpoints": {
+    "uploads.create": {
+      "p99LatencyMs": 500
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
+    "benchmark:api": "node benchmarks/api/benchmark.mjs",
+    "benchmark:api:smoke": "node benchmarks/api/benchmark.mjs --requests-per-endpoint 1 --concurrency 1 --output benchmarks/results/api-ci-smoke.json --markdown benchmarks/results/api-ci-smoke.md && node benchmarks/api/assert-thresholds.mjs --report benchmarks/results/api-ci-smoke.json --thresholds benchmarks/thresholds.json",
     "test": "npm run test -w apps/api"
   }
 }


### PR DESCRIPTION
## Summary
- Adds a dependency-free API benchmark runner under `benchmarks/api/`.
- Covers all 20 current `/api/*` endpoints with realistic JSON or multipart payloads.
- Uses a generated benchmark admin token for the protected admin metrics route.
- Writes JSON and Markdown reports to `benchmarks/results/`.
- Adds reviewable thresholds in `benchmarks/thresholds.json` plus a GitHub Actions smoke gate.

## Validation
- `npm run benchmark:api` (20 endpoints, 120 requests, 0 failures)
- `npm run benchmark:api:smoke` (20 endpoint smoke run, threshold gate passed)
- `node --test apps/api/src/tests/health.test.js`

Closes #30

## Benchmark Report

# API Benchmark Report

Generated: 2026-05-19T11:30:23.177Z

Base URL: `http://127.0.0.1:60906`

Requests per endpoint: 6
Concurrency per endpoint: 2

## Summary

- Endpoints: 20
- Total requests: 120
- Total failures: 0
- Error rate: 0%
- Slowest p95 endpoint: auth.register (9.93 ms)

## Endpoint Results

| Endpoint | Method | Path | Requests | Error rate | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | p95 TTFB ms |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| auth.register | POST | `/api/auth/register` | 6 | 0% | 284.33 | 284.33 | 6.55 | 9.93 | 9.93 | 9.7 |
| auth.login | POST | `/api/auth/login` | 6 | 0% | 671.75 | 671.75 | 2.86 | 3.51 | 3.51 | 3.42 |
| auth.oauthCallback | GET | `/api/auth/oauth/github/callback` | 6 | 0% | 937.51 | 937.51 | 2 | 2.57 | 2.57 | 2.41 |
| auth.refresh | POST | `/api/auth/refresh` | 6 | 0% | 944.45 | 944.45 | 1.7 | 2.92 | 2.92 | 2.82 |
| users.list | GET | `/api/users` | 6 | 0% | 1499.25 | 1499.25 | 1.21 | 1.48 | 1.48 | 1.43 |
| users.create | POST | `/api/users` | 6 | 0% | 1069.12 | 1069.12 | 1.63 | 2.11 | 2.11 | 2.06 |
| jobs.list | GET | `/api/jobs` | 6 | 0% | 1678.93 | 1678.93 | 1.1 | 1.29 | 1.29 | 1.25 |
| jobs.create | POST | `/api/jobs` | 6 | 0% | 998.95 | 998.95 | 1.76 | 2.27 | 2.27 | 2.22 |
| proposals.list | GET | `/api/proposals` | 6 | 0% | 1359.9 | 1359.9 | 1.22 | 1.65 | 1.65 | 1.56 |
| proposals.create | POST | `/api/proposals` | 6 | 0% | 842.15 | 842.15 | 2.22 | 2.54 | 2.54 | 2.45 |
| payments.create | POST | `/api/payments` | 6 | 0% | 808.67 | 808.67 | 2.28 | 2.83 | 2.83 | 2.77 |
| reviews.list | GET | `/api/reviews` | 6 | 0% | 1623.07 | 1623.07 | 1.1 | 1.41 | 1.41 | 1.36 |
| reviews.create | POST | `/api/reviews` | 6 | 0% | 1351.23 | 1351.23 | 1.39 | 1.68 | 1.68 | 1.64 |
| messages.list | GET | `/api/messages` | 6 | 0% | 1691.95 | 1691.95 | 1.09 | 1.27 | 1.27 | 1.23 |
| messages.create | POST | `/api/messages` | 6 | 0% | 1159.26 | 1159.26 | 1.45 | 1.95 | 1.95 | 1.89 |
| notifications.list | GET | `/api/notifications` | 6 | 0% | 1542.93 | 1542.93 | 1.22 | 1.4 | 1.4 | 1.35 |
| notifications.create | POST | `/api/notifications` | 6 | 0% | 1291.13 | 1291.13 | 1.47 | 1.63 | 1.63 | 1.58 |
| uploads.create | POST | `/api/uploads` | 6 | 0% | 428.76 | 428.76 | 2.97 | 6.92 | 6.92 | 6.87 |
| search.global | GET | `/api/search?q=benchmark` | 6 | 0% | 1338.87 | 1338.87 | 1.17 | 2.06 | 2.06 | 1.98 |
| admin.metrics | GET | `/api/admin/metrics` | 6 | 0% | 1050.51 | 1050.51 | 1.49 | 2.71 | 2.71 | 2.65 |

## Benchmark Environment

**Hardware**
- CPU model & core count: 12th Gen Intel(R) Core(TM) i9-12900HK, 14 cores / 20 logical processors
- RAM (total & available during benchmark): 31.77 GB total / about 6.52 GB free
- Storage type (SSD / NVMe / HDD): SSD, NVMe
- Network interface (Ethernet / WiFi / loopback): loopback
- Machine type (local workstation / cloud VM / CI runner ? include instance type if cloud): local workstation
- OS & version: Microsoft Windows 11 Home 10.0.26200

**Runtime**
- Node.js version (or relevant runtime): v24.11.0
- Any resource limits applied (Docker memory cap, cgroup limits, etc.): none
- Other significant processes running during benchmark (yes / no ? if yes, describe): yes, normal local desktop/background processes

**If submitted by or with an AI agent**
- Agent or tool name (e.g. Claude Code, Devin, Copilot Workspace, AutoGPT): OpenAI Codex
- Underlying model and version (e.g. claude-sonnet-4-5, gpt-4o ? if known): GPT-5-class Codex model
- Inference provider (e.g. Anthropic, OpenAI, Azure, self-hosted): OpenAI
- Orchestration framework if any (e.g. LangChain, AutoGen, custom): Codex desktop/tooling environment
- Execution mode (fully autonomous / human-supervised / human-initiated per step): human-initiated, agent-executed
- Did the agent have shell/tool access during execution (yes / no): yes
- Did the agent have internet access during execution (yes / no): yes
- Were benchmark commands run by the agent directly or handed off to the human to run: run directly by the agent
- Any known agent constraints or sandboxing that may have affected execution: benchmark was self-hosted on local loopback with a small request count; no external staging server was used