### PR TITLE
Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,71 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create Stripe payment intents");
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(env.stripeSecretKey);
+  }
+
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  const amount = payload.amount;
+
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("Payment amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("Payment currency must be a three-letter ISO currency code");
+  }
+
+  const metadata = payload.metadata ?? {};
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error("Payment metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    amount,
+    currency: currency.toLowerCase(),
+    metadata
   };
+}
+
+function normalizeStripeError(error) {
+  const message = error?.message ?? "Stripe payment intent creation failed";
+  return new Error(`Stripe payment intent creation failed: ${message}`);
+}
+
+export async function createPaymentIntent(payload) {
+  return createPaymentIntentWithClient(payload, getStripeClient());
+}
+
+export async function createPaymentIntentWithClient(payload, client) {
+  const { amount, currency, metadata } = validatePaymentPayload(payload);
+
+  try {
+    const paymentIntent = await client.paymentIntents.create({
+      amount,
+      currency,
+      metadata
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? amount,
+      currency: paymentIntent.currency ?? currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw normalizeStripeError(error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,116 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  createPaymentIntentWithClient
+} from "../services/paymentService.js";
+
+test("createPaymentIntentWithClient creates a Stripe PaymentIntent with validated arguments", async () => {
+  const create = mock.fn(async (args) => ({
+    id: "pi_test_123",
+    client_secret: "pi_test_123_secret_456",
+    amount: args.amount,
+    currency: args.currency
+  }));
+  const stripe = {
+    paymentIntents: {
+      create
+    }
+  };
+
+  const result = await createPaymentIntentWithClient(
+    {
+      amount: 2599,
+      currency: "USD",
+      metadata: {
+        jobId: "job_123",
+        clientId: "user_456"
+      }
+    },
+    stripe
+  );
+
+  assert.equal(create.mock.callCount(), 1);
+  assert.deepEqual(create.mock.calls[0].arguments[0], {
+    amount: 2599,
+    currency: "usd",
+    metadata: {
+      jobId: "job_123",
+      clientId: "user_456"
+    }
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 2599,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntentWithClient defaults currency to usd", async () => {
+  const create = mock.fn(async (args) => ({
+    id: "pi_default_currency",
+    client_secret: "pi_default_currency_secret",
+    amount: args.amount,
+    currency: args.currency
+  }));
+
+  await createPaymentIntentWithClient(
+    { amount: 500 },
+    { paymentIntents: { create } }
+  );
+
+  assert.equal(create.mock.calls[0].arguments[0].currency, "usd");
+});
+
+test("createPaymentIntentWithClient rejects invalid amounts before calling Stripe", async () => {
+  const create = mock.fn();
+
+  await assert.rejects(
+    () =>
+      createPaymentIntentWithClient(
+        { amount: 0 },
+        { paymentIntents: { create } }
+      ),
+    /positive integer/
+  );
+  assert.equal(create.mock.callCount(), 0);
+});
+
+test("createPaymentIntentWithClient preserves Stripe error messages", async () => {
+  const create = mock.fn(async () => {
+    const error = new Error("Your card was declined");
+    error.type = "StripeCardError";
+    throw error;
+  });
+
+  await assert.rejects(
+    () =>
+      createPaymentIntentWithClient(
+        { amount: 1000, currency: "usd" },
+        { paymentIntents: { create } }
+      ),
+    /Your card was declined/
+  );
+});
+
+test("createPaymentIntent creates a real Stripe PaymentIntent when smoke test env is enabled", {
+  skip:
+    process.env.RUN_STRIPE_SMOKE_TEST === "true" && process.env.STRIPE_SECRET_KEY
+      ? false
+      : "Set RUN_STRIPE_SMOKE_TEST=true and STRIPE_SECRET_KEY to run Stripe smoke test"
+}, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: {
+      smokeTest: "true"
+    }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary\n- Replace the payment stub with Stripe PaymentIntent creation using STRIPE_SECRET_KEY\n- Validate amount, currency, and metadata before calling Stripe\n- Return Stripe paymentId and clientSecret, preserving Stripe API error messages\n- Add mocked Stripe SDK unit coverage plus an env-gated real Stripe smoke test\n- Fix the API test script glob so node:test discovers test files reliably\n\n## Tests\n- npm test\n  - 5 passed\n  - 1 skipped: real Stripe smoke test requires RUN_STRIPE_SMOKE_TEST=true and STRIPE_SECRET_KEY\n\nAddresses #1