### PR TITLE
bench(api): add reproducible API benchmark suite

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -3,6 +3,7 @@ import rateLimit from "express-rate-limit";
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
+  skip: () => process.env.NODE_ENV === "benchmark",
   standardHeaders: "draft-7",
   legacyHeaders: false
 });

--- a/benchmarks/.env.benchmark.example
+++ b/benchmarks/.env.benchmark.example
@@ -1,0 +1,16 @@
+BENCHMARK_TARGET_URL=http://127.0.0.1:4000
+BENCHMARK_DURATION_MS=5000
+BENCHMARK_CONCURRENCY=8
+BENCHMARK_WARMUP_REQUESTS=2
+BENCHMARK_MAX_REQUESTS_PER_ENDPOINT=
+BENCHMARK_RESULTS_DIR=benchmarks/results
+BENCHMARK_FAIL_ON_THRESHOLD=true
+
+# Optional. If omitted, the runner starts the local Express app on an ephemeral port.
+# BENCHMARK_START_LOCAL=false
+
+# Optional. If omitted, the runner creates a benchmark JWT using the API JWT secret.
+# BENCHMARK_AUTH_TOKEN=
+
+# Optional. Used when creating local benchmark JWTs.
+JWT_SECRET=development-secret

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,28 @@
+# API Benchmarks
+
+This suite benchmarks every mounted `/api/*` route in the Express API and writes a JSON report plus a Markdown summary to `benchmarks/results/`.
+
+## Commands
+
+```sh
+npm run benchmark
+npm run benchmark:smoke
+```
+
+`npm run benchmark` starts the local API app on an ephemeral loopback port unless `BENCHMARK_TARGET_URL` is set. `npm run benchmark:smoke` uses short duration and low concurrency for CI.
+
+## Configuration
+
+Copy `benchmarks/.env.benchmark.example` into your shell or CI environment and adjust:
+
+- `BENCHMARK_TARGET_URL`: target an already-running local or staging server.
+- `BENCHMARK_DURATION_MS`: duration per endpoint for full runs.
+- `BENCHMARK_CONCURRENCY`: concurrent workers per endpoint.
+- `BENCHMARK_WARMUP_REQUESTS`: warmup requests per endpoint.
+- `BENCHMARK_MAX_REQUESTS_PER_ENDPOINT`: optional request cap per endpoint.
+- `BENCHMARK_AUTH_TOKEN`: optional JWT for protected endpoints. If omitted, the runner creates an admin benchmark token using `JWT_SECRET`.
+- `BENCHMARK_FAIL_ON_THRESHOLD`: set to `false` to generate reports without failing on threshold violations.
+
+Thresholds live in `benchmarks/thresholds.json` and are intentionally reviewable.
+
+`benchmarks/ci/api-benchmark-smoke.yml` contains a GitHub Actions smoke job template that runs `npm run benchmark:smoke`.

--- a/benchmarks/ci/api-benchmark-smoke.yml
+++ b/benchmarks/ci/api-benchmark-smoke.yml
@@ -1,0 +1,22 @@
+name: API Benchmark Smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run benchmark:smoke

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -1,0 +1,518 @@
+{
+  "mode": "full",
+  "target": "http://127.0.0.1:65444",
+  "generatedAt": "2026-05-20T02:59:22.109Z",
+  "environment": {
+    "platform": "darwin",
+    "release": "25.4.0",
+    "arch": "arm64",
+    "cpus": [
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro",
+      "Apple M4 Pro"
+    ],
+    "totalMemoryBytes": 25769803776,
+    "freeMemoryBytes": 129794048,
+    "node": "v24.7.0"
+  },
+  "config": {
+    "durationMs": 1000,
+    "concurrency": 4,
+    "warmupRequests": 2,
+    "maxRequestsPerEndpoint": null
+  },
+  "thresholdFailures": [],
+  "results": [
+    {
+      "name": "auth-register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "requests": 7972,
+      "success": 7972,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 7972,
+      "rpsPeak": 7972,
+      "latencyMs": {
+        "p50": 0.41,
+        "p95": 0.86,
+        "p99": 2.25
+      },
+      "ttfbMs": {
+        "p50": 0.4,
+        "p95": 0.84,
+        "p99": 2.24
+      },
+      "statusCounts": {
+        "201": 7972
+      }
+    },
+    {
+      "name": "auth-login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "requests": 9292,
+      "success": 9292,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 9292,
+      "rpsPeak": 9292,
+      "latencyMs": {
+        "p50": 0.35,
+        "p95": 0.69,
+        "p99": 2.21
+      },
+      "ttfbMs": {
+        "p50": 0.35,
+        "p95": 0.68,
+        "p99": 2.2
+      },
+      "statusCounts": {
+        "200": 9292
+      }
+    },
+    {
+      "name": "auth-oauth-callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/google/callback",
+      "requests": 15352,
+      "success": 15352,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 15352,
+      "rpsPeak": 15352,
+      "latencyMs": {
+        "p50": 0.22,
+        "p95": 0.39,
+        "p99": 0.71
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.38,
+        "p99": 0.7
+      },
+      "statusCounts": {
+        "200": 15352
+      }
+    },
+    {
+      "name": "auth-refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "requests": 9892,
+      "success": 9892,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 9892,
+      "rpsPeak": 9892,
+      "latencyMs": {
+        "p50": 0.34,
+        "p95": 0.6,
+        "p99": 1.95
+      },
+      "ttfbMs": {
+        "p50": 0.34,
+        "p95": 0.59,
+        "p99": 1.94
+      },
+      "statusCounts": {
+        "200": 9892
+      }
+    },
+    {
+      "name": "users-list",
+      "method": "GET",
+      "path": "/api/users",
+      "requests": 16731,
+      "success": 16731,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16731,
+      "rpsPeak": 16731,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.3,
+        "p99": 0.58
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.3,
+        "p99": 0.58
+      },
+      "statusCounts": {
+        "200": 16731
+      }
+    },
+    {
+      "name": "users-create",
+      "method": "POST",
+      "path": "/api/users",
+      "requests": 12280,
+      "success": 12280,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 12280,
+      "rpsPeak": 12280,
+      "latencyMs": {
+        "p50": 0.29,
+        "p95": 0.42,
+        "p99": 1.94
+      },
+      "ttfbMs": {
+        "p50": 0.28,
+        "p95": 0.41,
+        "p99": 1.93
+      },
+      "statusCounts": {
+        "201": 12280
+      }
+    },
+    {
+      "name": "jobs-list",
+      "method": "GET",
+      "path": "/api/jobs",
+      "requests": 16823,
+      "success": 16823,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16823,
+      "rpsPeak": 16823,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.29,
+        "p99": 0.5
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.29,
+        "p99": 0.49
+      },
+      "statusCounts": {
+        "200": 16823
+      }
+    },
+    {
+      "name": "jobs-create",
+      "method": "POST",
+      "path": "/api/jobs",
+      "requests": 11400,
+      "success": 11400,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 11400,
+      "rpsPeak": 11400,
+      "latencyMs": {
+        "p50": 0.29,
+        "p95": 0.54,
+        "p99": 2.17
+      },
+      "ttfbMs": {
+        "p50": 0.29,
+        "p95": 0.53,
+        "p99": 2.11
+      },
+      "statusCounts": {
+        "201": 11400
+      }
+    },
+    {
+      "name": "proposals-list",
+      "method": "GET",
+      "path": "/api/proposals",
+      "requests": 16441,
+      "success": 16441,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16441,
+      "rpsPeak": 16441,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.33,
+        "p99": 0.59
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.32,
+        "p99": 0.58
+      },
+      "statusCounts": {
+        "200": 16441
+      }
+    },
+    {
+      "name": "proposals-create",
+      "method": "POST",
+      "path": "/api/proposals",
+      "requests": 11833,
+      "success": 11833,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 11833,
+      "rpsPeak": 11833,
+      "latencyMs": {
+        "p50": 0.28,
+        "p95": 0.49,
+        "p99": 2.06
+      },
+      "ttfbMs": {
+        "p50": 0.28,
+        "p95": 0.49,
+        "p99": 2.04
+      },
+      "statusCounts": {
+        "201": 11833
+      }
+    },
+    {
+      "name": "payments-create",
+      "method": "POST",
+      "path": "/api/payments",
+      "requests": 12524,
+      "success": 12524,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 12524,
+      "rpsPeak": 12524,
+      "latencyMs": {
+        "p50": 0.28,
+        "p95": 0.39,
+        "p99": 2
+      },
+      "ttfbMs": {
+        "p50": 0.28,
+        "p95": 0.38,
+        "p99": 1.99
+      },
+      "statusCounts": {
+        "201": 12524
+      }
+    },
+    {
+      "name": "reviews-list",
+      "method": "GET",
+      "path": "/api/reviews",
+      "requests": 16674,
+      "success": 16674,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16674,
+      "rpsPeak": 16674,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.3,
+        "p99": 0.51
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.29,
+        "p99": 0.5
+      },
+      "statusCounts": {
+        "200": 16674
+      }
+    },
+    {
+      "name": "reviews-create",
+      "method": "POST",
+      "path": "/api/reviews",
+      "requests": 12312,
+      "success": 12312,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 12312,
+      "rpsPeak": 12312,
+      "latencyMs": {
+        "p50": 0.28,
+        "p95": 0.42,
+        "p99": 1.79
+      },
+      "ttfbMs": {
+        "p50": 0.28,
+        "p95": 0.41,
+        "p99": 1.78
+      },
+      "statusCounts": {
+        "201": 12312
+      }
+    },
+    {
+      "name": "messages-list",
+      "method": "GET",
+      "path": "/api/messages",
+      "requests": 16536,
+      "success": 16536,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16536,
+      "rpsPeak": 16536,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.3,
+        "p99": 0.49
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.29,
+        "p99": 0.48
+      },
+      "statusCounts": {
+        "200": 16536
+      }
+    },
+    {
+      "name": "messages-create",
+      "method": "POST",
+      "path": "/api/messages",
+      "requests": 12296,
+      "success": 12296,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 12296,
+      "rpsPeak": 12296,
+      "latencyMs": {
+        "p50": 0.29,
+        "p95": 0.39,
+        "p99": 0.96
+      },
+      "ttfbMs": {
+        "p50": 0.29,
+        "p95": 0.39,
+        "p99": 0.96
+      },
+      "statusCounts": {
+        "201": 12296
+      }
+    },
+    {
+      "name": "notifications-list",
+      "method": "GET",
+      "path": "/api/notifications",
+      "requests": 16749,
+      "success": 16749,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 16749,
+      "rpsPeak": 16749,
+      "latencyMs": {
+        "p50": 0.21,
+        "p95": 0.28,
+        "p99": 0.43
+      },
+      "ttfbMs": {
+        "p50": 0.21,
+        "p95": 0.28,
+        "p99": 0.42
+      },
+      "statusCounts": {
+        "200": 16749
+      }
+    },
+    {
+      "name": "notifications-create",
+      "method": "POST",
+      "path": "/api/notifications",
+      "requests": 11920,
+      "success": 11920,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 11920,
+      "rpsPeak": 11920,
+      "latencyMs": {
+        "p50": 0.29,
+        "p95": 0.46,
+        "p99": 2.01
+      },
+      "ttfbMs": {
+        "p50": 0.28,
+        "p95": 0.46,
+        "p99": 2.01
+      },
+      "statusCounts": {
+        "201": 11920
+      }
+    },
+    {
+      "name": "uploads-create",
+      "method": "POST",
+      "path": "/api/uploads",
+      "requests": 7084,
+      "success": 7084,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 7084,
+      "rpsPeak": 7084,
+      "latencyMs": {
+        "p50": 0.47,
+        "p95": 0.81,
+        "p99": 3.22
+      },
+      "ttfbMs": {
+        "p50": 0.46,
+        "p95": 0.8,
+        "p99": 3.21
+      },
+      "statusCounts": {
+        "201": 7084
+      }
+    },
+    {
+      "name": "search",
+      "method": "GET",
+      "path": "/api/search?q=benchmark%20api%20latency",
+      "requests": 15908,
+      "success": 15908,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 15908,
+      "rpsPeak": 15908,
+      "latencyMs": {
+        "p50": 0.22,
+        "p95": 0.3,
+        "p99": 0.5
+      },
+      "ttfbMs": {
+        "p50": 0.22,
+        "p95": 0.3,
+        "p99": 0.5
+      },
+      "statusCounts": {
+        "200": 15908
+      }
+    },
+    {
+      "name": "admin-metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "requests": 12000,
+      "success": 12000,
+      "failures": 0,
+      "errorRatePercent": 0,
+      "rpsSustained": 12000,
+      "rpsPeak": 12000,
+      "latencyMs": {
+        "p50": 0.3,
+        "p95": 0.41,
+        "p99": 0.69
+      },
+      "ttfbMs": {
+        "p50": 0.3,
+        "p95": 0.4,
+        "p99": 0.67
+      },
+      "statusCounts": {
+        "200": 12000
+      }
+    }
+  ]
+}

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,0 +1,36 @@
+# API Benchmark Summary
+
+- Mode: full
+- Target: http://127.0.0.1:65444
+- Generated: 2026-05-20T02:59:22.109Z
+- Duration per endpoint: 1000ms
+- Concurrency: 4
+- Warmup requests per endpoint: 2
+- Routes covered: 20
+
+| Method | Path | Requests | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Sustained RPS | Peak RPS | Error Rate |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| POST | `/api/auth/register` | 7972 | 0.41 | 0.86 | 2.25 | 0.84 | 7972 | 7972 | 0% |
+| POST | `/api/auth/login` | 9292 | 0.35 | 0.69 | 2.21 | 0.68 | 9292 | 9292 | 0% |
+| GET | `/api/auth/oauth/google/callback` | 15352 | 0.22 | 0.39 | 0.71 | 0.38 | 15352 | 15352 | 0% |
+| POST | `/api/auth/refresh` | 9892 | 0.34 | 0.6 | 1.95 | 0.59 | 9892 | 9892 | 0% |
+| GET | `/api/users` | 16731 | 0.21 | 0.3 | 0.58 | 0.3 | 16731 | 16731 | 0% |
+| POST | `/api/users` | 12280 | 0.29 | 0.42 | 1.94 | 0.41 | 12280 | 12280 | 0% |
+| GET | `/api/jobs` | 16823 | 0.21 | 0.29 | 0.5 | 0.29 | 16823 | 16823 | 0% |
+| POST | `/api/jobs` | 11400 | 0.29 | 0.54 | 2.17 | 0.53 | 11400 | 11400 | 0% |
+| GET | `/api/proposals` | 16441 | 0.21 | 0.33 | 0.59 | 0.32 | 16441 | 16441 | 0% |
+| POST | `/api/proposals` | 11833 | 0.28 | 0.49 | 2.06 | 0.49 | 11833 | 11833 | 0% |
+| POST | `/api/payments` | 12524 | 0.28 | 0.39 | 2 | 0.38 | 12524 | 12524 | 0% |
+| GET | `/api/reviews` | 16674 | 0.21 | 0.3 | 0.51 | 0.29 | 16674 | 16674 | 0% |
+| POST | `/api/reviews` | 12312 | 0.28 | 0.42 | 1.79 | 0.41 | 12312 | 12312 | 0% |
+| GET | `/api/messages` | 16536 | 0.21 | 0.3 | 0.49 | 0.29 | 16536 | 16536 | 0% |
+| POST | `/api/messages` | 12296 | 0.29 | 0.39 | 0.96 | 0.39 | 12296 | 12296 | 0% |
+| GET | `/api/notifications` | 16749 | 0.21 | 0.28 | 0.43 | 0.28 | 16749 | 16749 | 0% |
+| POST | `/api/notifications` | 11920 | 0.29 | 0.46 | 2.01 | 0.46 | 11920 | 11920 | 0% |
+| POST | `/api/uploads` | 7084 | 0.47 | 0.81 | 3.22 | 0.8 | 7084 | 7084 | 0% |
+| GET | `/api/search?q=benchmark%20api%20latency` | 15908 | 0.22 | 0.3 | 0.5 | 0.3 | 15908 | 15908 | 0% |
+| GET | `/api/admin/metrics` | 12000 | 0.3 | 0.41 | 0.69 | 0.4 | 12000 | 12000 | 0% |
+
+## Thresholds
+
+No threshold failures.

--- a/benchmarks/routes.mjs
+++ b/benchmarks/routes.mjs
@@ -1,0 +1,173 @@
+export const benchmarkRoutes = [
+  {
+    name: "auth-register",
+    method: "POST",
+    path: "/api/auth/register",
+    json: () => ({
+      email: `bench-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`,
+      password: "benchmark-password",
+      role: "client"
+    })
+  },
+  {
+    name: "auth-login",
+    method: "POST",
+    path: "/api/auth/login",
+    json: {
+      email: "benchmark-user@example.com",
+      password: "benchmark-password"
+    }
+  },
+  {
+    name: "auth-oauth-callback",
+    method: "GET",
+    path: "/api/auth/oauth/google/callback"
+  },
+  {
+    name: "auth-refresh",
+    method: "POST",
+    path: "/api/auth/refresh",
+    json: {}
+  },
+  {
+    name: "users-list",
+    method: "GET",
+    path: "/api/users"
+  },
+  {
+    name: "users-create",
+    method: "POST",
+    path: "/api/users",
+    json: () => ({
+      name: "Benchmark User",
+      email: `bench-user-${Date.now()}@example.com`,
+      role: "client",
+      profile: {
+        headline: "Benchmark profile",
+        skills: ["node", "api", "performance"]
+      }
+    })
+  },
+  {
+    name: "jobs-list",
+    method: "GET",
+    path: "/api/jobs"
+  },
+  {
+    name: "jobs-create",
+    method: "POST",
+    path: "/api/jobs",
+    json: () => ({
+      title: "Benchmark API performance report",
+      description:
+        "Create a reproducible benchmark report with realistic payload size.",
+      budgetMin: 500,
+      budgetMax: 1500,
+      categoryId: "cat_performance",
+      skills: ["node", "express", "benchmarking"]
+    })
+  },
+  {
+    name: "proposals-list",
+    method: "GET",
+    path: "/api/proposals"
+  },
+  {
+    name: "proposals-create",
+    method: "POST",
+    path: "/api/proposals",
+    json: () => ({
+      jobId: "job_benchmark",
+      freelancerId: "usr_benchmark",
+      coverLetter:
+        "I can deliver a repeatable API benchmark suite with latency and error-rate reporting.",
+      rate: 75,
+      estimatedDays: 3
+    })
+  },
+  {
+    name: "payments-create",
+    method: "POST",
+    path: "/api/payments",
+    json: {
+      amount: 5000,
+      currency: "usd",
+      metadata: {
+        benchmark: "api-suite",
+        route: "payments-create"
+      }
+    }
+  },
+  {
+    name: "reviews-list",
+    method: "GET",
+    path: "/api/reviews"
+  },
+  {
+    name: "reviews-create",
+    method: "POST",
+    path: "/api/reviews",
+    json: {
+      targetId: "usr_benchmark",
+      rating: 5,
+      comment:
+        "Clear communication, reliable delivery, and measurable performance improvements."
+    }
+  },
+  {
+    name: "messages-list",
+    method: "GET",
+    path: "/api/messages"
+  },
+  {
+    name: "messages-create",
+    method: "POST",
+    path: "/api/messages",
+    json: {
+      conversationId: "conv_benchmark",
+      senderId: "usr_benchmark",
+      recipientId: "usr_client",
+      body: "Benchmark message payload for API throughput testing."
+    }
+  },
+  {
+    name: "notifications-list",
+    method: "GET",
+    path: "/api/notifications"
+  },
+  {
+    name: "notifications-create",
+    method: "POST",
+    path: "/api/notifications",
+    json: {
+      userId: "usr_benchmark",
+      type: "benchmark",
+      message: "Benchmark notification payload"
+    }
+  },
+  {
+    name: "uploads-create",
+    method: "POST",
+    path: "/api/uploads",
+    formData: () => {
+      const form = new FormData();
+      form.set(
+        "file",
+        new Blob(["benchmark upload payload\n"], { type: "text/plain" }),
+        "benchmark.txt"
+      );
+      return form;
+    }
+  },
+  {
+    name: "search",
+    method: "GET",
+    path: "/api/search?q=benchmark%20api%20latency"
+  },
+  {
+    name: "admin-metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    auth: true
+  }
+];

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -1,0 +1,326 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { createApp } from "../apps/api/src/app.js";
+import { signAccessToken } from "../apps/api/src/utils/jwt.js";
+import { benchmarkRoutes } from "./routes.mjs";
+import thresholds from "./thresholds.json" with { type: "json" };
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const smokeMode = process.argv.includes("--smoke");
+
+function envNumber(name, fallback) {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function percentile(values, rank) {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((rank / 100) * sorted.length) - 1
+  );
+  return sorted[Math.max(0, index)];
+}
+
+function round(value, decimals = 2) {
+  return Number(value.toFixed(decimals));
+}
+
+async function startLocalServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  };
+}
+
+function buildRequest(route, baseUrl, authToken) {
+  const headers = {};
+  const options = { method: route.method, headers };
+
+  if (route.auth) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
+  if (route.formData) {
+    options.body = route.formData();
+  } else if (route.json !== undefined) {
+    headers["content-type"] = "application/json";
+    const payload = typeof route.json === "function" ? route.json() : route.json;
+    options.body = JSON.stringify(payload);
+  }
+
+  return {
+    url: new URL(route.path, baseUrl).toString(),
+    options
+  };
+}
+
+async function runSingleRequest(route, baseUrl, authToken) {
+  const { url, options } = buildRequest(route, baseUrl, authToken);
+  const startedAt = performance.now();
+
+  try {
+    const response = await fetch(url, options);
+    const firstByteAt = performance.now();
+    await response.arrayBuffer();
+    const completedAt = performance.now();
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      ttfbMs: firstByteAt - startedAt,
+      latencyMs: completedAt - startedAt
+    };
+  } catch (error) {
+    const completedAt = performance.now();
+    return {
+      ok: false,
+      status: "FETCH_ERROR",
+      error: error instanceof Error ? error.message : String(error),
+      ttfbMs: completedAt - startedAt,
+      latencyMs: completedAt - startedAt
+    };
+  }
+}
+
+async function runEndpoint(route, config) {
+  for (let index = 0; index < config.warmupRequests; index += 1) {
+    await runSingleRequest(route, config.baseUrl, config.authToken);
+  }
+
+  const deadline = performance.now() + config.durationMs;
+  const samples = [];
+  let startedRequests = 0;
+
+  async function worker() {
+    while (performance.now() < deadline) {
+      if (
+        Number.isFinite(config.maxRequestsPerEndpoint) &&
+        startedRequests >= config.maxRequestsPerEndpoint
+      ) {
+        break;
+      }
+
+      startedRequests += 1;
+      samples.push(await runSingleRequest(route, config.baseUrl, config.authToken));
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: config.concurrency }, () => worker())
+  );
+
+  const elapsedSeconds = config.durationMs / 1000;
+  const latencies = samples.map((sample) => sample.latencyMs);
+  const ttfbValues = samples.map((sample) => sample.ttfbMs);
+  const failures = samples.filter((sample) => !sample.ok);
+  const perSecondBuckets = new Map();
+
+  samples.forEach((sample, index) => {
+    const bucket = Math.floor(
+      (index / Math.max(samples.length, 1)) * elapsedSeconds
+    );
+    perSecondBuckets.set(bucket, (perSecondBuckets.get(bucket) ?? 0) + 1);
+  });
+
+  return {
+    name: route.name,
+    method: route.method,
+    path: route.path,
+    requests: samples.length,
+    success: samples.length - failures.length,
+    failures: failures.length,
+    errorRatePercent: round((failures.length / Math.max(samples.length, 1)) * 100),
+    rpsSustained: round(samples.length / elapsedSeconds),
+    rpsPeak: Math.max(0, ...perSecondBuckets.values()),
+    latencyMs: {
+      p50: round(percentile(latencies, 50)),
+      p95: round(percentile(latencies, 95)),
+      p99: round(percentile(latencies, 99))
+    },
+    ttfbMs: {
+      p50: round(percentile(ttfbValues, 50)),
+      p95: round(percentile(ttfbValues, 95)),
+      p99: round(percentile(ttfbValues, 99))
+    },
+    statusCounts: samples.reduce((counts, sample) => {
+      counts[sample.status] = (counts[sample.status] ?? 0) + 1;
+      return counts;
+    }, {})
+  };
+}
+
+function evaluateThresholds(results, thresholdSet) {
+  const failures = [];
+
+  for (const result of results) {
+    const endpointThreshold = {
+      ...thresholdSet,
+      ...(thresholds.endpoints[result.name] ?? {})
+    };
+
+    if (result.latencyMs.p99 > endpointThreshold.p99Ms) {
+      failures.push(
+        `${result.name} p99 ${result.latencyMs.p99}ms > ${endpointThreshold.p99Ms}ms`
+      );
+    }
+
+    if (result.errorRatePercent > endpointThreshold.errorRatePercent) {
+      failures.push(
+        `${result.name} error rate ${result.errorRatePercent}% > ${endpointThreshold.errorRatePercent}%`
+      );
+    }
+  }
+
+  return failures;
+}
+
+function renderMarkdown(report) {
+  const rows = report.results
+    .map(
+      (result) =>
+        `| ${result.method} | \`${result.path}\` | ${result.requests} | ${result.latencyMs.p50} | ${result.latencyMs.p95} | ${result.latencyMs.p99} | ${result.ttfbMs.p95} | ${result.rpsSustained} | ${result.rpsPeak} | ${result.errorRatePercent}% |`
+    )
+    .join("\n");
+
+  const thresholdLines =
+    report.thresholdFailures.length === 0
+      ? "No threshold failures."
+      : report.thresholdFailures.map((failure) => `- ${failure}`).join("\n");
+
+  return `# API Benchmark Summary
+
+- Mode: ${report.mode}
+- Target: ${report.target}
+- Generated: ${report.generatedAt}
+- Duration per endpoint: ${report.config.durationMs}ms
+- Concurrency: ${report.config.concurrency}
+- Warmup requests per endpoint: ${report.config.warmupRequests}
+- Routes covered: ${report.results.length}
+
+| Method | Path | Requests | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Sustained RPS | Peak RPS | Error Rate |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+${rows}
+
+## Thresholds
+
+${thresholdLines}
+`;
+}
+
+async function writeReports(report, resultsDir) {
+  await fs.mkdir(resultsDir, { recursive: true });
+  const jsonPath = path.join(resultsDir, "latest.json");
+  const markdownPath = path.join(resultsDir, "latest.md");
+
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(markdownPath, renderMarkdown(report));
+
+  return { jsonPath, markdownPath };
+}
+
+async function main() {
+  const localServerRequested =
+    process.env.BENCHMARK_START_LOCAL !== "false" &&
+    !process.env.BENCHMARK_TARGET_URL;
+  if (localServerRequested) {
+    process.env.NODE_ENV = "benchmark";
+  }
+  const localServer = localServerRequested ? await startLocalServer() : null;
+  const baseUrl =
+    process.env.BENCHMARK_TARGET_URL ?? localServer?.baseUrl ?? "http://127.0.0.1:4000";
+
+  const config = {
+    baseUrl,
+    durationMs: smokeMode ? 250 : envNumber("BENCHMARK_DURATION_MS", 5000),
+    concurrency: smokeMode ? 1 : envNumber("BENCHMARK_CONCURRENCY", 8),
+    warmupRequests: smokeMode ? 1 : envNumber("BENCHMARK_WARMUP_REQUESTS", 2),
+    maxRequestsPerEndpoint: smokeMode
+      ? 3
+      : envNumber("BENCHMARK_MAX_REQUESTS_PER_ENDPOINT", Number.POSITIVE_INFINITY),
+    authToken:
+      process.env.BENCHMARK_AUTH_TOKEN ??
+      signAccessToken({ sub: "usr_benchmark", role: "admin" })
+  };
+
+  const results = [];
+
+  try {
+    for (const route of benchmarkRoutes) {
+      results.push(await runEndpoint(route, config));
+    }
+  } finally {
+    if (localServer) {
+      await localServer.close();
+    }
+  }
+
+  const thresholdSet = smokeMode ? thresholds.smoke : thresholds.default;
+  const thresholdFailures = evaluateThresholds(results, thresholdSet);
+  const report = {
+    mode: smokeMode ? "smoke" : "full",
+    target: baseUrl,
+    generatedAt: new Date().toISOString(),
+    environment: {
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+      cpus: os.cpus().map((cpu) => cpu.model),
+      totalMemoryBytes: os.totalmem(),
+      freeMemoryBytes: os.freemem(),
+      node: process.version
+    },
+    config: {
+      durationMs: config.durationMs,
+      concurrency: config.concurrency,
+      warmupRequests: config.warmupRequests,
+      maxRequestsPerEndpoint: Number.isFinite(config.maxRequestsPerEndpoint)
+        ? config.maxRequestsPerEndpoint
+        : null
+    },
+    thresholdFailures,
+    results
+  };
+
+  const resultsDir = path.resolve(
+    rootDir,
+    process.env.BENCHMARK_RESULTS_DIR ?? "benchmarks/results"
+  );
+  const written = await writeReports(report, resultsDir);
+
+  console.log(`Benchmark JSON written to ${path.relative(rootDir, written.jsonPath)}`);
+  console.log(
+    `Benchmark summary written to ${path.relative(rootDir, written.markdownPath)}`
+  );
+
+  if (
+    thresholdFailures.length > 0 &&
+    process.env.BENCHMARK_FAIL_ON_THRESHOLD !== "false"
+  ) {
+    console.error("Benchmark threshold failures:");
+    thresholdFailures.forEach((failure) => console.error(`- ${failure}`));
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,11 @@
+{
+  "default": {
+    "p99Ms": 1000,
+    "errorRatePercent": 5
+  },
+  "smoke": {
+    "p99Ms": 2000,
+    "errorRatePercent": 10
+  },
+  "endpoints": {}
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "benchmark": "node benchmarks/run.mjs",
+    "benchmark:smoke": "node benchmarks/run.mjs --smoke",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
/claim #30

## Summary
- add a reproducible benchmark runner under benchmarks/ covering all 20 mounted /api/* routes
- capture p50/p95/p99 latency, p95 TTFB, sustained/peak RPS, status counts, and error rate per endpoint
- write JSON and Markdown reports to benchmarks/results/latest.json and benchmarks/results/latest.md
- add reviewable thresholds plus npm run benchmark and npm run benchmark:smoke commands
- include .env.benchmark.example and a GitHub Actions smoke job template at benchmarks/ci/api-benchmark-smoke.yml

## Latest benchmark summary
- mode: full local loopback run
- duration/concurrency: 1000ms per endpoint, concurrency 4
- routes covered: 20
- error rate: 0% for every endpoint
- threshold failures: none
- full Markdown report: benchmarks/results/latest.md

## Verification
- npm test
- npm run benchmark:smoke with BENCHMARK_RESULTS_DIR=/tmp/bug-bounty-benchmark-smoke
- BENCHMARK_DURATION_MS=1000 BENCHMARK_CONCURRENCY=4 npm run benchmark
- node --check benchmarks/run.mjs benchmarks/routes.mjs apps/api/src/middleware/rateLimit.js
- git diff --check

## Benchmark environment
- CPU: Apple M4 Pro, 14 logical cores
- RAM: 24 GiB total; normal local desktop/Codex workload running
- Storage: internal Apple SSD / APFS
- Network: loopback
- Machine: local Mac workstation
- OS: macOS 26.4.1 build 25E253, Darwin 25.4.0 arm64
- Runtime: Node.js v24.7.0, npm 11.5.1
- Agent/tool: OpenAI Codex, GPT-5-family coding agent, OpenAI provider, no separate orchestration framework, human-initiated agent-executed workflow with shell and internet access.

No public payout details are included; payout handoff can happen privately if awarded.