### PR TITLE
Add signed trace poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Signed Trace
+
+Scope enters first, a quiet line,
+with work made small enough to prove.
+The brief is not a shifting sign;
+it names the thing the hands will move.
+
+Then evidence begins to speak:
+a route, a test, a measured change.
+No promise leans on being sleek;
+the facts are left within their range.
+
+A reviewer reads the trail in turn,
+from patch to note to passing run.
+The record lets the question burn
+until the answer has been won.
+
+When payout closes out the thread,
+the ledger does not need applause.
+It keeps the path from claim to bread:
+clear work, clear proof, and cleaner laws.


### PR DESCRIPTION
Fixes #76

/claim #76

## Summary
- Adds an original four-stanza poem as POEM.md in the repository root.
- Keeps the submission scoped to the requested content file only.

## Creative Decision
I used an audit-trail metaphor because FreelanceFlow depends on clear scope, visible evidence, review, and payout records.

## Validation
- Verified POEM.md is present at the project root.
- Confirmed the poem has more than the required three stanzas.