### PR TITLE
Add Proof Ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Proof Ledger
+
+The board wakes up in morning light,
+with issues tagged in careful rows;
+a promise starts as plain text work,
+then earns its shape when evidence shows.
+
+No handshake counts until it lands,
+no claim is more than noise alone;
+the patch must stand where others read,
+with every tradeoff clearly shown.
+
+A scanner hums across the diff,
+a test log cools the heated room;
+the smallest useful fix can still
+make trust take root and systems bloom.
+
+So write the scope, then ship the proof,
+let reviewers trace the line;
+when value clears the final gate,
+the payout follows by design.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` with an original four-stanza technical poem written for this project.

## Creative Decision
I used a proof-ledger theme because the repository’s bounty workflow turns promises into value only when scoped work, evidence, review, and payout line up.

## Validation
- `POEM.md` is in the repository root.
- The poem has four stanzas, exceeding the three-stanza minimum.
- `git diff --check` passed.