### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { createPaymentIntent, PaymentServiceError } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentServiceError) {
+      return fail(res, error.message, error.statusCode);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,82 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+
+let stripeClient;
+
+export class PaymentServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+  }
+}
+
+function getStripeClient() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY is required to create payments", 500);
+  }
+
+  stripeClient ??= new Stripe(process.env.STRIPE_SECRET_KEY);
+  return stripeClient;
+}
+
+function normalizeAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentServiceError("amount must be a positive integer in the smallest currency unit");
+  }
+
+  return amount;
+}
+
+function normalizeCurrency(currency = "usd") {
+  const normalized = String(currency).trim().toLowerCase();
+
+  if (!/^[a-z]{3}$/.test(normalized)) {
+    throw new PaymentServiceError("currency must be a three-letter ISO currency code");
+  }
+
+  return normalized;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata == null) {
+    return {};
+  }
+
+  if (typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentServiceError("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [String(key), String(value)])
+  );
+}
+
+export async function createPaymentIntent(payload = {}, options = {}) {
+  const amount = normalizeAmount(payload.amount);
+  const currency = normalizeCurrency(payload.currency);
+  const metadata = normalizeMetadata(payload.metadata);
+  const client = options.stripeClient ?? getStripeClient();
+
+  try {
+    const intent = await client.paymentIntents.create({
+      amount,
+      currency,
+      metadata,
+      automatic_payment_methods: { enabled: true }
+    });
+
+    return {
+      paymentId: intent.id,
+      clientSecret: intent.client_secret,
+      amount: intent.amount,
+      currency: intent.currency,
+      status: intent.status,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw new PaymentServiceError(
+      error?.message || "Stripe payment intent creation failed",
+      error?.statusCode || 502
+    );
+  }
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -4,7 +4,7 @@ import { createApp } from "../app.js";
 
 test("GET /health returns ok payload", async () => {
   const app = createApp();
-  const server = app.listen(0);
+  const server = app.listen(0, "127.0.0.1");
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, PaymentServiceError } from "../services/paymentService.js";
+
+test("createPaymentIntent creates a Stripe PaymentIntent with normalized input", async () => {
+  let request;
+  const stripeClient = {
+    paymentIntents: {
+      async create(payload) {
+        request = payload;
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_secret_123",
+          amount: payload.amount,
+          currency: payload.currency,
+          status: "requires_payment_method"
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: { jobId: 42, source: "checkout" }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(request, {
+    amount: 2500,
+    currency: "usd",
+    metadata: { jobId: "42", source: "checkout" },
+    automatic_payment_methods: { enabled: true }
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_secret_123",
+    amount: 2500,
+    currency: "usd",
+    status: "requires_payment_method",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  let called = false;
+  const stripeClient = {
+    paymentIntents: {
+      async create() {
+        called = true;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.statusCode === 400 &&
+      error.message === "amount must be a positive integer in the smallest currency unit"
+  );
+  assert.equal(called, false);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      async create() {
+        const error = new Error("Your card was declined");
+        error.statusCode = 402;
+        throw error;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1500 }, { stripeClient }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.statusCode === 402 &&
+      error.message === "Your card was declined"
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Closes #1

/claim #1

Scope: replaces the timestamp payment stub with Stripe PaymentIntent creation from STRIPE_SECRET_KEY, validates amount/currency/metadata before provider calls, returns paymentId and clientSecret, preserves Stripe API messages through service errors, and adds mocked payment-service tests.

Validation: npm test -w apps/api passed: 4 tests, 0 failures. Dependency install was run with lifecycle scripts disabled.