### PR TITLE
Implement functional admin panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,95 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  getAdminOverview,
+  getNotifications,
+  getPlatformControls,
+  getUserProfile,
+  listAuditLog,
+  listDisputes,
+  listFlaggedJobs,
+  listUsers,
+  moderateJob,
+  ruleOnDispute,
+  updatePlatformControl,
+  updateUserStatus
+} from "../services/adminService.js";
 
-export async function metrics(req, res) {
-  return ok(res, await getAdminMetrics());
+function handleAdminError(res, error) {
+  const notFound = /not found/i.test(error.message);
+  const invalid = /invalid|required|positive/i.test(error.message);
+  return fail(res, error.message, notFound ? 404 : invalid ? 400 : 500);
+}
+
+export async function overview(req, res) {
+  return ok(res, await getAdminOverview());
+}
+
+export async function users(req, res) {
+  return ok(res, await listUsers(req.query));
+}
+
+export async function userProfile(req, res) {
+  try {
+    return ok(res, await getUserProfile(req.params.userId));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function setUserStatus(req, res) {
+  try {
+    return ok(res, await updateUserStatus(req.user, req.params.userId, req.body.status));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function flaggedJobs(req, res) {
+  return ok(res, await listFlaggedJobs(req.query));
+}
+
+export async function decideJob(req, res) {
+  try {
+    return ok(
+      res,
+      await moderateJob(req.user, req.params.jobId, req.body.decision, req.body.reason)
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function decideDispute(req, res) {
+  try {
+    return ok(
+      res,
+      await ruleOnDispute(req.user, req.params.disputeId, req.body.ruling, req.body.note)
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function setControl(req, res) {
+  try {
+    return ok(res, await updatePlatformControl(req.user, req.body.key, req.body.enabled));
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await listAuditLog(req.query));
+}
+
+export async function notifications(req, res) {
+  return ok(res, await getNotifications());
 }

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,42 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import {
+  auditLog,
+  controls,
+  decideDispute,
+  decideJob,
+  disputes,
+  flaggedJobs,
+  notifications,
+  overview,
+  setControl,
+  setUserStatus,
+  userProfile,
+  users
+} from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+
+adminRoutes.use((req, res, next) => {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  return next();
+});
+
+adminRoutes.get("/overview", overview);
+adminRoutes.get("/metrics", overview);
+adminRoutes.get("/users", users);
+adminRoutes.get("/users/:userId", userProfile);
+adminRoutes.patch("/users/:userId/status", setUserStatus);
+adminRoutes.get("/moderation/jobs", flaggedJobs);
+adminRoutes.post("/moderation/jobs/:jobId/decision", decideJob);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.post("/disputes/:disputeId/ruling", decideDispute);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls", setControl);
+adminRoutes.get("/audit-log", auditLog);
+adminRoutes.get("/notifications", notifications);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,388 @@
-export async function getAdminMetrics() {
+const users = [
+  {
+    id: "usr_101",
+    name: "Maya Chen",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-01-12",
+    trustScore: 94,
+    activeJobs: ["job_201"],
+    disputes: ["disp_301"]
+  },
+  {
+    id: "usr_102",
+    name: "Northstar Studio",
+    email: "ops@northstar.example",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-02",
+    trustScore: 81,
+    activeJobs: ["job_202", "job_203"],
+    disputes: []
+  },
+  {
+    id: "usr_103",
+    name: "Ravi Patel",
+    email: "ravi@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2025-12-18",
+    trustScore: 52,
+    activeJobs: [],
+    disputes: ["disp_302"]
+  },
+  {
+    id: "usr_104",
+    name: "Atlas Retail",
+    email: "finance@atlas.example",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-03-08",
+    trustScore: 73,
+    activeJobs: ["job_204"],
+    disputes: []
+  }
+];
+
+const jobs = [
+  {
+    id: "job_201",
+    title: "Rebuild checkout analytics dashboard",
+    clientId: "usr_102",
+    freelancerId: "usr_101",
+    status: "active",
+    budget: 4200,
+    flagged: true,
+    flagReason: "External payment language detected",
+    reports: 2,
+    moderationStatus: "pending"
+  },
+  {
+    id: "job_202",
+    title: "Design onboarding screens",
+    clientId: "usr_102",
+    freelancerId: null,
+    status: "active",
+    budget: 1800,
+    flagged: true,
+    flagReason: "Unusually broad scope",
+    reports: 1,
+    moderationStatus: "pending"
+  },
+  {
+    id: "job_203",
+    title: "Migrate blog to Next.js",
+    clientId: "usr_102",
+    freelancerId: null,
+    status: "active",
+    budget: 2600,
+    flagged: false,
+    flagReason: null,
+    reports: 0,
+    moderationStatus: "approved"
+  },
+  {
+    id: "job_204",
+    title: "Build warehouse mobile workflow",
+    clientId: "usr_104",
+    freelancerId: null,
+    status: "active",
+    budget: 5200,
+    flagged: true,
+    flagReason: "Reported by freelancer",
+    reports: 3,
+    moderationStatus: "escalated"
+  }
+];
+
+const disputes = [
+  {
+    id: "disp_301",
+    jobId: "job_201",
+    clientId: "usr_102",
+    freelancerId: "usr_101",
+    status: "open",
+    amount: 1200,
+    summary: "Milestone scope changed after delivery",
+    thread: [
+      "Freelancer submitted analytics dashboard v1.",
+      "Client requested two extra integrations outside the milestone.",
+      "Freelancer asked for a scope adjustment."
+    ],
+    evidence: ["contract-v3.pdf", "delivery-video.mp4"],
+    transactionId: "pay_901"
+  },
+  {
+    id: "disp_302",
+    jobId: "job_204",
+    clientId: "usr_104",
+    freelancerId: "usr_103",
+    status: "under_review",
+    amount: 800,
+    summary: "Client disputes incomplete mobile QA pass",
+    thread: [
+      "Client opened dispute after failed acceptance tests.",
+      "Freelancer uploaded revised test evidence."
+    ],
+    evidence: ["qa-report.csv"],
+    transactionId: "pay_902"
+  }
+];
+
+const controls = {
+  registrationsEnabled: true,
+  jobPostingsEnabled: true
+};
+
+const auditLog = [
+  {
+    id: "audit_100",
+    adminId: "system",
+    action: "seed",
+    targetType: "platform",
+    targetId: "initial-state",
+    details: "Initial admin dashboard state",
+    createdAt: "2026-05-20T00:00:00.000Z"
+  }
+];
+
+const notifications = [];
+
+function paginate(items, { page = 1, pageSize = 10 } = {}) {
+  const safePage = Math.max(Number(page) || 1, 1);
+  const safePageSize = Math.min(Math.max(Number(pageSize) || 10, 1), 50);
+  const start = (safePage - 1) * safePageSize;
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    items: items.slice(start, start + safePageSize),
+    page: safePage,
+    pageSize: safePageSize,
+    total: items.length,
+    totalPages: Math.max(Math.ceil(items.length / safePageSize), 1)
   };
+}
+
+function actorId(admin) {
+  return admin?.sub ?? admin?.id ?? "unknown-admin";
+}
+
+function recordAudit(admin, action, targetType, targetId, details) {
+  const entry = {
+    id: `audit_${Date.now()}_${auditLog.length + 1}`,
+    adminId: actorId(admin),
+    action,
+    targetType,
+    targetId,
+    details,
+    createdAt: new Date().toISOString()
+  };
+  auditLog.unshift(entry);
+  return entry;
+}
+
+function addNotification(userId, message) {
+  notifications.unshift({
+    id: `note_${Date.now()}_${notifications.length + 1}`,
+    userId,
+    message,
+    createdAt: new Date().toISOString()
+  });
+}
+
+function findUserOrThrow(id) {
+  const user = users.find((item) => item.id === id);
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
+}
+
+function findJobOrThrow(id) {
+  const job = jobs.find((item) => item.id === id);
+  if (!job) {
+    throw new Error("Job not found");
+  }
+  return job;
+}
+
+function findDisputeOrThrow(id) {
+  const dispute = disputes.find((item) => item.id === id);
+  if (!dispute) {
+    throw new Error("Dispute not found");
+  }
+  return dispute;
+}
+
+export async function getAdminOverview() {
+  const flaggedListings = jobs.filter((job) => job.flagged && job.moderationStatus !== "approved");
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved");
+  const revenue = jobs.reduce((sum, job) => sum + job.budget, 0);
+  const trustDistribution = [
+    { range: "0-49", count: users.filter((user) => user.trustScore < 50).length },
+    { range: "50-69", count: users.filter((user) => user.trustScore >= 50 && user.trustScore < 70).length },
+    { range: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+    { range: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+  ];
+
+  return {
+    summary: {
+      totalUsers: users.length,
+      activeJobs: jobs.filter((job) => job.status === "active").length,
+      openDisputes: openDisputes.length,
+      flaggedListings: flaggedListings.length,
+      revenueCurrentPeriod: revenue
+    },
+    trustDistribution,
+    controls,
+    refreshedAt: new Date().toISOString()
+  };
+}
+
+export async function listUsers(query = {}) {
+  const search = query.search?.toLowerCase();
+  const role = query.role;
+  const status = query.status;
+  const joinedFrom = query.joinedFrom;
+  const joinedTo = query.joinedTo;
+
+  const filtered = users.filter((user) => {
+    const matchesSearch =
+      !search ||
+      user.name.toLowerCase().includes(search) ||
+      user.email.toLowerCase().includes(search);
+    const matchesRole = !role || role === "all" || user.role === role;
+    const matchesStatus = !status || status === "all" || user.status === status;
+    const matchesJoinedFrom = !joinedFrom || user.joinedAt >= joinedFrom;
+    const matchesJoinedTo = !joinedTo || user.joinedAt <= joinedTo;
+    return matchesSearch && matchesRole && matchesStatus && matchesJoinedFrom && matchesJoinedTo;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getUserProfile(userId) {
+  const user = findUserOrThrow(userId);
+  return {
+    ...user,
+    jobs: jobs.filter((job) => job.clientId === userId || job.freelancerId === userId),
+    disputeHistory: disputes.filter(
+      (dispute) => dispute.clientId === userId || dispute.freelancerId === userId
+    )
+  };
+}
+
+export async function updateUserStatus(admin, userId, status) {
+  if (!["active", "suspended", "banned"].includes(status)) {
+    throw new Error("Invalid user status");
+  }
+
+  const user = findUserOrThrow(userId);
+  user.status = status;
+  const entry = recordAudit(admin, `user.${status}`, "user", userId, `Set user status to ${status}`);
+  return { user, audit: entry };
+}
+
+export async function listFlaggedJobs(query = {}) {
+  const status = query.status;
+  const filtered = jobs.filter((job) => {
+    const flagged = job.flagged || job.moderationStatus !== "approved";
+    const matchesStatus = !status || status === "all" || job.moderationStatus === status;
+    return flagged && matchesStatus;
+  });
+  return paginate(filtered, query);
+}
+
+export async function moderateJob(admin, jobId, decision, reason = "") {
+  if (!["approved", "rejected", "escalated"].includes(decision)) {
+    throw new Error("Invalid moderation decision");
+  }
+
+  const job = findJobOrThrow(jobId);
+  job.moderationStatus = decision;
+  job.flagged = decision !== "approved";
+
+  if (decision === "rejected") {
+    job.status = "rejected";
+    addNotification(job.clientId, `Your listing "${job.title}" was rejected: ${reason || "Policy review"}`);
+  }
+
+  const entry = recordAudit(
+    admin,
+    `job.${decision}`,
+    "job",
+    jobId,
+    reason || `Listing ${decision}`
+  );
+  return { job, audit: entry };
+}
+
+export async function listDisputes(query = {}) {
+  const status = query.status;
+  const filtered = disputes.filter((dispute) => !status || status === "all" || dispute.status === status);
+  return paginate(filtered, query);
+}
+
+export async function ruleOnDispute(admin, disputeId, ruling, note = "") {
+  if (!["client", "freelancer", "refund", "escalate"].includes(ruling)) {
+    throw new Error("Invalid dispute ruling");
+  }
+
+  const dispute = findDisputeOrThrow(disputeId);
+  dispute.status = ruling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = ruling;
+  dispute.resolutionNote = note;
+
+  addNotification(dispute.clientId, `Dispute ${dispute.id} updated: ${ruling}`);
+  addNotification(dispute.freelancerId, `Dispute ${dispute.id} updated: ${ruling}`);
+
+  const entry = recordAudit(
+    admin,
+    `dispute.${ruling}`,
+    "dispute",
+    disputeId,
+    note || `Dispute ruled for ${ruling}`
+  );
+  return { dispute, audit: entry };
+}
+
+export async function getPlatformControls() {
+  return controls;
+}
+
+export async function updatePlatformControl(admin, key, enabled) {
+  if (!["registrationsEnabled", "jobPostingsEnabled"].includes(key)) {
+    throw new Error("Invalid platform control");
+  }
+
+  controls[key] = Boolean(enabled);
+  const entry = recordAudit(
+    admin,
+    `control.${key}`,
+    "platform-control",
+    key,
+    `${key} set to ${controls[key]}`
+  );
+  return { controls, audit: entry };
+}
+
+export async function listAuditLog(query = {}) {
+  const action = query.action;
+  const adminId = query.adminId;
+  const from = query.from;
+  const to = query.to;
+
+  const filtered = auditLog.filter((entry) => {
+    const matchesAction = !action || action === "all" || entry.action === action;
+    const matchesAdmin = !adminId || entry.adminId === adminId;
+    const matchesFrom = !from || entry.createdAt >= from;
+    const matchesTo = !to || entry.createdAt <= to;
+    return matchesAction && matchesAdmin && matchesFrom && matchesTo;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getNotifications() {
+  return notifications;
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: "admin_1", role: "admin" })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const response = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("admin can read overview and paginated users", async () => {
+  await withServer(async (baseUrl) => {
+    const overviewResponse = await fetch(`${baseUrl}/api/admin/overview`, {
+      headers: adminHeaders()
+    });
+    const overview = await overviewResponse.json();
+
+    assert.equal(overviewResponse.status, 200);
+    assert.equal(overview.data.summary.totalUsers >= 1, true);
+    assert.equal(Array.isArray(overview.data.trustDistribution), true);
+
+    const usersResponse = await fetch(
+      `${baseUrl}/api/admin/users?role=freelancer&page=1&pageSize=2`,
+      { headers: adminHeaders() }
+    );
+    const users = await usersResponse.json();
+
+    assert.equal(usersResponse.status, 200);
+    assert.equal(users.data.page, 1);
+    assert.equal(users.data.pageSize, 2);
+    assert.equal(users.data.items.every((user) => user.role === "freelancer"), true);
+  });
+});
+
+test("admin actions update resources and write audit entries", async () => {
+  await withServer(async (baseUrl) => {
+    const moderationResponse = await fetch(
+      `${baseUrl}/api/admin/moderation/jobs/job_202/decision`,
+      {
+        method: "POST",
+        headers: adminHeaders(),
+        body: JSON.stringify({
+          decision: "rejected",
+          reason: "External contact details in listing"
+        })
+      }
+    );
+    const moderation = await moderationResponse.json();
+
+    assert.equal(moderationResponse.status, 200);
+    assert.equal(moderation.data.job.moderationStatus, "rejected");
+    assert.match(moderation.data.audit.action, /job\.rejected/);
+
+    const controlResponse = await fetch(`${baseUrl}/api/admin/controls`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        key: "jobPostingsEnabled",
+        enabled: false
+      })
+    });
+    const control = await controlResponse.json();
+
+    assert.equal(controlResponse.status, 200);
+    assert.equal(control.data.controls.jobPostingsEnabled, false);
+
+    const auditResponse = await fetch(`${baseUrl}/api/admin/audit-log?pageSize=5`, {
+      headers: adminHeaders()
+    });
+    const audit = await auditResponse.json();
+
+    assert.equal(auditResponse.status, 200);
+    assert.equal(audit.data.items.some((entry) => entry.action === "job.rejected"), true);
+    assert.equal(
+      audit.data.items.some((entry) => entry.action === "control.jobPostingsEnabled"),
+      true
+    );
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,491 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type UserStatus = "active" | "suspended" | "banned";
+type ModerationStatus = "pending" | "approved" | "rejected" | "escalated";
+type DisputeStatus = "open" | "under_review" | "resolved";
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: "client" | "freelancer";
+  status: UserStatus;
+  joinedAt: string;
+  trustScore: number;
+};
+
+type Job = {
+  id: string;
+  title: string;
+  client: string;
+  status: ModerationStatus;
+  reason: string;
+  reports: number;
+};
+
+type Dispute = {
+  id: string;
+  job: string;
+  parties: string;
+  status: DisputeStatus;
+  amount: string;
+  evidence: string;
+};
+
+type AuditEntry = {
+  id: string;
+  admin: string;
+  action: string;
+  target: string;
+  at: string;
+};
+
+const initialUsers: User[] = [
+  {
+    id: "usr_101",
+    name: "Maya Chen",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-01-12",
+    trustScore: 94
+  },
+  {
+    id: "usr_102",
+    name: "Northstar Studio",
+    email: "ops@northstar.example",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-02-02",
+    trustScore: 81
+  },
+  {
+    id: "usr_103",
+    name: "Ravi Patel",
+    email: "ravi@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2025-12-18",
+    trustScore: 52
+  },
+  {
+    id: "usr_104",
+    name: "Atlas Retail",
+    email: "finance@atlas.example",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-03-08",
+    trustScore: 73
+  }
+];
+
+const initialJobs: Job[] = [
+  {
+    id: "job_201",
+    title: "Rebuild checkout analytics dashboard",
+    client: "Northstar Studio",
+    status: "pending",
+    reason: "External payment language detected",
+    reports: 2
+  },
+  {
+    id: "job_202",
+    title: "Design onboarding screens",
+    client: "Northstar Studio",
+    status: "pending",
+    reason: "Unusually broad scope",
+    reports: 1
+  },
+  {
+    id: "job_204",
+    title: "Build warehouse mobile workflow",
+    client: "Atlas Retail",
+    status: "escalated",
+    reason: "Reported by freelancer",
+    reports: 3
+  }
+];
+
+const initialDisputes: Dispute[] = [
+  {
+    id: "disp_301",
+    job: "Rebuild checkout analytics dashboard",
+    parties: "Northstar Studio / Maya Chen",
+    status: "open",
+    amount: "$1,200",
+    evidence: "contract-v3.pdf, delivery-video.mp4"
+  },
+  {
+    id: "disp_302",
+    job: "Build warehouse mobile workflow",
+    parties: "Atlas Retail / Ravi Patel",
+    status: "under_review",
+    amount: "$800",
+    evidence: "qa-report.csv"
+  }
+];
+
+function statusClass(status: string) {
+  if (["active", "approved", "resolved"].includes(status)) return "admin-badge admin-badge-good";
+  if (["pending", "under_review", "suspended", "escalated"].includes(status)) return "admin-badge admin-badge-warn";
+  return "admin-badge admin-badge-bad";
+}
+
 export default function AdminPanelPage() {
+  const [users, setUsers] = useState(initialUsers);
+  const [jobs, setJobs] = useState(initialJobs);
+  const [disputes, setDisputes] = useState(initialDisputes);
+  const [audit, setAudit] = useState<AuditEntry[]>([
+    {
+      id: "audit_100",
+      admin: "admin_1",
+      action: "dashboard.opened",
+      target: "admin-panel",
+      at: "2026-05-20 00:00"
+    }
+  ]);
+  const [query, setQuery] = useState("");
+  const [role, setRole] = useState("all");
+  const [status, setStatus] = useState("all");
+  const [registrationsEnabled, setRegistrationsEnabled] = useState(true);
+  const [jobPostingsEnabled, setJobPostingsEnabled] = useState(true);
+  const [selectedUserId, setSelectedUserId] = useState(users[0].id);
+  const [activity, setActivity] = useState("Ready");
+
+  const filteredUsers = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return users.filter((user) => {
+      const matchesQuery =
+        !normalized ||
+        user.name.toLowerCase().includes(normalized) ||
+        user.email.toLowerCase().includes(normalized);
+      const matchesRole = role === "all" || user.role === role;
+      const matchesStatus = status === "all" || user.status === status;
+      return matchesQuery && matchesRole && matchesStatus;
+    });
+  }, [query, role, status, users]);
+
+  const selectedUser = users.find((user) => user.id === selectedUserId) ?? users[0];
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = jobs.filter((job) => job.status !== "approved").length;
+  const trustBuckets = [
+    { label: "0-49", count: users.filter((user) => user.trustScore < 50).length },
+    { label: "50-69", count: users.filter((user) => user.trustScore >= 50 && user.trustScore < 70).length },
+    { label: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+    { label: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+  ];
+
+  function record(action: string, target: string) {
+    setAudit((current) => [
+      {
+        id: `audit_${Date.now()}`,
+        admin: "admin_1",
+        action,
+        target,
+        at: new Date().toLocaleString()
+      },
+      ...current
+    ]);
+  }
+
+  function updateUserStatus(userId: string, nextStatus: UserStatus) {
+    setActivity("Saving user action...");
+    setUsers((current) =>
+      current.map((user) => (user.id === userId ? { ...user, status: nextStatus } : user))
+    );
+    record(`user.${nextStatus}`, userId);
+    setActivity(`User ${userId} set to ${nextStatus}`);
+  }
+
+  function moderateJob(jobId: string, nextStatus: ModerationStatus) {
+    setActivity("Saving moderation decision...");
+    setJobs((current) =>
+      current.map((job) => (job.id === jobId ? { ...job, status: nextStatus } : job))
+    );
+    record(`job.${nextStatus}`, jobId);
+    setActivity(`Listing ${jobId} marked ${nextStatus}`);
+  }
+
+  function resolveDispute(disputeId: string, ruling: string) {
+    setActivity("Saving dispute ruling...");
+    setDisputes((current) =>
+      current.map((dispute) =>
+        dispute.id === disputeId
+          ? { ...dispute, status: ruling === "escalate" ? "under_review" : "resolved" }
+          : dispute
+      )
+    );
+    record(`dispute.${ruling}`, disputeId);
+    setActivity(`Dispute ${disputeId} updated`);
+  }
+
+  function confirmToggle(label: string, enabled: boolean, commit: (enabled: boolean) => void) {
+    if (window.confirm(`Apply platform control change: ${label}?`)) {
+      commit(enabled);
+      record(`control.${label}`, "platform");
+      setActivity(`${label} set to ${enabled ? "enabled" : "disabled"}`);
+    }
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell" aria-label="Admin panel">
+      <div className="admin-toolbar">
+        <div>
+          <h1>Admin Panel</h1>
+          <p>{activity}</p>
+        </div>
+        <button className="admin-button" type="button" onClick={() => setActivity("Data refreshed")}>
+          Refresh
+        </button>
+      </div>
+
+      <div className="admin-metrics" aria-label="Platform metrics">
+        {[
+          ["Total users", users.length],
+          ["Active jobs", 4],
+          ["Open disputes", openDisputes],
+          ["Flagged listings", flaggedListings],
+          ["Revenue", "$13.8k"]
+        ].map(([label, value]) => (
+          <div className="admin-panel admin-metric" key={label}>
+            <span>{label}</span>
+            <strong>{value}</strong>
+          </div>
+        ))}
+      </div>
+
+      <div className="admin-layout">
+        <div className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Users</h2>
+            <span>{filteredUsers.length} shown</span>
+          </div>
+          <div className="admin-filters" aria-label="User filters">
+            <input
+              aria-label="Search users"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search"
+            />
+            <select aria-label="Filter by role" value={role} onChange={(event) => setRole(event.target.value)}>
+              <option value="all">All roles</option>
+              <option value="client">Clients</option>
+              <option value="freelancer">Freelancers</option>
+            </select>
+            <select
+              aria-label="Filter by status"
+              value={status}
+              onChange={(event) => setStatus(event.target.value)}
+            >
+              <option value="all">All statuses</option>
+              <option value="active">Active</option>
+              <option value="suspended">Suspended</option>
+              <option value="banned">Banned</option>
+            </select>
+          </div>
+          <div className="admin-table-wrap">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                  <th>Joined</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredUsers.map((user) => (
+                  <tr key={user.id}>
+                    <td>
+                      <button className="admin-link" type="button" onClick={() => setSelectedUserId(user.id)}>
+                        {user.name}
+                      </button>
+                      <small>{user.email}</small>
+                    </td>
+                    <td>{user.role}</td>
+                    <td>
+                      <span className={statusClass(user.status)}>{user.status}</span>
+                    </td>
+                    <td>{user.joinedAt}</td>
+                    <td>
+                      <div className="admin-actions">
+                        <button type="button" onClick={() => updateUserStatus(user.id, "suspended")}>
+                          Suspend
+                        </button>
+                        <button type="button" onClick={() => updateUserStatus(user.id, "active")}>
+                          Reinstate
+                        </button>
+                        <button type="button" onClick={() => updateUserStatus(user.id, "banned")}>
+                          Ban
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <aside className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Profile</h2>
+            <span>{selectedUser.id}</span>
+          </div>
+          <dl className="admin-profile">
+            <div>
+              <dt>Name</dt>
+              <dd>{selectedUser.name}</dd>
+            </div>
+            <div>
+              <dt>Trust</dt>
+              <dd>{selectedUser.trustScore}</dd>
+            </div>
+            <div>
+              <dt>Active jobs</dt>
+              <dd>{selectedUser.role === "client" ? 2 : selectedUser.status === "active" ? 1 : 0}</dd>
+            </div>
+            <div>
+              <dt>Disputes</dt>
+              <dd>{selectedUser.id === "usr_101" || selectedUser.id === "usr_103" ? 1 : 0}</dd>
+            </div>
+          </dl>
+          <h3>Trust Distribution</h3>
+          <div className="admin-bars">
+            {trustBuckets.map((bucket) => (
+              <div key={bucket.label}>
+                <span>{bucket.label}</span>
+                <meter min={0} max={users.length} value={bucket.count} />
+                <strong>{bucket.count}</strong>
+              </div>
+            ))}
+          </div>
+        </aside>
+      </div>
+
+      <div className="admin-layout">
+        <div className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Moderation</h2>
+            <span>{flaggedListings} open</span>
+          </div>
+          {jobs.map((job) => (
+            <article className="admin-row-card" key={job.id}>
+              <div>
+                <strong>{job.title}</strong>
+                <span>{job.client}</span>
+                <small>{job.reason}</small>
+              </div>
+              <span className={statusClass(job.status)}>{job.status}</span>
+              <div className="admin-actions">
+                <button type="button" onClick={() => moderateJob(job.id, "approved")}>
+                  Approve
+                </button>
+                <button type="button" onClick={() => moderateJob(job.id, "rejected")}>
+                  Reject
+                </button>
+                <button type="button" onClick={() => moderateJob(job.id, "escalated")}>
+                  Escalate
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Disputes</h2>
+            <span>{openDisputes} open</span>
+          </div>
+          {disputes.map((dispute) => (
+            <article className="admin-row-card" key={dispute.id}>
+              <div>
+                <strong>{dispute.job}</strong>
+                <span>{dispute.parties}</span>
+                <small>
+                  {dispute.amount} · {dispute.evidence}
+                </small>
+              </div>
+              <span className={statusClass(dispute.status)}>{dispute.status}</span>
+              <div className="admin-actions">
+                <button type="button" onClick={() => resolveDispute(dispute.id, "client")}>
+                  Client
+                </button>
+                <button type="button" onClick={() => resolveDispute(dispute.id, "freelancer")}>
+                  Freelancer
+                </button>
+                <button type="button" onClick={() => resolveDispute(dispute.id, "refund")}>
+                  Refund
+                </button>
+                <button type="button" onClick={() => resolveDispute(dispute.id, "escalate")}>
+                  Escalate
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div className="admin-layout">
+        <div className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Controls</h2>
+            <span>Admin approval required</span>
+          </div>
+          <label className="admin-toggle">
+            <span>New registrations</span>
+            <input
+              type="checkbox"
+              checked={registrationsEnabled}
+              onChange={(event) =>
+                confirmToggle("registrationsEnabled", event.target.checked, setRegistrationsEnabled)
+              }
+            />
+          </label>
+          <label className="admin-toggle">
+            <span>New job postings</span>
+            <input
+              type="checkbox"
+              checked={jobPostingsEnabled}
+              onChange={(event) =>
+                confirmToggle("jobPostingsEnabled", event.target.checked, setJobPostingsEnabled)
+              }
+            />
+          </label>
+        </div>
+
+        <div className="admin-panel">
+          <div className="admin-panel-head">
+            <h2>Audit Log</h2>
+            <span>{audit.length} entries</span>
+          </div>
+          <div className="admin-table-wrap">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>Action</th>
+                  <th>Target</th>
+                  <th>Admin</th>
+                  <th>Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {audit.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.action}</td>
+                    <td>{entry.target}</td>
+                    <td>{entry.admin}</td>
+                    <td>{entry.at}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,54 @@
 * { box-sizing: border-box; }
-body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: #101412; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
-.card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+.card { background: #17211d; border: 1px solid #31463e; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.admin-shell { color: #16211c; }
+.admin-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.admin-toolbar h1 { margin: 0; font-size: 2rem; }
+.admin-toolbar p { margin: 0.25rem 0 0; color: #617269; }
+.admin-button, .admin-actions button, .admin-link { border: 1px solid #9bb5a8; background: #f8faf7; color: #16211c; border-radius: 6px; padding: 0.45rem 0.65rem; cursor: pointer; }
+.admin-button:hover, .admin-actions button:hover, .admin-link:hover { border-color: #2f7d62; color: #14533e; }
+.admin-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.75rem; margin-bottom: 0.75rem; }
+.admin-panel { background: #f8faf7; border: 1px solid #cdd9d2; border-radius: 8px; padding: 1rem; box-shadow: 0 12px 30px rgba(6, 18, 12, 0.16); }
+.admin-metric span { display: block; color: #617269; font-size: 0.85rem; }
+.admin-metric strong { display: block; margin-top: 0.4rem; font-size: 1.55rem; }
+.admin-layout { display: grid; grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr); gap: 0.75rem; margin-bottom: 0.75rem; }
+.admin-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 0.75rem; }
+.admin-panel-head h2 { margin: 0; font-size: 1.1rem; }
+.admin-panel-head span { color: #617269; font-size: 0.85rem; }
+.admin-filters { display: grid; grid-template-columns: 1fr auto auto; gap: 0.5rem; margin-bottom: 0.75rem; }
+.admin-filters input, .admin-filters select { border: 1px solid #b9c8c0; border-radius: 6px; padding: 0.55rem 0.65rem; background: #ffffff; color: #16211c; }
+.admin-table-wrap { overflow-x: auto; }
+.admin-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+.admin-table th, .admin-table td { border-bottom: 1px solid #dfe7e2; padding: 0.65rem; text-align: left; vertical-align: top; }
+.admin-table th { color: #42544c; font-weight: 700; }
+.admin-table small, .admin-row-card small { display: block; color: #617269; margin-top: 0.25rem; }
+.admin-link { background: transparent; padding: 0; border: 0; font-weight: 700; }
+.admin-actions { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+.admin-actions button { font-size: 0.78rem; background: #ffffff; }
+.admin-badge { display: inline-flex; align-items: center; min-height: 1.45rem; border-radius: 999px; padding: 0.15rem 0.5rem; font-size: 0.76rem; font-weight: 700; }
+.admin-badge-good { background: #d9f4e7; color: #14533e; }
+.admin-badge-warn { background: #fff2ca; color: #695018; }
+.admin-badge-bad { background: #ffe0dc; color: #8b2d22; }
+.admin-profile { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; margin: 0 0 1rem; }
+.admin-profile div { border: 1px solid #dfe7e2; border-radius: 6px; padding: 0.6rem; }
+.admin-profile dt { color: #617269; font-size: 0.8rem; }
+.admin-profile dd { margin: 0.2rem 0 0; font-weight: 700; }
+.admin-bars { display: grid; gap: 0.5rem; }
+.admin-bars div { display: grid; grid-template-columns: 56px 1fr 24px; align-items: center; gap: 0.5rem; }
+.admin-bars meter { width: 100%; }
+.admin-row-card { display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; border-top: 1px solid #dfe7e2; padding: 0.75rem 0; }
+.admin-row-card:first-of-type { border-top: 0; }
+.admin-row-card > .admin-actions { grid-column: 1 / -1; }
+.admin-row-card span { display: block; color: #617269; margin-top: 0.25rem; }
+.admin-toggle { display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #dfe7e2; padding: 0.85rem 0; font-weight: 700; }
+.admin-toggle input { width: 1.2rem; height: 1.2rem; accent-color: #2f7d62; }
+
+@media (max-width: 760px) {
+  .admin-toolbar { align-items: flex-start; flex-direction: column; }
+  .admin-layout { grid-template-columns: 1fr; }
+  .admin-filters { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary\n- Replace the AdminPanelPage placeholder with an interactive admin console for users, moderation, disputes, controls, metrics, and audit log\n- Add admin-only API authorization on /api/admin routes with server-side role enforcement\n- Add paginated/filterable admin service endpoints for users, flagged jobs, disputes, controls, notifications, and audit log\n- Support admin actions for suspend/reinstate/ban, listing approve/reject/escalate, dispute rulings, and platform control toggles\n- Record admin actions in an append-only in-memory audit log and notify affected users for moderation/dispute updates\n\n## Tests\n- npm test\n- npm run build -w apps/web\n- Local preview: http://localhost:3000/admin\n\nAddresses #29