### PR TITLE
Add original technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,25 @@
+# The Verification Room
+
+The brief arrives with its edges showing,
+one issue, one door, one narrow line of work.
+FreelanceFlow keeps the room well lit:
+a scope on the table, a branch in the hand,
+and no promise larger than the change itself.
+
+Someone writes the proof before the praise.
+Screenshots, tests, notes, and diffs
+wait in a quiet row,
+so review is not a guess
+and trust does not have to lean on charm.
+
+The marketplace moves when the evidence moves.
+A proposal becomes a pull request,
+a pull request becomes a question,
+a question becomes a cleaner patch
+with every loose claim tightened into shape.
+
+When the merge light turns green,
+payment is not a favor passed in the hallway.
+It is the last line of the contract:
+work delivered, work reviewed,
+work flowing back to the person who made it real.


### PR DESCRIPTION
## Summary
- add `POEM.md` in the project root for #76
- original four-stanza poem written specifically around FreelanceFlow scope, evidence, review, and payout flow

## Creative note
I chose a quiet verification-room tone because the project frames bounty work around scoped issues, review evidence, and payment after merge.

## Demo / evidence
- Markdown-only change is visible directly in the PR Files changed view.
- GitHub check `update-leaderboard` passed.

## Validation
- `git diff --check`
- Not run: project tests/build, because this is a Markdown-only content change and this session avoids executing untrusted repo scripts.

/claim #76
Closes #76