### PR TITLE
Add scope ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Scope Ledger
+
+Before a bid becomes a bridge,
+the work is named in measured lines:
+one fault to trace, one proof to bring,
+one patch that leaves a cleaner sign.
+
+The tester keeps a quiet page
+where failing steps are written plain;
+the builder answers with a diff,
+and turns the red path green again.
+
+Review arrives without a drum,
+just questions sharpened into light;
+each note resolves a hidden edge,
+each run confirms the shape is right.
+
+Then payout follows verified work,
+not luck, not noise, not borrowed claim;
+a ledger closes, trust remains,
+and every careful fix has name.


### PR DESCRIPTION
## Summary
- Add an original project-specific poem as `POEM.md` in the repository root.

## Creative Note
I used a scope-ledger theme to connect clear requirements, evidence, review, and payout to the bounty workflow.

## Validation
- `wc -l POEM.md` -> 21 lines
- `git diff --check` -> passed

/claim #76