### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,57 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+function createStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create a Stripe PaymentIntent");
+  }
+
+  return new Stripe(env.stripeSecretKey);
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("payload.amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("payload.currency must be a three-letter ISO currency code");
+  }
+
+  if (
+    payload.metadata !== undefined &&
+    (!payload.metadata || typeof payload.metadata !== "object" || Array.isArray(payload.metadata))
+  ) {
+    throw new Error("payload.metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: payload.metadata ?? {}
   };
+}
+
+export async function createPaymentIntent(payload, stripeClient = createStripeClient()) {
+  const paymentPayload = validatePaymentPayload(payload);
+
+  try {
+    const paymentIntent = await stripeClient.paymentIntents.create(paymentPayload);
+
+    return {
+      clientSecret: paymentIntent.client_secret,
+      paymentId: paymentIntent.id
+    };
+  } catch (error) {
+    if (error?.message) {
+      throw new Error(error.message);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent validates amount before calling Stripe", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: test.mock.fn()
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0, currency: "usd" }, stripeClient),
+    /payload\.amount must be a positive integer/
+  );
+
+  assert.equal(stripeClient.paymentIntents.create.mock.callCount(), 0);
+});
+
+test("createPaymentIntent defaults currency and maps Stripe response fields", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: test.mock.fn(async () => ({
+        id: "pi_test_123",
+        client_secret: "pi_test_123_secret_456"
+      }))
+    }
+  };
+
+  const result = await createPaymentIntent({ amount: 2500 }, stripeClient);
+
+  assert.deepEqual(stripeClient.paymentIntents.create.mock.calls[0].arguments[0], {
+    amount: 2500,
+    currency: "usd",
+    metadata: {}
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456"
+  });
+});
+
+test("createPaymentIntent passes currency and metadata to Stripe", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: test.mock.fn(async () => ({
+        id: "pi_test_metadata",
+        client_secret: "pi_test_metadata_secret"
+      }))
+    }
+  };
+
+  await createPaymentIntent(
+    {
+      amount: 4999,
+      currency: "CAD",
+      metadata: { jobId: "job_123", source: "api" }
+    },
+    stripeClient
+  );
+
+  assert.deepEqual(stripeClient.paymentIntents.create.mock.calls[0].arguments[0], {
+    amount: 4999,
+    currency: "cad",
+    metadata: { jobId: "job_123", source: "api" }
+  });
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: test.mock.fn(async () => {
+        throw new Error("Your card was declined.");
+      })
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1200, currency: "usd" }, stripeClient),
+    /Your card was declined\./
+  );
+});

--- a/apps/api/src/tests/paymentSmoke.test.js
+++ b/apps/api/src/tests/paymentSmoke.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("creates a real Stripe test-mode PaymentIntent when explicitly enabled", { skip: process.env.STRIPE_LIVE_SMOKE !== "true" }, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smoke: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Closes #1

/claim #1

Scope: replaces the fake timestamp payment stub with a real Stripe PaymentIntent service initialized from `STRIPE_SECRET_KEY`, validates amount/currency/metadata before calling Stripe, maps `paymentIntent.id` to `paymentId`, maps `paymentIntent.client_secret` to `clientSecret`, and preserves original Stripe error messages.

Validation:
- `npm test -w apps/api` -> 5 passed, 1 guarded live Stripe smoke skipped
- `npm test` -> 5 passed, 1 guarded live Stripe smoke skipped
- `git diff --check` -> passed

Live Stripe smoke test: included as `apps/api/src/tests/paymentSmoke.test.js`, guarded by `STRIPE_LIVE_SMOKE=true` so it only calls Stripe when a reviewer provides a test-mode `STRIPE_SECRET_KEY`.