### PR TITLE
Add release-window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Release Window
+
+Scope arrives like morning light,
+plain enough to measure.
+Each promise takes a numbered place,
+each risk becomes a ledger.
+
+Evidence gathers on the bench,
+screens, traces, quiet notes.
+The patch does not ask to be trusted;
+it shows the path it wrote.
+
+Reviewers lean into the diff
+and test where shadows gather.
+Questions turn the brittle parts
+to work that can hold weather.
+
+When the merge light finally turns,
+the handoff stays precise:
+fair work, clear proof, paid release,
+and trust that shipped twice.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the repository root.
- Wrote an original four-stanza poem specifically around FreelanceFlow's scope, evidence, review, release, and payout workflow.

## Creative Decision
I used a release-window theme because it matches the project's focus on scoped work, visible proof, review, and fair payment.

## Validation
- Markdown-only change.
- `git diff --check` passed.
