### PR TITLE
[codex] Implement Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  const message =
+    err.expose === true || statusCode < 500
+      ? err.message
+      : "Unexpected server error";
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", asyncHandler(createPayment));

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,172 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+    this.expose = true;
+  }
+}
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+    this.statusCode = 503;
+    this.expose = true;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message, statusCode, cause) {
+    super(message, { cause });
+    this.name = "PaymentProviderError";
+    this.statusCode = statusCode;
+    this.expose = true;
+  }
+}
+
+export async function createPaymentIntent(payload = {}, options = {}) {
+  const amount = validateAmount(payload.amount);
+  const currency = validateCurrency(payload.currency);
+  const metadata = validateMetadata(payload.metadata);
+  const client = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await client.paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? amount,
+      currency: paymentIntent.currency ?? currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(
+        error.message,
+        getStripeErrorStatusCode(error),
+        error
+      );
+    }
+
+    throw error;
+  }
+}
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentConfigurationError(
+      "STRIPE_SECRET_KEY is required to create payment intents."
+    );
+  }
+
+  stripeClient ??= new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentValidationError(
+      "payload.amount is required and must be a positive integer in the smallest currency unit."
+    );
+  }
+
+  return amount;
+}
+
+function validateCurrency(currency = "usd") {
+  if (typeof currency !== "string") {
+    throw new PaymentValidationError(
+      "payload.currency must be a three-letter ISO currency code."
+    );
+  }
+
+  const normalizedCurrency = currency.trim().toLowerCase();
+
+  if (!/^[a-z]{3}$/.test(normalizedCurrency)) {
+    throw new PaymentValidationError(
+      "payload.currency must be a three-letter ISO currency code."
+    );
+  }
+
+  return normalizedCurrency;
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata)
+  ) {
+    throw new PaymentValidationError("payload.metadata must be an object.");
+  }
+
+  const entries = Object.entries(metadata);
+
+  if (entries.length > 50) {
+    throw new PaymentValidationError(
+      "payload.metadata cannot contain more than 50 keys."
+    );
+  }
+
+  return entries.reduce((accumulator, [key, value]) => {
+    if (typeof key !== "string" || key.length === 0 || key.length > 40) {
+      throw new PaymentValidationError(
+        "payload.metadata keys must be 1 to 40 characters long."
+      );
+    }
+
+    if (key.includes("[") || key.includes("]")) {
+      throw new PaymentValidationError(
+        "payload.metadata keys cannot contain square brackets."
+      );
+    }
+
+    if (!["string", "number", "boolean"].includes(typeof value)) {
+      throw new PaymentValidationError(
+        "payload.metadata values must be strings, numbers, or booleans."
+      );
+    }
+
+    const normalizedValue = String(value);
+
+    if (normalizedValue.length > 500) {
+      throw new PaymentValidationError(
+        "payload.metadata values cannot exceed 500 characters."
+      );
+    }
+
+    accumulator[key] = normalizedValue;
+    return accumulator;
+  }, {});
+}
+
+function isStripeError(error) {
+  return typeof error?.type === "string" && error.type.startsWith("Stripe");
+}
+
+function getStripeErrorStatusCode(error) {
+  if (error.type === "StripeCardError") {
+    return 402;
+  }
+
+  if (error.type === "StripeInvalidRequestError") {
+    return 400;
+  }
+
+  return error.statusCode ?? 502;
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,130 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  PaymentProviderError,
+  PaymentValidationError
+} from "../services/paymentService.js";
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated fields", async () => {
+  const create = mock.fn(async (paymentIntentPayload) => ({
+    id: "pi_test_123",
+    client_secret: "pi_test_123_secret_abc",
+    amount: paymentIntentPayload.amount,
+    currency: paymentIntentPayload.currency
+  }));
+
+  const stripeClient = {
+    paymentIntents: { create }
+  };
+
+  const result = await createPaymentIntent(
+    {
+      amount: 1250,
+      currency: "USD",
+      metadata: {
+        jobId: "job_123",
+        milestone: 2,
+        escrow: true
+      }
+    },
+    { stripeClient }
+  );
+
+  assert.equal(create.mock.callCount(), 1);
+  assert.deepEqual(create.mock.calls[0].arguments[0], {
+    amount: 1250,
+    currency: "usd",
+    metadata: {
+      jobId: "job_123",
+      milestone: "2",
+      escrow: "true"
+    }
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 1250,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const create = mock.fn(async (paymentIntentPayload) => ({
+    id: "pi_test_default_currency",
+    client_secret: "pi_test_default_currency_secret",
+    amount: paymentIntentPayload.amount,
+    currency: paymentIntentPayload.currency
+  }));
+
+  await createPaymentIntent(
+    { amount: 500 },
+    { stripeClient: { paymentIntents: { create } } }
+  );
+
+  assert.deepEqual(create.mock.calls[0].arguments[0], {
+    amount: 500,
+    currency: "usd"
+  });
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  const create = mock.fn();
+
+  await assert.rejects(
+    createPaymentIntent(
+      { amount: 12.5 },
+      { stripeClient: { paymentIntents: { create } } }
+    ),
+    PaymentValidationError
+  );
+
+  assert.equal(create.mock.callCount(), 0);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Your card was declined.");
+  stripeError.type = "StripeCardError";
+  stripeError.statusCode = 402;
+
+  const create = mock.fn(async () => {
+    throw stripeError;
+  });
+
+  await assert.rejects(
+    createPaymentIntent(
+      { amount: 500, currency: "usd" },
+      { stripeClient: { paymentIntents: { create } } }
+    ),
+    (error) => {
+      assert.ok(error instanceof PaymentProviderError);
+      assert.equal(error.message, "Your card was declined.");
+      assert.equal(error.statusCode, 402);
+      assert.equal(error.cause, stripeError);
+      return true;
+    }
+  );
+});
+
+test(
+  "createPaymentIntent can create a test-mode Stripe PaymentIntent",
+  {
+    skip:
+      process.env.RUN_STRIPE_SMOKE_TEST !== "true"
+        ? "set RUN_STRIPE_SMOKE_TEST=true to run this live Stripe smoke test"
+        : !process.env.STRIPE_SECRET_KEY
+          ? "set STRIPE_SECRET_KEY to run this live Stripe smoke test"
+          : false
+  },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 50,
+      currency: "usd",
+      metadata: { test: "payment-service-smoke" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_.*_secret_/);
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Replaces the stub payment intent implementation with Stripe's Node SDK.
- Validates amount, currency, and metadata before calling Stripe.
- Returns `paymentId` and `clientSecret` from the created PaymentIntent.
- Converts Stripe API errors into exposed payment provider errors while preserving the original message.
- Adds unit coverage with a mocked Stripe client and a guarded live Stripe smoke test.

## Validation
- `npm test`

Closes #1
/claim #1