### PR TITLE
Add handoff ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Handoff Ledger
+
+Before a promise leaves the page,
+it asks for scope in honest ink:
+what must be built, what waits outside,
+what proves the work did not just blink.
+
+A proposal crosses the quiet hall,
+carrying names, dates, risks, and price;
+the client reads the edges twice,
+the freelancer trims ambition nice.
+
+Then evidence gathers in ordered light:
+a test result, a screenshot, a note;
+not theater, not a victory lap,
+just enough truth to keep it afloat.
+
+Review arrives with sleeves rolled high,
+measuring claims against the done;
+the cleanest fix speaks plainly there,
+and needs no trumpet, flare, or pun.
+
+When merge and payment share a line,
+the ledger finally learns to breathe:
+trust is not magic in the wire,
+but clear work handed underneath.


### PR DESCRIPTION
Closes #76

/claim #76

Creative note: I used a handoff-ledger theme because FreelanceFlow depends on clear scope, evidence, review, merge, and payout moving cleanly from one person to the next.

Preview: https://github.com/surim0n/bug-bounty/blob/add-handoff-ledger-poem-76/POEM.md

Validation:
- Added root POEM.md
- Confirmed the poem has five stanzas, meeting the minimum three-stanza requirement
- git diff --check passed