### PR TITLE
docs: add project-specific technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,27 @@
+# A Vault for Honest Work
+
+At midnight, the marketplace hums in blue,
+where clients pin their tasks like stars.
+A worker signs in, the dashboard wakes,
+and guarded tokens sleep behind the bars.
+
+No secret shouts from open code,
+no payment drifts as nameless smoke.
+The intent is shaped, the amount is checked,
+then Stripe returns the client-secret note.
+
+A banana stands beside the vault,
+bright as a warning, calm as a key.
+It keeps the small things serious:
+metadata clean, errors honest, tests set free.
+
+Messages cross the quiet wire,
+reviews arrive with careful light.
+Each proposal, job, and notification
+keeps its ledger through the night.
+
+So let the bounty board remember
+that trust is built in patient parts:
+one route, one test, one guarded field,
+one secure payment for honest hearts.
+


### PR DESCRIPTION
/claim #76

## Summary
- Adds an original five-stanza poem in `POEM.md` at the project root.
- Uses SecureBanana-specific imagery around guarded secrets, payment intents, reviews, notifications, and trustworthy marketplace work.

## One-line note
I chose a technical trust-and-payment theme so the poem feels written for this project instead of being a generic creative artifact.

## Verification
- Confirmed `POEM.md` is in the project root.
- Confirmed the poem has more than three stanzas.
- Ran `git diff --check`.