### PR TITLE
Add quiet contract poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Quiet Contract
+
+Scope enters first, in a line cleanly drawn,
+where a job becomes promise, and promise gets priced.
+No handshake is hidden, no question left open;
+the work has a shape before work has a name.
+
+Proof follows close with its lamp on the table,
+commits, screenshots, tests, and the path they reveal.
+Freelancer and client read the same trail of evidence,
+turning uncertainty into something they can both inspect.
+
+Review is the pause that keeps trust from drifting,
+a careful second look before payment is released.
+Comments become rails, checks become witnesses,
+and a finished task earns more than a quiet merge.
+
+Then the ledger breathes out: invoice, payout, record.
+The dashboard remembers what the chat used to carry.
+In FreelanceFlow, good work does not vanish at delivery;
+it leaves a clear receipt for the next honest build.


### PR DESCRIPTION
/claim #76

## Summary
- Add `POEM.md` at the repository root.
- Include an original four-stanza poem written specifically around FreelanceFlow's scope, proof, review, and payout workflow.

## Creative Decision
I chose a quiet contract theme because the project turns freelance work into explicit scope, visible evidence, review, and a clear payment record.

## Validation
- `git diff --check`
- `POEM.md` is in the repository root.
- The poem has 4 stanzas, exceeding the 3-stanza minimum.
- Scope is limited to the requested Markdown file.

## Demo
The complete Markdown artifact is visible directly in the `POEM.md` diff.
