### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,18 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = Number.isInteger(err.status) ? err.status : 500;
+  const message =
+    err.expose || status < 500 ? err.message : "Unexpected server error";
+
+  if (status >= 500) {
+    console.error("Unhandled API error:", err);
+  }
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,153 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+const DEFAULT_CURRENCY = "usd";
+
+let injectedStripeClient;
+let cachedStripeClient;
+let cachedStripeSecretKey;
+
+export class PaymentServiceError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.status = status;
+    this.expose = true;
+  }
+}
+
+export function setStripeClientForTests(client) {
+  injectedStripeClient = client;
+}
+
+export function resetStripeClientForTests() {
+  injectedStripeClient = undefined;
+  cachedStripeClient = undefined;
+  cachedStripeSecretKey = undefined;
+}
+
+function getStripeSecretKey() {
+  return process.env.STRIPE_SECRET_KEY ?? env.stripeSecretKey;
+}
+
+function getStripeClient() {
+  if (injectedStripeClient) {
+    return injectedStripeClient;
+  }
+
+  const secretKey = getStripeSecretKey();
+  if (!secretKey) {
+    throw new PaymentServiceError("Stripe secret key is not configured", 500);
+  }
+
+  if (!cachedStripeClient || cachedStripeSecretKey !== secretKey) {
+    cachedStripeClient = new Stripe(secretKey);
+    cachedStripeSecretKey = secretKey;
+  }
+
+  return cachedStripeClient;
+}
+
+function normalizeAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentServiceError(
+      "Amount must be a positive integer in the smallest currency unit"
+    );
+  }
+
+  return amount;
+}
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return DEFAULT_CURRENCY;
+  }
+
+  if (typeof currency !== "string") {
+    throw new PaymentServiceError("Currency must be a three-letter ISO code");
+  }
+
+  const normalizedCurrency = currency.trim().toLowerCase();
+  if (!/^[a-z]{3}$/.test(normalizedCurrency)) {
+    throw new PaymentServiceError("Currency must be a three-letter ISO code");
+  }
+
+  return normalizedCurrency;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined || metadata === null) {
+    return undefined;
+  }
+
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentServiceError("Metadata must be an object");
+  }
+
+  const normalizedMetadata = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!key || key.length > 40 || key.includes("[") || key.includes("]")) {
+      throw new PaymentServiceError(
+        "Metadata keys must be non-empty, under 40 characters, and cannot contain brackets"
+      );
+    }
+
+    if (!["string", "number", "boolean"].includes(typeof value)) {
+      throw new PaymentServiceError(
+        "Metadata values must be strings, numbers, or booleans"
+      );
+    }
+
+    const stringValue = String(value);
+    if (stringValue.length > 500) {
+      throw new PaymentServiceError(
+        "Metadata values must be 500 characters or fewer"
+      );
+    }
+
+    normalizedMetadata[key] = stringValue;
+  }
+
+  return Object.keys(normalizedMetadata).length ? normalizedMetadata : undefined;
+}
+
+export async function createPaymentIntent(payload = {}) {
+  const amount = normalizeAmount(payload.amount);
+  const currency = normalizeCurrency(payload.currency);
+  const metadata = normalizeMetadata(payload.metadata);
+  const stripe = getStripeClient();
+
+  const paymentIntentPayload = { amount, currency };
+  if (metadata) {
+    paymentIntentPayload.metadata = metadata;
+  }
+
+  try {
+    const paymentIntent =
+      await stripe.paymentIntents.create(paymentIntentPayload);
+
+    if (!paymentIntent?.id || !paymentIntent?.client_secret) {
+      throw new PaymentServiceError(
+        "Stripe did not return a usable PaymentIntent",
+        502
+      );
+    }
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? amount,
+      currency: paymentIntent.currency ?? currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentServiceError) {
+      throw error;
+    }
+
+    throw new PaymentServiceError(
+      error?.message ?? "Stripe payment intent creation failed",
+      error?.statusCode ?? 502
+    );
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,231 @@
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  PaymentServiceError,
+  createPaymentIntent,
+  resetStripeClientForTests,
+  setStripeClientForTests
+} from "../services/paymentService.js";
+
+afterEach(() => {
+  resetStripeClientForTests();
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent with normalized input", async () => {
+  let capturedPayload;
+  setStripeClientForTests({
+    paymentIntents: {
+      create: async (payload) => {
+        capturedPayload = payload;
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_secret_123",
+          amount: payload.amount,
+          currency: payload.currency
+        };
+      }
+    }
+  });
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: {
+      orderId: 42,
+      customerTier: "pro",
+      invoiceReady: true
+    }
+  });
+
+  assert.deepEqual(capturedPayload, {
+    amount: 2500,
+    currency: "usd",
+    metadata: {
+      orderId: "42",
+      customerTier: "pro",
+      invoiceReady: "true"
+    }
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_secret_123",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  let capturedPayload;
+  setStripeClientForTests({
+    paymentIntents: {
+      create: async (payload) => {
+        capturedPayload = payload;
+        return {
+          id: "pi_default_currency",
+          client_secret: "pi_default_currency_secret",
+          amount: payload.amount,
+          currency: payload.currency
+        };
+      }
+    }
+  });
+
+  await createPaymentIntent({ amount: 1000 });
+
+  assert.equal(capturedPayload.currency, "usd");
+  assert.equal(capturedPayload.metadata, undefined);
+});
+
+test("createPaymentIntent rejects invalid payment amounts", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.status === 400 &&
+      error.message ===
+        "Amount must be a positive integer in the smallest currency unit"
+  );
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10.5 }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.message ===
+        "Amount must be a positive integer in the smallest currency unit"
+  );
+});
+
+test("createPaymentIntent rejects invalid metadata before calling Stripe", async () => {
+  setStripeClientForTests({
+    paymentIntents: {
+      create: async () => {
+        throw new Error("Stripe should not be called for invalid metadata");
+      }
+    }
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: ["not", "object"] }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.status === 400 &&
+      error.message === "Metadata must be an object"
+  );
+});
+
+test("createPaymentIntent preserves Stripe provider error messages", async () => {
+  setStripeClientForTests({
+    paymentIntents: {
+      create: async () => {
+        const stripeError = new Error("Your card was declined.");
+        stripeError.statusCode = 402;
+        throw stripeError;
+      }
+    }
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usd" }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.status === 402 &&
+      error.message === "Your card was declined."
+  );
+});
+
+test("POST /api/payments returns the created Stripe client secret", async () => {
+  setStripeClientForTests({
+    paymentIntents: {
+      create: async (payload) => ({
+        id: "pi_route_123",
+        client_secret: "pi_route_secret_123",
+        amount: payload.amount,
+        currency: payload.currency
+      })
+    }
+  });
+
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: 1200 })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(payload, {
+    success: true,
+    data: {
+      paymentId: "pi_route_123",
+      clientSecret: "pi_route_secret_123",
+      amount: 1200,
+      currency: "usd",
+      provider: "stripe"
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payments returns validation errors through middleware", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount: -1 })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Amount must be a positive integer in the smallest currency unit"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test(
+  "optionally creates a real Stripe test PaymentIntent",
+  {
+    skip:
+      process.env.RUN_STRIPE_SMOKE !== "1" ||
+      !process.env.STRIPE_SECRET_KEY?.startsWith("sk_test_")
+  },
+  async () => {
+    resetStripeClientForTests();
+
+    const result = await createPaymentIntent({
+      amount: 50,
+      currency: "usd",
+      metadata: { source: "api-smoke-test" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_/);
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- replace the fake timestamp payment ID with a real Stripe PaymentIntent creation flow
- validate positive integer amounts, three-letter currency codes, and Stripe-compatible metadata before provider calls
- return both paymentId and clientSecret, preserve Stripe provider error messages, and route payment errors through Express middleware
- add mocked service and endpoint coverage plus an opt-in Stripe test-key smoke test

## Verification
- npm test -w apps/api
- npm test
- git diff --check

## Demo
The endpoint test exercises POST /api/payments with a mocked Stripe client and verifies the 201 response includes paymentId, clientSecret, amount, currency, and provider. The guarded smoke test is skipped unless RUN_STRIPE_SMOKE=1 and STRIPE_SECRET_KEY is a Stripe test key.

/claim #1

Closes #1.

Preferred fallback payout if manual payment is used: PayPal aa.631@hotmail.com