### PR TITLE
feat: add API benchmark suite

### DIFF
--- a/.env.benchmark.example
+++ b/.env.benchmark.example
@@ -1,0 +1,16 @@
+# Optional: benchmark an existing local/staging server instead of starting one in-process.
+# BENCHMARK_TARGET_URL=http://127.0.0.1:4000
+
+# Dedicated bearer token for protected routes such as /api/admin/metrics.
+# If omitted, the runner obtains a short-lived token from /api/auth/login.
+# BENCHMARK_TOKEN=
+
+# Full local run defaults.
+BENCHMARK_DURATION_SECONDS=10
+BENCHMARK_CONCURRENCY=8
+BENCHMARK_WARMUP_REQUESTS=2
+BENCHMARK_OUTPUT_DIR=benchmarks/results
+BENCHMARK_THRESHOLDS_PATH=benchmarks/thresholds.json
+
+# Keep local benchmark runs from measuring rate-limit failures instead of API handler performance.
+RATE_LIMIT_MAX=100000

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -40,7 +40,7 @@ jobs:
           BENCHMARK_DURATION_SECONDS: "3"
           BENCHMARK_CONCURRENCY: "2"
           BENCHMARK_WARMUP_REQUESTS: "1"
-          RATE_LIMIT_MAX: "100000"
+          RATE_LIMIT_MAX: "10000000"
         run: npm run benchmark
 
       - name: Upload benchmark reports

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -1,0 +1,51 @@
+name: API benchmark smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run API tests
+        run: npm run test -w apps/api
+
+      - name: Run benchmark config tests
+        run: npm run test:benchmarks
+
+      - name: Run API benchmark smoke gate
+        env:
+          NODE_ENV: benchmark
+          BENCHMARK_SMOKE: "true"
+          BENCHMARK_DURATION_SECONDS: "3"
+          BENCHMARK_CONCURRENCY: "2"
+          BENCHMARK_WARMUP_REQUESTS: "1"
+          RATE_LIMIT_MAX: "100000"
+        run: npm run benchmark
+
+      - name: Upload benchmark reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: api-benchmark-results
+          path: benchmarks/results/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.*
 coverage
 *.log
+!.env.benchmark.example

--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+## API Benchmarks
+
+Run the full local API benchmark suite:
+
+```bash
+npm run benchmark
+```
+
+The benchmark runner covers every `/api/` endpoint, writes JSON and Markdown reports to `benchmarks/results/`, and enforces reviewable p99/error-rate thresholds from `benchmarks/thresholds.json`. To benchmark staging, copy `.env.benchmark.example` to `.env.benchmark` and set `BENCHMARK_TARGET_URL` plus a dedicated `BENCHMARK_TOKEN`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,7 +21,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(createApiLimiter());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,13 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export function createApiLimiter() {
+  const windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 15 * 60 * 1000);
+  const limit = Number(process.env.RATE_LIMIT_MAX ?? 200);
+
+  return rateLimit({
+    windowMs,
+    limit,
+    standardHeaders: "draft-7",
+    legacyHeaders: false
+  });
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,68 @@
+# API Benchmark Suite
+
+This suite benchmarks every route mounted under `/api/` and writes reproducible JSON and Markdown reports to `benchmarks/results/`.
+
+## Run locally
+
+```bash
+npm run benchmark
+```
+
+By default, the runner starts the Express API in-process on an ephemeral local port, raises the local benchmark rate-limit ceiling, creates a dedicated benchmark JWT via `/api/auth/login`, and benchmarks each endpoint independently.
+
+## Run against staging
+
+```bash
+cp .env.benchmark.example .env.benchmark
+BENCHMARK_TARGET_URL=https://staging.example.com BENCHMARK_TOKEN=<dedicated-token> npm run benchmark
+```
+
+Use a dedicated benchmark token for protected routes such as `/api/admin/metrics`. If `BENCHMARK_TOKEN` is omitted, the runner attempts to obtain one from `/api/auth/login` using the benchmark fixture credentials.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BENCHMARK_TARGET_URL` | unset | Existing local/staging API URL. If unset, a local in-process server starts automatically. |
+| `BENCHMARK_TOKEN` | unset | Dedicated bearer token for auth-protected benchmark routes. |
+| `BENCHMARK_DURATION_SECONDS` | `10` | Per-endpoint measurement duration. |
+| `BENCHMARK_CONCURRENCY` | `8` | Concurrent workers per endpoint. |
+| `BENCHMARK_WARMUP_REQUESTS` | `2` | Warmup calls before each measured endpoint run. |
+| `BENCHMARK_OUTPUT_DIR` | `benchmarks/results` | Output directory for JSON and Markdown reports. |
+| `BENCHMARK_THRESHOLDS_PATH` | `benchmarks/thresholds.json` | Reviewable p99/error-rate gate config. |
+| `BENCHMARK_SMOKE` | `false` | Marks CI smoke runs in generated reports. |
+| `RATE_LIMIT_MAX` | app default | Set high for local benchmark runs to prevent rate-limit noise. |
+
+## Metrics captured per endpoint
+
+- p50, p95, and p99 total latency in milliseconds
+- p50, p95, and p99 time to first byte (TTFB) in milliseconds
+- sustained requests per second
+- peak one-second requests per second
+- status-code distribution
+- error count and error-rate percentage
+
+## CI smoke gate
+
+`.github/workflows/benchmark-smoke.yml` runs a low-concurrency benchmark on pull requests. The job fails when any endpoint exceeds its p99 or error-rate threshold from `benchmarks/thresholds.json`.
+
+## Endpoint coverage
+
+The endpoint catalog in `benchmarks/endpoints.mjs` covers every Express route mounted under `/api/`:
+
+- `/api/auth/register`
+- `/api/auth/login`
+- `/api/auth/oauth/:provider/callback`
+- `/api/auth/refresh`
+- `/api/users`
+- `/api/jobs`
+- `/api/proposals`
+- `/api/payments`
+- `/api/reviews`
+- `/api/messages`
+- `/api/notifications`
+- `/api/uploads`
+- `/api/search`
+- `/api/admin/metrics`
+
+Payloads are shaped from `packages/db/prisma/schema.prisma` and the current API validators/controllers.

--- a/benchmarks/endpoints.mjs
+++ b/benchmarks/endpoints.mjs
@@ -1,0 +1,177 @@
+const timestamp = () => Date.now();
+
+const benchmarkIds = {
+  client: "usr_bench_client",
+  freelancer: "usr_bench_freelancer",
+  job: "job_bench_marketplace_api",
+  proposal: "prp_bench_marketplace_api",
+  category: "cat_bench_development"
+};
+
+export const endpoints = [
+  {
+    name: "Register user",
+    method: "POST",
+    path: "/api/auth/register",
+    body: () => ({
+      email: `bench+${timestamp()}@example.com`,
+      password: "benchmark-password",
+      role: "client"
+    })
+  },
+  {
+    name: "Login user",
+    method: "POST",
+    path: "/api/auth/login",
+    body: () => ({
+      email: "bench.client@example.com",
+      password: "benchmark-password"
+    })
+  },
+  {
+    name: "OAuth callback",
+    method: "GET",
+    path: "/api/auth/oauth/github/callback?code=benchmark-code&state=benchmark-state"
+  },
+  {
+    name: "Refresh token",
+    method: "POST",
+    path: "/api/auth/refresh"
+  },
+  {
+    name: "List users",
+    method: "GET",
+    path: "/api/users"
+  },
+  {
+    name: "Create user",
+    method: "POST",
+    path: "/api/users",
+    body: () => ({
+      email: `bench.user.${timestamp()}@example.com`,
+      fullName: "Benchmark User",
+      passwordHash: "benchmark-password-hash",
+      role: "FREELANCER",
+      bio: "Full-stack marketplace engineer benchmark profile",
+      skills: ["node", "express", "postgres"]
+    })
+  },
+  {
+    name: "List jobs",
+    method: "GET",
+    path: "/api/jobs"
+  },
+  {
+    name: "Create job",
+    method: "POST",
+    path: "/api/jobs",
+    body: () => ({
+      title: "Build marketplace API performance dashboard",
+      description: "Design, implement, and document a production-ready API performance dashboard for marketplace operators.",
+      budgetMin: 1200,
+      budgetMax: 3500,
+      categoryId: benchmarkIds.category,
+      skills: ["node", "express", "observability", "load-testing"]
+    })
+  },
+  {
+    name: "List proposals",
+    method: "GET",
+    path: "/api/proposals"
+  },
+  {
+    name: "Create proposal",
+    method: "POST",
+    path: "/api/proposals",
+    body: () => ({
+      coverLetter: "I can deliver the benchmark dashboard with reproducible metrics, CI smoke gates, and documentation.",
+      bidAmount: 2400,
+      estDuration: "2 weeks",
+      jobId: benchmarkIds.job,
+      freelancerId: benchmarkIds.freelancer
+    })
+  },
+  {
+    name: "Create payment",
+    method: "POST",
+    path: "/api/payments",
+    body: () => ({
+      amount: 750,
+      currency: "usd",
+      jobId: benchmarkIds.job,
+      status: "pending"
+    })
+  },
+  {
+    name: "List reviews",
+    method: "GET",
+    path: "/api/reviews"
+  },
+  {
+    name: "Create review",
+    method: "POST",
+    path: "/api/reviews",
+    body: () => ({
+      rating: 5,
+      comment: "Fast delivery with clear benchmark evidence and reliable reporting.",
+      reviewerId: benchmarkIds.client,
+      revieweeId: benchmarkIds.freelancer
+    })
+  },
+  {
+    name: "List messages",
+    method: "GET",
+    path: "/api/messages"
+  },
+  {
+    name: "Send message",
+    method: "POST",
+    path: "/api/messages",
+    body: () => ({
+      body: "Can you share the latest benchmark summary and p99 regression status?",
+      senderId: benchmarkIds.client,
+      receiverId: benchmarkIds.freelancer
+    })
+  },
+  {
+    name: "List notifications",
+    method: "GET",
+    path: "/api/notifications"
+  },
+  {
+    name: "Create notification",
+    method: "POST",
+    path: "/api/notifications",
+    body: () => ({
+      userId: benchmarkIds.client,
+      title: "Benchmark report ready",
+      body: "The API benchmark summary has been generated and is ready for review."
+    })
+  },
+  {
+    name: "Upload file",
+    method: "POST",
+    path: "/api/uploads",
+    multipart: () => ({
+      fieldName: "file",
+      filename: "benchmark-profile.txt",
+      type: "text/plain",
+      content: "Benchmark upload payload representing a freelancer profile attachment.\n"
+    })
+  },
+  {
+    name: "Search marketplace",
+    method: "GET",
+    path: "/api/search?q=node%20express%20benchmark"
+  },
+  {
+    name: "Admin metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    auth: true
+  }
+];
+
+export function endpointKey(endpoint) {
+  return `${endpoint.method} ${endpoint.path.split("?")[0]}`;
+}

--- a/benchmarks/results/benchmark-results.json
+++ b/benchmarks/results/benchmark-results.json
@@ -1,0 +1,692 @@
+{
+  "generatedAt": "2026-05-20T03:56:14.377Z",
+  "targetUrl": "http://127.0.0.1:43289",
+  "config": {
+    "concurrency": 2,
+    "durationSeconds": 1,
+    "warmupRequests": 1,
+    "smoke": true
+  },
+  "results": [
+    {
+      "key": "POST /api/auth/register",
+      "name": "Register user",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "requests": 343,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 343
+      },
+      "latencyMs": {
+        "p50": 5.25,
+        "p95": 9.76,
+        "p99": 20.47,
+        "min": 2.64,
+        "max": 30.48
+      },
+      "ttfbMs": {
+        "p50": 5.08,
+        "p95": 9.3,
+        "p99": 19.91
+      },
+      "rps": {
+        "sustained": 342.58,
+        "peak": 261
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/auth/login",
+      "name": "Login user",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "requests": 413,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 413
+      },
+      "latencyMs": {
+        "p50": 4.2,
+        "p95": 9.81,
+        "p99": 15.17,
+        "min": 2.39,
+        "max": 16.49
+      },
+      "ttfbMs": {
+        "p50": 4.1,
+        "p95": 9.74,
+        "p99": 15.08
+      },
+      "rps": {
+        "sustained": 412.16,
+        "peak": 335
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/auth/oauth/github/callback",
+      "name": "OAuth callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback?code=benchmark-code&state=benchmark-state",
+      "requests": 776,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 776
+      },
+      "latencyMs": {
+        "p50": 2.15,
+        "p95": 3.97,
+        "p99": 11.4,
+        "min": 1.38,
+        "max": 20.5
+      },
+      "ttfbMs": {
+        "p50": 2.07,
+        "p95": 3.61,
+        "p99": 11.3
+      },
+      "rps": {
+        "sustained": 774.45,
+        "peak": 610
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/auth/refresh",
+      "name": "Refresh token",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "requests": 790,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 790
+      },
+      "latencyMs": {
+        "p50": 2.35,
+        "p95": 3.31,
+        "p99": 7.47,
+        "min": 1.56,
+        "max": 10.76
+      },
+      "ttfbMs": {
+        "p50": 2.27,
+        "p95": 3.21,
+        "p99": 7.33
+      },
+      "rps": {
+        "sustained": 788.87,
+        "peak": 616
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/users",
+      "name": "List users",
+      "method": "GET",
+      "path": "/api/users",
+      "requests": 1041,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1041
+      },
+      "latencyMs": {
+        "p50": 1.73,
+        "p95": 2.48,
+        "p99": 9.38,
+        "min": 0.83,
+        "max": 12.81
+      },
+      "ttfbMs": {
+        "p50": 1.67,
+        "p95": 2.37,
+        "p99": 9.27
+      },
+      "rps": {
+        "sustained": 1040.18,
+        "peak": 750
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/users",
+      "name": "Create user",
+      "method": "POST",
+      "path": "/api/users",
+      "requests": 836,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 836
+      },
+      "latencyMs": {
+        "p50": 2.15,
+        "p95": 3.35,
+        "p99": 9.1,
+        "min": 1.35,
+        "max": 11.57
+      },
+      "ttfbMs": {
+        "p50": 2.1,
+        "p95": 3.31,
+        "p99": 9.04
+      },
+      "rps": {
+        "sustained": 835.53,
+        "peak": 657
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/jobs",
+      "name": "List jobs",
+      "method": "GET",
+      "path": "/api/jobs",
+      "requests": 1072,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1072
+      },
+      "latencyMs": {
+        "p50": 1.66,
+        "p95": 2.87,
+        "p99": 8.29,
+        "min": 1.05,
+        "max": 9.6
+      },
+      "ttfbMs": {
+        "p50": 1.61,
+        "p95": 2.79,
+        "p99": 8.19
+      },
+      "rps": {
+        "sustained": 1070.33,
+        "peak": 836
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/jobs",
+      "name": "Create job",
+      "method": "POST",
+      "path": "/api/jobs",
+      "requests": 358,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 358
+      },
+      "latencyMs": {
+        "p50": 3.51,
+        "p95": 15.18,
+        "p99": 25.94,
+        "min": 2.13,
+        "max": 82.8
+      },
+      "ttfbMs": {
+        "p50": 3.44,
+        "p95": 14.89,
+        "p99": 25.8
+      },
+      "rps": {
+        "sustained": 357.59,
+        "peak": 234
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/proposals",
+      "name": "List proposals",
+      "method": "GET",
+      "path": "/api/proposals",
+      "requests": 890,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 890
+      },
+      "latencyMs": {
+        "p50": 1.76,
+        "p95": 4.08,
+        "p99": 13.23,
+        "min": 1.08,
+        "max": 18.39
+      },
+      "ttfbMs": {
+        "p50": 1.7,
+        "p95": 3.93,
+        "p99": 12.59
+      },
+      "rps": {
+        "sustained": 889.69,
+        "peak": 628
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/proposals",
+      "name": "Create proposal",
+      "method": "POST",
+      "path": "/api/proposals",
+      "requests": 639,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 639
+      },
+      "latencyMs": {
+        "p50": 2.61,
+        "p95": 6.77,
+        "p99": 12.67,
+        "min": 1.33,
+        "max": 20.28
+      },
+      "ttfbMs": {
+        "p50": 2.54,
+        "p95": 6.71,
+        "p99": 12.62
+      },
+      "rps": {
+        "sustained": 638.29,
+        "peak": 460
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/payments",
+      "name": "Create payment",
+      "method": "POST",
+      "path": "/api/payments",
+      "requests": 816,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 816
+      },
+      "latencyMs": {
+        "p50": 2.16,
+        "p95": 4.07,
+        "p99": 9.06,
+        "min": 1.29,
+        "max": 25.18
+      },
+      "ttfbMs": {
+        "p50": 2.09,
+        "p95": 3.98,
+        "p99": 9
+      },
+      "rps": {
+        "sustained": 815.09,
+        "peak": 538
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/reviews",
+      "name": "List reviews",
+      "method": "GET",
+      "path": "/api/reviews",
+      "requests": 1261,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1261
+      },
+      "latencyMs": {
+        "p50": 1.45,
+        "p95": 2.15,
+        "p99": 7.38,
+        "min": 0.9,
+        "max": 9.72
+      },
+      "ttfbMs": {
+        "p50": 1.4,
+        "p95": 2.08,
+        "p99": 7.28
+      },
+      "rps": {
+        "sustained": 1259.92,
+        "peak": 896
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/reviews",
+      "name": "Create review",
+      "method": "POST",
+      "path": "/api/reviews",
+      "requests": 883,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 883
+      },
+      "latencyMs": {
+        "p50": 1.98,
+        "p95": 3.68,
+        "p99": 11.91,
+        "min": 1.2,
+        "max": 19.27
+      },
+      "ttfbMs": {
+        "p50": 1.92,
+        "p95": 3.57,
+        "p99": 11.78
+      },
+      "rps": {
+        "sustained": 882.34,
+        "peak": 624
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/messages",
+      "name": "List messages",
+      "method": "GET",
+      "path": "/api/messages",
+      "requests": 1188,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1188
+      },
+      "latencyMs": {
+        "p50": 1.47,
+        "p95": 2.17,
+        "p99": 7.66,
+        "min": 0.92,
+        "max": 16.08
+      },
+      "ttfbMs": {
+        "p50": 1.43,
+        "p95": 2.11,
+        "p99": 7.57
+      },
+      "rps": {
+        "sustained": 1187.26,
+        "peak": 863
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/messages",
+      "name": "Send message",
+      "method": "POST",
+      "path": "/api/messages",
+      "requests": 788,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 788
+      },
+      "latencyMs": {
+        "p50": 2.17,
+        "p95": 4.35,
+        "p99": 9.54,
+        "min": 1.39,
+        "max": 19.04
+      },
+      "ttfbMs": {
+        "p50": 2.11,
+        "p95": 4.24,
+        "p99": 9.43
+      },
+      "rps": {
+        "sustained": 787.84,
+        "peak": 537
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/notifications",
+      "name": "List notifications",
+      "method": "GET",
+      "path": "/api/notifications",
+      "requests": 1204,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1204
+      },
+      "latencyMs": {
+        "p50": 1.41,
+        "p95": 2.47,
+        "p99": 8.14,
+        "min": 0.91,
+        "max": 14.6
+      },
+      "ttfbMs": {
+        "p50": 1.37,
+        "p95": 2.4,
+        "p99": 8.09
+      },
+      "rps": {
+        "sustained": 1203.42,
+        "peak": 811
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/notifications",
+      "name": "Create notification",
+      "method": "POST",
+      "path": "/api/notifications",
+      "requests": 991,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 991
+      },
+      "latencyMs": {
+        "p50": 1.82,
+        "p95": 2.81,
+        "p99": 7.93,
+        "min": 1.19,
+        "max": 12.95
+      },
+      "ttfbMs": {
+        "p50": 1.77,
+        "p95": 2.71,
+        "p99": 7.83
+      },
+      "rps": {
+        "sustained": 989.81,
+        "peak": 676
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "POST /api/uploads",
+      "name": "Upload file",
+      "method": "POST",
+      "path": "/api/uploads",
+      "requests": 366,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "201": 366
+      },
+      "latencyMs": {
+        "p50": 4.9,
+        "p95": 9.09,
+        "p99": 16.99,
+        "min": 2.44,
+        "max": 26.18
+      },
+      "ttfbMs": {
+        "p50": 4.8,
+        "p95": 8.97,
+        "p99": 16.86
+      },
+      "rps": {
+        "sustained": 365.19,
+        "peak": 220
+      },
+      "threshold": {
+        "p99Ms": 3000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/search",
+      "name": "Search marketplace",
+      "method": "GET",
+      "path": "/api/search?q=node%20express%20benchmark",
+      "requests": 1046,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 1046
+      },
+      "latencyMs": {
+        "p50": 1.67,
+        "p95": 2.83,
+        "p99": 7.85,
+        "min": 1.06,
+        "max": 19.38
+      },
+      "ttfbMs": {
+        "p50": 1.62,
+        "p95": 2.74,
+        "p99": 7.8
+      },
+      "rps": {
+        "sustained": 1044.91,
+        "peak": 672
+      },
+      "threshold": {
+        "p99Ms": 2000,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "key": "GET /api/admin/metrics",
+      "name": "Admin metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "requests": 833,
+      "errors": 0,
+      "errorRatePercent": 0,
+      "statusCodes": {
+        "200": 833
+      },
+      "latencyMs": {
+        "p50": 2.26,
+        "p95": 3.21,
+        "p99": 7.32,
+        "min": 1.32,
+        "max": 8.95
+      },
+      "ttfbMs": {
+        "p50": 2.2,
+        "p95": 3.13,
+        "p99": 7.28
+      },
+      "rps": {
+        "sustained": 831.57,
+        "peak": 534
+      },
+      "threshold": {
+        "p99Ms": 1500,
+        "errorRatePercent": 0
+      },
+      "passed": true,
+      "failures": []
+    }
+  ]
+}

--- a/benchmarks/results/benchmark-results.json
+++ b/benchmarks/results/benchmark-results.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-05-20T03:56:14.377Z",
-  "targetUrl": "http://127.0.0.1:43289",
+  "generatedAt": "2026-05-20T04:16:11.873Z",
+  "targetUrl": "http://127.0.0.1:43277",
   "config": {
     "concurrency": 2,
-    "durationSeconds": 1,
+    "durationSeconds": 3,
     "warmupRequests": 1,
     "smoke": true
   },
@@ -13,27 +13,27 @@
       "name": "Register user",
       "method": "POST",
       "path": "/api/auth/register",
-      "requests": 343,
+      "requests": 697,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 343
+        "201": 697
       },
       "latencyMs": {
-        "p50": 5.25,
-        "p95": 9.76,
-        "p99": 20.47,
-        "min": 2.64,
-        "max": 30.48
+        "p50": 6.55,
+        "p95": 19.45,
+        "p99": 44.85,
+        "min": 3.5,
+        "max": 66.27
       },
       "ttfbMs": {
-        "p50": 5.08,
-        "p95": 9.3,
-        "p99": 19.91
+        "p50": 6.39,
+        "p95": 18.76,
+        "p99": 44.54
       },
       "rps": {
-        "sustained": 342.58,
-        "peak": 261
+        "sustained": 232.11,
+        "peak": 294
       },
       "threshold": {
         "p99Ms": 2000,
@@ -47,27 +47,27 @@
       "name": "Login user",
       "method": "POST",
       "path": "/api/auth/login",
-      "requests": 413,
+      "requests": 1081,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 413
+        "200": 1081
       },
       "latencyMs": {
-        "p50": 4.2,
-        "p95": 9.81,
-        "p99": 15.17,
-        "min": 2.39,
-        "max": 16.49
+        "p50": 4.72,
+        "p95": 10.12,
+        "p99": 19.58,
+        "min": 2.51,
+        "max": 52.87
       },
       "ttfbMs": {
-        "p50": 4.1,
-        "p95": 9.74,
-        "p99": 15.08
+        "p50": 4.59,
+        "p95": 9.89,
+        "p99": 19.2
       },
       "rps": {
-        "sustained": 412.16,
-        "peak": 335
+        "sustained": 360.05,
+        "peak": 416
       },
       "threshold": {
         "p99Ms": 2000,
@@ -81,27 +81,27 @@
       "name": "OAuth callback",
       "method": "GET",
       "path": "/api/auth/oauth/github/callback?code=benchmark-code&state=benchmark-state",
-      "requests": 776,
+      "requests": 2125,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 776
+        "200": 2125
       },
       "latencyMs": {
-        "p50": 2.15,
-        "p95": 3.97,
-        "p99": 11.4,
-        "min": 1.38,
-        "max": 20.5
+        "p50": 2.36,
+        "p95": 5.17,
+        "p99": 12.64,
+        "min": 1.21,
+        "max": 33
       },
       "ttfbMs": {
-        "p50": 2.07,
-        "p95": 3.61,
-        "p99": 11.3
+        "p50": 2.28,
+        "p95": 4.95,
+        "p99": 12.36
       },
       "rps": {
-        "sustained": 774.45,
-        "peak": 610
+        "sustained": 708.12,
+        "peak": 701
       },
       "threshold": {
         "p99Ms": 2000,
@@ -115,27 +115,27 @@
       "name": "Refresh token",
       "method": "POST",
       "path": "/api/auth/refresh",
-      "requests": 790,
+      "requests": 2017,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 790
+        "200": 2017
       },
       "latencyMs": {
-        "p50": 2.35,
-        "p95": 3.31,
-        "p99": 7.47,
-        "min": 1.56,
-        "max": 10.76
+        "p50": 2.65,
+        "p95": 4.75,
+        "p99": 10,
+        "min": 1.38,
+        "max": 16.48
       },
       "ttfbMs": {
-        "p50": 2.27,
-        "p95": 3.21,
-        "p99": 7.33
+        "p50": 2.57,
+        "p95": 4.59,
+        "p99": 9.92
       },
       "rps": {
-        "sustained": 788.87,
-        "peak": 616
+        "sustained": 672.07,
+        "peak": 676
       },
       "threshold": {
         "p99Ms": 2000,
@@ -149,27 +149,27 @@
       "name": "List users",
       "method": "GET",
       "path": "/api/users",
-      "requests": 1041,
+      "requests": 2882,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1041
+        "200": 2882
       },
       "latencyMs": {
-        "p50": 1.73,
-        "p95": 2.48,
-        "p99": 9.38,
-        "min": 0.83,
-        "max": 12.81
+        "p50": 1.72,
+        "p95": 3.53,
+        "p99": 10.32,
+        "min": 1.02,
+        "max": 27.53
       },
       "ttfbMs": {
-        "p50": 1.67,
-        "p95": 2.37,
-        "p99": 9.27
+        "p50": 1.65,
+        "p95": 3.37,
+        "p99": 10.24
       },
       "rps": {
-        "sustained": 1040.18,
-        "peak": 750
+        "sustained": 960.54,
+        "peak": 1078
       },
       "threshold": {
         "p99Ms": 2000,
@@ -183,27 +183,27 @@
       "name": "Create user",
       "method": "POST",
       "path": "/api/users",
-      "requests": 836,
+      "requests": 2001,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 836
+        "201": 2001
       },
       "latencyMs": {
-        "p50": 2.15,
-        "p95": 3.35,
-        "p99": 9.1,
-        "min": 1.35,
-        "max": 11.57
+        "p50": 2.59,
+        "p95": 4.81,
+        "p99": 11.87,
+        "min": 1.18,
+        "max": 30.73
       },
       "ttfbMs": {
-        "p50": 2.1,
-        "p95": 3.31,
-        "p99": 9.04
+        "p50": 2.51,
+        "p95": 4.66,
+        "p99": 11.74
       },
       "rps": {
-        "sustained": 835.53,
-        "peak": 657
+        "sustained": 666.84,
+        "peak": 674
       },
       "threshold": {
         "p99Ms": 2000,
@@ -217,27 +217,27 @@
       "name": "List jobs",
       "method": "GET",
       "path": "/api/jobs",
-      "requests": 1072,
+      "requests": 3284,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1072
+        "200": 3284
       },
       "latencyMs": {
-        "p50": 1.66,
-        "p95": 2.87,
-        "p99": 8.29,
-        "min": 1.05,
-        "max": 9.6
+        "p50": 1.62,
+        "p95": 2.58,
+        "p99": 7.64,
+        "min": 0.99,
+        "max": 19.55
       },
       "ttfbMs": {
-        "p50": 1.61,
-        "p95": 2.79,
-        "p99": 8.19
+        "p50": 1.56,
+        "p95": 2.48,
+        "p99": 7.51
       },
       "rps": {
-        "sustained": 1070.33,
-        "peak": 836
+        "sustained": 1094.49,
+        "peak": 1134
       },
       "threshold": {
         "p99Ms": 2000,
@@ -251,27 +251,27 @@
       "name": "Create job",
       "method": "POST",
       "path": "/api/jobs",
-      "requests": 358,
+      "requests": 2056,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 358
+        "201": 2056
       },
       "latencyMs": {
-        "p50": 3.51,
-        "p95": 15.18,
-        "p99": 25.94,
-        "min": 2.13,
-        "max": 82.8
+        "p50": 2.51,
+        "p95": 4.98,
+        "p99": 13.24,
+        "min": 1.43,
+        "max": 21.47
       },
       "ttfbMs": {
-        "p50": 3.44,
-        "p95": 14.89,
-        "p99": 25.8
+        "p50": 2.44,
+        "p95": 4.88,
+        "p99": 13.08
       },
       "rps": {
-        "sustained": 357.59,
-        "peak": 234
+        "sustained": 683.23,
+        "peak": 726
       },
       "threshold": {
         "p99Ms": 2000,
@@ -285,27 +285,27 @@
       "name": "List proposals",
       "method": "GET",
       "path": "/api/proposals",
-      "requests": 890,
+      "requests": 3150,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 890
+        "200": 3150
       },
       "latencyMs": {
-        "p50": 1.76,
-        "p95": 4.08,
-        "p99": 13.23,
-        "min": 1.08,
-        "max": 18.39
+        "p50": 1.59,
+        "p95": 2.82,
+        "p99": 9.62,
+        "min": 0.97,
+        "max": 25.25
       },
       "ttfbMs": {
-        "p50": 1.7,
-        "p95": 3.93,
-        "p99": 12.59
+        "p50": 1.53,
+        "p95": 2.73,
+        "p99": 9.55
       },
       "rps": {
-        "sustained": 889.69,
-        "peak": 628
+        "sustained": 1049.92,
+        "peak": 1002
       },
       "threshold": {
         "p99Ms": 2000,
@@ -319,27 +319,27 @@
       "name": "Create proposal",
       "method": "POST",
       "path": "/api/proposals",
-      "requests": 639,
+      "requests": 2287,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 639
+        "201": 2287
       },
       "latencyMs": {
-        "p50": 2.61,
-        "p95": 6.77,
-        "p99": 12.67,
-        "min": 1.33,
-        "max": 20.28
+        "p50": 2.29,
+        "p95": 3.91,
+        "p99": 10.27,
+        "min": 1.29,
+        "max": 20.8
       },
       "ttfbMs": {
-        "p50": 2.54,
-        "p95": 6.71,
-        "p99": 12.62
+        "p50": 2.22,
+        "p95": 3.75,
+        "p99": 10.16
       },
       "rps": {
-        "sustained": 638.29,
-        "peak": 460
+        "sustained": 761.89,
+        "peak": 780
       },
       "threshold": {
         "p99Ms": 2000,
@@ -353,27 +353,27 @@
       "name": "Create payment",
       "method": "POST",
       "path": "/api/payments",
-      "requests": 816,
+      "requests": 2023,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 816
+        "201": 2023
       },
       "latencyMs": {
-        "p50": 2.16,
-        "p95": 4.07,
-        "p99": 9.06,
-        "min": 1.29,
-        "max": 25.18
+        "p50": 2.49,
+        "p95": 4.71,
+        "p99": 13.64,
+        "min": 1.34,
+        "max": 38.24
       },
       "ttfbMs": {
-        "p50": 2.09,
-        "p95": 3.98,
-        "p99": 9
+        "p50": 2.41,
+        "p95": 4.57,
+        "p99": 13.58
       },
       "rps": {
-        "sustained": 815.09,
-        "peak": 538
+        "sustained": 673.81,
+        "peak": 723
       },
       "threshold": {
         "p99Ms": 2000,
@@ -387,27 +387,27 @@
       "name": "List reviews",
       "method": "GET",
       "path": "/api/reviews",
-      "requests": 1261,
+      "requests": 2756,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1261
+        "200": 2756
       },
       "latencyMs": {
-        "p50": 1.45,
-        "p95": 2.15,
-        "p99": 7.38,
-        "min": 0.9,
-        "max": 9.72
+        "p50": 1.76,
+        "p95": 4.12,
+        "p99": 10.13,
+        "min": 0.98,
+        "max": 31.98
       },
       "ttfbMs": {
-        "p50": 1.4,
-        "p95": 2.08,
-        "p99": 7.28
+        "p50": 1.7,
+        "p95": 3.98,
+        "p99": 9.99
       },
       "rps": {
-        "sustained": 1259.92,
-        "peak": 896
+        "sustained": 918.18,
+        "peak": 954
       },
       "threshold": {
         "p99Ms": 2000,
@@ -421,27 +421,27 @@
       "name": "Create review",
       "method": "POST",
       "path": "/api/reviews",
-      "requests": 883,
+      "requests": 2156,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 883
+        "201": 2156
       },
       "latencyMs": {
-        "p50": 1.98,
-        "p95": 3.68,
-        "p99": 11.91,
-        "min": 1.2,
-        "max": 19.27
+        "p50": 2.39,
+        "p95": 4.78,
+        "p99": 12.16,
+        "min": 1.35,
+        "max": 20.28
       },
       "ttfbMs": {
-        "p50": 1.92,
-        "p95": 3.57,
-        "p99": 11.78
+        "p50": 2.32,
+        "p95": 4.7,
+        "p99": 12.06
       },
       "rps": {
-        "sustained": 882.34,
-        "peak": 624
+        "sustained": 718.34,
+        "peak": 715
       },
       "threshold": {
         "p99Ms": 2000,
@@ -455,27 +455,27 @@
       "name": "List messages",
       "method": "GET",
       "path": "/api/messages",
-      "requests": 1188,
+      "requests": 2870,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1188
+        "200": 2870
       },
       "latencyMs": {
-        "p50": 1.47,
-        "p95": 2.17,
-        "p99": 7.66,
-        "min": 0.92,
-        "max": 16.08
+        "p50": 1.72,
+        "p95": 3.63,
+        "p99": 10.87,
+        "min": 0.99,
+        "max": 30.61
       },
       "ttfbMs": {
-        "p50": 1.43,
-        "p95": 2.11,
-        "p99": 7.57
+        "p50": 1.66,
+        "p95": 3.46,
+        "p99": 10.81
       },
       "rps": {
-        "sustained": 1187.26,
-        "peak": 863
+        "sustained": 956.59,
+        "peak": 1019
       },
       "threshold": {
         "p99Ms": 2000,
@@ -489,27 +489,27 @@
       "name": "Send message",
       "method": "POST",
       "path": "/api/messages",
-      "requests": 788,
+      "requests": 2206,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 788
+        "201": 2206
       },
       "latencyMs": {
-        "p50": 2.17,
-        "p95": 4.35,
-        "p99": 9.54,
-        "min": 1.39,
-        "max": 19.04
+        "p50": 2.37,
+        "p95": 4.6,
+        "p99": 10.14,
+        "min": 1.27,
+        "max": 28.14
       },
       "ttfbMs": {
-        "p50": 2.11,
-        "p95": 4.24,
-        "p99": 9.43
+        "p50": 2.29,
+        "p95": 4.44,
+        "p99": 9.97
       },
       "rps": {
-        "sustained": 787.84,
-        "peak": 537
+        "sustained": 734.43,
+        "peak": 811
       },
       "threshold": {
         "p99Ms": 2000,
@@ -523,27 +523,27 @@
       "name": "List notifications",
       "method": "GET",
       "path": "/api/notifications",
-      "requests": 1204,
+      "requests": 2655,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1204
+        "200": 2655
       },
       "latencyMs": {
-        "p50": 1.41,
-        "p95": 2.47,
-        "p99": 8.14,
-        "min": 0.91,
-        "max": 14.6
+        "p50": 1.77,
+        "p95": 5.14,
+        "p99": 10.7,
+        "min": 0.98,
+        "max": 23.38
       },
       "ttfbMs": {
-        "p50": 1.37,
-        "p95": 2.4,
-        "p99": 8.09
+        "p50": 1.7,
+        "p95": 4.95,
+        "p99": 10.24
       },
       "rps": {
-        "sustained": 1203.42,
-        "peak": 811
+        "sustained": 884.73,
+        "peak": 927
       },
       "threshold": {
         "p99Ms": 2000,
@@ -557,27 +557,27 @@
       "name": "Create notification",
       "method": "POST",
       "path": "/api/notifications",
-      "requests": 991,
+      "requests": 2011,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 991
+        "201": 2011
       },
       "latencyMs": {
-        "p50": 1.82,
-        "p95": 2.81,
-        "p99": 7.93,
-        "min": 1.19,
-        "max": 12.95
+        "p50": 2.49,
+        "p95": 5.96,
+        "p99": 12.8,
+        "min": 1.31,
+        "max": 19.95
       },
       "ttfbMs": {
-        "p50": 1.77,
-        "p95": 2.71,
-        "p99": 7.83
+        "p50": 2.42,
+        "p95": 5.87,
+        "p99": 12.66
       },
       "rps": {
-        "sustained": 989.81,
-        "peak": 676
+        "sustained": 669.81,
+        "peak": 706
       },
       "threshold": {
         "p99Ms": 2000,
@@ -591,27 +591,27 @@
       "name": "Upload file",
       "method": "POST",
       "path": "/api/uploads",
-      "requests": 366,
+      "requests": 736,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "201": 366
+        "201": 736
       },
       "latencyMs": {
-        "p50": 4.9,
-        "p95": 9.09,
-        "p99": 16.99,
-        "min": 2.44,
-        "max": 26.18
+        "p50": 5.48,
+        "p95": 22.71,
+        "p99": 48.36,
+        "min": 2.67,
+        "max": 84.58
       },
       "ttfbMs": {
-        "p50": 4.8,
-        "p95": 8.97,
-        "p99": 16.86
+        "p50": 5.35,
+        "p95": 21.48,
+        "p99": 47.65
       },
       "rps": {
-        "sustained": 365.19,
-        "peak": 220
+        "sustained": 245.24,
+        "peak": 264
       },
       "threshold": {
         "p99Ms": 3000,
@@ -625,27 +625,27 @@
       "name": "Search marketplace",
       "method": "GET",
       "path": "/api/search?q=node%20express%20benchmark",
-      "requests": 1046,
+      "requests": 2454,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 1046
+        "200": 2454
       },
       "latencyMs": {
-        "p50": 1.67,
-        "p95": 2.83,
-        "p99": 7.85,
-        "min": 1.06,
-        "max": 19.38
+        "p50": 1.92,
+        "p95": 4.99,
+        "p99": 13.7,
+        "min": 1.11,
+        "max": 29
       },
       "ttfbMs": {
-        "p50": 1.62,
-        "p95": 2.74,
-        "p99": 7.8
+        "p50": 1.85,
+        "p95": 4.86,
+        "p99": 13.47
       },
       "rps": {
-        "sustained": 1044.91,
-        "peak": 672
+        "sustained": 817.67,
+        "peak": 848
       },
       "threshold": {
         "p99Ms": 2000,
@@ -659,27 +659,27 @@
       "name": "Admin metrics",
       "method": "GET",
       "path": "/api/admin/metrics",
-      "requests": 833,
+      "requests": 1750,
       "errors": 0,
       "errorRatePercent": 0,
       "statusCodes": {
-        "200": 833
+        "200": 1750
       },
       "latencyMs": {
-        "p50": 2.26,
-        "p95": 3.21,
-        "p99": 7.32,
-        "min": 1.32,
-        "max": 8.95
+        "p50": 3.05,
+        "p95": 5.47,
+        "p99": 12.4,
+        "min": 1.48,
+        "max": 24.56
       },
       "ttfbMs": {
-        "p50": 2.2,
-        "p95": 3.13,
-        "p99": 7.28
+        "p50": 2.97,
+        "p95": 5.29,
+        "p99": 12.26
       },
       "rps": {
-        "sustained": 831.57,
-        "peak": 534
+        "sustained": 582.43,
+        "peak": 614
       },
       "threshold": {
         "p99Ms": 1500,

--- a/benchmarks/results/benchmark-summary.md
+++ b/benchmarks/results/benchmark-summary.md
@@ -1,35 +1,35 @@
 # API Benchmark Summary
 
-Generated: 2026-05-20T03:56:14.377Z
-Target: http://127.0.0.1:43289
+Generated: 2026-05-20T04:16:11.873Z
+Target: http://127.0.0.1:43277
 Mode: CI smoke
 Concurrency: 2
-Duration per endpoint: 1s
+Duration per endpoint: 3s
 
 ## Results
 
 | Endpoint | Requests | p50 | p95 | p99 | TTFB p95 | Sustained RPS | Peak RPS | Error Rate | Gate |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-`POST /api/auth/register` | 343 | 5.25ms | 9.76ms | 20.47ms | 9.3ms | 342.58 | 261 | 0% | ✅ pass
-`POST /api/auth/login` | 413 | 4.2ms | 9.81ms | 15.17ms | 9.74ms | 412.16 | 335 | 0% | ✅ pass
-`GET /api/auth/oauth/github/callback` | 776 | 2.15ms | 3.97ms | 11.4ms | 3.61ms | 774.45 | 610 | 0% | ✅ pass
-`POST /api/auth/refresh` | 790 | 2.35ms | 3.31ms | 7.47ms | 3.21ms | 788.87 | 616 | 0% | ✅ pass
-`GET /api/users` | 1041 | 1.73ms | 2.48ms | 9.38ms | 2.37ms | 1040.18 | 750 | 0% | ✅ pass
-`POST /api/users` | 836 | 2.15ms | 3.35ms | 9.1ms | 3.31ms | 835.53 | 657 | 0% | ✅ pass
-`GET /api/jobs` | 1072 | 1.66ms | 2.87ms | 8.29ms | 2.79ms | 1070.33 | 836 | 0% | ✅ pass
-`POST /api/jobs` | 358 | 3.51ms | 15.18ms | 25.94ms | 14.89ms | 357.59 | 234 | 0% | ✅ pass
-`GET /api/proposals` | 890 | 1.76ms | 4.08ms | 13.23ms | 3.93ms | 889.69 | 628 | 0% | ✅ pass
-`POST /api/proposals` | 639 | 2.61ms | 6.77ms | 12.67ms | 6.71ms | 638.29 | 460 | 0% | ✅ pass
-`POST /api/payments` | 816 | 2.16ms | 4.07ms | 9.06ms | 3.98ms | 815.09 | 538 | 0% | ✅ pass
-`GET /api/reviews` | 1261 | 1.45ms | 2.15ms | 7.38ms | 2.08ms | 1259.92 | 896 | 0% | ✅ pass
-`POST /api/reviews` | 883 | 1.98ms | 3.68ms | 11.91ms | 3.57ms | 882.34 | 624 | 0% | ✅ pass
-`GET /api/messages` | 1188 | 1.47ms | 2.17ms | 7.66ms | 2.11ms | 1187.26 | 863 | 0% | ✅ pass
-`POST /api/messages` | 788 | 2.17ms | 4.35ms | 9.54ms | 4.24ms | 787.84 | 537 | 0% | ✅ pass
-`GET /api/notifications` | 1204 | 1.41ms | 2.47ms | 8.14ms | 2.4ms | 1203.42 | 811 | 0% | ✅ pass
-`POST /api/notifications` | 991 | 1.82ms | 2.81ms | 7.93ms | 2.71ms | 989.81 | 676 | 0% | ✅ pass
-`POST /api/uploads` | 366 | 4.9ms | 9.09ms | 16.99ms | 8.97ms | 365.19 | 220 | 0% | ✅ pass
-`GET /api/search` | 1046 | 1.67ms | 2.83ms | 7.85ms | 2.74ms | 1044.91 | 672 | 0% | ✅ pass
-`GET /api/admin/metrics` | 833 | 2.26ms | 3.21ms | 7.32ms | 3.13ms | 831.57 | 534 | 0% | ✅ pass
+`POST /api/auth/register` | 697 | 6.55ms | 19.45ms | 44.85ms | 18.76ms | 232.11 | 294 | 0% | ✅ pass
+`POST /api/auth/login` | 1081 | 4.72ms | 10.12ms | 19.58ms | 9.89ms | 360.05 | 416 | 0% | ✅ pass
+`GET /api/auth/oauth/github/callback` | 2125 | 2.36ms | 5.17ms | 12.64ms | 4.95ms | 708.12 | 701 | 0% | ✅ pass
+`POST /api/auth/refresh` | 2017 | 2.65ms | 4.75ms | 10ms | 4.59ms | 672.07 | 676 | 0% | ✅ pass
+`GET /api/users` | 2882 | 1.72ms | 3.53ms | 10.32ms | 3.37ms | 960.54 | 1078 | 0% | ✅ pass
+`POST /api/users` | 2001 | 2.59ms | 4.81ms | 11.87ms | 4.66ms | 666.84 | 674 | 0% | ✅ pass
+`GET /api/jobs` | 3284 | 1.62ms | 2.58ms | 7.64ms | 2.48ms | 1094.49 | 1134 | 0% | ✅ pass
+`POST /api/jobs` | 2056 | 2.51ms | 4.98ms | 13.24ms | 4.88ms | 683.23 | 726 | 0% | ✅ pass
+`GET /api/proposals` | 3150 | 1.59ms | 2.82ms | 9.62ms | 2.73ms | 1049.92 | 1002 | 0% | ✅ pass
+`POST /api/proposals` | 2287 | 2.29ms | 3.91ms | 10.27ms | 3.75ms | 761.89 | 780 | 0% | ✅ pass
+`POST /api/payments` | 2023 | 2.49ms | 4.71ms | 13.64ms | 4.57ms | 673.81 | 723 | 0% | ✅ pass
+`GET /api/reviews` | 2756 | 1.76ms | 4.12ms | 10.13ms | 3.98ms | 918.18 | 954 | 0% | ✅ pass
+`POST /api/reviews` | 2156 | 2.39ms | 4.78ms | 12.16ms | 4.7ms | 718.34 | 715 | 0% | ✅ pass
+`GET /api/messages` | 2870 | 1.72ms | 3.63ms | 10.87ms | 3.46ms | 956.59 | 1019 | 0% | ✅ pass
+`POST /api/messages` | 2206 | 2.37ms | 4.6ms | 10.14ms | 4.44ms | 734.43 | 811 | 0% | ✅ pass
+`GET /api/notifications` | 2655 | 1.77ms | 5.14ms | 10.7ms | 4.95ms | 884.73 | 927 | 0% | ✅ pass
+`POST /api/notifications` | 2011 | 2.49ms | 5.96ms | 12.8ms | 5.87ms | 669.81 | 706 | 0% | ✅ pass
+`POST /api/uploads` | 736 | 5.48ms | 22.71ms | 48.36ms | 21.48ms | 245.24 | 264 | 0% | ✅ pass
+`GET /api/search` | 2454 | 1.92ms | 4.99ms | 13.7ms | 4.86ms | 817.67 | 848 | 0% | ✅ pass
+`GET /api/admin/metrics` | 1750 | 3.05ms | 5.47ms | 12.4ms | 5.29ms | 582.43 | 614 | 0% | ✅ pass
 
 ## Gate
 

--- a/benchmarks/results/benchmark-summary.md
+++ b/benchmarks/results/benchmark-summary.md
@@ -1,0 +1,36 @@
+# API Benchmark Summary
+
+Generated: 2026-05-20T03:56:14.377Z
+Target: http://127.0.0.1:43289
+Mode: CI smoke
+Concurrency: 2
+Duration per endpoint: 1s
+
+## Results
+
+| Endpoint | Requests | p50 | p95 | p99 | TTFB p95 | Sustained RPS | Peak RPS | Error Rate | Gate |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+`POST /api/auth/register` | 343 | 5.25ms | 9.76ms | 20.47ms | 9.3ms | 342.58 | 261 | 0% | ✅ pass
+`POST /api/auth/login` | 413 | 4.2ms | 9.81ms | 15.17ms | 9.74ms | 412.16 | 335 | 0% | ✅ pass
+`GET /api/auth/oauth/github/callback` | 776 | 2.15ms | 3.97ms | 11.4ms | 3.61ms | 774.45 | 610 | 0% | ✅ pass
+`POST /api/auth/refresh` | 790 | 2.35ms | 3.31ms | 7.47ms | 3.21ms | 788.87 | 616 | 0% | ✅ pass
+`GET /api/users` | 1041 | 1.73ms | 2.48ms | 9.38ms | 2.37ms | 1040.18 | 750 | 0% | ✅ pass
+`POST /api/users` | 836 | 2.15ms | 3.35ms | 9.1ms | 3.31ms | 835.53 | 657 | 0% | ✅ pass
+`GET /api/jobs` | 1072 | 1.66ms | 2.87ms | 8.29ms | 2.79ms | 1070.33 | 836 | 0% | ✅ pass
+`POST /api/jobs` | 358 | 3.51ms | 15.18ms | 25.94ms | 14.89ms | 357.59 | 234 | 0% | ✅ pass
+`GET /api/proposals` | 890 | 1.76ms | 4.08ms | 13.23ms | 3.93ms | 889.69 | 628 | 0% | ✅ pass
+`POST /api/proposals` | 639 | 2.61ms | 6.77ms | 12.67ms | 6.71ms | 638.29 | 460 | 0% | ✅ pass
+`POST /api/payments` | 816 | 2.16ms | 4.07ms | 9.06ms | 3.98ms | 815.09 | 538 | 0% | ✅ pass
+`GET /api/reviews` | 1261 | 1.45ms | 2.15ms | 7.38ms | 2.08ms | 1259.92 | 896 | 0% | ✅ pass
+`POST /api/reviews` | 883 | 1.98ms | 3.68ms | 11.91ms | 3.57ms | 882.34 | 624 | 0% | ✅ pass
+`GET /api/messages` | 1188 | 1.47ms | 2.17ms | 7.66ms | 2.11ms | 1187.26 | 863 | 0% | ✅ pass
+`POST /api/messages` | 788 | 2.17ms | 4.35ms | 9.54ms | 4.24ms | 787.84 | 537 | 0% | ✅ pass
+`GET /api/notifications` | 1204 | 1.41ms | 2.47ms | 8.14ms | 2.4ms | 1203.42 | 811 | 0% | ✅ pass
+`POST /api/notifications` | 991 | 1.82ms | 2.81ms | 7.93ms | 2.71ms | 989.81 | 676 | 0% | ✅ pass
+`POST /api/uploads` | 366 | 4.9ms | 9.09ms | 16.99ms | 8.97ms | 365.19 | 220 | 0% | ✅ pass
+`GET /api/search` | 1046 | 1.67ms | 2.83ms | 7.85ms | 2.74ms | 1044.91 | 672 | 0% | ✅ pass
+`GET /api/admin/metrics` | 833 | 2.26ms | 3.21ms | 7.32ms | 3.13ms | 831.57 | 534 | 0% | ✅ pass
+
+## Gate
+
+All thresholds passed.

--- a/benchmarks/run-benchmark.mjs
+++ b/benchmarks/run-benchmark.mjs
@@ -48,7 +48,7 @@ function loadEnvFile() {
 
 async function startLocalServer() {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "benchmark";
-  process.env.RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX ?? "100000";
+  process.env.RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX ?? "10000000";
 
   const app = createApp();
   const server = createServer(app);

--- a/benchmarks/run-benchmark.mjs
+++ b/benchmarks/run-benchmark.mjs
@@ -1,0 +1,341 @@
+import { createServer } from "node:http";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import { createApp } from "../apps/api/src/app.js";
+import { endpoints, endpointKey } from "./endpoints.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const resultsDir = path.join(__dirname, "results");
+
+function createConfig() {
+  return {
+    targetUrl: process.env.BENCHMARK_TARGET_URL,
+    token: process.env.BENCHMARK_TOKEN,
+    durationSeconds: Number(process.env.BENCHMARK_DURATION_SECONDS ?? 10),
+    concurrency: Number(process.env.BENCHMARK_CONCURRENCY ?? 8),
+    warmupRequests: Number(process.env.BENCHMARK_WARMUP_REQUESTS ?? 2),
+    outputDir: process.env.BENCHMARK_OUTPUT_DIR ?? resultsDir,
+    thresholdsPath: process.env.BENCHMARK_THRESHOLDS_PATH ?? path.join(__dirname, "thresholds.json"),
+    smoke: process.env.BENCHMARK_SMOKE === "true"
+  };
+}
+
+let config = createConfig();
+
+function loadEnvFile() {
+  const envPath = path.join(repoRoot, ".env.benchmark");
+  if (!existsSync(envPath)) {
+    return;
+  }
+
+  const raw = readFileSync(envPath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || !trimmed.includes("=")) {
+      continue;
+    }
+    const [key, ...valueParts] = trimmed.split("=");
+    if (!process.env[key]) {
+      process.env[key] = valueParts.join("=").replace(/^['\"]|['\"]$/g, "");
+    }
+  }
+}
+
+async function startLocalServer() {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "benchmark";
+  process.env.RATE_LIMIT_MAX = process.env.RATE_LIMIT_MAX ?? "100000";
+
+  const app = createApp();
+  const server = createServer(app);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1");
+  });
+
+  const { port } = server.address();
+  return {
+    targetUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+  };
+}
+
+async function getBenchmarkToken(targetUrl) {
+  if (config.token) {
+    return config.token;
+  }
+
+  const response = await fetch(new URL("/api/auth/login", targetUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "bench.client@example.com", password: "benchmark-password" })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to create benchmark token: ${response.status} ${await response.text()}`);
+  }
+
+  const payload = await response.json();
+  return payload.data.token;
+}
+
+function makeRequestOptions(endpoint, token) {
+  const headers = {};
+  const options = { method: endpoint.method, headers };
+
+  if (endpoint.auth) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  if (endpoint.body) {
+    headers["content-type"] = "application/json";
+    options.body = JSON.stringify(endpoint.body());
+  }
+
+  if (endpoint.multipart) {
+    const payload = endpoint.multipart();
+    const form = new FormData();
+    const file = new Blob([payload.content], { type: payload.type });
+    form.append(payload.fieldName, file, payload.filename);
+    options.body = form;
+  }
+
+  return options;
+}
+
+async function timedFetch(targetUrl, endpoint, token) {
+  const url = new URL(endpoint.path, targetUrl);
+  const startedAt = performance.now();
+  let response;
+  let ttfbMs;
+  try {
+    response = await fetch(url, makeRequestOptions(endpoint, token));
+    ttfbMs = performance.now() - startedAt;
+    await response.arrayBuffer();
+    const latencyMs = performance.now() - startedAt;
+    return {
+      ok: response.ok,
+      status: response.status,
+      latencyMs,
+      ttfbMs,
+      completedAt: Date.now()
+    };
+  } catch (error) {
+    const latencyMs = performance.now() - startedAt;
+    return {
+      ok: false,
+      status: 0,
+      latencyMs,
+      ttfbMs: latencyMs,
+      error: error.message,
+      completedAt: Date.now()
+    };
+  }
+}
+
+function percentile(values, p) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+function round(value, digits = 2) {
+  return Number(value.toFixed(digits));
+}
+
+async function warmupEndpoint(targetUrl, endpoint, token) {
+  for (let i = 0; i < config.warmupRequests; i += 1) {
+    await timedFetch(targetUrl, endpoint, token);
+  }
+}
+
+async function runEndpointBenchmark(targetUrl, endpoint, token) {
+  await warmupEndpoint(targetUrl, endpoint, token);
+
+  const deadline = performance.now() + config.durationSeconds * 1000;
+  const startedAt = performance.now();
+  const results = [];
+
+  async function worker() {
+    while (performance.now() < deadline) {
+      results.push(await timedFetch(targetUrl, endpoint, token));
+    }
+  }
+
+  await Promise.all(Array.from({ length: config.concurrency }, () => worker()));
+  const durationMs = performance.now() - startedAt;
+  const latencies = results.map((result) => result.latencyMs);
+  const ttfb = results.map((result) => result.ttfbMs);
+  const errors = results.filter((result) => !result.ok);
+  const bucketCounts = new Map();
+  for (const result of results) {
+    const bucket = Math.floor(result.completedAt / 1000);
+    bucketCounts.set(bucket, (bucketCounts.get(bucket) ?? 0) + 1);
+  }
+
+  return {
+    key: endpointKey(endpoint),
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    requests: results.length,
+    errors: errors.length,
+    errorRatePercent: round((errors.length / Math.max(results.length, 1)) * 100),
+    statusCodes: results.reduce((acc, result) => {
+      acc[result.status] = (acc[result.status] ?? 0) + 1;
+      return acc;
+    }, {}),
+    latencyMs: {
+      p50: round(percentile(latencies, 50)),
+      p95: round(percentile(latencies, 95)),
+      p99: round(percentile(latencies, 99)),
+      min: round(Math.min(...latencies)),
+      max: round(Math.max(...latencies))
+    },
+    ttfbMs: {
+      p50: round(percentile(ttfb, 50)),
+      p95: round(percentile(ttfb, 95)),
+      p99: round(percentile(ttfb, 99))
+    },
+    rps: {
+      sustained: round(results.length / (durationMs / 1000)),
+      peak: Math.max(0, ...bucketCounts.values())
+    }
+  };
+}
+
+async function readThresholds() {
+  const raw = await readFile(config.thresholdsPath, "utf8");
+  return JSON.parse(raw);
+}
+
+function thresholdFor(thresholds, result) {
+  return {
+    ...thresholds.default,
+    ...(thresholds.endpoints?.[result.key] ?? {})
+  };
+}
+
+function evaluateThresholds(thresholds, results) {
+  return results.map((result) => {
+    const threshold = thresholdFor(thresholds, result);
+    const failures = [];
+    if (result.latencyMs.p99 > threshold.p99Ms) {
+      failures.push(`p99 ${result.latencyMs.p99}ms > ${threshold.p99Ms}ms`);
+    }
+    if (result.errorRatePercent > threshold.errorRatePercent) {
+      failures.push(`error rate ${result.errorRatePercent}% > ${threshold.errorRatePercent}%`);
+    }
+    return { ...result, threshold, passed: failures.length === 0, failures };
+  });
+}
+
+function markdownReport(report) {
+  const lines = [
+    "# API Benchmark Summary",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Target: ${report.targetUrl}`,
+    `Mode: ${report.config.smoke ? "CI smoke" : "full"}`,
+    `Concurrency: ${report.config.concurrency}`,
+    `Duration per endpoint: ${report.config.durationSeconds}s`,
+    "",
+    "## Results",
+    "",
+    "| Endpoint | Requests | p50 | p95 | p99 | TTFB p95 | Sustained RPS | Peak RPS | Error Rate | Gate |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+  ];
+
+  for (const result of report.results) {
+    lines.push([
+      `\`${result.key}\``,
+      result.requests,
+      `${result.latencyMs.p50}ms`,
+      `${result.latencyMs.p95}ms`,
+      `${result.latencyMs.p99}ms`,
+      `${result.ttfbMs.p95}ms`,
+      result.rps.sustained,
+      result.rps.peak,
+      `${result.errorRatePercent}%`,
+      result.passed ? "✅ pass" : `❌ ${result.failures.join("; ")}`
+    ].join(" | "));
+  }
+
+  const failed = report.results.filter((result) => !result.passed);
+  lines.push("", "## Gate", "", failed.length === 0 ? "All thresholds passed." : `${failed.length} endpoint(s) failed thresholds.`);
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  loadEnvFile();
+  config = createConfig();
+
+  let localServer;
+  let targetUrl = process.env.BENCHMARK_TARGET_URL ?? config.targetUrl;
+  if (!targetUrl) {
+    localServer = await startLocalServer();
+    targetUrl = localServer.targetUrl;
+  }
+
+  const token = await getBenchmarkToken(targetUrl);
+  const thresholds = await readThresholds();
+  const results = [];
+
+  try {
+    for (const endpoint of endpoints) {
+      process.stdout.write(`Benchmarking ${endpointKey(endpoint)} ... `);
+      const result = await runEndpointBenchmark(targetUrl, endpoint, token);
+      results.push(result);
+      console.log(`${result.requests} requests, p99 ${result.latencyMs.p99}ms, errors ${result.errorRatePercent}%`);
+    }
+  } finally {
+    if (localServer) {
+      await localServer.close();
+    }
+  }
+
+  const evaluated = evaluateThresholds(thresholds, results);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    targetUrl,
+    config: {
+      concurrency: config.concurrency,
+      durationSeconds: config.durationSeconds,
+      warmupRequests: config.warmupRequests,
+      smoke: config.smoke
+    },
+    results: evaluated
+  };
+
+  await mkdir(config.outputDir, { recursive: true });
+  const jsonPath = path.join(config.outputDir, "benchmark-results.json");
+  const mdPath = path.join(config.outputDir, "benchmark-summary.md");
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(mdPath, markdownReport(report));
+
+  console.log(`\nWrote ${jsonPath}`);
+  console.log(`Wrote ${mdPath}`);
+
+  const failed = evaluated.filter((result) => !result.passed);
+  if (failed.length > 0) {
+    console.error("\nBenchmark threshold failures:");
+    for (const result of failed) {
+      console.error(`- ${result.key}: ${result.failures.join("; ")}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/benchmarks/tests/benchmark-config.test.mjs
+++ b/benchmarks/tests/benchmark-config.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { endpoints, endpointKey } from "../endpoints.mjs";
+
+const expectedApiRoutes = [
+  "POST /api/auth/register",
+  "POST /api/auth/login",
+  "GET /api/auth/oauth/github/callback",
+  "POST /api/auth/refresh",
+  "GET /api/users",
+  "POST /api/users",
+  "GET /api/jobs",
+  "POST /api/jobs",
+  "GET /api/proposals",
+  "POST /api/proposals",
+  "POST /api/payments",
+  "GET /api/reviews",
+  "POST /api/reviews",
+  "GET /api/messages",
+  "POST /api/messages",
+  "GET /api/notifications",
+  "POST /api/notifications",
+  "POST /api/uploads",
+  "GET /api/search",
+  "GET /api/admin/metrics"
+];
+
+test("benchmark endpoint catalog covers every mounted /api route", () => {
+  const actual = endpoints.map(endpointKey).sort();
+  assert.deepEqual(actual, expectedApiRoutes.sort());
+});
+
+test("write endpoints define realistic request payloads", () => {
+  for (const endpoint of endpoints.filter((item) => item.method !== "GET")) {
+    assert.ok(endpoint.body || endpoint.multipart || endpoint.path.includes("/auth/refresh"), `${endpointKey(endpoint)} needs a payload fixture`);
+  }
+});
+
+test("protected endpoints are marked for benchmark token usage", () => {
+  const protectedEndpoints = endpoints.filter((endpoint) => endpoint.auth).map(endpointKey);
+  assert.deepEqual(protectedEndpoints, ["GET /api/admin/metrics"]);
+});

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,14 @@
+{
+  "default": {
+    "p99Ms": 2000,
+    "errorRatePercent": 0
+  },
+  "endpoints": {
+    "POST /api/uploads": {
+      "p99Ms": 3000
+    },
+    "GET /api/admin/metrics": {
+      "p99Ms": 1500
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "packages/*"
   ],
   "scripts": {
+    "benchmark": "node benchmarks/run-benchmark.mjs",
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api && npm run test:benchmarks",
+    "test:benchmarks": "node --test \"benchmarks/tests/**/*.test.mjs\""
   }
 }


### PR DESCRIPTION
## Summary

/claim #30

Adds a reproducible API benchmark suite for every route mounted under `/api/`.

- Adds `npm run benchmark` with a dependency-free Node benchmark runner under `benchmarks/`
- Covers auth, users, jobs, proposals, payments, reviews, messages, notifications, uploads, search, and admin metrics endpoints
- Captures p50/p95/p99 latency, p95 TTFB, sustained RPS, peak RPS, status-code distribution, and error rate per endpoint
- Writes JSON and Markdown reports to `benchmarks/results/`
- Adds reviewable thresholds in `benchmarks/thresholds.json`
- Adds a low-concurrency GitHub Actions smoke benchmark that fails on p99/error-rate regressions
- Adds `.env.benchmark.example` for local/staging configuration with a dedicated benchmark token
- Makes API rate-limit settings configurable while preserving production defaults

## Contributor Disclosure

### Benchmark Environment

**Hardware**
- CPU model & core count: local VM/container runner used by Hermes Agent
- RAM (total & available during benchmark): local VM/container runner
- Storage type (SSD / NVMe / HDD): local ephemeral workspace storage
- Network interface (Ethernet / WiFi / loopback): loopback (`127.0.0.1`)
- Machine type (local workstation / cloud VM / CI runner — include instance type if cloud): local agent VM/container
- OS & version: Linux 6.8.0-111-generic

**Runtime**
- Node.js version (or relevant runtime): v22.22.2
- Any resource limits applied (Docker memory cap, cgroup limits, etc.): none intentionally applied beyond the agent runtime
- Other significant processes running during benchmark (yes / no — if yes, describe): yes — normal Hermes agent/tooling processes

**If submitted by or with an AI agent**
- Agent or tool name (e.g. Claude Code, Devin, Copilot Workspace, AutoGPT): Hermes Agent + OpenAI Codex-compatible coding workflow
- Underlying model and version (e.g. claude-sonnet-4-5, gpt-4o — if known): gpt-5.5 available locally; implementation verified by Hermes Agent
- Inference provider (e.g. Anthropic, OpenAI, Azure, self-hosted): OpenAI / Hermes Agent environment
- Orchestration framework if any (e.g. LangChain, AutoGen, custom): Hermes Agent tool orchestration
- Execution mode (fully autonomous / human-supervised / human-initiated per step): human-initiated, agent-executed, human-supervised through Abdulhamid
- Did the agent have shell/tool access during execution (yes / no): yes
- Did the agent have internet access during execution (yes / no): yes
- Were benchmark commands run by the agent directly or handed off to the human to run: run directly by the agent
- Any known agent constraints or sandboxing that may have affected execution: GitHub PR creation required external auth; code/test/benchmark execution was local


## Test Plan

- `npm ci`
- `npm test`
- `NODE_ENV=benchmark BENCHMARK_SMOKE=true BENCHMARK_DURATION_SECONDS=3 BENCHMARK_CONCURRENCY=2 BENCHMARK_WARMUP_REQUESTS=1 RATE_LIMIT_MAX=10000000 npm run benchmark`
- `npm run build`
- `git diff --check`

## Benchmark Summary

# API Benchmark Summary

Generated: 2026-05-20T04:16:11.873Z
Target: http://127.0.0.1:43277
Mode: CI smoke
Concurrency: 2
Duration per endpoint: 3s

## Results

| Endpoint | Requests | p50 | p95 | p99 | TTFB p95 | Sustained RPS | Peak RPS | Error Rate | Gate |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
`POST /api/auth/register` | 697 | 6.55ms | 19.45ms | 44.85ms | 18.76ms | 232.11 | 294 | 0% | ✅ pass
`POST /api/auth/login` | 1081 | 4.72ms | 10.12ms | 19.58ms | 9.89ms | 360.05 | 416 | 0% | ✅ pass
`GET /api/auth/oauth/github/callback` | 2125 | 2.36ms | 5.17ms | 12.64ms | 4.95ms | 708.12 | 701 | 0% | ✅ pass
`POST /api/auth/refresh` | 2017 | 2.65ms | 4.75ms | 10ms | 4.59ms | 672.07 | 676 | 0% | ✅ pass
`GET /api/users` | 2882 | 1.72ms | 3.53ms | 10.32ms | 3.37ms | 960.54 | 1078 | 0% | ✅ pass
`POST /api/users` | 2001 | 2.59ms | 4.81ms | 11.87ms | 4.66ms | 666.84 | 674 | 0% | ✅ pass
`GET /api/jobs` | 3284 | 1.62ms | 2.58ms | 7.64ms | 2.48ms | 1094.49 | 1134 | 0% | ✅ pass
`POST /api/jobs` | 2056 | 2.51ms | 4.98ms | 13.24ms | 4.88ms | 683.23 | 726 | 0% | ✅ pass
`GET /api/proposals` | 3150 | 1.59ms | 2.82ms | 9.62ms | 2.73ms | 1049.92 | 1002 | 0% | ✅ pass
`POST /api/proposals` | 2287 | 2.29ms | 3.91ms | 10.27ms | 3.75ms | 761.89 | 780 | 0% | ✅ pass
`POST /api/payments` | 2023 | 2.49ms | 4.71ms | 13.64ms | 4.57ms | 673.81 | 723 | 0% | ✅ pass
`GET /api/reviews` | 2756 | 1.76ms | 4.12ms | 10.13ms | 3.98ms | 918.18 | 954 | 0% | ✅ pass
`POST /api/reviews` | 2156 | 2.39ms | 4.78ms | 12.16ms | 4.7ms | 718.34 | 715 | 0% | ✅ pass
`GET /api/messages` | 2870 | 1.72ms | 3.63ms | 10.87ms | 3.46ms | 956.59 | 1019 | 0% | ✅ pass
`POST /api/messages` | 2206 | 2.37ms | 4.6ms | 10.14ms | 4.44ms | 734.43 | 811 | 0% | ✅ pass
`GET /api/notifications` | 2655 | 1.77ms | 5.14ms | 10.7ms | 4.95ms | 884.73 | 927 | 0% | ✅ pass
`POST /api/notifications` | 2011 | 2.49ms | 5.96ms | 12.8ms | 5.87ms | 669.81 | 706 | 0% | ✅ pass
`POST /api/uploads` | 736 | 5.48ms | 22.71ms | 48.36ms | 21.48ms | 245.24 | 264 | 0% | ✅ pass
`GET /api/search` | 2454 | 1.92ms | 4.99ms | 13.7ms | 4.86ms | 817.67 | 848 | 0% | ✅ pass
`GET /api/admin/metrics` | 1750 | 3.05ms | 5.47ms | 12.4ms | 5.29ms | 582.43 | 614 | 0% | ✅ pass

## Gate

All thresholds passed.

