### PR TITLE
feat: full Admin Panel — 6 modules, server-side auth (#29)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,121 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { ok, fail } from "../utils/response.js";
+import {
+  getUsers, updateUserStatus, getUserById,
+  getFlaggedJobs, moderateJob,
+  getDisputes, resolveDispute,
+  getAdminMetrics,
+  toggleRegistrations, toggleJobPostings,
+  getAuditLog,
+} from "../services/adminService.js";
+
+// --- User Management ---
+
+export async function listUsers(req, res) {
+  const { page, limit, role, status, search } = req.query;
+  return ok(res, await getUsers({
+    page: parseInt(page) || 1,
+    limit: parseInt(limit) || 10,
+    role,
+    status,
+    search,
+  }));
+}
+
+export async function updateUser(req, res) {
+  try {
+    const { userId } = req.params;
+    const { status } = req.body;
+    if (!["active", "suspended", "banned"].includes(status)) {
+      return fail(res, "Invalid status", 400);
+    }
+    const user = await updateUserStatus(parseInt(userId), status, req.user?.id || 0);
+    return ok(res, user);
+  } catch (err) {
+    return fail(res, err.message, 404);
+  }
+}
+
+export async function viewUser(req, res) {
+  try {
+    const user = await getUserById(parseInt(req.params.userId));
+    return ok(res, user);
+  } catch (err) {
+    return fail(res, err.message, 404);
+  }
+}
+
+// --- Job Moderation ---
+
+export async function listFlaggedJobs(req, res) {
+  const { page, limit } = req.query;
+  return ok(res, await getFlaggedJobs({ page: parseInt(page) || 1, limit: parseInt(limit) || 10 }));
+}
+
+export async function moderateFlaggedJob(req, res) {
+  try {
+    const { jobId } = req.params;
+    const { action, reason } = req.body;
+    if (!["approved", "rejected", "escalated"].includes(action)) {
+      return fail(res, "Invalid action", 400);
+    }
+    const job = await moderateJob(parseInt(jobId), action, reason || "", req.user?.id || 0);
+    return ok(res, job);
+  } catch (err) {
+    return fail(res, err.message, 404);
+  }
+}
+
+// --- Dispute Resolution ---
+
+export async function listDisputes(req, res) {
+  const { page, limit, status } = req.query;
+  return ok(res, await getDisputes({ page: parseInt(page) || 1, limit: parseInt(limit) || 10, status }));
+}
+
+export async function resolveDisputeAction(req, res) {
+  try {
+    const { disputeId } = req.params;
+    const { ruling } = req.body;
+    if (!["freelancer", "client", "escalate"].includes(ruling)) {
+      return fail(res, "Invalid ruling", 400);
+    }
+    const dispute = await resolveDispute(parseInt(disputeId), ruling, req.user?.id || 0);
+    return ok(res, dispute);
+  } catch (err) {
+    return fail(res, err.message, 404);
+  }
+}
+
+// --- Metrics ---
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+// --- Platform Controls ---
+
+export async function toggleRegistration(req, res) {
+  const { enabled } = req.body;
+  const config = await toggleRegistrations(!!enabled, req.user?.id || 0);
+  return ok(res, config);
+}
+
+export async function togglePostings(req, res) {
+  const { enabled } = req.body;
+  const config = await toggleJobPostings(!!enabled, req.user?.id || 0);
+  return ok(res, config);
+}
+
+// --- Audit Log ---
+
+export async function auditLog(req, res) {
+  const { page, limit, adminId, action, dateFrom, dateTo } = req.query;
+  return ok(res, await getAuditLog({
+    page: parseInt(page) || 1,
+    limit: parseInt(limit) || 20,
+    adminId: adminId ? parseInt(adminId) : undefined,
+    action,
+    dateFrom,
+    dateTo,
+  }));
 }

--- a/apps/api/src/middleware/adminAuth.js
+++ b/apps/api/src/middleware/adminAuth.js
@@ -1,0 +1,15 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Middleware that verifies the authenticated user has admin role.
+ * Must be used AFTER authMiddleware so req.user is set.
+ */
+export function adminAuthMiddleware(req, res, next) {
+  if (!req.user) {
+    return fail(res, "Authentication required", 401);
+  }
+  if (req.user.role !== "admin") {
+    return fail(res, "Forbidden — admin access only", 403);
+  }
+  next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,40 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminAuthMiddleware } from "../middleware/adminAuth.js";
+import {
+  listUsers, updateUser, viewUser,
+  listFlaggedJobs, moderateFlaggedJob,
+  listDisputes, resolveDisputeAction,
+  metrics,
+  toggleRegistration, togglePostings,
+  auditLog,
+} from "../controllers/adminController.js";
 
 export const adminRoutes = Router();
 
+// All admin routes require auth + admin role
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminAuthMiddleware);
+
+// Dashboard
 adminRoutes.get("/metrics", metrics);
+
+// User management
+adminRoutes.get("/users", listUsers);
+adminRoutes.get("/users/:userId", viewUser);
+adminRoutes.patch("/users/:userId/status", updateUser);
+
+// Job moderation
+adminRoutes.get("/jobs/flagged", listFlaggedJobs);
+adminRoutes.post("/jobs/:jobId/moderate", moderateFlaggedJob);
+
+// Disputes
+adminRoutes.get("/disputes", listDisputes);
+adminRoutes.post("/disputes/:disputeId/resolve", resolveDisputeAction);
+
+// Platform controls
+adminRoutes.post("/controls/registrations", toggleRegistration);
+adminRoutes.post("/controls/postings", togglePostings);
+
+// Audit log
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,161 @@
+// Admin service — all admin operations: users, jobs, disputes, metrics, controls, audit log
+
+// In-memory stores (mock — replace with DB queries in production)
+const users = [
+  { id: 1, name: "Alice Chen", email: "alice@example.com", role: "freelancer", status: "active", joinDate: "2026-01-15", trustScore: 92, activeJobs: 3 },
+  { id: 2, name: "Bob Smith", email: "bob@example.com", role: "client", status: "active", joinDate: "2026-02-20", trustScore: 78, activeJobs: 1 },
+  { id: 3, name: "Carol Davis", email: "carol@example.com", role: "freelancer", status: "suspended", joinDate: "2026-03-10", trustScore: 45, activeJobs: 0 },
+  { id: 4, name: "Dan Wilson", email: "dan@example.com", role: "admin", status: "active", joinDate: "2025-11-01", trustScore: 100, activeJobs: 0 },
+  { id: 5, name: "Eve Johnson", email: "eve@example.com", role: "freelancer", status: "active", joinDate: "2026-04-05", trustScore: 88, activeJobs: 2 },
+];
+
+const flaggedJobs = [
+  { id: 201, title: "SEO spam article", postedBy: "bob@example.com", flagReason: "Spam content", status: "pending", flaggedAt: "2026-05-15" },
+  { id: 202, title: "Fake review service", postedBy: "unknown@example.com", flagReason: "Scam", status: "pending", flaggedAt: "2026-05-17" },
+];
+
+const disputes = [
+  { id: 301, jobId: 101, freelancerId: 1, clientId: 2, status: "open", reason: "Deliverable mismatch", amount: 500, openedAt: "2026-05-10" },
+  { id: 302, jobId: 102, freelancerId: 5, clientId: 2, status: "under_review", reason: "Late delivery", amount: 800, openedAt: "2026-05-08" },
+  { id: 303, jobId: 103, freelancerId: 1, clientId: 3, status: "resolved", reason: "Scope change", amount: 300, openedAt: "2026-04-20", resolvedAt: "2026-04-22" },
+];
+
+let platformConfig = {
+  registrationsEnabled: true,
+  jobPostingsEnabled: true,
+};
+
+const auditLog = [];
+
+function addAuditEntry(adminId, action, details) {
+  auditLog.push({
+    id: auditLog.length + 1,
+    adminId,
+    action,
+    details,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+// --- User Management ---
+
+export async function getUsers({ page = 1, limit = 10, role, status, search } = {}) {
+  let filtered = [...users];
+  if (role) filtered = filtered.filter(u => u.role === role);
+  if (status) filtered = filtered.filter(u => u.status === status);
+  if (search) {
+    const q = search.toLowerCase();
+    filtered = filtered.filter(u => u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q));
+  }
+  const total = filtered.length;
+  const start = (page - 1) * limit;
+  const items = filtered.slice(start, start + limit);
+  return { items, total, page, totalPages: Math.ceil(total / limit) };
+}
+
+export async function updateUserStatus(userId, status, adminId) {
+  const user = users.find(u => u.id === userId);
+  if (!user) throw new Error("User not found");
+  user.status = status;
+  addAuditEntry(adminId, `user_${status}`, `User ${userId} (${user.email}) set to ${status}`);
+  return user;
+}
+
+export async function getUserById(userId) {
+  const user = users.find(u => u.id === userId);
+  if (!user) throw new Error("User not found");
+  const userDisputes = disputes.filter(d => d.freelancerId === userId || d.clientId === userId);
+  return { ...user, disputes: userDisputes };
+}
+
+// --- Job Moderation ---
+
+export async function getFlaggedJobs({ page = 1, limit = 10 } = {}) {
+  const total = flaggedJobs.length;
+  const start = (page - 1) * limit;
+  const items = flaggedJobs.slice(start, start + limit);
+  return { items, total, page, totalPages: Math.ceil(total / limit) };
+}
+
+export async function moderateJob(jobId, action, reason, adminId) {
+  const job = flaggedJobs.find(j => j.id === jobId);
+  if (!job) throw new Error("Flagged job not found");
+  job.status = action; // "approved", "rejected", "escalated"
+  addAuditEntry(adminId, `job_${action}`, `Job ${jobId} "${job.title}" ${action} — ${reason}`);
+  return job;
+}
+
+// --- Dispute Resolution ---
+
+export async function getDisputes({ page = 1, limit = 10, status } = {}) {
+  let filtered = [...disputes];
+  if (status) filtered = filtered.filter(d => d.status === status);
+  const total = filtered.length;
+  const start = (page - 1) * limit;
+  const items = filtered.slice(start, start + limit);
+  return { items, total, page, totalPages: Math.ceil(total / limit) };
+}
+
+export async function resolveDispute(disputeId, ruling, adminId) {
+  const dispute = disputes.find(d => d.id === disputeId);
+  if (!dispute) throw new Error("Dispute not found");
+  dispute.status = "resolved";
+  dispute.resolvedAt = new Date().toISOString();
+  dispute.ruling = ruling;
+  addAuditEntry(adminId, "dispute_resolved", `Dispute ${disputeId} resolved in favor of ${ruling}`);
+  return dispute;
+}
+
+// --- Metrics ---
+
 export async function getAdminMetrics() {
+  const activeUsers = users.filter(u => u.status === "active").length;
+  const openDisputes = disputes.filter(d => d.status === "open" || d.status === "under_review").length;
+  const flaggedCount = flaggedJobs.filter(j => j.status === "pending").length;
+
+  const trustScores = users.map(u => u.trustScore).sort((a, b) => a - b);
+  const distribution = {};
+  const brackets = [[0, 25], [26, 50], [51, 75], [76, 100]];
+  for (const [min, max] of brackets) {
+    const count = trustScores.filter(s => s >= min && s <= max).length;
+    distribution[`${min}-${max}`] = count;
+  }
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    totalUsers: users.length,
+    activeJobs: 42,
+    openDisputes,
+    flaggedListings: flaggedCount,
+    revenue: 128900,
+    trustDistribution: distribution,
+    platformConfig: { ...platformConfig },
   };
+}
+
+// --- Platform Controls ---
+
+export async function toggleRegistrations(enabled, adminId) {
+  platformConfig.registrationsEnabled = enabled;
+  addAuditEntry(adminId, "toggle_registrations", `Registrations ${enabled ? "enabled" : "disabled"}`);
+  return { ...platformConfig };
+}
+
+export async function toggleJobPostings(enabled, adminId) {
+  platformConfig.jobPostingsEnabled = enabled;
+  addAuditEntry(adminId, "toggle_job_postings", `Job postings ${enabled ? "enabled" : "disabled"}`);
+  return { ...platformConfig };
+}
+
+// --- Audit Log ---
+
+export async function getAuditLog({ page = 1, limit = 20, adminId, action, dateFrom, dateTo } = {}) {
+  let filtered = [...auditLog].reverse();
+  if (adminId) filtered = filtered.filter(e => e.adminId === adminId);
+  if (action) filtered = filtered.filter(e => e.action === action);
+  if (dateFrom) filtered = filtered.filter(e => e.timestamp >= dateFrom);
+  if (dateTo) filtered = filtered.filter(e => e.timestamp <= dateTo);
+  const total = filtered.length;
+  const start = (page - 1) * limit;
+  const items = filtered.slice(start, start + limit);
+  return { items, total, page, totalPages: Math.ceil(total / limit) };
 }

--- a/apps/web/app/admin/components/AuditLog.tsx
+++ b/apps/web/app/admin/components/AuditLog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface AuditEntry { id: number; adminId: number; action: string; details: string; timestamp: string; }
+
+export default function AuditLog() {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: "20" });
+      if (actionFilter) params.set("action", actionFilter);
+      const res = await fetch(`/api/admin/audit-log?${params}`);
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      setEntries(data.items);
+      setTotal(data.total);
+      setTotalPages(data.totalPages);
+    } catch (e: any) { setError(e.message); }
+    finally { setLoading(false); }
+  }, [page, actionFilter]);
+
+  useEffect(() => { fetch(); }, [fetch]);
+
+  if (loading) return <div role="status">Loading audit log...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+
+  return (
+    <div>
+      <div style={{ marginBottom: "1rem" }}>
+        <select value={actionFilter} onChange={e => { setActionFilter(e.target.value); setPage(1); }} style={{ padding: "0.4rem", borderRadius: 4, border: "1px solid #4b5563", background: "#1f2937", color: "#fff" }} aria-label="Filter by action type">
+          <option value="">All Actions</option>
+          <option value="user_suspended">User Suspended</option>
+          <option value="user_banned">User Banned</option>
+          <option value="user_active">User Reinstate</option>
+          <option value="job_approved">Job Approved</option>
+          <option value="job_rejected">Job Rejected</option>
+          <option value="dispute_resolved">Dispute Resolved</option>
+          <option value="toggle_registrations">Toggle Registrations</option>
+          <option value="toggle_job_postings">Toggle Postings</option>
+        </select>
+      </div>
+
+      {entries.length === 0 ? (
+        <p style={{ color: "#9ca3af" }}>No audit entries yet.</p>
+      ) : (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }} role="table" aria-label="Audit log">
+            <thead>
+              <tr style={{ borderBottom: "2px solid #374151", textAlign: "left" }}>
+                <th style={{ padding: "0.5rem" }}>Time</th>
+                <th style={{ padding: "0.5rem" }}>Admin</th>
+                <th style={{ padding: "0.5rem" }}>Action</th>
+                <th style={{ padding: "0.5rem" }}>Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(e => (
+                <tr key={e.id} style={{ borderBottom: "1px solid #1f2937" }}>
+                  <td style={{ padding: "0.5rem", whiteSpace: "nowrap", color: "#9ca3af" }}>{new Date(e.timestamp).toLocaleString()}</td>
+                  <td style={{ padding: "0.5rem" }}>#{e.adminId}</td>
+                  <td style={{ padding: "0.5rem" }}><Badge>{e.action}</Badge></td>
+                  <td style={{ padding: "0.5rem", color: "#9ca3af" }}>{e.details}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "1rem", fontSize: "0.875rem", color: "#9ca3af" }}>
+        <span>{total} total entries</span>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page <= 1} style={pageBtnStyle} aria-label="Previous page">Prev</button>
+          <span style={{ padding: "0.25rem 0.5rem" }}>{page} / {totalPages}</span>
+          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page >= totalPages} style={pageBtnStyle} aria-label="Next page">Next</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Badge({ children }: { children: string }) {
+  return <span style={{ padding: "0.1rem 0.4rem", borderRadius: 4, background: "#374151", fontSize: "0.75rem" }}>{children}</span>;
+}
+
+const pageBtnStyle = { padding: "0.25rem 0.75rem", border: "1px solid #4b5563", borderRadius: 4, background: "#1f2937", color: "#fff", cursor: "pointer", fontSize: "0.875rem" } as const;

--- a/apps/web/app/admin/components/DisputeResolution.tsx
+++ b/apps/web/app/admin/components/DisputeResolution.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Dispute { id: number; jobId: number; freelancerId: number; clientId: number; status: string; reason: string; amount: number; openedAt: string; resolvedAt?: string; ruling?: string; }
+
+export default function DisputeResolution() {
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const url = filter ? `/api/admin/disputes?status=${filter}` : "/api/admin/disputes";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      setDisputes(data.items);
+    } catch (e: any) { setError(e.message); }
+    finally { setLoading(false); }
+  }, [filter]);
+
+  useEffect(() => { fetch(); }, [fetch]);
+
+  const resolve = async (disputeId: number, ruling: string) => {
+    await fetch(`/api/admin/disputes/${disputeId}/resolve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ruling }),
+    });
+    fetch();
+  };
+
+  if (loading) return <div role="status">Loading disputes...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+
+  return (
+    <div>
+      <div style={{ marginBottom: "1rem" }}>
+        <select value={filter} onChange={e => setFilter(e.target.value)} style={{ padding: "0.4rem", borderRadius: 4, border: "1px solid #4b5563", background: "#1f2937", color: "#fff" }} aria-label="Filter disputes">
+          <option value="">All</option>
+          <option value="open">Open</option>
+          <option value="under_review">Under Review</option>
+          <option value="resolved">Resolved</option>
+        </select>
+      </div>
+
+      {disputes.length === 0 ? (
+        <p style={{ color: "#9ca3af" }}>No disputes found.</p>
+      ) : (
+        disputes.map(d => (
+          <div key={d.id} className="card" style={{ padding: "1rem", marginBottom: "0.75rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "0.25rem" }}>
+              <strong>Dispute #{d.id}</strong>
+              <StatusBadge status={d.status} />
+            </div>
+            <div style={{ fontSize: "0.875rem", color: "#9ca3af", marginBottom: "0.25rem" }}>
+              Job #{d.jobId} • ${d.amount} • {d.reason}
+            </div>
+            <div style={{ fontSize: "0.75rem", color: "#6b7280", marginBottom: "0.5rem" }}>
+              Freelancer #{d.freelancerId} vs Client #{d.clientId} • {d.openedAt}
+              {d.resolvedAt && ` • Resolved: ${d.resolvedAt}`}
+              {d.ruling && ` • Ruling: ${d.ruling}`}
+            </div>
+            {d.status !== "resolved" && (
+              <div style={{ display: "flex", gap: "0.5rem" }}>
+                <button onClick={() => resolve(d.id, "freelancer")} style={btn("#22c55e")} aria-label="Rule in favor of freelancer">Freelancer</button>
+                <button onClick={() => resolve(d.id, "client")} style={btn("#3b82f6")} aria-label="Rule in favor of client">Client</button>
+                <button onClick={() => resolve(d.id, "escalate")} style={btn("#eab308")} aria-label="Escalate dispute">Escalate</button>
+              </div>
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = { open: "#ef4444", under_review: "#eab308", resolved: "#22c55e" };
+  return <span style={{ padding: "0.1rem 0.4rem", borderRadius: 4, background: colors[status] || "#6b7280", color: "#000", fontSize: "0.75rem", fontWeight: 600 }}>{status}</span>;
+}
+
+const btn = (c: string) => ({ padding: "0.3rem 0.75rem", border: "none", borderRadius: 4, background: c, color: "#000", cursor: "pointer", fontWeight: 600, fontSize: "0.8rem" } as const);

--- a/apps/web/app/admin/components/JobModeration.tsx
+++ b/apps/web/app/admin/components/JobModeration.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface FlaggedJob { id: number; title: string; postedBy: string; flagReason: string; status: string; flaggedAt: string; }
+
+export default function JobModeration() {
+  const [jobs, setJobs] = useState<FlaggedJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/jobs/flagged");
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      setJobs(data.items);
+    } catch (e: any) { setError(e.message); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { fetch(); }, [fetch]);
+
+  const moderate = async (jobId: number, action: string) => {
+    const reason = prompt(`Reason for ${action}:`);
+    await fetch(`/api/admin/jobs/${jobId}/moderate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action, reason: reason || "" }),
+    });
+    fetch();
+  };
+
+  if (loading) return <div role="status">Loading moderation queue...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+
+  return (
+    <div>
+      <h3 style={{ marginBottom: "1rem" }}>Flagged Jobs ({jobs.length})</h3>
+      {jobs.length === 0 ? (
+        <p style={{ color: "#9ca3af" }}>No flagged jobs — queue is clear.</p>
+      ) : (
+        jobs.map(j => (
+          <div key={j.id} className="card" style={{ padding: "1rem", marginBottom: "0.75rem" }}>
+            <div style={{ fontWeight: 600, marginBottom: "0.25rem" }}>{j.title}</div>
+            <div style={{ fontSize: "0.875rem", color: "#9ca3af", marginBottom: "0.5rem" }}>
+              by {j.postedBy} • {j.flagReason} • {j.flaggedAt}
+            </div>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <button onClick={() => moderate(j.id, "approved")} style={btn("#22c55e")} aria-label={`Approve ${j.title}`}>Approve</button>
+              <button onClick={() => moderate(j.id, "rejected")} style={btn("#ef4444")} aria-label={`Reject ${j.title}`}>Reject</button>
+              <button onClick={() => moderate(j.id, "escalated")} style={btn("#eab308")} aria-label={`Escalate ${j.title}`}>Escalate</button>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+const btn = (c: string) => ({ padding: "0.3rem 0.75rem", border: "none", borderRadius: 4, background: c, color: "#000", cursor: "pointer", fontWeight: 600, fontSize: "0.8rem" } as const);

--- a/apps/web/app/admin/components/MetricsDashboard.tsx
+++ b/apps/web/app/admin/components/MetricsDashboard.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export default function MetricsDashboard() {
+  const [metrics, setMetrics] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchMetrics = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/metrics");
+      if (!res.ok) throw new Error("Failed to load metrics");
+      const data = await res.json();
+      setMetrics(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchMetrics(); }, [fetchMetrics]);
+
+  if (loading) return <div role="status">Loading metrics...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+  if (!metrics) return null;
+
+  return (
+    <div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem", marginBottom: "2rem" }}>
+        <SummaryCard label="Total Users" value={metrics.totalUsers} />
+        <SummaryCard label="Active Jobs" value={metrics.activeJobs} />
+        <SummaryCard label="Open Disputes" value={metrics.openDisputes} />
+        <SummaryCard label="Flagged Listings" value={metrics.flaggedListings} />
+        <SummaryCard label="Revenue" value={`$${(metrics.revenue / 100).toLocaleString()}`} />
+      </div>
+
+      <div className="card" style={{ padding: "1rem" }}>
+        <h3 style={{ marginBottom: "0.75rem" }}>Trust Score Distribution</h3>
+        {metrics.trustDistribution && Object.entries(metrics.trustDistribution).map(([range, count]: [string, any]) => (
+          <div key={range} style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.5rem" }}>
+            <span style={{ width: 80, fontSize: "0.875rem" }}>{range}</span>
+            <div style={{ flex: 1, background: "#374151", borderRadius: 4, height: 20, overflow: "hidden" }}>
+              <div style={{ width: `${(count / metrics.totalUsers) * 100}%`, background: "#4f46e5", height: "100%", borderRadius: 4, minWidth: count > 0 ? 8 : 0 }} />
+            </div>
+            <span style={{ fontSize: "0.875rem", minWidth: 30 }}>{count}</span>
+          </div>
+        ))}
+      </div>
+
+      <button onClick={fetchMetrics} style={{ marginTop: "1rem", padding: "0.5rem 1rem", background: "#374151", color: "#fff", border: "none", borderRadius: 4, cursor: "pointer" }} aria-label="Refresh metrics">
+        Refresh
+      </button>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="card" style={{ padding: "1rem", textAlign: "center" }}>
+      <div style={{ fontSize: "0.75rem", color: "#9ca3af", marginBottom: "0.25rem" }}>{label}</div>
+      <div style={{ fontSize: "1.5rem", fontWeight: 700 }}>{value}</div>
+    </div>
+  );
+}

--- a/apps/web/app/admin/components/PlatformControls.tsx
+++ b/apps/web/app/admin/components/PlatformControls.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export default function PlatformControls() {
+  const [config, setConfig] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [confirmAction, setConfirmAction] = useState<{ type: string; enabled: boolean } | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/metrics");
+      if (!res.ok) throw new Error("Failed");
+      const data = await res.json();
+      setConfig(data.platformConfig);
+    } catch (e: any) { setError(e.message); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { fetch(); }, [fetch]);
+
+  const toggle = async (type: string, enabled: boolean) => {
+    const endpoint = type === "registrations" ? "registrations" : "postings";
+    await fetch(`/api/admin/controls/${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    });
+    setConfirmAction(null);
+    fetch();
+  };
+
+  if (loading) return <div role="status">Loading controls...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+  if (!config) return null;
+
+  return (
+    <div>
+      <ControlCard
+        title="User Registrations"
+        description="Allow new users to sign up on the platform."
+        enabled={config.registrationsEnabled}
+        onToggle={(enabled) => setConfirmAction({ type: "registrations", enabled })}
+      />
+      <ControlCard
+        title="Job Postings"
+        description="Allow users to post new jobs and listings."
+        enabled={config.jobPostingsEnabled}
+        onToggle={(enabled) => setConfirmAction({ type: "postings", enabled })}
+      />
+
+      {confirmAction && (
+        <div className="card" style={{ padding: "1rem", marginTop: "1rem", background: "#1f2937", border: "2px solid #4f46e5" }}>
+          <p style={{ marginBottom: "0.5rem" }}>
+            Confirm: {confirmAction.enabled ? "Enable" : "Disable"} {confirmAction.type === "registrations" ? "user registrations" : "job postings"}?
+          </p>
+          <div style={{ display: "flex", gap: "0.5rem" }}>
+            <button onClick={() => toggle(confirmAction.type, confirmAction.enabled)} style={{ padding: "0.4rem 1rem", border: "none", borderRadius: 4, background: "#4f46e5", color: "#fff", cursor: "pointer", fontWeight: 600 }}>
+              Confirm
+            </button>
+            <button onClick={() => setConfirmAction(null)} style={{ padding: "0.4rem 1rem", border: "1px solid #4b5563", borderRadius: 4, background: "transparent", color: "#9ca3af", cursor: "pointer" }}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ControlCard({ title, description, enabled, onToggle }: { title: string; description: string; enabled: boolean; onToggle: (v: boolean) => void }) {
+  return (
+    <div className="card" style={{ padding: "1rem", marginBottom: "0.75rem", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div>
+        <div style={{ fontWeight: 600 }}>{title}</div>
+        <div style={{ fontSize: "0.875rem", color: "#9ca3af" }}>{description}</div>
+      </div>
+      <button
+        onClick={() => onToggle(!enabled)}
+        style={{
+          padding: "0.4rem 1rem",
+          border: "none",
+          borderRadius: 4,
+          background: enabled ? "#22c55e" : "#6b7280",
+          color: "#000",
+          cursor: "pointer",
+          fontWeight: 600,
+          fontSize: "0.875rem",
+        }}
+        aria-label={`${enabled ? "Disable" : "Enable"} ${title}`}
+        role="switch"
+        aria-checked={enabled}
+      >
+        {enabled ? "Enabled" : "Disabled"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/admin/components/UserManagement.tsx
+++ b/apps/web/app/admin/components/UserManagement.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  joinDate: string;
+  trustScore: number;
+  activeJobs: number;
+}
+
+export default function UserManagement() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: "10" });
+      if (search) params.set("search", search);
+      if (roleFilter) params.set("role", roleFilter);
+      if (statusFilter) params.set("status", statusFilter);
+      const res = await fetch(`/api/admin/users?${params}`);
+      if (!res.ok) throw new Error("Failed to load users");
+      const data = await res.json();
+      setUsers(data.items);
+      setTotal(data.total);
+      setTotalPages(data.totalPages);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search, roleFilter, statusFilter]);
+
+  useEffect(() => { fetchUsers(); }, [fetchUsers]);
+
+  const updateStatus = async (userId: number, status: string) => {
+    await fetch(`/api/admin/users/${userId}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    fetchUsers();
+  };
+
+  if (loading) return <div role="status">Loading users...</div>;
+  if (error) return <div role="alert" style={{ color: "red" }}>{error}</div>;
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem", flexWrap: "wrap" }}>
+        <input
+          type="text"
+          placeholder="Search name or email..."
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          style={{ padding: "0.4rem 0.75rem", borderRadius: 4, border: "1px solid #4b5563", background: "#1f2937", color: "#fff", flex: 1, minWidth: 200 }}
+          aria-label="Search users"
+        />
+        <select value={roleFilter} onChange={(e) => { setRoleFilter(e.target.value); setPage(1); }} style={{ padding: "0.4rem", borderRadius: 4, border: "1px solid #4b5563", background: "#1f2937", color: "#fff" }} aria-label="Filter by role">
+          <option value="">All Roles</option>
+          <option value="freelancer">Freelancer</option>
+          <option value="client">Client</option>
+          <option value="admin">Admin</option>
+        </select>
+        <select value={statusFilter} onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }} style={{ padding: "0.4rem", borderRadius: 4, border: "1px solid #4b5563", background: "#1f2937", color: "#fff" }} aria-label="Filter by status">
+          <option value="">All Status</option>
+          <option value="active">Active</option>
+          <option value="suspended">Suspended</option>
+          <option value="banned">Banned</option>
+        </select>
+      </div>
+
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }} role="table" aria-label="User list">
+          <thead>
+            <tr style={{ borderBottom: "2px solid #374151", textAlign: "left" }}>
+              <th style={{ padding: "0.5rem" }}>Name</th>
+              <th style={{ padding: "0.5rem" }}>Email</th>
+              <th style={{ padding: "0.5rem" }}>Role</th>
+              <th style={{ padding: "0.5rem" }}>Status</th>
+              <th style={{ padding: "0.5rem" }}>Trust</th>
+              <th style={{ padding: "0.5rem" }}>Joined</th>
+              <th style={{ padding: "0.5rem" }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.length === 0 ? (
+              <tr><td colSpan={7} style={{ padding: "2rem", textAlign: "center", color: "#9ca3af" }}>No users found</td></tr>
+            ) : (
+              users.map((u) => (
+                <tr key={u.id} style={{ borderBottom: "1px solid #1f2937" }}>
+                  <td style={{ padding: "0.5rem" }}>{u.name}</td>
+                  <td style={{ padding: "0.5rem", color: "#9ca3af" }}>{u.email}</td>
+                  <td style={{ padding: "0.5rem" }}><Badge>{u.role}</Badge></td>
+                  <td style={{ padding: "0.5rem" }}><StatusBadge status={u.status} /></td>
+                  <td style={{ padding: "0.5rem" }}>{u.trustScore}</td>
+                  <td style={{ padding: "0.5rem", color: "#9ca3af" }}>{u.joinDate}</td>
+                  <td style={{ padding: "0.5rem", display: "flex", gap: "0.25rem" }}>
+                    {u.status !== "active" && <button onClick={() => updateStatus(u.id, "active")} style={btnStyle("#22c55e")} aria-label={`Reinstate ${u.name}`}>Reinstate</button>}
+                    {u.status === "active" && <button onClick={() => updateStatus(u.id, "suspended")} style={btnStyle("#eab308")} aria-label={`Suspend ${u.name}`}>Suspend</button>}
+                    {u.status !== "banned" && <button onClick={() => updateStatus(u.id, "banned")} style={btnStyle("#ef4444")} aria-label={`Ban ${u.name}`}>Ban</button>}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "1rem", fontSize: "0.875rem", color: "#9ca3af" }}>
+        <span>{total} total users</span>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page <= 1} style={pageBtnStyle} aria-label="Previous page">Prev</button>
+          <span style={{ padding: "0.25rem 0.5rem" }}>{page} / {totalPages}</span>
+          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page >= totalPages} style={pageBtnStyle} aria-label="Next page">Next</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Badge({ children }: { children: string }) {
+  return <span style={{ padding: "0.1rem 0.4rem", borderRadius: 4, background: "#374151", fontSize: "0.75rem" }}>{children}</span>;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = { active: "#22c55e", suspended: "#eab308", banned: "#ef4444" };
+  return <span style={{ padding: "0.1rem 0.4rem", borderRadius: 4, background: colors[status] || "#6b7280", color: "#000", fontSize: "0.75rem", fontWeight: 600 }}>{status}</span>;
+}
+
+const btnStyle = (color: string) => ({
+  padding: "0.2rem 0.5rem",
+  fontSize: "0.75rem",
+  border: "none",
+  borderRadius: 4,
+  background: color,
+  color: "#000",
+  cursor: "pointer",
+  fontWeight: 600,
+} as const);
+
+const pageBtnStyle = {
+  padding: "0.25rem 0.75rem",
+  border: "1px solid #4b5563",
+  borderRadius: 4,
+  background: "#1f2937",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+} as const;

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,83 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import UserManagement from "./components/UserManagement";
+import JobModeration from "./components/JobModeration";
+import DisputeResolution from "./components/DisputeResolution";
+import MetricsDashboard from "./components/MetricsDashboard";
+import PlatformControls from "./components/PlatformControls";
+import AuditLog from "./components/AuditLog";
+
+const TABS = [
+  { id: "metrics", label: "Dashboard" },
+  { id: "users", label: "Users" },
+  { id: "jobs", label: "Moderation" },
+  { id: "disputes", label: "Disputes" },
+  { id: "controls", label: "Controls" },
+  { id: "audit", label: "Audit Log" },
+];
+
 export default function AdminPanelPage() {
+  const [activeTab, setActiveTab] = useState("metrics");
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/metrics")
+      .then((r) => {
+        setAuthorized(r.ok);
+      })
+      .catch(() => setAuthorized(false));
+  }, []);
+
+  if (authorized === null) {
+    return <div className="card" role="status" aria-label="Loading admin panel">Loading admin panel...</div>;
+  }
+
+  if (!authorized) {
+    return (
+      <div className="card" role="alert">
+        <h2>Access Denied</h2>
+        <p>You do not have administrator privileges.</p>
+      </div>
+    );
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
+    <div className="admin-panel" style={{ maxWidth: 1200, margin: "0 auto", padding: "1rem" }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "1rem" }}>Admin Panel</h1>
+
+      <nav role="tablist" aria-label="Admin sections" style={{ display: "flex", gap: "0.25rem", marginBottom: "1.5rem", borderBottom: "2px solid #374151", paddingBottom: "0.5rem" }}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              padding: "0.5rem 1rem",
+              border: "none",
+              background: activeTab === tab.id ? "#4f46e5" : "transparent",
+              color: activeTab === tab.id ? "#fff" : "#9ca3af",
+              borderRadius: "0.375rem",
+              cursor: "pointer",
+              fontWeight: 500,
+              fontSize: "0.875rem",
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={activeTab}>
+        {activeTab === "metrics" && <MetricsDashboard />}
+        {activeTab === "users" && <UserManagement />}
+        {activeTab === "jobs" && <JobModeration />}
+        {activeTab === "disputes" && <DisputeResolution />}
+        {activeTab === "controls" && <PlatformControls />}
+        {activeTab === "audit" && <AuditLog />}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## What
Full admin panel replacing the placeholder stub. 6 tabbed modules with server-side auth guard.

## Modules
1. **Dashboard** — summary cards (users, jobs, disputes, revenue) + trust score distribution
2. **Users** — searchable/filterable table, suspend/ban/reinstate actions, paginated
3. **Moderation** — flagged jobs queue with approve/reject/escalate
4. **Disputes** — filterable queue, rule in favor of freelancer/client, escalate
5. **Controls** — toggle registrations & job postings with confirmation dialog
6. **Audit Log** — filterable by action type, paginated, append-only

## Backend (337 lines)
- `adminService.js` — all data operations with mock stores
- `adminController.js` — 10 REST endpoints
- `adminRoutes.js` — all routes behind auth + admin middleware
- `adminAuth.js` — server-side role check (403 for non-admins)

## Key Features
- Admin-only access enforced server-side
- Server-side pagination on all data tables
- Loading, empty, and error states for every section  
- ARIA labels, keyboard navigable
- Audit log records all admin actions with timestamp

Closes #29