### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/.github/workflows/payment-service-smoke.yml
+++ b/.github/workflows/payment-service-smoke.yml
@@ -1,0 +1,32 @@
+name: Payment service smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/payment-service-smoke.yml"
+      - "apps/api/**"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  payment-service-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run API tests
+        run: npm test -w apps/api

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,91 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let cachedStripeClient;
+let cachedStripeSecretKey;
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return "usd";
+  }
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new Error("currency must be a three-letter ISO currency code");
+  }
+
+  return currency.toLowerCase();
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined || metadata === null) {
+    return undefined;
+  }
+
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [key, String(value)])
+  );
+}
+
+function validatePayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("amount must be a positive integer in the smallest currency unit");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: normalizeCurrency(payload.currency),
+    metadata: normalizeMetadata(payload.metadata)
   };
+}
+
+function getStripeClient({ stripeClient, stripeSecretKey = env.stripeSecretKey } = {}) {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  if (!stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create a payment intent");
+  }
+
+  if (!cachedStripeClient || cachedStripeSecretKey !== stripeSecretKey) {
+    cachedStripeClient = new Stripe(stripeSecretKey);
+    cachedStripeSecretKey = stripeSecretKey;
+  }
+
+  return cachedStripeClient;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const request = validatePayload(payload);
+  const stripeClient = getStripeClient(options);
+
+  try {
+    const paymentIntent = await stripeClient.paymentIntents.create({
+      amount: request.amount,
+      currency: request.currency,
+      ...(request.metadata ? { metadata: request.metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? request.amount,
+      currency: paymentIntent.currency ?? request.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error && typeof error.message === "string" && (error.type || error.rawType)) {
+      throw new Error(error.message);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+function createMockStripeClient(handler) {
+  return {
+    paymentIntents: {
+      create: handler
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe payment intent with validated arguments", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(async (request) => {
+    calls.push(request);
+    return {
+      id: "pi_test_123",
+      client_secret: "pi_test_123_secret_456",
+      amount: request.amount,
+      currency: request.currency
+    };
+  });
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: { jobId: 42, proposalId: "prop_1" }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        jobId: "42",
+        proposalId: "prop_1"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  let requestBody;
+  const stripeClient = createMockStripeClient(async (request) => {
+    requestBody = request;
+    return {
+      id: "pi_default_currency",
+      client_secret: "secret",
+      amount: request.amount,
+      currency: request.currency
+    };
+  });
+
+  await createPaymentIntent({ amount: 1000 }, { stripeClient });
+
+  assert.deepEqual(requestBody, { amount: 1000, currency: "usd" });
+});
+
+test("createPaymentIntent rejects invalid payment input before calling Stripe", async () => {
+  let called = false;
+  const stripeClient = createMockStripeClient(async () => {
+    called = true;
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    /amount must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, currency: "us-dollar" }, { stripeClient }),
+    /currency must be a three-letter ISO currency code/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, metadata: ["bad"] }, { stripeClient }),
+    /metadata must be an object/
+  );
+  assert.equal(called, false);
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  const stripeClient = createMockStripeClient(async () => {
+    const error = new Error("Your card was declined");
+    error.type = "StripeCardError";
+    throw error;
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 500 }, { stripeClient }),
+    /Your card was declined/
+  );
+});
+
+test(
+  "createPaymentIntent smoke test can create a Stripe test-mode payment intent",
+  { skip: process.env.STRIPE_LIVE_SMOKE !== "true" || !process.env.STRIPE_SECRET_KEY },
+  async () => {
+    assert.match(
+      process.env.STRIPE_SECRET_KEY,
+      /^sk_test_/,
+      "smoke test requires a Stripe test-mode secret key"
+    );
+
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { smoke: "true" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_/);
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -2051,6 +2052,23 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaces the timestamp-based payment stub with Stripe `paymentIntents.create()`.
- Initializes Stripe from `STRIPE_SECRET_KEY` with no hardcoded keys.
- Validates amount, currency, and metadata before calling Stripe.
- Returns `paymentId` and `clientSecret`, and preserves Stripe API error messages.
- Adds mocked service tests plus an opt-in Stripe test-mode smoke test.

## Demo video
https://raw.githubusercontent.com/Ckeplinger199/bug-bounty/demo-videos-2026-05-20/bounty-demo-videos/2026-05-20/pr-424-stripe-demo.mp4

## Validation
- `npm test -w apps/api` passed: 5 passed, 1 guarded smoke test skipped without live Stripe credentials.
- `npm test` passed: 5 passed, 1 guarded smoke test skipped without live Stripe credentials.
- Demo video SHA-256: `279e4a9fde2bf9bb1951d4204d4db397e61aeb870e4f056c2aca90894390a6a2`.
- `git diff --check` passed.

