### PR TITLE
Implement Stripe payment intent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^17.7.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,72 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create payment intents");
+  }
+
+  stripeClient ??= new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error("Payment amount is required and must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency.trim())) {
+    throw new Error("Payment currency must be a three-letter ISO currency code");
+  }
+
+  if (payload.metadata !== undefined && (payload.metadata === null || typeof payload.metadata !== "object" || Array.isArray(payload.metadata))) {
+    throw new Error("Payment metadata must be an object when provided");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.trim().toLowerCase(),
+    metadata: payload.metadata
   };
+}
+
+export async function createPaymentIntent(payload, client) {
+  const params = validatePaymentPayload(payload);
+  const stripe = client ?? getStripeClient();
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: params.amount,
+      currency: params.currency,
+      ...(params.metadata ? { metadata: params.metadata } : {})
+    });
+
+    if (!paymentIntent.client_secret) {
+      throw new Error("Stripe did not return a client secret for the payment intent");
+    }
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: params.amount,
+      currency: params.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown Stripe error";
+    throw new Error(`Stripe payment intent failed: ${message}`, { cause: error });
+  }
+}
+
+export async function createStripePaymentIntentSmokeTest() {
+  return createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: {
+      smokeTest: "true"
+    }
+  });
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, createStripePaymentIntentSmokeTest } from "../services/paymentService.js";
+
+function createStripeMock({ response, error } = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    client: {
+      paymentIntents: {
+        async create(params) {
+          calls.push(params);
+          if (error) {
+            throw error;
+          }
+          return response ?? {
+            id: "pi_test_123",
+            client_secret: "pi_test_123_secret_abc"
+          };
+        }
+      }
+    }
+  };
+}
+
+test("createPaymentIntent validates payload and maps Stripe response", async () => {
+  const stripe = createStripeMock();
+
+  const result = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD",
+    metadata: {
+      jobId: "job_123"
+    }
+  }, stripe.client);
+
+  assert.deepEqual(stripe.calls, [{
+    amount: 2500,
+    currency: "usd",
+    metadata: {
+      jobId: "job_123"
+    }
+  }]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const stripe = createStripeMock();
+
+  await createPaymentIntent({ amount: 100 }, stripe.client);
+
+  assert.deepEqual(stripe.calls, [{
+    amount: 100,
+    currency: "usd"
+  }]);
+});
+
+test("createPaymentIntent rejects invalid amount before calling Stripe", async () => {
+  const stripe = createStripeMock();
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, stripe.client),
+    /positive integer/
+  );
+
+  assert.deepEqual(stripe.calls, []);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Your card was declined");
+  stripeError.type = "StripeCardError";
+  const stripe = createStripeMock({ error: stripeError });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 500 }, stripe.client),
+    /Your card was declined/
+  );
+});
+
+test("live Stripe smoke creates a test-mode payment intent when explicitly enabled", {
+  skip: process.env.RUN_STRIPE_SMOKE !== "true" || !process.env.STRIPE_SECRET_KEY
+}, async () => {
+  const result = await createStripePaymentIntentSmokeTest();
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^17.7.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2053,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+      "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary
- Replaced the stubbed payment intent service with a Stripe SDK-backed implementation.
- Validates positive integer amounts, normalizes/defaults currency to `usd`, preserves optional metadata, and maps Stripe `id` / `client_secret` to `paymentId` / `clientSecret`.
- Added node:test coverage with a mocked Stripe client and a guarded live smoke test that only runs when `RUN_STRIPE_SMOKE=true` and `STRIPE_SECRET_KEY` are set.

## Validation
- `npm test -w apps/api` passed: 5 tests passed, 1 guarded Stripe smoke test skipped because no live Stripe key is configured.
- `git diff --check` passed.

## Smoke Test
The live Stripe smoke path is implemented in `createStripePaymentIntentSmokeTest()` and guarded by environment variables so CI can opt in with Stripe test credentials without making accidental API calls.