### PR TITLE
feat(api): implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,21 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode =
+    Number.isInteger(err.statusCode) && err.statusCode >= 400
+      ? err.statusCode
+      : 500;
+  const message =
+    err.expose && err.message ? err.message : "Unexpected server error";
+
+  if (!err.expose) {
+    console.error("Unhandled API error:", err);
+  }
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,141 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+let stripeClient;
+let stripeClientSecret;
+
+class PaymentServiceError extends Error {
+  constructor(message, statusCode, cause) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+    this.expose = true;
+    this.cause = cause;
+  }
+}
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+
+  if (!secretKey) {
+    throw new PaymentServiceError(
+      "STRIPE_SECRET_KEY environment variable is required",
+      503
+    );
+  }
+
+  if (!stripeClient || stripeClientSecret !== secretKey) {
+    stripeClient = new Stripe(secretKey);
+    stripeClientSecret = secretKey;
+  }
+
+  return stripeClient;
+}
+
+function normalizeCurrency(currency) {
+  const normalizedCurrency = String(currency ?? "usd").toLowerCase();
+
+  if (!/^[a-z]{3}$/.test(normalizedCurrency)) {
+    throw new PaymentServiceError(
+      "payload.currency must be a 3-letter currency code",
+      400
+    );
+  }
+
+  return normalizedCurrency;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata)
+  ) {
+    throw new PaymentServiceError("payload.metadata must be an object", 400);
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === undefined || value === null) {
+        throw new PaymentServiceError(
+          "payload.metadata values must not be null or undefined",
+          400
+        );
+      }
+
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw new PaymentServiceError(
+          "payload.metadata values must be strings, numbers, or booleans",
+          400
+        );
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentServiceError("payload must be an object", 400);
+  }
+
+  if (payload.amount === undefined || payload.amount === null) {
+    throw new PaymentServiceError(
+      "payload.amount is required and must be a positive integer",
+      400
+    );
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentServiceError(
+      "payload.amount must be a positive integer in the smallest currency unit",
+      400
+    );
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: normalizeCurrency(payload.currency),
+    metadata: normalizeMetadata(payload.metadata)
   };
+}
+
+function buildStripeCreateParams(validatedPayload) {
+  return {
+    amount: validatedPayload.amount,
+    currency: validatedPayload.currency,
+    ...(validatedPayload.metadata
+      ? { metadata: validatedPayload.metadata }
+      : {})
+  };
+}
+
+export async function createPaymentIntent(payload, client) {
+  const validatedPayload = validatePaymentPayload(payload);
+  const paymentClient = client ?? getStripeClient();
+
+  try {
+    const paymentIntent = await paymentClient.paymentIntents.create(
+      buildStripeCreateParams(validatedPayload)
+    );
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Stripe PaymentIntent creation failed";
+
+    throw new PaymentServiceError(message, 502, error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+function createMockStripeClient(response, calls = []) {
+  return {
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+        if (response instanceof Error) {
+          throw response;
+        }
+        return response;
+      }
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated arguments", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(
+    {
+      id: "pi_123",
+      client_secret: "pi_123_secret_abc",
+      amount: 2500,
+      currency: "usd"
+    },
+    calls
+  );
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: { orderId: 42, recurring: false }
+    },
+    stripeClient
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { orderId: "42", recurring: "false" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_123",
+    clientSecret: "pi_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(
+    {
+      id: "pi_default",
+      client_secret: "pi_default_secret",
+      amount: 500,
+      currency: "usd"
+    },
+    calls
+  );
+
+  await createPaymentIntent({ amount: 500 }, stripeClient);
+
+  assert.deepEqual(calls, [{ amount: 500, currency: "usd" }]);
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient({}, calls);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, stripeClient),
+    /positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10.5 }, stripeClient),
+    /positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({}, stripeClient),
+    /amount is required/
+  );
+
+  assert.deepEqual(calls, []);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Your card was declined");
+  stripeError.type = "StripeCardError";
+  const stripeClient = createMockStripeClient(stripeError);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 2000, currency: "usd" }, stripeClient),
+    (error) => {
+      assert.equal(error.message, "Your card was declined");
+      assert.equal(error.statusCode, 502);
+      assert.equal(error.expose, true);
+      assert.equal(error.cause, stripeError);
+      return true;
+    }
+  );
+});
+
+test("POST /api/payments surfaces missing Stripe configuration", async () => {
+  const previousSecret = process.env.STRIPE_SECRET_KEY;
+  delete process.env.STRIPE_SECRET_KEY;
+
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "STRIPE_SECRET_KEY environment variable is required"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    if (previousSecret === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = previousSecret;
+    }
+  }
+});
+
+const canRunStripeSmokeTest =
+  process.env.RUN_STRIPE_SMOKE === "1" &&
+  process.env.STRIPE_SECRET_KEY?.startsWith("sk_test_");
+
+test(
+  "smoke: creates a live Stripe test-mode PaymentIntent",
+  {
+    skip:
+      !canRunStripeSmokeTest &&
+      "Set RUN_STRIPE_SMOKE=1 and STRIPE_SECRET_KEY=sk_test_... to run"
+  },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { source: "api-smoke-test" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- replace the timestamp-based payment stub with a real Stripe PaymentIntent call initialized from STRIPE_SECRET_KEY
- validate amount, currency, and optional metadata before calling Stripe
- map Stripe id/client_secret to paymentId/clientSecret and preserve Stripe error messages through the API error path
- add mocked service tests plus an opt-in live Stripe smoke test guarded by RUN_STRIPE_SMOKE=1 and a test-mode key

## Demo / verification
- npm test - 6 passing, 1 smoke test skipped unless RUN_STRIPE_SMOKE=1 and STRIPE_SECRET_KEY=sk_test_... are set
- node --check apps/api/src/services/paymentService.js apps/api/src/controllers/paymentController.js apps/api/src/middleware/errorHandler.js apps/api/src/tests/paymentService.test.js
- git diff --check

No public payout details are included; payout handoff can happen privately if this is awarded.