### PR TITLE
feat(admin): implement operations panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,83 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  decideFlaggedJob,
+  getAdminMetrics,
+  getDispute,
+  getPlatformControls,
+  listAuditLog,
+  listDisputes,
+  listFlaggedJobs,
+  listUsers,
+  ruleDispute,
+  setPlatformControl,
+  updateUserStatus
+} from "../services/adminService.js";
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await listUsers(req.query));
+}
+
+export async function setUserStatus(req, res) {
+  const result = await updateUserStatus(req.params.userId, req.body, req.user);
+  if (!result) {
+    return fail(res, "User not found or invalid status", 404);
+  }
+
+  return ok(res, result);
+}
+
+export async function flaggedJobs(req, res) {
+  return ok(res, await listFlaggedJobs(req.query));
+}
+
+export async function setJobDecision(req, res) {
+  const result = await decideFlaggedJob(req.params.jobId, req.body, req.user);
+  if (!result) {
+    return fail(res, "Job not found or invalid decision", 404);
+  }
+
+  return ok(res, result);
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function disputeDetails(req, res) {
+  const dispute = await getDispute(req.params.disputeId);
+  if (!dispute) {
+    return fail(res, "Dispute not found", 404);
+  }
+
+  return ok(res, dispute);
+}
+
+export async function setDisputeRuling(req, res) {
+  const result = await ruleDispute(req.params.disputeId, req.body, req.user);
+  if (!result) {
+    return fail(res, "Dispute not found or invalid ruling", 404);
+  }
+
+  return ok(res, result);
+}
+
+export async function platformControls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function setControl(req, res) {
+  const result = await setPlatformControl(req.params.controlKey, req.body, req.user);
+  if (!result) {
+    return fail(res, "Control not found or invalid payload", 404);
+  }
+
+  return ok(res, result);
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await listAuditLog(req.query));
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminOnlyMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,31 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  auditLog,
+  disputeDetails,
+  disputes,
+  flaggedJobs,
+  metrics,
+  platformControls,
+  setControl,
+  setDisputeRuling,
+  setJobDecision,
+  setUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { adminOnlyMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnlyMiddleware);
+
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:userId/status", setUserStatus);
+adminRoutes.get("/moderation/jobs", flaggedJobs);
+adminRoutes.post("/moderation/jobs/:jobId/decision", setJobDecision);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.get("/disputes/:disputeId", disputeDetails);
+adminRoutes.post("/disputes/:disputeId/ruling", setDisputeRuling);
+adminRoutes.get("/controls", platformControls);
+adminRoutes.patch("/controls/:controlKey", setControl);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,431 @@
+const initialUsers = [
+  {
+    id: "usr_1001",
+    name: "Maya Chen",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-01-12T10:20:00.000Z",
+    trustScore: 94,
+    activeJobs: ["job_502"],
+    disputeHistory: ["dsp_9002"],
+    profile: { location: "Singapore", skills: ["Next.js", "Node.js"], completedJobs: 38 }
+  },
+  {
+    id: "usr_1002",
+    name: "Jordan Reed",
+    email: "jordan@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-03T15:05:00.000Z",
+    trustScore: 81,
+    activeJobs: ["job_501", "job_503"],
+    disputeHistory: ["dsp_9001"],
+    profile: { location: "United States", company: "Northstar Labs", completedJobs: 17 }
+  },
+  {
+    id: "usr_1003",
+    name: "Iris Novak",
+    email: "iris@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-03-18T09:30:00.000Z",
+    trustScore: 47,
+    activeJobs: [],
+    disputeHistory: ["dsp_9001"],
+    profile: { location: "Germany", skills: ["Security review", "Python"], completedJobs: 4 }
+  },
+  {
+    id: "usr_1004",
+    name: "Theo Park",
+    email: "theo@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-04-02T12:45:00.000Z",
+    trustScore: 72,
+    activeJobs: ["job_504"],
+    disputeHistory: [],
+    profile: { location: "South Korea", company: "Orbit Forge", completedJobs: 9 }
+  },
+  {
+    id: "usr_1005",
+    name: "Rina Alvarez",
+    email: "rina@example.com",
+    role: "freelancer",
+    status: "banned",
+    joinedAt: "2025-12-04T08:15:00.000Z",
+    trustScore: 18,
+    activeJobs: [],
+    disputeHistory: ["dsp_9003"],
+    profile: { location: "Mexico", skills: ["Content", "Data entry"], completedJobs: 2 }
+  }
+];
+
+const initialJobs = [
+  {
+    id: "job_501",
+    title: "Audit OAuth callback handling",
+    clientId: "usr_1002",
+    budget: 1200,
+    status: "flagged",
+    moderationStatus: "pending",
+    flagReason: "Automated rule detected off-platform payment wording.",
+    reports: 3,
+    postedAt: "2026-05-15T10:00:00.000Z"
+  },
+  {
+    id: "job_502",
+    title: "Build invoice reconciliation dashboard",
+    clientId: "usr_1004",
+    budget: 2600,
+    status: "active",
+    moderationStatus: "approved",
+    flagReason: "",
+    reports: 0,
+    postedAt: "2026-05-10T11:30:00.000Z"
+  },
+  {
+    id: "job_503",
+    title: "Scrape private marketplace leads",
+    clientId: "usr_1002",
+    budget: 850,
+    status: "flagged",
+    moderationStatus: "escalated",
+    flagReason: "User report says the task may violate third-party terms.",
+    reports: 2,
+    postedAt: "2026-05-17T16:15:00.000Z"
+  },
+  {
+    id: "job_504",
+    title: "Create accessible profile settings page",
+    clientId: "usr_1004",
+    budget: 900,
+    status: "active",
+    moderationStatus: "approved",
+    flagReason: "",
+    reports: 0,
+    postedAt: "2026-05-18T09:05:00.000Z"
+  }
+];
+
+const initialDisputes = [
+  {
+    id: "dsp_9001",
+    jobId: "job_501",
+    clientId: "usr_1002",
+    freelancerId: "usr_1003",
+    status: "open",
+    amount: 650,
+    openedAt: "2026-05-18T06:30:00.000Z",
+    transaction: { id: "txn_7001", escrowStatus: "held", currency: "usd" },
+    thread: [
+      { authorId: "usr_1002", body: "The deliverable missed the agreed OAuth test cases.", createdAt: "2026-05-18T06:35:00.000Z" },
+      { authorId: "usr_1003", body: "I uploaded the missing cases in the second archive.", createdAt: "2026-05-18T07:02:00.000Z" }
+    ],
+    evidence: [
+      { id: "ev_1", type: "screenshot", label: "Missing test report" },
+      { id: "ev_2", type: "attachment", label: "Second archive manifest" }
+    ]
+  },
+  {
+    id: "dsp_9002",
+    jobId: "job_502",
+    clientId: "usr_1004",
+    freelancerId: "usr_1001",
+    status: "under_review",
+    amount: 300,
+    openedAt: "2026-05-19T02:20:00.000Z",
+    transaction: { id: "txn_7002", escrowStatus: "held", currency: "usd" },
+    thread: [{ authorId: "usr_1001", body: "The scope changed after milestone approval.", createdAt: "2026-05-19T02:24:00.000Z" }],
+    evidence: [{ id: "ev_3", type: "message", label: "Milestone approval transcript" }]
+  }
+];
+
+const initialControls = {
+  registrations: {
+    key: "registrations",
+    label: "New user registrations",
+    enabled: true,
+    updatedBy: "system",
+    updatedAt: "2026-05-18T00:00:00.000Z"
+  },
+  jobPostings: {
+    key: "jobPostings",
+    label: "New job postings",
+    enabled: true,
+    updatedBy: "system",
+    updatedAt: "2026-05-18T00:00:00.000Z"
+  }
+};
+
+let users = structuredClone(initialUsers);
+let jobs = structuredClone(initialJobs);
+let disputes = structuredClone(initialDisputes);
+let controls = structuredClone(initialControls);
+let notifications = [];
+let auditLog = [
+  {
+    id: "aud_1",
+    adminId: "system",
+    action: "admin.bootstrap",
+    targetType: "platform",
+    targetId: "seed",
+    note: "Seeded admin review data",
+    createdAt: "2026-05-18T00:00:00.000Z"
+  }
+];
+
+const VALID_USER_STATUSES = new Set(["active", "suspended", "banned"]);
+const VALID_MODERATION_DECISIONS = new Set(["approve", "reject", "escalate"]);
+const VALID_DISPUTE_RULINGS = new Set(["freelancer", "client", "refund", "escalate"]);
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function paginate(items, query = {}) {
+  const page = Math.max(Number.parseInt(query.page ?? "1", 10) || 1, 1);
+  const pageSize = Math.min(Math.max(Number.parseInt(query.pageSize ?? "10", 10) || 10, 1), 50);
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+
+  return {
+    items: clone(items.slice(start, start + pageSize)),
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: Math.max(Math.ceil(total / pageSize), 1)
+    }
+  };
+}
+
+function matchesDateRange(value, from, to) {
+  const timestamp = new Date(value).getTime();
+  if (from && timestamp < new Date(from).getTime()) return false;
+  if (to && timestamp > new Date(to).getTime()) return false;
+  return true;
+}
+
+function appendAudit(admin, action, targetType, targetId, note, metadata = {}) {
+  const entry = {
+    id: `aud_${auditLog.length + 1}`,
+    adminId: admin?.sub ?? admin?.email ?? "unknown_admin",
+    action,
+    targetType,
+    targetId,
+    note,
+    metadata,
+    createdAt: nowIso()
+  };
+  auditLog.push(entry);
+  return clone(entry);
+}
+
+function sendNotification(userId, type, message, metadata = {}) {
+  const notification = {
+    id: `ntf_${notifications.length + 1}`,
+    userId,
+    type,
+    message,
+    metadata,
+    createdAt: nowIso()
+  };
+  notifications.push(notification);
+  return notification;
+}
+
+function trustDistribution() {
+  const buckets = [
+    { label: "0-49", min: 0, max: 49 },
+    { label: "50-69", min: 50, max: 69 },
+    { label: "70-89", min: 70, max: 89 },
+    { label: "90-100", min: 90, max: 100 }
+  ];
+
+  return buckets.map((bucket) => ({
+    label: bucket.label,
+    count: users.filter((user) => user.trustScore >= bucket.min && user.trustScore <= bucket.max).length
+  }));
+}
+
 export async function getAdminMetrics() {
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    totalUsers: users.length,
+    activeJobs: jobs.filter((job) => job.status === "active").length,
+    openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+    flaggedListings: jobs.filter((job) => job.status === "flagged").length,
+    revenueCurrentPeriod: 128900,
+    trustDistribution: trustDistribution(),
+    generatedAt: nowIso()
   };
+}
+
+export async function listUsers(query) {
+  const search = query.search?.toLowerCase();
+  const filtered = users.filter((user) => {
+    if (search && !`${user.name} ${user.email}`.toLowerCase().includes(search)) return false;
+    if (query.role && user.role !== query.role) return false;
+    if (query.status && user.status !== query.status) return false;
+    return matchesDateRange(user.joinedAt, query.joinedFrom, query.joinedTo);
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function updateUserStatus(userId, payload, admin) {
+  if (!VALID_USER_STATUSES.has(payload.status)) {
+    return null;
+  }
+
+  const user = users.find((candidate) => candidate.id === userId);
+  if (!user) return null;
+
+  const previousStatus = user.status;
+  user.status = payload.status;
+  user.statusReason = payload.reason ?? "";
+  user.updatedAt = nowIso();
+
+  const audit = appendAudit(admin, `user.${payload.status}`, "user", userId, payload.reason ?? "Status updated", {
+    previousStatus,
+    nextStatus: payload.status
+  });
+
+  return { user: clone(user), audit };
+}
+
+export async function listFlaggedJobs(query) {
+  const filtered = jobs.filter((job) => {
+    if (query.status && job.moderationStatus !== query.status) return false;
+    if (query.search && !job.title.toLowerCase().includes(query.search.toLowerCase())) return false;
+    return true;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function decideFlaggedJob(jobId, payload, admin) {
+  if (!VALID_MODERATION_DECISIONS.has(payload.decision)) {
+    return null;
+  }
+
+  const job = jobs.find((candidate) => candidate.id === jobId);
+  if (!job) return null;
+
+  const previousStatus = job.moderationStatus;
+  const nextStatus = payload.decision === "approve" ? "approved" : payload.decision === "reject" ? "rejected" : "escalated";
+  job.moderationStatus = nextStatus;
+  job.status = nextStatus === "approved" ? "active" : "flagged";
+  job.decisionReason = payload.reason ?? "";
+  job.reviewedAt = nowIso();
+
+  if (nextStatus === "rejected") {
+    sendNotification(job.clientId, "listing_rejected", `Your listing "${job.title}" was rejected.`, {
+      jobId,
+      reason: payload.reason ?? ""
+    });
+  }
+
+  const audit = appendAudit(admin, `job.${nextStatus}`, "job", jobId, payload.reason ?? "Listing moderation decision", {
+    previousStatus,
+    nextStatus
+  });
+
+  return { job: clone(job), audit };
+}
+
+export async function listDisputes(query) {
+  const filtered = disputes.filter((dispute) => {
+    if (query.status && dispute.status !== query.status) return false;
+    return true;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getDispute(disputeId) {
+  const dispute = disputes.find((candidate) => candidate.id === disputeId);
+  return dispute ? clone(dispute) : null;
+}
+
+export async function ruleDispute(disputeId, payload, admin) {
+  if (!VALID_DISPUTE_RULINGS.has(payload.ruling)) {
+    return null;
+  }
+
+  const dispute = disputes.find((candidate) => candidate.id === disputeId);
+  if (!dispute) return null;
+
+  const previousStatus = dispute.status;
+  dispute.status = payload.ruling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = payload.ruling;
+  dispute.resolutionNote = payload.note ?? "";
+  dispute.resolvedAt = dispute.status === "resolved" ? nowIso() : undefined;
+
+  const message = payload.ruling === "escalate" ? "Your dispute was escalated for senior review." : `Your dispute was resolved: ${payload.ruling}.`;
+  sendNotification(dispute.clientId, "dispute_ruling", message, { disputeId, ruling: payload.ruling });
+  sendNotification(dispute.freelancerId, "dispute_ruling", message, { disputeId, ruling: payload.ruling });
+
+  const audit = appendAudit(admin, `dispute.${payload.ruling}`, "dispute", disputeId, payload.note ?? "Dispute ruling recorded", {
+    previousStatus,
+    nextStatus: dispute.status
+  });
+
+  return { dispute: clone(dispute), audit };
+}
+
+export async function getPlatformControls() {
+  return clone(Object.values(controls));
+}
+
+export async function setPlatformControl(controlKey, payload, admin) {
+  const control = controls[controlKey];
+  if (!control || typeof payload.enabled !== "boolean") {
+    return null;
+  }
+
+  const previousEnabled = control.enabled;
+  control.enabled = payload.enabled;
+  control.updatedBy = admin?.sub ?? "unknown_admin";
+  control.updatedAt = nowIso();
+
+  const audit = appendAudit(admin, "control.toggle", "control", controlKey, payload.reason ?? "Platform control updated", {
+    previousEnabled,
+    nextEnabled: payload.enabled
+  });
+
+  return { control: clone(control), audit };
+}
+
+export async function listAuditLog(query) {
+  const filtered = auditLog.filter((entry) => {
+    if (query.adminId && entry.adminId !== query.adminId) return false;
+    if (query.action && entry.action !== query.action) return false;
+    return matchesDateRange(entry.createdAt, query.from, query.to);
+  });
+
+  return paginate([...filtered].reverse(), query);
+}
+
+export function resetAdminStateForTests() {
+  users = structuredClone(initialUsers);
+  jobs = structuredClone(initialJobs);
+  disputes = structuredClone(initialDisputes);
+  controls = structuredClone(initialControls);
+  notifications = [];
+  auditLog = [
+    {
+      id: "aud_1",
+      adminId: "system",
+      action: "admin.bootstrap",
+      targetType: "platform",
+      targetId: "seed",
+      note: "Seeded admin review data",
+      createdAt: "2026-05-18T00:00:00.000Z"
+    }
+  ];
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { resetAdminStateForTests } from "../services/adminService.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    authorization: `Bearer ${signAccessToken({ sub: "adm_1", role: "admin" })}`,
+    "content-type": "application/json"
+  };
+}
+
+function clientHeaders() {
+  return {
+    authorization: `Bearer ${signAccessToken({ sub: "usr_client", role: "client" })}`,
+    "content-type": "application/json"
+  };
+}
+
+test("admin routes require an authenticated admin token", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const anonymous = await fetch(`${baseUrl}/api/admin/metrics`);
+    assert.equal(anonymous.status, 401);
+
+    const client = await fetch(`${baseUrl}/api/admin/metrics`, { headers: clientHeaders() });
+    assert.equal(client.status, 403);
+  });
+});
+
+test("admin metrics include required summary and trust distribution", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers: adminHeaders() });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.totalUsers, 5);
+    assert.equal(payload.data.flaggedListings, 2);
+    assert.deepEqual(
+      payload.data.trustDistribution.map((bucket) => bucket.label),
+      ["0-49", "50-69", "70-89", "90-100"]
+    );
+  });
+});
+
+test("admin user list is filtered and paginated server-side", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users?role=freelancer&pageSize=2`, { headers: adminHeaders() });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.items.length, 2);
+    assert.equal(payload.data.pagination.total, 3);
+    assert.ok(payload.data.items.every((user) => user.role === "freelancer"));
+  });
+});
+
+test("admin user actions update status and append audit entries", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const action = await fetch(`${baseUrl}/api/admin/users/usr_1001/status`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ status: "suspended", reason: "Chargeback review" })
+    });
+    const actionPayload = await action.json();
+
+    assert.equal(action.status, 200);
+    assert.equal(actionPayload.data.user.status, "suspended");
+    assert.equal(actionPayload.data.audit.action, "user.suspended");
+
+    const audit = await fetch(`${baseUrl}/api/admin/audit-log?action=user.suspended`, { headers: adminHeaders() });
+    const auditPayload = await audit.json();
+
+    assert.equal(audit.status, 200);
+    assert.equal(auditPayload.data.items.length, 1);
+    assert.equal(auditPayload.data.items[0].targetId, "usr_1001");
+  });
+});
+
+test("admin moderation and dispute decisions produce audit records", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const moderation = await fetch(`${baseUrl}/api/admin/moderation/jobs/job_501/decision`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ decision: "reject", reason: "Requests off-platform payment" })
+    });
+    const moderationPayload = await moderation.json();
+
+    assert.equal(moderation.status, 200);
+    assert.equal(moderationPayload.data.job.moderationStatus, "rejected");
+    assert.equal(moderationPayload.data.audit.action, "job.rejected");
+
+    const ruling = await fetch(`${baseUrl}/api/admin/disputes/dsp_9001/ruling`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ ruling: "refund", note: "Evidence supports refund" })
+    });
+    const rulingPayload = await ruling.json();
+
+    assert.equal(ruling.status, 200);
+    assert.equal(rulingPayload.data.dispute.status, "resolved");
+    assert.equal(rulingPayload.data.audit.action, "dispute.refund");
+  });
+});
+
+test("admin platform controls require boolean payload and log toggles", async () => {
+  resetAdminStateForTests();
+
+  await withServer(async (baseUrl) => {
+    const invalid = await fetch(`${baseUrl}/api/admin/controls/registrations`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ enabled: "no" })
+    });
+    assert.equal(invalid.status, 404);
+
+    const response = await fetch(`${baseUrl}/api/admin/controls/registrations`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ enabled: false, reason: "Incident response window" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.control.enabled, false);
+    assert.equal(payload.data.audit.action, "control.toggle");
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,397 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type UserStatus = "active" | "suspended" | "banned";
+type JobStatus = "pending" | "approved" | "rejected" | "escalated";
+type DisputeStatus = "open" | "under_review" | "resolved";
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: "freelancer" | "client";
+  status: UserStatus;
+  joinedAt: string;
+  trustScore: number;
+  activeJobs: string[];
+  disputes: string[];
+};
+
+type Job = {
+  id: string;
+  title: string;
+  client: string;
+  status: JobStatus;
+  flagReason: string;
+  reports: number;
+};
+
+type Dispute = {
+  id: string;
+  job: string;
+  client: string;
+  freelancer: string;
+  status: DisputeStatus;
+  amount: number;
+  thread: string[];
+  evidence: string[];
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  action: string;
+  target: string;
+  createdAt: string;
+};
+
+const initialUsers: User[] = [
+  { id: "usr_1001", name: "Maya Chen", email: "maya@example.com", role: "freelancer", status: "active", joinedAt: "2026-01-12", trustScore: 94, activeJobs: ["job_502"], disputes: ["dsp_9002"] },
+  { id: "usr_1002", name: "Jordan Reed", email: "jordan@example.com", role: "client", status: "active", joinedAt: "2026-02-03", trustScore: 81, activeJobs: ["job_501", "job_503"], disputes: ["dsp_9001"] },
+  { id: "usr_1003", name: "Iris Novak", email: "iris@example.com", role: "freelancer", status: "suspended", joinedAt: "2026-03-18", trustScore: 47, activeJobs: [], disputes: ["dsp_9001"] },
+  { id: "usr_1004", name: "Theo Park", email: "theo@example.com", role: "client", status: "active", joinedAt: "2026-04-02", trustScore: 72, activeJobs: ["job_504"], disputes: [] }
+];
+
+const initialJobs: Job[] = [
+  { id: "job_501", title: "Audit OAuth callback handling", client: "Jordan Reed", status: "pending", flagReason: "Off-platform payment wording", reports: 3 },
+  { id: "job_503", title: "Scrape private marketplace leads", client: "Jordan Reed", status: "escalated", flagReason: "Potential terms violation", reports: 2 },
+  { id: "job_505", title: "Bulk import customer invoices", client: "Theo Park", status: "pending", flagReason: "Sensitive data request", reports: 1 }
+];
+
+const initialDisputes: Dispute[] = [
+  { id: "dsp_9001", job: "Audit OAuth callback handling", client: "Jordan Reed", freelancer: "Iris Novak", status: "open", amount: 650, thread: ["Missing OAuth test cases", "Second archive uploaded"], evidence: ["Test report", "Archive manifest"] },
+  { id: "dsp_9002", job: "Build invoice dashboard", client: "Theo Park", freelancer: "Maya Chen", status: "under_review", amount: 300, thread: ["Scope changed after milestone approval"], evidence: ["Milestone transcript"] }
+];
+
+function stamp() {
+  return new Date().toISOString();
+}
+
+function statusClass(status: string) {
+  return `status-pill status-${status.replace("_", "-")}`;
+}
+
 export default function AdminPanelPage() {
+  const [users, setUsers] = useState(initialUsers);
+  const [jobs, setJobs] = useState(initialJobs);
+  const [disputes, setDisputes] = useState(initialDisputes);
+  const [auditLog, setAuditLog] = useState<AuditEntry[]>([
+    { id: "aud_1", adminId: "adm_1", action: "admin.view", target: "panel", createdAt: stamp() }
+  ]);
+  const [registrationOpen, setRegistrationOpen] = useState(true);
+  const [jobPostingOpen, setJobPostingOpen] = useState(true);
+  const [userSearch, setUserSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [selectedUserId, setSelectedUserId] = useState(users[0]?.id ?? "");
+  const [auditActionFilter, setAuditActionFilter] = useState("all");
+  const [refreshedAt, setRefreshedAt] = useState(stamp());
+
+  const selectedUser = users.find((user) => user.id === selectedUserId) ?? users[0];
+
+  const filteredUsers = useMemo(() => {
+    const query = userSearch.trim().toLowerCase();
+    return users.filter((user) => {
+      if (query && !`${user.name} ${user.email}`.toLowerCase().includes(query)) return false;
+      if (roleFilter !== "all" && user.role !== roleFilter) return false;
+      if (statusFilter !== "all" && user.status !== statusFilter) return false;
+      return true;
+    });
+  }, [roleFilter, statusFilter, userSearch, users]);
+
+  const metrics = useMemo(() => {
+    const trustBuckets = [
+      { label: "0-49", count: users.filter((user) => user.trustScore < 50).length },
+      { label: "50-69", count: users.filter((user) => user.trustScore >= 50 && user.trustScore < 70).length },
+      { label: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+      { label: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+    ];
+
+    return {
+      totalUsers: users.length,
+      activeJobs: users.reduce((count, user) => count + user.activeJobs.length, 0),
+      openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+      flaggedListings: jobs.filter((job) => job.status === "pending" || job.status === "escalated").length,
+      revenue: "$128,900",
+      trustBuckets
+    };
+  }, [disputes, jobs, users]);
+
+  const filteredAudit = auditLog.filter((entry) => auditActionFilter === "all" || entry.action === auditActionFilter);
+
+  function addAudit(action: string, target: string) {
+    setAuditLog((entries) => [
+      { id: `aud_${entries.length + 1}`, adminId: "adm_1", action, target, createdAt: stamp() },
+      ...entries
+    ]);
+  }
+
+  function updateUserStatus(userId: string, status: UserStatus) {
+    setUsers((current) => current.map((user) => (user.id === userId ? { ...user, status } : user)));
+    addAudit(`user.${status}`, userId);
+  }
+
+  function decideJob(jobId: string, status: JobStatus) {
+    setJobs((current) => current.map((job) => (job.id === jobId ? { ...job, status } : job)));
+    addAudit(`job.${status}`, jobId);
+  }
+
+  function ruleDispute(disputeId: string, status: DisputeStatus, action: string) {
+    setDisputes((current) => current.map((dispute) => (dispute.id === disputeId ? { ...dispute, status } : dispute)));
+    addAudit(action, disputeId);
+  }
+
+  function toggleControl(control: "registrations" | "jobPostings", enabled: boolean) {
+    const label = control === "registrations" ? "registrations" : "job postings";
+    if (!window.confirm(`Apply platform control change for ${label}?`)) return;
+    if (control === "registrations") setRegistrationOpen(enabled);
+    if (control === "jobPostings") setJobPostingOpen(enabled);
+    addAudit("control.toggle", control);
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
+    <div className="admin-shell">
+      <header className="admin-header">
+        <div>
+          <p className="eyebrow">Admin Console</p>
+          <h1>Operations Panel</h1>
+        </div>
+        <button
+          className="primary-button"
+          type="button"
+          onClick={() => {
+            setRefreshedAt(stamp());
+            addAudit("admin.refresh", "panel");
+          }}
+        >
+          Refresh Data
+        </button>
+      </header>
+
+      <section className="metric-grid" aria-label="Platform metrics">
+        <div className="metric-tile"><span>Total users</span><strong>{metrics.totalUsers}</strong></div>
+        <div className="metric-tile"><span>Active jobs</span><strong>{metrics.activeJobs}</strong></div>
+        <div className="metric-tile"><span>Open disputes</span><strong>{metrics.openDisputes}</strong></div>
+        <div className="metric-tile"><span>Flagged listings</span><strong>{metrics.flaggedListings}</strong></div>
+        <div className="metric-tile"><span>Period revenue</span><strong>{metrics.revenue}</strong></div>
+      </section>
+
+      <section className="admin-section">
+        <div className="section-heading">
+          <div>
+            <h2>Trust Distribution</h2>
+            <p>Last refreshed {new Date(refreshedAt).toLocaleString()}</p>
+          </div>
+        </div>
+        <div className="trust-chart" aria-label="Trust score distribution">
+          {metrics.trustBuckets.map((bucket) => (
+            <div className="trust-bar" key={bucket.label}>
+              <span>{bucket.label}</span>
+              <div><i style={{ width: `${Math.max(bucket.count * 24, 8)}%` }} /></div>
+              <strong>{bucket.count}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="admin-section">
+        <div className="section-heading">
+          <div>
+            <h2>User Management</h2>
+            <p>{filteredUsers.length} visible users</p>
+          </div>
+          <div className="filter-row">
+            <label>
+              <span>Search</span>
+              <input value={userSearch} onChange={(event) => setUserSearch(event.target.value)} placeholder="Name or email" />
+            </label>
+            <label>
+              <span>Role</span>
+              <select value={roleFilter} onChange={(event) => setRoleFilter(event.target.value)}>
+                <option value="all">All</option>
+                <option value="freelancer">Freelancer</option>
+                <option value="client">Client</option>
+              </select>
+            </label>
+            <label>
+              <span>Status</span>
+              <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+                <option value="all">All</option>
+                <option value="active">Active</option>
+                <option value="suspended">Suspended</option>
+                <option value="banned">Banned</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Joined</th>
+                <th>Trust</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredUsers.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <button className="link-button" type="button" onClick={() => setSelectedUserId(user.id)}>
+                      {user.name}
+                    </button>
+                    <small>{user.email}</small>
+                  </td>
+                  <td>{user.role}</td>
+                  <td><span className={statusClass(user.status)}>{user.status}</span></td>
+                  <td>{user.joinedAt}</td>
+                  <td>{user.trustScore}</td>
+                  <td className="action-cell">
+                    <button type="button" onClick={() => updateUserStatus(user.id, "active")}>Reinstate</button>
+                    <button type="button" onClick={() => updateUserStatus(user.id, "suspended")}>Suspend</button>
+                    <button type="button" onClick={() => updateUserStatus(user.id, "banned")}>Ban</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {selectedUser ? (
+          <aside className="detail-panel" aria-label="Selected user details">
+            <strong>{selectedUser.name}</strong>
+            <span>Active jobs: {selectedUser.activeJobs.join(", ") || "None"}</span>
+            <span>Disputes: {selectedUser.disputes.join(", ") || "None"}</span>
+          </aside>
+        ) : null}
+      </section>
+
+      <section className="admin-section">
+        <div className="section-heading">
+          <div>
+            <h2>Job Moderation</h2>
+            <p>{jobs.length} flagged listings</p>
+          </div>
+        </div>
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Listing</th>
+                <th>Client</th>
+                <th>Reason</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {jobs.map((job) => (
+                <tr key={job.id}>
+                  <td>{job.title}<small>{job.reports} reports</small></td>
+                  <td>{job.client}</td>
+                  <td>{job.flagReason}</td>
+                  <td><span className={statusClass(job.status)}>{job.status}</span></td>
+                  <td className="action-cell">
+                    <button type="button" onClick={() => decideJob(job.id, "approved")}>Approve</button>
+                    <button type="button" onClick={() => decideJob(job.id, "rejected")}>Reject</button>
+                    <button type="button" onClick={() => decideJob(job.id, "escalated")}>Escalate</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="admin-section">
+        <div className="section-heading">
+          <div>
+            <h2>Dispute Resolution</h2>
+            <p>{disputes.length} active case records</p>
+          </div>
+        </div>
+        <div className="dispute-grid">
+          {disputes.map((dispute) => (
+            <article className="case-panel" key={dispute.id}>
+              <div className="case-title">
+                <h3>{dispute.job}</h3>
+                <span className={statusClass(dispute.status)}>{dispute.status}</span>
+              </div>
+              <p>{dispute.client} vs {dispute.freelancer} - ${dispute.amount}</p>
+              <dl>
+                <dt>Thread</dt>
+                <dd>{dispute.thread.join(" / ")}</dd>
+                <dt>Evidence</dt>
+                <dd>{dispute.evidence.join(", ")}</dd>
+              </dl>
+              <div className="action-cell">
+                <button type="button" onClick={() => ruleDispute(dispute.id, "resolved", "dispute.freelancer")}>Freelancer</button>
+                <button type="button" onClick={() => ruleDispute(dispute.id, "resolved", "dispute.client")}>Client</button>
+                <button type="button" onClick={() => ruleDispute(dispute.id, "resolved", "dispute.refund")}>Refund</button>
+                <button type="button" onClick={() => ruleDispute(dispute.id, "under_review", "dispute.escalate")}>Escalate</button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="admin-section controls-section">
+        <div>
+          <h2>Platform Controls</h2>
+          <p>Changes require confirmation and are logged.</p>
+        </div>
+        <label className="toggle-row">
+          <span>New user registrations</span>
+          <input type="checkbox" checked={registrationOpen} onChange={(event) => toggleControl("registrations", event.target.checked)} />
+        </label>
+        <label className="toggle-row">
+          <span>New job postings</span>
+          <input type="checkbox" checked={jobPostingOpen} onChange={(event) => toggleControl("jobPostings", event.target.checked)} />
+        </label>
+      </section>
+
+      <section className="admin-section">
+        <div className="section-heading">
+          <div>
+            <h2>Audit Log</h2>
+            <p>{filteredAudit.length} entries</p>
+          </div>
+          <label className="compact-filter">
+            <span>Action</span>
+            <select value={auditActionFilter} onChange={(event) => setAuditActionFilter(event.target.value)}>
+              <option value="all">All</option>
+              {[...new Set(auditLog.map((entry) => entry.action))].map((action) => (
+                <option key={action} value={action}>{action}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Admin</th>
+                <th>Action</th>
+                <th>Target</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredAudit.map((entry) => (
+                <tr key={entry.id}>
+                  <td>{new Date(entry.createdAt).toLocaleString()}</td>
+                  <td>{entry.adminId}</td>
+                  <td>{entry.action}</td>
+                  <td>{entry.target}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,73 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+button, input, select { font: inherit; }
+button { cursor: pointer; }
+
+.admin-shell { display: grid; gap: 1rem; }
+.admin-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.admin-header h1 { margin: 0; font-size: 2rem; }
+.eyebrow { margin: 0 0 0.25rem; color: #8fb4ff; font-size: 0.8rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.primary-button, .action-cell button, .link-button {
+  border: 1px solid #3b82f6;
+  border-radius: 8px;
+  background: #1d4ed8;
+  color: #ffffff;
+  padding: 0.55rem 0.8rem;
+}
+.link-button { background: transparent; border: none; color: #bfdbfe; padding: 0; text-align: left; }
+.metric-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.metric-tile, .admin-section, .case-panel, .detail-panel {
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+}
+.metric-tile { min-height: 92px; padding: 1rem; display: grid; align-content: space-between; }
+.metric-tile span, .section-heading p, .admin-section p, table small, .detail-panel span { color: #a8b3cf; }
+.metric-tile strong { font-size: 1.6rem; }
+.admin-section { padding: 1rem; display: grid; gap: 1rem; }
+.section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.section-heading h2, .case-title h3, .controls-section h2 { margin: 0; }
+.section-heading p, .controls-section p { margin: 0.25rem 0 0; }
+.filter-row { display: flex; flex-wrap: wrap; gap: 0.75rem; justify-content: flex-end; }
+.filter-row label, .compact-filter, .toggle-row { display: grid; gap: 0.35rem; color: #d8e1ff; }
+.filter-row input, .filter-row select, .compact-filter select {
+  min-width: 150px;
+  border: 1px solid #31406f;
+  border-radius: 8px;
+  background: #0f1730;
+  color: #f2f5ff;
+  padding: 0.55rem 0.65rem;
+}
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; min-width: 700px; }
+th, td { border-bottom: 1px solid #26345f; padding: 0.75rem; text-align: left; vertical-align: top; }
+th { color: #bcd0ff; font-size: 0.82rem; text-transform: uppercase; }
+td small { display: block; margin-top: 0.25rem; }
+.action-cell { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.action-cell button { background: #0f1730; border-color: #33446f; padding: 0.4rem 0.55rem; }
+.status-pill { display: inline-flex; align-items: center; min-height: 1.6rem; border-radius: 999px; padding: 0.2rem 0.55rem; font-size: 0.78rem; font-weight: 700; text-transform: capitalize; }
+.status-active, .status-approved, .status-resolved { background: #0f3d2e; color: #8ff0c0; }
+.status-suspended, .status-pending, .status-under-review, .status-escalated { background: #3d3410; color: #f6d77a; }
+.status-banned, .status-rejected, .status-open { background: #451b25; color: #ff9eb0; }
+.detail-panel { padding: 0.85rem; display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.trust-chart { display: grid; gap: 0.7rem; }
+.trust-bar { display: grid; align-items: center; gap: 0.7rem; grid-template-columns: 68px 1fr 32px; }
+.trust-bar div { height: 12px; overflow: hidden; border-radius: 999px; background: #26345f; }
+.trust-bar i { display: block; height: 100%; border-radius: inherit; background: #52c6b8; }
+.dispute-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.85rem; }
+.case-panel { padding: 1rem; display: grid; gap: 0.75rem; }
+.case-title { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.case-panel dl { display: grid; gap: 0.35rem; margin: 0; }
+.case-panel dt { color: #bcd0ff; font-weight: 700; }
+.case-panel dd { margin: 0; color: #d8e1ff; }
+.controls-section { grid-template-columns: minmax(220px, 1fr) repeat(2, minmax(180px, 220px)); align-items: center; }
+.toggle-row { align-items: center; grid-template-columns: 1fr auto; }
+.toggle-row input { width: 20px; height: 20px; }
+
+@media (max-width: 720px) {
+  .admin-header, .section-heading, .controls-section { grid-template-columns: 1fr; display: grid; }
+  .filter-row { justify-content: stretch; }
+  .filter-row label, .filter-row input, .filter-row select { width: 100%; }
+}


### PR DESCRIPTION
## Summary
- replace the /admin placeholder with a functional operations panel for metrics, users, moderation, disputes, controls, and audit review
- add server-side admin-only enforcement for every /api/admin route plus paginated/filterable admin endpoints
- implement user status actions, job moderation decisions, dispute rulings, platform control toggles, notification hooks, and append-only audit entries
- add focused API coverage for auth, pagination, actions, controls, and audit behavior

## Validation
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check

## Demo
The /admin route builds and renders as a static admin console with interactive local controls. Short video upload is not included from this CLI environment; validation commands above exercise the API and build the UI route.

## Disclosure
Implemented with Codex assistance. No private payout details are included.

/claim #29