### PR TITLE
Add FreelanceFlow poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Ledger of Fair Work
+
+The brief arrives with edges clearly drawn,  
+a scope of work, a budget, and a name.  
+No whispered promise fades before the dawn;  
+the terms stay visible, precise, and plain.  
+
+A proposal answers with a careful map,  
+not noise, not guesswork, not a borrowed line.  
+It marks the risks before they form a gap,  
+then turns intent into a working sign.  
+
+The patch comes forward with its proof in hand,  
+each test a receipt, each note a steady light.  
+Reviewers read the change and understand  
+what moved, what stayed, and why the fix is right.  
+
+Then payout follows through the trusted flow,  
+not as a favor, but as earned repair.  
+FreelanceFlow keeps the record clean below:  
+clear work, clear review, and payment fair.


### PR DESCRIPTION
/claim #76

One-line creative note: I used an escrow-and-review ledger tone because FreelanceFlow is about making scope, evidence, review, and payout visible and fair.

Validation:
- Added `POEM.md` at the repository root
- Original project-specific poem
- Four stanzas, meeting the minimum three-stanza requirement
- Markdown-only content change
- `git diff --check` passed
