### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error.statusCode) {
+      return fail(res, error.message, error.statusCode);
+    }
+
+    return next(error);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,120 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+
+const DEFAULT_CURRENCY = "usd";
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+    this.statusCode = 400;
+  }
+}
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+    this.statusCode = 503;
+  }
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
+}
+
+let stripeClient;
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentConfigurationError("STRIPE_SECRET_KEY is required to create a payment intent.");
+  }
+
+  stripeClient = new Stripe(secretKey);
+  return stripeClient;
+}
+
+function normalizeCurrency(currency) {
+  if (currency === undefined || currency === null || currency === "") {
+    return DEFAULT_CURRENCY;
+  }
+
+  if (typeof currency !== "string" || !/^[a-zA-Z]{3}$/.test(currency)) {
+    throw new PaymentValidationError("currency must be a three-letter ISO currency code.");
+  }
+
+  return currency.toLowerCase();
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentValidationError("amount must be a positive integer in the smallest currency unit.");
+  }
+
+  return amount;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined || metadata === null) {
+    return undefined;
+  }
+
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentValidationError("metadata must be an object when provided.");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === undefined || value === null) {
+        throw new PaymentValidationError("metadata values must be strings, numbers, or booleans.");
+      }
+
+      if (!["string", "number", "boolean"].includes(typeof value)) {
+        throw new PaymentValidationError("metadata values must be strings, numbers, or booleans.");
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function isStripeError(error) {
+  return error?.type?.startsWith?.("Stripe") || error?.raw || error?.rawType;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const amount = validateAmount(payload?.amount);
+  const currency = normalizeCurrency(payload?.currency);
+  const metadata = normalizeMetadata(payload?.metadata);
+  const client = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await client.paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? amount,
+      currency: paymentIntent.currency ?? currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (isStripeError(error)) {
+      throw new PaymentProviderError(`Stripe payment intent failed: ${error.message}`);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid payment amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 0 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "amount must be a positive integer in the smallest currency unit."
+    });
+  });
+});
+
+test("POST /api/payments reports missing Stripe configuration", async () => {
+  const originalSecretKey = process.env.STRIPE_SECRET_KEY;
+  delete process.env.STRIPE_SECRET_KEY;
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount: 1500, currency: "usd" })
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "STRIPE_SECRET_KEY is required to create a payment intent."
+      });
+    });
+  } finally {
+    if (originalSecretKey === undefined) {
+      delete process.env.STRIPE_SECRET_KEY;
+    } else {
+      process.env.STRIPE_SECRET_KEY = originalSecretKey;
+    }
+  }
+});

--- a/apps/api/src/tests/paymentService.smoke.test.js
+++ b/apps/api/src/tests/paymentService.smoke.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+const shouldRunStripeSmoke =
+  process.env.RUN_STRIPE_SMOKE_TEST === "1" && Boolean(process.env.STRIPE_SECRET_KEY);
+
+test("createPaymentIntent can create a test-mode Stripe PaymentIntent", { skip: !shouldRunStripeSmoke }, async () => {
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: {
+      smoke: true,
+      source: "freelanceflow-api-test"
+    }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  PaymentProviderError,
+  PaymentValidationError
+} from "../services/paymentService.js";
+
+function createMockStripeClient(handler) {
+  return {
+    paymentIntents: {
+      create: handler
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated payload values", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(async (payload) => {
+    calls.push(payload);
+    return {
+      id: "pi_test_123",
+      client_secret: "pi_test_123_secret_abc",
+      amount: payload.amount,
+      currency: payload.currency
+    };
+  });
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: {
+        jobId: "job_123",
+        retry: 1,
+        escrowed: true
+      }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: {
+        jobId: "job_123",
+        retry: "1",
+        escrowed: "true"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+  const stripeClient = createMockStripeClient(async (payload) => {
+    calls.push(payload);
+    return {
+      id: "pi_default_currency",
+      client_secret: "pi_default_currency_secret",
+      amount: payload.amount,
+      currency: payload.currency
+    };
+  });
+
+  await createPaymentIntent({ amount: 1000 }, { stripeClient });
+
+  assert.equal(calls[0].currency, "usd");
+});
+
+test("createPaymentIntent rejects invalid amount values before calling Stripe", async () => {
+  let calls = 0;
+  const stripeClient = createMockStripeClient(async () => {
+    calls += 1;
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    PaymentValidationError
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 12.5 }, { stripeClient }),
+    PaymentValidationError
+  );
+  await assert.rejects(
+    () => createPaymentIntent({}, { stripeClient }),
+    PaymentValidationError
+  );
+
+  assert.equal(calls, 0);
+});
+
+test("createPaymentIntent rejects invalid currency and metadata", async () => {
+  const stripeClient = createMockStripeClient(async () => {
+    throw new Error("Stripe should not be called");
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usdollar" }, { stripeClient }),
+    PaymentValidationError
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: ["bad"] }, { stripeClient }),
+    PaymentValidationError
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: { bad: null } }, { stripeClient }),
+    PaymentValidationError
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = createMockStripeClient(async () => {
+    const error = new Error("No such payment method: pm_missing");
+    error.type = "StripeInvalidRequestError";
+    throw error;
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000 }, { stripeClient }),
+    (error) => {
+      assert.ok(error instanceof PaymentProviderError);
+      assert.equal(error.statusCode, 502);
+      assert.match(error.message, /No such payment method: pm_missing/);
+      return true;
+    }
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary

Implements the Stripe PaymentIntent payment service for issue #1.

/claim #1

## Changes

- Replaces the timestamp-based payment stub with a real Stripe SDK `paymentIntents.create(...)` call.
- Initializes Stripe lazily from `STRIPE_SECRET_KEY` without hardcoded credentials.
- Validates `amount`, `currency`, and metadata before provider calls.
- Maps Stripe `id` and `client_secret` to `paymentId` and `clientSecret`.
- Preserves Stripe provider error messages behind a typed API error.
- Adds route/service coverage plus a guarded live Stripe smoke test that is skipped unless explicitly enabled with a test key.

## Validation

- `npm test`
- `git diff --check`

Test result: 9 node:test tests discovered, 8 passed, 1 guarded live Stripe smoke test skipped without opt-in credentials.
