### PR TITLE
docs: add original technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Ledger of Clear Work
+
+In FreelanceFlow, a brief begins as light,
+with scope set down where every hand can see;
+the task is small, the promise measured right,
+and trust is built from plain delivery.
+
+A branch records the path from need to proof,
+each diff a line of work made legible;
+reviewers read beneath the polished roof,
+where passing checks make claims credible.
+
+No hidden gate should cloud a worker's pay,
+no vague approval drift beyond the done;
+the clearest systems mark the honest way,
+then move the earned reward when proof has won.
+
+So let the queue be fair, the signal clean,
+the spec precise, the outcome understood;
+between the ask and merge, let all be seen,
+and useful craft become a common good.


### PR DESCRIPTION
/claim #76

Summary:
- Adds `POEM.md` at the project root.
- Original four-stanza poem written for FreelanceFlow about clear scope, verifiable work, review, and fair payout flow.

Creative decision: I chose a concise work-ledger theme because the project centers on structured freelance collaboration, trust, and proof of delivery.

Validation:
- `git diff --check`