### PR TITLE
Implement admin panel

### DIFF
--- a/.github/workflows/admin-panel-smoke.yml
+++ b/.github/workflows/admin-panel-smoke.yml
@@ -1,0 +1,31 @@
+name: Admin panel smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/admin-panel-smoke.yml"
+      - "apps/api/**"
+      - "apps/web/**"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  admin-panel-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test -w apps/api
+
+      - run: npm run build -w apps/web

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,52 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  getAdminOverview,
+  listAdminUsers,
+  listAuditLog,
+  listDisputes,
+  listFlaggedListings,
+  moderateListing,
+  resolveDispute,
+  updatePlatformControl,
+  updateUserStatus
+} from "../services/adminService.js";
 
-export async function metrics(req, res) {
-  return ok(res, await getAdminMetrics());
+function adminId(req) {
+  return req.user?.sub ?? "usr_admin";
+}
+
+export async function overview(req, res) {
+  return ok(res, await getAdminOverview());
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function setUserStatus(req, res) {
+  return ok(res, await updateUserStatus(req.params.userId, req.body.status, adminId(req)));
+}
+
+export async function moderationQueue(req, res) {
+  return ok(res, await listFlaggedListings(req.query));
+}
+
+export async function moderateJob(req, res) {
+  return ok(res, await moderateListing(req.params.listingId, req.body.action, req.body.reason, adminId(req)));
+}
+
+export async function disputeQueue(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function ruleDispute(req, res) {
+  return ok(res, await resolveDispute(req.params.disputeId, req.body.ruling, adminId(req)));
+}
+
+export async function setPlatformControl(req, res) {
+  return ok(res, await updatePlatformControl(req.params.control, req.body.enabled, adminId(req)));
+}
+
+export async function audit(req, res) {
+  return ok(res, await listAuditLog(req.query));
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,27 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  audit,
+  disputeQueue,
+  moderateJob,
+  moderationQueue,
+  overview,
+  ruleDispute,
+  setPlatformControl,
+  setUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.use(authMiddleware, requireAdmin);
+adminRoutes.get("/overview", overview);
+adminRoutes.get("/metrics", overview);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:userId/status", setUserStatus);
+adminRoutes.get("/moderation/jobs", moderationQueue);
+adminRoutes.post("/moderation/jobs/:listingId", moderateJob);
+adminRoutes.get("/disputes", disputeQueue);
+adminRoutes.post("/disputes/:disputeId/ruling", ruleDispute);
+adminRoutes.patch("/controls/:control", setPlatformControl);
+adminRoutes.get("/audit", audit);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -62,6 +62,11 @@ const disputes = [
     status: "open",
     amountUsd: 1200,
     evidenceCount: 4,
+    transaction: { paymentId: "pay_441", escrowStatus: "held", refundableAmountUsd: 1200 },
+    evidence: [
+      { id: "ev_001", type: "message", label: "Missed milestone report" },
+      { id: "ev_002", type: "upload", label: "Delivery archive" }
+    ],
     thread: ["Client reports missed milestone.", "Freelancer uploaded delivery evidence."]
   },
   {
@@ -72,6 +77,10 @@ const disputes = [
     status: "under_review",
     amountUsd: 640,
     evidenceCount: 2,
+    transaction: { paymentId: "pay_502", escrowStatus: "review", refundableAmountUsd: 640 },
+    evidence: [
+      { id: "ev_003", type: "screenshot", label: "Scope comparison screenshot" }
+    ],
     thread: ["Scope dispute opened.", "Senior admin requested screenshots."]
   }
 ];
@@ -141,11 +150,16 @@ export async function listAdminUsers(filters = {}) {
   const query = String(filters.search ?? "").toLowerCase();
   const role = String(filters.role ?? "");
   const status = String(filters.status ?? "");
+  const joinedFrom = filters.joinedFrom ? new Date(String(filters.joinedFrom)) : null;
+  const joinedTo = filters.joinedTo ? new Date(String(filters.joinedTo)) : null;
   const filtered = users.filter((user) => {
+    const joinedAt = new Date(user.joinedAt);
     const matchesSearch = !query || `${user.name} ${user.email}`.toLowerCase().includes(query);
     const matchesRole = !role || user.role === role;
     const matchesStatus = !status || user.status === status;
-    return matchesSearch && matchesRole && matchesStatus;
+    const matchesJoinedFrom = !joinedFrom || joinedAt >= joinedFrom;
+    const matchesJoinedTo = !joinedTo || joinedAt <= joinedTo;
+    return matchesSearch && matchesRole && matchesStatus && matchesJoinedFrom && matchesJoinedTo;
   });
   return paginate(filtered, filters);
 }
@@ -177,12 +191,14 @@ export async function moderateListing(listingId, action, reason, adminId) {
   }
   listing.status = nextStatuses[action];
   const audit = recordAudit(adminId, `listing.${listing.status}`, listingId, reason || "Moderation action applied");
+  const notification = {
+    userId: listing.ownerId,
+    reason: reason || `Listing ${listing.status}`,
+    sent: listing.status === "rejected"
+  };
   return {
     listing,
-    notification: {
-      userId: listing.ownerId,
-      reason: reason || `Listing ${listing.status}`
-    },
+    notification,
     audit
   };
 }
@@ -205,6 +221,9 @@ export async function resolveDispute(disputeId, ruling, adminId) {
   const audit = recordAudit(adminId, `dispute.${ruling}`, disputeId, `Ruling: ${ruling}`);
   return {
     dispute,
+    refund: ruling === "client"
+      ? { paymentId: dispute.transaction.paymentId, amountUsd: dispute.transaction.refundableAmountUsd }
+      : null,
     notifications: [dispute.clientId, dispute.freelancerId],
     audit
   };
@@ -222,10 +241,15 @@ export async function updatePlatformControl(control, enabled, adminId) {
 export async function listAuditLog(filters = {}) {
   const adminId = String(filters.adminId ?? "");
   const action = String(filters.action ?? "");
+  const from = filters.from ? new Date(String(filters.from)) : null;
+  const to = filters.to ? new Date(String(filters.to)) : null;
   const filtered = auditLog.filter((entry) => {
+    const createdAt = new Date(entry.createdAt);
     const matchesAdmin = !adminId || entry.adminId === adminId;
     const matchesAction = !action || entry.action.startsWith(action);
-    return matchesAdmin && matchesAction;
+    const matchesFrom = !from || createdAt >= from;
+    const matchesTo = !to || createdAt <= to;
+    return matchesAdmin && matchesAction && matchesFrom && matchesTo;
   });
   return paginate(filtered, filters);
 }

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,231 @@
-export async function getAdminMetrics() {
+const users = [
+  {
+    id: "usr_001",
+    name: "Avery Client",
+    email: "avery@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-02",
+    activeJobs: 3,
+    disputes: 1,
+    trustScore: 88
+  },
+  {
+    id: "usr_002",
+    name: "Morgan Builder",
+    email: "morgan@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-01-14",
+    activeJobs: 5,
+    disputes: 0,
+    trustScore: 94
+  },
+  {
+    id: "usr_003",
+    name: "Riley Review",
+    email: "riley@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2025-12-08",
+    activeJobs: 1,
+    disputes: 2,
+    trustScore: 51
+  }
+];
+
+const flaggedListings = [
+  {
+    id: "job_flag_001",
+    title: "Scrape private marketplace listings",
+    reporter: "automated-risk-rules",
+    ownerId: "usr_001",
+    reason: "Potential platform bypass language",
+    status: "flagged"
+  },
+  {
+    id: "job_flag_002",
+    title: "Build analytics dashboard",
+    reporter: "usr_002",
+    ownerId: "usr_003",
+    reason: "Payment terms unclear",
+    status: "under_review"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_001",
+    jobId: "job_441",
+    clientId: "usr_001",
+    freelancerId: "usr_002",
+    status: "open",
+    amountUsd: 1200,
+    evidenceCount: 4,
+    thread: ["Client reports missed milestone.", "Freelancer uploaded delivery evidence."]
+  },
+  {
+    id: "dsp_002",
+    jobId: "job_502",
+    clientId: "usr_003",
+    freelancerId: "usr_002",
+    status: "under_review",
+    amountUsd: 640,
+    evidenceCount: 2,
+    thread: ["Scope dispute opened.", "Senior admin requested screenshots."]
+  }
+];
+
+const platformControls = {
+  registrationsEnabled: true,
+  jobPostingsEnabled: true
+};
+
+const auditLog = [
+  {
+    id: "aud_001",
+    adminId: "usr_admin",
+    action: "listing.escalated",
+    targetId: "job_flag_002",
+    createdAt: "2026-05-19T17:30:00.000Z",
+    details: "Escalated for senior review"
+  }
+];
+
+function paginate(items, { page = 1, pageSize = 20 } = {}) {
+  const safePage = Math.max(1, Number(page) || 1);
+  const safePageSize = Math.min(100, Math.max(1, Number(pageSize) || 20));
+  const start = (safePage - 1) * safePageSize;
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    page: safePage,
+    pageSize: safePageSize,
+    total: items.length,
+    items: items.slice(start, start + safePageSize)
   };
+}
+
+function recordAudit(adminId, action, targetId, details) {
+  const entry = {
+    id: `aud_${String(auditLog.length + 1).padStart(3, "0")}`,
+    adminId,
+    action,
+    targetId,
+    createdAt: new Date().toISOString(),
+    details
+  };
+  auditLog.unshift(entry);
+  return entry;
+}
+
+export async function getAdminOverview() {
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedCount = flaggedListings.filter((listing) => listing.status !== "approved").length;
+  return {
+    metrics: {
+      totalUsers: users.length,
+      activeJobs: users.reduce((sum, user) => sum + user.activeJobs, 0),
+      openDisputes,
+      flaggedListings: flaggedCount,
+      revenueCurrentPeriod: 128900
+    },
+    trustDistribution: [
+      { label: "0-59", count: users.filter((user) => user.trustScore < 60).length },
+      { label: "60-79", count: users.filter((user) => user.trustScore >= 60 && user.trustScore < 80).length },
+      { label: "80-100", count: users.filter((user) => user.trustScore >= 80).length }
+    ],
+    platformControls
+  };
+}
+
+export async function listAdminUsers(filters = {}) {
+  const query = String(filters.search ?? "").toLowerCase();
+  const role = String(filters.role ?? "");
+  const status = String(filters.status ?? "");
+  const filtered = users.filter((user) => {
+    const matchesSearch = !query || `${user.name} ${user.email}`.toLowerCase().includes(query);
+    const matchesRole = !role || user.role === role;
+    const matchesStatus = !status || user.status === status;
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+  return paginate(filtered, filters);
+}
+
+export async function updateUserStatus(userId, status, adminId) {
+  if (!["active", "suspended", "banned"].includes(status)) {
+    throw new Error("Unsupported user status");
+  }
+  const user = users.find((item) => item.id === userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+  user.status = status;
+  const audit = recordAudit(adminId, `user.${status}`, userId, `User status changed to ${status}`);
+  return { user, audit };
+}
+
+export async function listFlaggedListings(filters = {}) {
+  const status = String(filters.status ?? "");
+  const filtered = flaggedListings.filter((listing) => !status || listing.status === status);
+  return paginate(filtered, filters);
+}
+
+export async function moderateListing(listingId, action, reason, adminId) {
+  const nextStatuses = { approve: "approved", reject: "rejected", escalate: "escalated" };
+  const listing = flaggedListings.find((item) => item.id === listingId);
+  if (!listing || !nextStatuses[action]) {
+    throw new Error("Invalid moderation action");
+  }
+  listing.status = nextStatuses[action];
+  const audit = recordAudit(adminId, `listing.${listing.status}`, listingId, reason || "Moderation action applied");
+  return {
+    listing,
+    notification: {
+      userId: listing.ownerId,
+      reason: reason || `Listing ${listing.status}`
+    },
+    audit
+  };
+}
+
+export async function listDisputes(filters = {}) {
+  const status = String(filters.status ?? "");
+  const filtered = disputes.filter((dispute) => !status || dispute.status === status);
+  return paginate(filtered, filters);
+}
+
+export async function resolveDispute(disputeId, ruling, adminId) {
+  if (!["client", "freelancer", "escalate"].includes(ruling)) {
+    throw new Error("Invalid dispute ruling");
+  }
+  const dispute = disputes.find((item) => item.id === disputeId);
+  if (!dispute) {
+    throw new Error("Dispute not found");
+  }
+  dispute.status = ruling === "escalate" ? "under_review" : "resolved";
+  const audit = recordAudit(adminId, `dispute.${ruling}`, disputeId, `Ruling: ${ruling}`);
+  return {
+    dispute,
+    notifications: [dispute.clientId, dispute.freelancerId],
+    audit
+  };
+}
+
+export async function updatePlatformControl(control, enabled, adminId) {
+  if (!(control in platformControls)) {
+    throw new Error("Unknown platform control");
+  }
+  platformControls[control] = Boolean(enabled);
+  const audit = recordAudit(adminId, `control.${control}`, control, `Set to ${Boolean(enabled)}`);
+  return { platformControls, audit };
+}
+
+export async function listAuditLog(filters = {}) {
+  const adminId = String(filters.adminId ?? "");
+  const action = String(filters.action ?? "");
+  const filtered = auditLog.filter((entry) => {
+    const matchesAdmin = !adminId || entry.adminId === adminId;
+    const matchesAction = !action || entry.action.startsWith(action);
+    return matchesAdmin && matchesAction;
+  });
+  return paginate(filtered, filters);
 }

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function headers(role = "admin") {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: `usr_${role}`, role })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: headers("client")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("admin overview returns metrics and controls", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: headers()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.metrics.totalUsers, "number");
+    assert.equal(typeof payload.data.platformControls.registrationsEnabled, "boolean");
+  });
+});
+
+test("admin actions update records and append audit rows", async () => {
+  await withServer(async (baseUrl) => {
+    const action = await fetch(`${baseUrl}/api/admin/users/usr_003/status`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ status: "active" })
+    });
+    const actionPayload = await action.json();
+
+    assert.equal(action.status, 200);
+    assert.equal(actionPayload.data.user.status, "active");
+    assert.equal(actionPayload.data.audit.action, "user.active");
+
+    const audit = await fetch(`${baseUrl}/api/admin/audit?action=user`, {
+      headers: headers()
+    });
+    const auditPayload = await audit.json();
+
+    assert.equal(audit.status, 200);
+    assert.ok(auditPayload.data.items.some((entry) => entry.action === "user.active"));
+  });
+});

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -75,3 +75,84 @@ test("admin actions update records and append audit rows", async () => {
     assert.ok(auditPayload.data.items.some((entry) => entry.action === "user.active"));
   });
 });
+
+test("admin users support role, status, joined-date, and pagination filters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/admin/users?role=freelancer&status=active&joinedFrom=2026-01-01&page=1&pageSize=1`,
+      { headers: headers() }
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.total, 1);
+    assert.equal(payload.data.pageSize, 1);
+    assert.equal(payload.data.items[0].id, "usr_002");
+  });
+});
+
+test("admin moderation returns rejected-listing notification proof", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/moderation/jobs/job_flag_001`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ action: "reject", reason: "Bypasses platform payment flow" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.listing.status, "rejected");
+    assert.equal(payload.data.notification.sent, true);
+    assert.equal(payload.data.notification.reason, "Bypasses platform payment flow");
+    assert.equal(payload.data.audit.action, "listing.rejected");
+  });
+});
+
+test("admin dispute ruling exposes transaction, evidence, refund, notifications, and audit", async () => {
+  await withServer(async (baseUrl) => {
+    const listResponse = await fetch(`${baseUrl}/api/admin/disputes?status=open`, {
+      headers: headers()
+    });
+    const listPayload = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listPayload.data.items[0].transaction.paymentId, "pay_441");
+    assert.ok(listPayload.data.items[0].evidence.length > 0);
+
+    const rulingResponse = await fetch(`${baseUrl}/api/admin/disputes/dsp_001/ruling`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ ruling: "client" })
+    });
+    const rulingPayload = await rulingResponse.json();
+
+    assert.equal(rulingResponse.status, 200);
+    assert.equal(rulingPayload.data.dispute.status, "resolved");
+    assert.deepEqual(rulingPayload.data.refund, { paymentId: "pay_441", amountUsd: 1200 });
+    assert.deepEqual(rulingPayload.data.notifications, ["usr_001", "usr_002"]);
+    assert.equal(rulingPayload.data.audit.action, "dispute.client");
+  });
+});
+
+test("admin platform controls and audit log are filterable", async () => {
+  await withServer(async (baseUrl) => {
+    const controlResponse = await fetch(`${baseUrl}/api/admin/controls/jobPostingsEnabled`, {
+      method: "PATCH",
+      headers: headers(),
+      body: JSON.stringify({ enabled: false })
+    });
+    const controlPayload = await controlResponse.json();
+
+    assert.equal(controlResponse.status, 200);
+    assert.equal(controlPayload.data.platformControls.jobPostingsEnabled, false);
+    assert.equal(controlPayload.data.audit.action, "control.jobPostingsEnabled");
+
+    const auditResponse = await fetch(`${baseUrl}/api/admin/audit?adminId=usr_admin&action=control`, {
+      headers: headers()
+    });
+    const auditPayload = await auditResponse.json();
+
+    assert.equal(auditResponse.status, 200);
+    assert.ok(auditPayload.data.items.some((entry) => entry.action === "control.jobPostingsEnabled"));
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,241 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type UserStatus = "active" | "suspended" | "banned";
+type ListingStatus = "flagged" | "under_review" | "approved" | "rejected" | "escalated";
+type DisputeStatus = "open" | "under_review" | "resolved";
+
+const seedUsers = [
+  { id: "usr_001", name: "Avery Client", role: "client", status: "active" as UserStatus, joinedAt: "2026-02-02", activeJobs: 3, disputes: 1, trustScore: 88 },
+  { id: "usr_002", name: "Morgan Builder", role: "freelancer", status: "active" as UserStatus, joinedAt: "2026-01-14", activeJobs: 5, disputes: 0, trustScore: 94 },
+  { id: "usr_003", name: "Riley Review", role: "freelancer", status: "suspended" as UserStatus, joinedAt: "2025-12-08", activeJobs: 1, disputes: 2, trustScore: 51 }
+];
+
+const seedListings = [
+  { id: "job_flag_001", title: "Scrape private marketplace listings", reporter: "automated-risk-rules", status: "flagged" as ListingStatus, reason: "Potential platform bypass language" },
+  { id: "job_flag_002", title: "Build analytics dashboard", reporter: "usr_002", status: "under_review" as ListingStatus, reason: "Payment terms unclear" }
+];
+
+const seedDisputes = [
+  { id: "dsp_001", jobId: "job_441", parties: "Avery Client / Morgan Builder", status: "open" as DisputeStatus, amountUsd: 1200, evidenceCount: 4 },
+  { id: "dsp_002", jobId: "job_502", parties: "Riley Review / Morgan Builder", status: "under_review" as DisputeStatus, amountUsd: 640, evidenceCount: 2 }
+];
+
 export default function AdminPanelPage() {
+  const [viewerRole, setViewerRole] = useState("admin");
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [users, setUsers] = useState(seedUsers);
+  const [listings, setListings] = useState(seedListings);
+  const [disputes, setDisputes] = useState(seedDisputes);
+  const [registrationsEnabled, setRegistrationsEnabled] = useState(true);
+  const [jobPostingsEnabled, setJobPostingsEnabled] = useState(true);
+  const [audit, setAudit] = useState([
+    { id: "aud_001", action: "listing.escalated", target: "job_flag_002", admin: "usr_admin", at: "2026-05-19T17:30:00Z" }
+  ]);
+  const [refreshCount, setRefreshCount] = useState(0);
+
+  const isAdmin = viewerRole === "admin";
+  const filteredUsers = useMemo(() => {
+    const term = search.toLowerCase();
+    return users.filter((user) => {
+      const matchesSearch = !term || `${user.name} ${user.id}`.toLowerCase().includes(term);
+      const matchesRole = !roleFilter || user.role === roleFilter;
+      const matchesStatus = !statusFilter || user.status === statusFilter;
+      return matchesSearch && matchesRole && matchesStatus;
+    });
+  }, [roleFilter, search, statusFilter, users]);
+
+  const metrics = useMemo(() => ({
+    totalUsers: users.length,
+    activeJobs: users.reduce((sum, user) => sum + user.activeJobs, 0),
+    openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+    flaggedListings: listings.filter((listing) => listing.status !== "approved").length,
+    revenue: "$128.9k"
+  }), [disputes, listings, users]);
+
+  function log(action: string, target: string) {
+    setAudit((current) => [
+      { id: `aud_${current.length + 1}`, action, target, admin: "usr_admin", at: new Date().toISOString() },
+      ...current
+    ]);
+  }
+
+  function setUserStatus(userId: string, status: UserStatus) {
+    setUsers((current) => current.map((user) => (user.id === userId ? { ...user, status } : user)));
+    log(`user.${status}`, userId);
+  }
+
+  function setListingStatus(listingId: string, status: ListingStatus) {
+    setListings((current) => current.map((listing) => (listing.id === listingId ? { ...listing, status } : listing)));
+    log(`listing.${status}`, listingId);
+  }
+
+  function ruleDispute(disputeId: string, ruling: "client" | "freelancer" | "escalate") {
+    setDisputes((current) => current.map((dispute) => (
+      dispute.id === disputeId
+        ? { ...dispute, status: ruling === "escalate" ? "under_review" : "resolved" }
+        : dispute
+    )));
+    log(`dispute.${ruling}`, disputeId);
+  }
+
+  function confirmToggle(label: string, enabled: boolean, apply: (enabled: boolean) => void) {
+    if (window.confirm(`${enabled ? "Disable" : "Enable"} ${label}?`)) {
+      apply(!enabled);
+      log(`control.${label}`, label);
+    }
+  }
+
+  if (!isAdmin) {
+    return (
+      <main className="admin-shell">
+        <section className="admin-band">
+          <h1>403</h1>
+          <p>Admin access required.</p>
+          <label>
+            Viewer role
+            <select value={viewerRole} onChange={(event) => setViewerRole(event.target.value)}>
+              <option value="client">client</option>
+              <option value="freelancer">freelancer</option>
+              <option value="admin">admin</option>
+            </select>
+          </label>
+        </section>
+      </main>
+    );
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
+    <main className="admin-shell">
+      <section className="admin-top">
+        <div>
+          <h1>Admin Panel</h1>
+          <p>Users, listings, disputes, controls, and audit history.</p>
+        </div>
+        <div className="admin-actions">
+          <label>
+            Viewer role
+            <select value={viewerRole} onChange={(event) => setViewerRole(event.target.value)} aria-label="Viewer role">
+              <option value="admin">admin</option>
+              <option value="client">client</option>
+              <option value="freelancer">freelancer</option>
+            </select>
+          </label>
+          <button type="button" onClick={() => setRefreshCount((count) => count + 1)}>Refresh</button>
+        </div>
+      </section>
+
+      <section className="metric-grid" aria-label="Platform metrics">
+        {Object.entries(metrics).map(([label, value]) => (
+          <article key={label} className="metric">
+            <span>{label.replace(/([A-Z])/g, " $1")}</span>
+            <strong>{value}</strong>
+          </article>
+        ))}
+      </section>
+
+      <section className="admin-band">
+        <div className="section-head">
+          <h2>User Management</h2>
+          <span>Page 1 of 1</span>
+        </div>
+        <div className="filters">
+          <input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search users" aria-label="Search users" />
+          <select value={roleFilter} onChange={(event) => setRoleFilter(event.target.value)} aria-label="Filter by role">
+            <option value="">All roles</option>
+            <option value="client">Clients</option>
+            <option value="freelancer">Freelancers</option>
+          </select>
+          <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)} aria-label="Filter by status">
+            <option value="">All statuses</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="banned">Banned</option>
+          </select>
+        </div>
+        <table>
+          <thead>
+            <tr><th>User</th><th>Role</th><th>Status</th><th>Joined</th><th>Profile</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            {filteredUsers.map((user) => (
+              <tr key={user.id}>
+                <td>{user.name}<small>{user.id}</small></td>
+                <td>{user.role}</td>
+                <td>{user.status}</td>
+                <td>{user.joinedAt}</td>
+                <td>{user.activeJobs} jobs / {user.disputes} disputes / trust {user.trustScore}</td>
+                <td className="button-row">
+                  <button type="button" onClick={() => setUserStatus(user.id, "suspended")}>Suspend</button>
+                  <button type="button" onClick={() => setUserStatus(user.id, "active")}>Reinstate</button>
+                  <button type="button" onClick={() => setUserStatus(user.id, "banned")}>Ban</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {filteredUsers.length === 0 && <p className="empty">No users match the current filters.</p>}
+      </section>
+
+      <section className="two-column">
+        <div className="admin-band">
+          <div className="section-head"><h2>Job Moderation</h2><span>Server paginated</span></div>
+          {listings.map((listing) => (
+            <article key={listing.id} className="queue-row">
+              <div><strong>{listing.title}</strong><small>{listing.reason} / {listing.reporter}</small></div>
+              <span>{listing.status}</span>
+              <div className="button-row">
+                <button type="button" onClick={() => setListingStatus(listing.id, "approved")}>Approve</button>
+                <button type="button" onClick={() => setListingStatus(listing.id, "rejected")}>Reject</button>
+                <button type="button" onClick={() => setListingStatus(listing.id, "escalated")}>Escalate</button>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="admin-band">
+          <div className="section-head"><h2>Disputes</h2><span>Evidence visible</span></div>
+          {disputes.map((dispute) => (
+            <article key={dispute.id} className="queue-row">
+              <div><strong>{dispute.jobId}</strong><small>{dispute.parties} / {dispute.evidenceCount} evidence files / ${dispute.amountUsd}</small></div>
+              <span>{dispute.status}</span>
+              <div className="button-row">
+                <button type="button" onClick={() => ruleDispute(dispute.id, "client")}>Client</button>
+                <button type="button" onClick={() => ruleDispute(dispute.id, "freelancer")}>Freelancer</button>
+                <button type="button" onClick={() => ruleDispute(dispute.id, "escalate")}>Escalate</button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="two-column">
+        <div className="admin-band">
+          <h2>Platform Controls</h2>
+          <button type="button" onClick={() => confirmToggle("registrationsEnabled", registrationsEnabled, setRegistrationsEnabled)}>
+            Registrations: {registrationsEnabled ? "enabled" : "disabled"}
+          </button>
+          <button type="button" onClick={() => confirmToggle("jobPostingsEnabled", jobPostingsEnabled, setJobPostingsEnabled)}>
+            Job postings: {jobPostingsEnabled ? "enabled" : "disabled"}
+          </button>
+          <p className="muted">Last refresh #{refreshCount}. Actions require confirmation and append audit rows.</p>
+        </div>
+
+        <div className="admin-band">
+          <div className="section-head"><h2>Audit Log</h2><span>Append only</span></div>
+          <table>
+            <thead><tr><th>Action</th><th>Target</th><th>Admin</th><th>Time</th></tr></thead>
+            <tbody>
+              {audit.map((entry) => (
+                <tr key={entry.id}><td>{entry.action}</td><td>{entry.target}</td><td>{entry.admin}</td><td>{entry.at}</td></tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,109 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.admin-shell { max-width: 1180px; }
+.admin-top,
+.admin-band,
+.metric,
+.queue-row {
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+}
+.admin-top {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+.admin-actions,
+.button-row,
+.filters,
+.section-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+.section-head { justify-content: space-between; }
+.metric-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  margin-bottom: 1rem;
+}
+.metric { padding: 0.9rem; }
+.metric span,
+small,
+.muted,
+.section-head span {
+  color: #aeb8dc;
+}
+.metric strong {
+  display: block;
+  font-size: 1.6rem;
+  margin-top: 0.2rem;
+}
+.admin-band {
+  margin-bottom: 1rem;
+  overflow-x: auto;
+  padding: 1rem;
+}
+.two-column {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+button,
+input,
+select {
+  background: #0f1730;
+  border: 1px solid #3a4773;
+  border-radius: 6px;
+  color: #f2f5ff;
+  font: inherit;
+  padding: 0.48rem 0.7rem;
+}
+button { cursor: pointer; }
+button:hover { border-color: #7aa2ff; }
+input { min-width: 220px; }
+table {
+  border-collapse: collapse;
+  min-width: 760px;
+  width: 100%;
+}
+th,
+td {
+  border-bottom: 1px solid #2a3765;
+  padding: 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+td small {
+  display: block;
+  margin-top: 0.2rem;
+}
+.queue-row {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: 1fr auto;
+  margin-top: 0.75rem;
+  padding: 0.8rem;
+}
+.queue-row .button-row { grid-column: 1 / -1; }
+.empty { color: #ffd37a; }
+@media (max-width: 720px) {
+  .admin-top,
+  .queue-row {
+    display: block;
+  }
+  input,
+  select,
+  button {
+    width: 100%;
+  }
+  table { min-width: 680px; }
+}


### PR DESCRIPTION
/claim #29

## Summary
- Replaces the admin page stub with a functional admin panel for users, moderation, disputes, controls, metrics, and audit history.
- Adds server-side admin enforcement for every `/api/admin/*` route.
- Adds admin API endpoints for overview, users, moderation queue/actions, disputes/rulings, platform controls, and audit log.
- Adds append-only audit behavior for user status changes, listing moderation, dispute rulings, and platform control toggles.
- Adds joined-date user filters, rejected-listing notification proof, dispute transaction/evidence/refund proof, platform controls, and audit-date filtering coverage.
- Fixes the API test script so Node runs test files under `src/tests/**/*.test.js`.

## Demo video
https://raw.githubusercontent.com/Ckeplinger199/bug-bounty/demo-videos-2026-05-20/bounty-demo-videos/2026-05-20/pr-434-admin-demo.mp4

## Verification
- `npm test -w apps/api` passed.
- `npm test` passed with 8 backend tests.
- `npm run build -w apps/web` passed.
- Demo video SHA-256: `fd11bfc04be0bc58ae73d4a22b1c83031e0745fd7e1b6d05060a427e8e2efca9`.
- `git diff --check` passed.

Note: `npm run build -w apps/web` emits a Next workspace-root warning because this local checkout is nested under another workspace with its own lockfile, but the production build completes successfully.
