### PR TITLE
Add API benchmark suite

### DIFF
--- a/.env.benchmark.example
+++ b/.env.benchmark.example
@@ -1,0 +1,10 @@
+# Benchmark target. Leave blank to run against an in-process local API server.
+BENCHMARK_TARGET_URL=
+
+# Low values are suitable for CI smoke runs. Increase locally for deeper runs.
+BENCHMARK_DURATION_MS=3000
+BENCHMARK_CONCURRENCY=8
+
+# Dedicated benchmark auth identity used for protected routes.
+BENCHMARK_USER_ID=bench_user
+BENCHMARK_USER_ROLE=admin

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -1,0 +1,22 @@
+name: Benchmark Smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/benchmark-smoke.yml"
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run benchmark:smoke

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -4,5 +4,6 @@ export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  skip: () => process.env.BENCHMARK_DISABLE_RATE_LIMIT === "true"
 });

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -1,0 +1,825 @@
+{
+  "generatedAt": "2026-05-20T04:28:18.515Z",
+  "mode": "full",
+  "target": {
+    "baseUrl": "http://127.0.0.1:65288",
+    "source": "in-process local app"
+  },
+  "config": {
+    "durationMs": 3000,
+    "concurrency": 8
+  },
+  "environment": {
+    "node": "v22.21.1",
+    "os": "Darwin 25.3.0 darwin",
+    "cpu": "Apple M2 Max (12 cores)",
+    "ramMb": 32768,
+    "freeRamMb": 92
+  },
+  "endpoints": [
+    {
+      "method": "POST",
+      "path": "/api/auth/register",
+      "name": "Auth register"
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/login",
+      "name": "Auth login"
+    },
+    {
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "name": "OAuth callback"
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "name": "Auth refresh"
+    },
+    {
+      "method": "GET",
+      "path": "/api/users",
+      "name": "List users"
+    },
+    {
+      "method": "POST",
+      "path": "/api/users",
+      "name": "Create user"
+    },
+    {
+      "method": "GET",
+      "path": "/api/jobs",
+      "name": "List jobs"
+    },
+    {
+      "method": "POST",
+      "path": "/api/jobs",
+      "name": "Create job"
+    },
+    {
+      "method": "GET",
+      "path": "/api/proposals",
+      "name": "List proposals"
+    },
+    {
+      "method": "POST",
+      "path": "/api/proposals",
+      "name": "Create proposal"
+    },
+    {
+      "method": "POST",
+      "path": "/api/payments",
+      "name": "Create payment"
+    },
+    {
+      "method": "GET",
+      "path": "/api/reviews",
+      "name": "List reviews"
+    },
+    {
+      "method": "POST",
+      "path": "/api/reviews",
+      "name": "Create review"
+    },
+    {
+      "method": "GET",
+      "path": "/api/messages",
+      "name": "List messages"
+    },
+    {
+      "method": "POST",
+      "path": "/api/messages",
+      "name": "Send message"
+    },
+    {
+      "method": "GET",
+      "path": "/api/notifications",
+      "name": "List notifications"
+    },
+    {
+      "method": "POST",
+      "path": "/api/notifications",
+      "name": "Create notification"
+    },
+    {
+      "method": "POST",
+      "path": "/api/uploads",
+      "name": "Upload file"
+    },
+    {
+      "method": "GET",
+      "path": "/api/search?q=marketplace%20dashboard%20node",
+      "name": "Search"
+    },
+    {
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "name": "Admin metrics"
+    }
+  ],
+  "results": [
+    {
+      "name": "Auth register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "requests": 13627,
+      "elapsedMs": 3001,
+      "sustainedRps": 4541.25,
+      "peakRps": 5418.98,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 13627
+      },
+      "latencyMs": {
+        "p50": 1.48,
+        "p95": 3.02,
+        "p99": 4.02
+      },
+      "ttfbMs": {
+        "p50": 1.47,
+        "p95": 3,
+        "p99": 4.01
+      }
+    },
+    {
+      "name": "Auth login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "requests": 17702,
+      "elapsedMs": 3001,
+      "sustainedRps": 5899.36,
+      "peakRps": 6452.26,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 17702
+      },
+      "latencyMs": {
+        "p50": 1.24,
+        "p95": 2.21,
+        "p99": 2.61
+      },
+      "ttfbMs": {
+        "p50": 1.23,
+        "p95": 2.2,
+        "p99": 2.59
+      }
+    },
+    {
+      "name": "OAuth callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "requests": 26327,
+      "elapsedMs": 3001,
+      "sustainedRps": 8772.29,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 26327
+      },
+      "latencyMs": {
+        "p50": 0.82,
+        "p95": 1.68,
+        "p99": 2.01
+      },
+      "ttfbMs": {
+        "p50": 0.82,
+        "p95": 1.67,
+        "p99": 2.01
+      }
+    },
+    {
+      "name": "Auth refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "requests": 21632,
+      "elapsedMs": 3001,
+      "sustainedRps": 7209.41,
+      "peakRps": 7927.01,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 21632
+      },
+      "latencyMs": {
+        "p50": 1.01,
+        "p95": 1.9,
+        "p99": 2.34
+      },
+      "ttfbMs": {
+        "p50": 1,
+        "p95": 1.9,
+        "p99": 2.34
+      }
+    },
+    {
+      "name": "List users",
+      "method": "GET",
+      "path": "/api/users",
+      "requests": 27072,
+      "elapsedMs": 3000,
+      "sustainedRps": 9022.83,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 27072
+      },
+      "latencyMs": {
+        "p50": 0.81,
+        "p95": 1.63,
+        "p99": 1.97
+      },
+      "ttfbMs": {
+        "p50": 0.8,
+        "p95": 1.62,
+        "p99": 1.96
+      }
+    },
+    {
+      "name": "Create user",
+      "method": "POST",
+      "path": "/api/users",
+      "requests": 20816,
+      "elapsedMs": 3000,
+      "sustainedRps": 6937.86,
+      "peakRps": 7642.1,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20816
+      },
+      "latencyMs": {
+        "p50": 1.05,
+        "p95": 2.02,
+        "p99": 2.35
+      },
+      "ttfbMs": {
+        "p50": 1.04,
+        "p95": 2.01,
+        "p99": 2.35
+      }
+    },
+    {
+      "name": "List jobs",
+      "method": "GET",
+      "path": "/api/jobs",
+      "requests": 26504,
+      "elapsedMs": 3001,
+      "sustainedRps": 8832.73,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 26504
+      },
+      "latencyMs": {
+        "p50": 0.81,
+        "p95": 1.76,
+        "p99": 2.15
+      },
+      "ttfbMs": {
+        "p50": 0.8,
+        "p95": 1.76,
+        "p99": 2.14
+      }
+    },
+    {
+      "name": "Create job",
+      "method": "POST",
+      "path": "/api/jobs",
+      "requests": 20096,
+      "elapsedMs": 3000,
+      "sustainedRps": 6697.62,
+      "peakRps": 7498.25,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20096
+      },
+      "latencyMs": {
+        "p50": 1.07,
+        "p95": 2.16,
+        "p99": 2.63
+      },
+      "ttfbMs": {
+        "p50": 1.06,
+        "p95": 2.15,
+        "p99": 2.62
+      }
+    },
+    {
+      "name": "List proposals",
+      "method": "GET",
+      "path": "/api/proposals",
+      "requests": 23808,
+      "elapsedMs": 3000,
+      "sustainedRps": 7934.85,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 23808
+      },
+      "latencyMs": {
+        "p50": 0.83,
+        "p95": 1.9,
+        "p99": 3.42
+      },
+      "ttfbMs": {
+        "p50": 0.82,
+        "p95": 1.89,
+        "p99": 3.4
+      }
+    },
+    {
+      "name": "Create proposal",
+      "method": "POST",
+      "path": "/api/proposals",
+      "requests": 20584,
+      "elapsedMs": 3000,
+      "sustainedRps": 6860.73,
+      "peakRps": 7663.14,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20584
+      },
+      "latencyMs": {
+        "p50": 1.04,
+        "p95": 2.14,
+        "p99": 2.43
+      },
+      "ttfbMs": {
+        "p50": 1.04,
+        "p95": 2.13,
+        "p99": 2.42
+      }
+    },
+    {
+      "name": "Create payment",
+      "method": "POST",
+      "path": "/api/payments",
+      "requests": 20411,
+      "elapsedMs": 3000,
+      "sustainedRps": 6802.78,
+      "peakRps": 7665.59,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20411
+      },
+      "latencyMs": {
+        "p50": 1.04,
+        "p95": 2.2,
+        "p99": 2.57
+      },
+      "ttfbMs": {
+        "p50": 1.04,
+        "p95": 2.19,
+        "p99": 2.56
+      }
+    },
+    {
+      "name": "List reviews",
+      "method": "GET",
+      "path": "/api/reviews",
+      "requests": 26736,
+      "elapsedMs": 3000,
+      "sustainedRps": 8910.75,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 26736
+      },
+      "latencyMs": {
+        "p50": 0.81,
+        "p95": 1.74,
+        "p99": 1.99
+      },
+      "ttfbMs": {
+        "p50": 0.81,
+        "p95": 1.74,
+        "p99": 1.99
+      }
+    },
+    {
+      "name": "Create review",
+      "method": "POST",
+      "path": "/api/reviews",
+      "requests": 20382,
+      "elapsedMs": 3001,
+      "sustainedRps": 6792.25,
+      "peakRps": 7608.18,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20382
+      },
+      "latencyMs": {
+        "p50": 1.05,
+        "p95": 2.15,
+        "p99": 2.51
+      },
+      "ttfbMs": {
+        "p50": 1.05,
+        "p95": 2.14,
+        "p99": 2.5
+      }
+    },
+    {
+      "name": "List messages",
+      "method": "GET",
+      "path": "/api/messages",
+      "requests": 26120,
+      "elapsedMs": 3000,
+      "sustainedRps": 8705.48,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 26120
+      },
+      "latencyMs": {
+        "p50": 0.82,
+        "p95": 1.81,
+        "p99": 2.14
+      },
+      "ttfbMs": {
+        "p50": 0.81,
+        "p95": 1.81,
+        "p99": 2.13
+      }
+    },
+    {
+      "name": "Send message",
+      "method": "POST",
+      "path": "/api/messages",
+      "requests": 20482,
+      "elapsedMs": 3000,
+      "sustainedRps": 6826.47,
+      "peakRps": 7607.58,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20482
+      },
+      "latencyMs": {
+        "p50": 1.05,
+        "p95": 2.1,
+        "p99": 2.39
+      },
+      "ttfbMs": {
+        "p50": 1.05,
+        "p95": 2.1,
+        "p99": 2.38
+      }
+    },
+    {
+      "name": "List notifications",
+      "method": "GET",
+      "path": "/api/notifications",
+      "requests": 26792,
+      "elapsedMs": 3001,
+      "sustainedRps": 8928.65,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 26792
+      },
+      "latencyMs": {
+        "p50": 0.81,
+        "p95": 1.76,
+        "p99": 2.06
+      },
+      "ttfbMs": {
+        "p50": 0.8,
+        "p95": 1.76,
+        "p99": 2.05
+      }
+    },
+    {
+      "name": "Create notification",
+      "method": "POST",
+      "path": "/api/notifications",
+      "requests": 20240,
+      "elapsedMs": 3000,
+      "sustainedRps": 6745.57,
+      "peakRps": 7532.07,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 20240
+      },
+      "latencyMs": {
+        "p50": 1.06,
+        "p95": 2.19,
+        "p99": 2.48
+      },
+      "ttfbMs": {
+        "p50": 1.06,
+        "p95": 2.18,
+        "p99": 2.47
+      }
+    },
+    {
+      "name": "Upload file",
+      "method": "POST",
+      "path": "/api/uploads",
+      "requests": 13296,
+      "elapsedMs": 3001,
+      "sustainedRps": 4430.82,
+      "peakRps": 4981.58,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "201": 13296
+      },
+      "latencyMs": {
+        "p50": 1.61,
+        "p95": 2.98,
+        "p99": 3.38
+      },
+      "ttfbMs": {
+        "p50": 1.6,
+        "p95": 2.97,
+        "p99": 3.37
+      }
+    },
+    {
+      "name": "Search",
+      "method": "GET",
+      "path": "/api/search?q=marketplace%20dashboard%20node",
+      "requests": 25880,
+      "elapsedMs": 3001,
+      "sustainedRps": 8624.84,
+      "peakRps": 8000,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 25880
+      },
+      "latencyMs": {
+        "p50": 0.84,
+        "p95": 1.81,
+        "p99": 2.08
+      },
+      "ttfbMs": {
+        "p50": 0.83,
+        "p95": 1.8,
+        "p99": 2.07
+      }
+    },
+    {
+      "name": "Admin metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "requests": 20001,
+      "elapsedMs": 3001,
+      "sustainedRps": 6664.89,
+      "peakRps": 7339.73,
+      "errorRatePct": 0,
+      "statusCodes": {
+        "200": 20001
+      },
+      "latencyMs": {
+        "p50": 1.09,
+        "p95": 2.18,
+        "p99": 2.55
+      },
+      "ttfbMs": {
+        "p50": 1.08,
+        "p95": 2.17,
+        "p99": 2.53
+      }
+    }
+  ],
+  "gates": [
+    {
+      "endpoint": "POST /api/auth/register",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 4.02,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/auth/login",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.61,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/auth/oauth/github/callback",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.01,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/auth/refresh",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.34,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/users",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 1.97,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/users",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.35,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/jobs",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.15,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/jobs",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.63,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/proposals",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 3.42,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/proposals",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.43,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/payments",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.57,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/reviews",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 1.99,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/reviews",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.51,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/messages",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.14,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/messages",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.39,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/notifications",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.06,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/notifications",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.48,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "POST /api/uploads",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 1200,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 3.38,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/search?q=marketplace%20dashboard%20node",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.08,
+        "errorRatePct": 0
+      }
+    },
+    {
+      "endpoint": "GET /api/admin/metrics",
+      "pass": true,
+      "threshold": {
+        "maxP99Ms": 500,
+        "maxErrorRatePct": 0
+      },
+      "observed": {
+        "p99Ms": 2.55,
+        "errorRatePct": 0
+      }
+    }
+  ]
+}

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,0 +1,65 @@
+# API Benchmark Summary
+
+Generated: 2026-05-20T04:28:18.515Z
+
+Target: `http://127.0.0.1:65288`
+Mode: `full`
+Duration per endpoint: 3000ms
+Concurrency: 8
+
+## Environment
+
+- Runtime: Node.js v22.21.1
+- OS: Darwin 25.3.0 darwin
+- CPU: Apple M2 Max (12 cores)
+- RAM: 32768MB total, 92MB free at start
+
+## Results
+
+Endpoint | Requests | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | TTFB p50 ms | TTFB p95 ms | TTFB p99 ms | Error % | Status codes
+--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---
+`POST /api/auth/register` | 13627 | 4541.25 | 5418.98 | 1.48 | 3.02 | 4.02 | 1.47 | 3 | 4.01 | 0 | 201: 13627
+`POST /api/auth/login` | 17702 | 5899.36 | 6452.26 | 1.24 | 2.21 | 2.61 | 1.23 | 2.2 | 2.59 | 0 | 200: 17702
+`GET /api/auth/oauth/github/callback` | 26327 | 8772.29 | 8000 | 0.82 | 1.68 | 2.01 | 0.82 | 1.67 | 2.01 | 0 | 200: 26327
+`POST /api/auth/refresh` | 21632 | 7209.41 | 7927.01 | 1.01 | 1.9 | 2.34 | 1 | 1.9 | 2.34 | 0 | 200: 21632
+`GET /api/users` | 27072 | 9022.83 | 8000 | 0.81 | 1.63 | 1.97 | 0.8 | 1.62 | 1.96 | 0 | 200: 27072
+`POST /api/users` | 20816 | 6937.86 | 7642.1 | 1.05 | 2.02 | 2.35 | 1.04 | 2.01 | 2.35 | 0 | 201: 20816
+`GET /api/jobs` | 26504 | 8832.73 | 8000 | 0.81 | 1.76 | 2.15 | 0.8 | 1.76 | 2.14 | 0 | 200: 26504
+`POST /api/jobs` | 20096 | 6697.62 | 7498.25 | 1.07 | 2.16 | 2.63 | 1.06 | 2.15 | 2.62 | 0 | 201: 20096
+`GET /api/proposals` | 23808 | 7934.85 | 8000 | 0.83 | 1.9 | 3.42 | 0.82 | 1.89 | 3.4 | 0 | 200: 23808
+`POST /api/proposals` | 20584 | 6860.73 | 7663.14 | 1.04 | 2.14 | 2.43 | 1.04 | 2.13 | 2.42 | 0 | 201: 20584
+`POST /api/payments` | 20411 | 6802.78 | 7665.59 | 1.04 | 2.2 | 2.57 | 1.04 | 2.19 | 2.56 | 0 | 201: 20411
+`GET /api/reviews` | 26736 | 8910.75 | 8000 | 0.81 | 1.74 | 1.99 | 0.81 | 1.74 | 1.99 | 0 | 200: 26736
+`POST /api/reviews` | 20382 | 6792.25 | 7608.18 | 1.05 | 2.15 | 2.51 | 1.05 | 2.14 | 2.5 | 0 | 201: 20382
+`GET /api/messages` | 26120 | 8705.48 | 8000 | 0.82 | 1.81 | 2.14 | 0.81 | 1.81 | 2.13 | 0 | 200: 26120
+`POST /api/messages` | 20482 | 6826.47 | 7607.58 | 1.05 | 2.1 | 2.39 | 1.05 | 2.1 | 2.38 | 0 | 201: 20482
+`GET /api/notifications` | 26792 | 8928.65 | 8000 | 0.81 | 1.76 | 2.06 | 0.8 | 1.76 | 2.05 | 0 | 200: 26792
+`POST /api/notifications` | 20240 | 6745.57 | 7532.07 | 1.06 | 2.19 | 2.48 | 1.06 | 2.18 | 2.47 | 0 | 201: 20240
+`POST /api/uploads` | 13296 | 4430.82 | 4981.58 | 1.61 | 2.98 | 3.38 | 1.6 | 2.97 | 3.37 | 0 | 201: 13296
+`GET /api/search?q=marketplace%20dashboard%20node` | 25880 | 8624.84 | 8000 | 0.84 | 1.81 | 2.08 | 0.83 | 1.8 | 2.07 | 0 | 200: 25880
+`GET /api/admin/metrics` | 20001 | 6664.89 | 7339.73 | 1.09 | 2.18 | 2.55 | 1.08 | 2.17 | 2.53 | 0 | 200: 20001
+
+## Regression Gate
+
+Endpoint | Result | Observed p99 ms | Max p99 ms | Observed error % | Max error %
+--- | --- | ---: | ---: | ---: | ---:
+`POST /api/auth/register` | pass | 4.02 | 500 | 0 | 0
+`POST /api/auth/login` | pass | 2.61 | 500 | 0 | 0
+`GET /api/auth/oauth/github/callback` | pass | 2.01 | 500 | 0 | 0
+`POST /api/auth/refresh` | pass | 2.34 | 500 | 0 | 0
+`GET /api/users` | pass | 1.97 | 500 | 0 | 0
+`POST /api/users` | pass | 2.35 | 500 | 0 | 0
+`GET /api/jobs` | pass | 2.15 | 500 | 0 | 0
+`POST /api/jobs` | pass | 2.63 | 500 | 0 | 0
+`GET /api/proposals` | pass | 3.42 | 500 | 0 | 0
+`POST /api/proposals` | pass | 2.43 | 500 | 0 | 0
+`POST /api/payments` | pass | 2.57 | 500 | 0 | 0
+`GET /api/reviews` | pass | 1.99 | 500 | 0 | 0
+`POST /api/reviews` | pass | 2.51 | 500 | 0 | 0
+`GET /api/messages` | pass | 2.14 | 500 | 0 | 0
+`POST /api/messages` | pass | 2.39 | 500 | 0 | 0
+`GET /api/notifications` | pass | 2.06 | 500 | 0 | 0
+`POST /api/notifications` | pass | 2.48 | 500 | 0 | 0
+`POST /api/uploads` | pass | 3.38 | 1200 | 0 | 0
+`GET /api/search?q=marketplace%20dashboard%20node` | pass | 2.08 | 500 | 0 | 0
+`GET /api/admin/metrics` | pass | 2.55 | 500 | 0 | 0

--- a/benchmarks/run-benchmarks.mjs
+++ b/benchmarks/run-benchmarks.mjs
@@ -1,0 +1,369 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { cpus, freemem, platform, release, totalmem, type } from "node:os";
+import process from "node:process";
+
+const smoke = process.env.BENCHMARK_SMOKE === "true";
+const durationMs = Number(process.env.BENCHMARK_DURATION_MS ?? (smoke ? 800 : 3000));
+const concurrency = Number(process.env.BENCHMARK_CONCURRENCY ?? (smoke ? 2 : 8));
+const targetFromEnv = process.env.BENCHMARK_TARGET_URL?.replace(/\/$/, "");
+const resultsDir = new URL("./results/", import.meta.url);
+const thresholds = JSON.parse(await readFile(new URL("./thresholds.json", import.meta.url), "utf8"));
+
+process.env.BENCHMARK_DISABLE_RATE_LIMIT ??= "true";
+const { createApp } = await import("../apps/api/src/app.js");
+const { signAccessToken } = await import("../apps/api/src/utils/jwt.js");
+
+const benchmarkToken = signAccessToken({
+  sub: process.env.BENCHMARK_USER_ID ?? "bench_user",
+  role: process.env.BENCHMARK_USER_ROLE ?? "admin"
+});
+
+const jsonHeaders = { "content-type": "application/json" };
+const authHeaders = { authorization: `Bearer ${benchmarkToken}` };
+
+const endpoints = [
+  {
+    name: "Auth register",
+    method: "POST",
+    path: "/api/auth/register",
+    headers: jsonHeaders,
+    body: () => ({
+      email: `bench-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`,
+      password: "correct-horse-battery",
+      role: "freelancer"
+    })
+  },
+  {
+    name: "Auth login",
+    method: "POST",
+    path: "/api/auth/login",
+    headers: jsonHeaders,
+    body: () => ({
+      email: "benchmark@example.com",
+      password: "correct-horse-battery"
+    })
+  },
+  { name: "OAuth callback", method: "GET", path: "/api/auth/oauth/github/callback" },
+  { name: "Auth refresh", method: "POST", path: "/api/auth/refresh" },
+  { name: "List users", method: "GET", path: "/api/users" },
+  {
+    name: "Create user",
+    method: "POST",
+    path: "/api/users",
+    headers: jsonHeaders,
+    body: () => ({
+      email: `bench-user-${Date.now()}@example.com`,
+      displayName: "Benchmark User",
+      bio: "Benchmark profile payload with representative marketplace profile text."
+    })
+  },
+  { name: "List jobs", method: "GET", path: "/api/jobs" },
+  {
+    name: "Create job",
+    method: "POST",
+    path: "/api/jobs",
+    headers: jsonHeaders,
+    body: () => ({
+      title: "Build a benchmarkable marketplace dashboard",
+      description: "Create a practical dashboard with milestones, proposals, payments, and review summaries.",
+      budgetMin: 500,
+      budgetMax: 2500,
+      categoryId: "software-development",
+      skills: ["node", "react", "api-performance", "testing"]
+    })
+  },
+  { name: "List proposals", method: "GET", path: "/api/proposals" },
+  {
+    name: "Create proposal",
+    method: "POST",
+    path: "/api/proposals",
+    headers: jsonHeaders,
+    body: () => ({
+      jobId: "job_benchmark",
+      freelancerId: "usr_benchmark",
+      coverLetter: "I can deliver this benchmarked marketplace workflow with clear milestones.",
+      amount: 1200,
+      estimatedDays: 10
+    })
+  },
+  {
+    name: "Create payment",
+    method: "POST",
+    path: "/api/payments",
+    headers: jsonHeaders,
+    body: () => ({
+      amount: 100000,
+      currency: "usd",
+      jobId: "job_benchmark",
+      metadata: { source: "benchmark" }
+    })
+  },
+  { name: "List reviews", method: "GET", path: "/api/reviews" },
+  {
+    name: "Create review",
+    method: "POST",
+    path: "/api/reviews",
+    headers: jsonHeaders,
+    body: () => ({
+      subjectId: "usr_benchmark",
+      rating: 5,
+      comment: "Clear delivery, responsive updates, and clean handoff."
+    })
+  },
+  { name: "List messages", method: "GET", path: "/api/messages" },
+  {
+    name: "Send message",
+    method: "POST",
+    path: "/api/messages",
+    headers: jsonHeaders,
+    body: () => ({
+      conversationId: "conv_benchmark",
+      senderId: "usr_benchmark",
+      body: "Benchmark message payload with a realistic short project update."
+    })
+  },
+  { name: "List notifications", method: "GET", path: "/api/notifications" },
+  {
+    name: "Create notification",
+    method: "POST",
+    path: "/api/notifications",
+    headers: jsonHeaders,
+    body: () => ({
+      userId: "usr_benchmark",
+      type: "proposal_update",
+      message: "Your benchmark proposal has moved to review."
+    })
+  },
+  {
+    name: "Upload file",
+    method: "POST",
+    path: "/api/uploads",
+    body: () => {
+      const form = new FormData();
+      form.append("file", new Blob(["benchmark attachment\n".repeat(32)], { type: "text/plain" }), "benchmark.txt");
+      return form;
+    }
+  },
+  { name: "Search", method: "GET", path: "/api/search?q=marketplace%20dashboard%20node" },
+  {
+    name: "Admin metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    headers: authHeaders
+  }
+];
+
+function percentile(values, pct) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil((pct / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, index))];
+}
+
+async function startLocalServer() {
+  if (targetFromEnv) {
+    return { baseUrl: targetFromEnv, close: async () => {} };
+  }
+
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+  };
+}
+
+async function makeRequest(baseUrl, endpoint) {
+  const headers = { ...(endpoint.headers ?? {}) };
+  const init = { method: endpoint.method, headers };
+  const generatedBody = endpoint.body?.();
+  if (generatedBody instanceof FormData) {
+    init.body = generatedBody;
+    delete init.headers["content-type"];
+  } else if (generatedBody !== undefined) {
+    init.body = JSON.stringify(generatedBody);
+  }
+
+  const start = performance.now();
+  let response;
+  try {
+    response = await fetch(`${baseUrl}${endpoint.path}`, init);
+    const ttfbMs = performance.now() - start;
+    await response.arrayBuffer();
+    const latencyMs = performance.now() - start;
+    return { latencyMs, ttfbMs, ok: response.ok, status: response.status };
+  } catch (error) {
+    const latencyMs = performance.now() - start;
+    return { latencyMs, ttfbMs: latencyMs, ok: false, status: 0, error: error.message };
+  }
+}
+
+async function runEndpoint(baseUrl, endpoint) {
+  const deadline = performance.now() + durationMs;
+  const samples = [];
+  let started = 0;
+
+  async function worker() {
+    while (performance.now() < deadline) {
+      started += 1;
+      samples.push(await makeRequest(baseUrl, endpoint));
+    }
+  }
+
+  const start = performance.now();
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  const elapsedMs = performance.now() - start;
+  const latencies = samples.map((sample) => sample.latencyMs);
+  const ttfbs = samples.map((sample) => sample.ttfbMs);
+  const errors = samples.filter((sample) => !sample.ok).length;
+  const statuses = samples.reduce((acc, sample) => {
+    acc[sample.status] = (acc[sample.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    requests: samples.length,
+    elapsedMs: Math.round(elapsedMs),
+    sustainedRps: Number((samples.length / (elapsedMs / 1000)).toFixed(2)),
+    peakRps: Number((1000 / Math.max(1, percentile(latencies, 50)) * concurrency).toFixed(2)),
+    errorRatePct: Number(((errors / Math.max(1, samples.length)) * 100).toFixed(2)),
+    statusCodes: statuses,
+    latencyMs: {
+      p50: Number(percentile(latencies, 50).toFixed(2)),
+      p95: Number(percentile(latencies, 95).toFixed(2)),
+      p99: Number(percentile(latencies, 99).toFixed(2))
+    },
+    ttfbMs: {
+      p50: Number(percentile(ttfbs, 50).toFixed(2)),
+      p95: Number(percentile(ttfbs, 95).toFixed(2)),
+      p99: Number(percentile(ttfbs, 99).toFixed(2))
+    }
+  };
+}
+
+function thresholdFor(result) {
+  const key = `${result.method} ${result.path.split("?")[0]}`;
+  return {
+    ...(smoke ? thresholds.smoke : thresholds.defaults),
+    ...(thresholds.endpoints[key] ?? {})
+  };
+}
+
+function evaluateThresholds(results) {
+  return results.map((result) => {
+    const threshold = thresholdFor(result);
+    return {
+      endpoint: `${result.method} ${result.path}`,
+      pass: result.latencyMs.p99 <= threshold.maxP99Ms && result.errorRatePct <= threshold.maxErrorRatePct,
+      threshold,
+      observed: {
+        p99Ms: result.latencyMs.p99,
+        errorRatePct: result.errorRatePct
+      }
+    };
+  });
+}
+
+function renderMarkdown(report) {
+  const rows = report.results.map((result) => [
+    `\`${result.method} ${result.path}\``,
+    result.requests,
+    result.sustainedRps,
+    result.peakRps,
+    result.latencyMs.p50,
+    result.latencyMs.p95,
+    result.latencyMs.p99,
+    result.ttfbMs.p50,
+    result.ttfbMs.p95,
+    result.ttfbMs.p99,
+    result.errorRatePct,
+    Object.entries(result.statusCodes).map(([code, count]) => `${code}: ${count}`).join(", ")
+  ].join(" | "));
+
+  const gateRows = report.gates.map((gate) => [
+    `\`${gate.endpoint}\``,
+    gate.pass ? "pass" : "fail",
+    gate.observed.p99Ms,
+    gate.threshold.maxP99Ms,
+    gate.observed.errorRatePct,
+    gate.threshold.maxErrorRatePct
+  ].join(" | "));
+
+  return `# API Benchmark Summary
+
+Generated: ${report.generatedAt}
+
+Target: \`${report.target.baseUrl}\`
+Mode: \`${report.mode}\`
+Duration per endpoint: ${report.config.durationMs}ms
+Concurrency: ${report.config.concurrency}
+
+## Environment
+
+- Runtime: Node.js ${report.environment.node}
+- OS: ${report.environment.os}
+- CPU: ${report.environment.cpu}
+- RAM: ${report.environment.ramMb}MB total, ${report.environment.freeRamMb}MB free at start
+
+## Results
+
+Endpoint | Requests | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | TTFB p50 ms | TTFB p95 ms | TTFB p99 ms | Error % | Status codes
+--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---
+${rows.join("\n")}
+
+## Regression Gate
+
+Endpoint | Result | Observed p99 ms | Max p99 ms | Observed error % | Max error %
+--- | --- | ---: | ---: | ---: | ---:
+${gateRows.join("\n")}
+`;
+}
+
+const local = await startLocalServer();
+try {
+  await mkdir(resultsDir, { recursive: true });
+  const results = [];
+  for (const endpoint of endpoints) {
+    process.stdout.write(`Benchmarking ${endpoint.method} ${endpoint.path} ... `);
+    const result = await runEndpoint(local.baseUrl, endpoint);
+    results.push(result);
+    process.stdout.write(`${result.requests} requests, p99 ${result.latencyMs.p99}ms, errors ${result.errorRatePct}%\n`);
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    mode: smoke ? "smoke" : "full",
+    target: { baseUrl: local.baseUrl, source: targetFromEnv ? "external" : "in-process local app" },
+    config: { durationMs, concurrency },
+    environment: {
+      node: process.version,
+      os: `${type()} ${release()} ${platform()}`,
+      cpu: `${cpus()[0]?.model ?? "unknown"} (${cpus().length} cores)`,
+      ramMb: Math.round(totalmem() / 1024 / 1024),
+      freeRamMb: Math.round(freemem() / 1024 / 1024)
+    },
+    endpoints: endpoints.map(({ method, path, name }) => ({ method, path, name })),
+    results
+  };
+  report.gates = evaluateThresholds(results);
+
+  await writeFile(new URL("./latest.json", resultsDir), `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(new URL("./latest.md", resultsDir), renderMarkdown(report));
+
+  const failed = report.gates.filter((gate) => !gate.pass);
+  if (failed.length > 0) {
+    console.error(`Benchmark gate failed for ${failed.length} endpoint(s).`);
+    process.exitCode = 1;
+  }
+} finally {
+  await local.close();
+}

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,15 @@
+{
+  "defaults": {
+    "maxP99Ms": 500,
+    "maxErrorRatePct": 0
+  },
+  "smoke": {
+    "maxP99Ms": 1000,
+    "maxErrorRatePct": 0
+  },
+  "endpoints": {
+    "POST /api/uploads": {
+      "maxP99Ms": 1200
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api",
+    "benchmark": "node benchmarks/run-benchmarks.mjs",
+    "benchmark:smoke": "BENCHMARK_SMOKE=true node benchmarks/run-benchmarks.mjs"
   }
 }


### PR DESCRIPTION
Closes #30

/claim #30

Scope: dependency-free benchmark suite under `benchmarks/` covering all mounted `/api/*` routes with representative payloads and benchmark auth, JSON + Markdown output under `benchmarks/results/`, reviewable thresholds, root benchmark commands, a `.env.benchmark.example`, and a CI smoke benchmark gate.

Validation run:
- `npm test` -> 1 test passed
- `npm run benchmark:smoke` -> completed across all endpoints, 0% errors
- `npm run benchmark` -> completed across all endpoints, 0% errors
- `git diff --check` -> passed

# API Benchmark Summary

Generated: 2026-05-20T04:28:18.515Z

Target: `http://127.0.0.1:65288`
Mode: `full`
Duration per endpoint: 3000ms
Concurrency: 8

## Environment

- Runtime: Node.js v22.21.1
- OS: Darwin 25.3.0 darwin
- CPU: Apple M2 Max (12 cores)
- RAM: 32768MB total, 92MB free at start

## Results

Endpoint | Requests | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | TTFB p50 ms | TTFB p95 ms | TTFB p99 ms | Error % | Status codes
--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---
`POST /api/auth/register` | 13627 | 4541.25 | 5418.98 | 1.48 | 3.02 | 4.02 | 1.47 | 3 | 4.01 | 0 | 201: 13627
`POST /api/auth/login` | 17702 | 5899.36 | 6452.26 | 1.24 | 2.21 | 2.61 | 1.23 | 2.2 | 2.59 | 0 | 200: 17702
`GET /api/auth/oauth/github/callback` | 26327 | 8772.29 | 8000 | 0.82 | 1.68 | 2.01 | 0.82 | 1.67 | 2.01 | 0 | 200: 26327
`POST /api/auth/refresh` | 21632 | 7209.41 | 7927.01 | 1.01 | 1.9 | 2.34 | 1 | 1.9 | 2.34 | 0 | 200: 21632
`GET /api/users` | 27072 | 9022.83 | 8000 | 0.81 | 1.63 | 1.97 | 0.8 | 1.62 | 1.96 | 0 | 200: 27072
`POST /api/users` | 20816 | 6937.86 | 7642.1 | 1.05 | 2.02 | 2.35 | 1.04 | 2.01 | 2.35 | 0 | 201: 20816
`GET /api/jobs` | 26504 | 8832.73 | 8000 | 0.81 | 1.76 | 2.15 | 0.8 | 1.76 | 2.14 | 0 | 200: 26504
`POST /api/jobs` | 20096 | 6697.62 | 7498.25 | 1.07 | 2.16 | 2.63 | 1.06 | 2.15 | 2.62 | 0 | 201: 20096
`GET /api/proposals` | 23808 | 7934.85 | 8000 | 0.83 | 1.9 | 3.42 | 0.82 | 1.89 | 3.4 | 0 | 200: 23808
`POST /api/proposals` | 20584 | 6860.73 | 7663.14 | 1.04 | 2.14 | 2.43 | 1.04 | 2.13 | 2.42 | 0 | 201: 20584
`POST /api/payments` | 20411 | 6802.78 | 7665.59 | 1.04 | 2.2 | 2.57 | 1.04 | 2.19 | 2.56 | 0 | 201: 20411
`GET /api/reviews` | 26736 | 8910.75 | 8000 | 0.81 | 1.74 | 1.99 | 0.81 | 1.74 | 1.99 | 0 | 200: 26736
`POST /api/reviews` | 20382 | 6792.25 | 7608.18 | 1.05 | 2.15 | 2.51 | 1.05 | 2.14 | 2.5 | 0 | 201: 20382
`GET /api/messages` | 26120 | 8705.48 | 8000 | 0.82 | 1.81 | 2.14 | 0.81 | 1.81 | 2.13 | 0 | 200: 26120
`POST /api/messages` | 20482 | 6826.47 | 7607.58 | 1.05 | 2.1 | 2.39 | 1.05 | 2.1 | 2.38 | 0 | 201: 20482
`GET /api/notifications` | 26792 | 8928.65 | 8000 | 0.81 | 1.76 | 2.06 | 0.8 | 1.76 | 2.05 | 0 | 200: 26792
`POST /api/notifications` | 20240 | 6745.57 | 7532.07 | 1.06 | 2.19 | 2.48 | 1.06 | 2.18 | 2.47 | 0 | 201: 20240
`POST /api/uploads` | 13296 | 4430.82 | 4981.58 | 1.61 | 2.98 | 3.38 | 1.6 | 2.97 | 3.37 | 0 | 201: 13296
`GET /api/search?q=marketplace%20dashboard%20node` | 25880 | 8624.84 | 8000 | 0.84 | 1.81 | 2.08 | 0.83 | 1.8 | 2.07 | 0 | 200: 25880
`GET /api/admin/metrics` | 20001 | 6664.89 | 7339.73 | 1.09 | 2.18 | 2.55 | 1.08 | 2.17 | 2.53 | 0 | 200: 20001

## Regression Gate

Endpoint | Result | Observed p99 ms | Max p99 ms | Observed error % | Max error %
--- | --- | ---: | ---: | ---: | ---:
`POST /api/auth/register` | pass | 4.02 | 500 | 0 | 0
`POST /api/auth/login` | pass | 2.61 | 500 | 0 | 0
`GET /api/auth/oauth/github/callback` | pass | 2.01 | 500 | 0 | 0
`POST /api/auth/refresh` | pass | 2.34 | 500 | 0 | 0
`GET /api/users` | pass | 1.97 | 500 | 0 | 0
`POST /api/users` | pass | 2.35 | 500 | 0 | 0
`GET /api/jobs` | pass | 2.15 | 500 | 0 | 0
`POST /api/jobs` | pass | 2.63 | 500 | 0 | 0
`GET /api/proposals` | pass | 3.42 | 500 | 0 | 0
`POST /api/proposals` | pass | 2.43 | 500 | 0 | 0
`POST /api/payments` | pass | 2.57 | 500 | 0 | 0
`GET /api/reviews` | pass | 1.99 | 500 | 0 | 0
`POST /api/reviews` | pass | 2.51 | 500 | 0 | 0
`GET /api/messages` | pass | 2.14 | 500 | 0 | 0
`POST /api/messages` | pass | 2.39 | 500 | 0 | 0
`GET /api/notifications` | pass | 2.06 | 500 | 0 | 0
`POST /api/notifications` | pass | 2.48 | 500 | 0 | 0
`POST /api/uploads` | pass | 3.38 | 1200 | 0 | 0
`GET /api/search?q=marketplace%20dashboard%20node` | pass | 2.08 | 500 | 0 | 0
`GET /api/admin/metrics` | pass | 2.55 | 500 | 0 | 0