### PR TITLE
Implement Stripe payment intent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,53 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export function setStripeClient(client) {
+  stripeClient = client;
+}
+
+function getStripeClient() {
+  if (!stripeClient) {
+    if (!env.stripeSecretKey) {
+      throw new Error("STRIPE_SECRET_KEY is required to create a payment intent");
+    }
+    stripeClient = new Stripe(env.stripeSecretKey);
+  }
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("currency must be a three-letter ISO currency code");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    ...(payload.metadata && { metadata: payload.metadata })
   };
+}
+
+export async function createPaymentIntent(payload) {
+  const paymentPayload = validatePaymentPayload(payload);
+
+  try {
+    const paymentIntent = await getStripeClient().paymentIntents.create(paymentPayload);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw new Error(error.message);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, setStripeClient } from "../services/paymentService.js";
+
+test.afterEach(() => {
+  setStripeClient(undefined);
+});
+
+test("createPaymentIntent validates amount", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 0 }),
+    /amount must be a positive integer/
+  );
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 12.5 }),
+    /amount must be a positive integer/
+  );
+});
+
+test("createPaymentIntent validates currency", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 1000, currency: "usdollar" }),
+    /currency must be a three-letter ISO currency code/
+  );
+});
+
+test("createPaymentIntent creates Stripe PaymentIntent with defaults", async () => {
+  const calls = [];
+  setStripeClient({
+    paymentIntents: {
+      async create(payload) {
+        calls.push(payload);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_456",
+          amount: payload.amount,
+          currency: payload.currency
+        };
+      }
+    }
+  });
+
+  const result = await createPaymentIntent({ amount: 1500 });
+
+  assert.deepEqual(calls, [{ amount: 1500, currency: "usd" }]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 1500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent passes currency and metadata", async () => {
+  const calls = [];
+  setStripeClient({
+    paymentIntents: {
+      async create(payload) {
+        calls.push(payload);
+        return {
+          id: "pi_test_456",
+          client_secret: "secret",
+          amount: payload.amount,
+          currency: payload.currency
+        };
+      }
+    }
+  });
+
+  await createPaymentIntent({
+    amount: 2500,
+    currency: "EUR",
+    metadata: { orderId: "order_1" }
+  });
+
+  assert.deepEqual(calls, [
+    { amount: 2500, currency: "eur", metadata: { orderId: "order_1" } }
+  ]);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  setStripeClient({
+    paymentIntents: {
+      async create() {
+        const error = new Error("Your card was declined");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  });
+
+  await assert.rejects(
+    createPaymentIntent({ amount: 1500 }),
+    /Your card was declined/
+  );
+});
+
+test("createPaymentIntent live Stripe smoke test", { skip: process.env.RUN_STRIPE_SMOKE !== "1" }, async () => {
+  setStripeClient(undefined);
+  const result = await createPaymentIntent({ amount: 100, currency: "usd" });
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary

- Replaced the `pay_${Date.now()}` stub with a Stripe Node SDK `PaymentIntent` creation flow.
- Initialized Stripe from `STRIPE_SECRET_KEY` only; no hardcoded keys.
- Added validation for positive-integer `amount`, 3-letter `currency`, default `usd`, optional metadata passthrough.
- Returned Stripe `id` as `paymentId` and `client_secret` as `clientSecret`.
- Added mocked node:test coverage plus a guarded live smoke test behind `RUN_STRIPE_SMOKE=1`.

## Validation

```bash
npm test -w apps/api
```

Result: 6 passed, 1 skipped smoke test.

/claim #1
