### PR TITLE
Add original poem for issue #76

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Workbench of Trust
+
+A brief arrives with edges still unclear,
+its budget held beside a careful name.
+The client writes the shape of what they need,
+the builder tests the promise, not the fame.
+
+A proposal folds the distance into terms:
+one scope, one price, one path through doubt and time.
+No handshake drifts away in private air;
+the record keeps each milestone in line.
+
+The work begins where messages stay bright,
+with proofs attached before the invoice speaks.
+Each review is not a gate to slow the craft,
+but daylight on the part the contract seeks.
+
+Then payment moves because the trail is plain:
+the brief, the build, the check, the trusted close.
+FreelanceFlow turns scattered work into a place
+where fair exchange is something everyone knows.


### PR DESCRIPTION
## Summary
- Added an original, project-specific poem in `POEM.md`.

## Acceptance checklist
- [x] Original poem written for this project specifically
- [x] Minimum 3 stanzas
- [x] Submitted as `POEM.md` in the project root
- [x] PR description includes a one-line creative decision note

## Creative decision
I used a "workbench of trust" theme to connect FreelanceFlow's scope, proof, review, and payment flow in a concise four-stanza poem.

## Demo
Short demo video: https://raw.githubusercontent.com/Isjuanplayer/bug-bounty/codex/poem-demo-assets/docs/poem-demo.mp4

The complete poem is also visible directly in the PR diff as `POEM.md`.

/claim #76
