### PR TITLE
Add proof route poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Proof Route
+
+The brief arrives as measured light,
+a title, budget, careful scope;
+we pin its edges to the board
+and leave no room for drifting hope.
+
+A proposal crosses into work,
+not loud, not dressed in borrowed fire;
+just small commits with honest names,
+each one a rung of proof made higher.
+
+The API keeps a patient trace:
+who asked, who built, what changed, what passed.
+A review note lands beside the diff,
+and brittle guesses fall away fast.
+
+Then merge becomes a quiet receipt,
+not luck, not theatre, not a bet;
+the payout follows verified trust,
+a clean relay from promise to debt.
+
+So FreelanceFlow can hold the line
+between a need and work well done:
+scope, evidence, message, release,
+four signals routed into one.


### PR DESCRIPTION
/claim #76

## Summary
- Added an original project-specific poem at `POEM.md`.
- Creative note: I used a proof-routing metaphor to connect scope, commits, API traces, review notes, and payout receipts into one marketplace workflow.

## Validation
- Confirmed `POEM.md` is present at the project root.
- Confirmed the poem has five stanzas, exceeding the minimum three-stanza requirement.
- Ran `git diff --check`.
- Scope is limited to the requested Markdown artifact.