### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,10 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode = err.statusCode ?? 500;
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message: statusCode >= 500 && !err.statusCode ? "Unexpected server error" : err.message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,94 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClientFactory = (secretKey) => new Stripe(secretKey);
+
+export class PaymentServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+  }
+}
+
+export function setStripeClientFactoryForTesting(factory) {
+  stripeClientFactory = factory;
+}
+
+export function resetStripeClientFactoryForTesting() {
+  stripeClientFactory = (secretKey) => new Stripe(secretKey);
+}
+
+export async function createPaymentIntent(payload = {}) {
+  const amount = validateAmount(payload.amount);
+  const currency = validateCurrency(payload.currency ?? "usd");
+  const metadata = validateMetadata(payload.metadata);
+  const stripeSecretKey = getStripeSecretKey();
+
+  if (!stripeSecretKey) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY is required to create payment intents", 500);
+  }
+
+  try {
+    const stripe = stripeClientFactory(stripeSecretKey);
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount,
+      currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    if (error instanceof PaymentServiceError) {
+      throw error;
+    }
+
+    throw new PaymentServiceError(error.message || "Stripe payment intent creation failed", 502);
+  }
+}
+
+function getStripeSecretKey() {
+  return process.env.STRIPE_SECRET_KEY || env.stripeSecretKey;
+}
+
+function validateAmount(amount) {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new PaymentServiceError("Payment amount is required and must be a positive integer");
+  }
+
+  return amount;
+}
+
+function validateCurrency(currency) {
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentServiceError("Payment currency must be a 3-letter ISO currency code");
+  }
+
+  return currency.toLowerCase();
+}
+
+function validateMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentServiceError("Payment metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (typeof value !== "string") {
+        throw new PaymentServiceError("Payment metadata values must be strings");
+      }
+
+      return [key, value];
+    })
+  );
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  resetStripeClientFactoryForTesting,
+  setStripeClientFactoryForTesting
+} from "../services/paymentService.js";
+
+test.afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  resetStripeClientFactoryForTesting();
+});
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated defaults", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const calls = [];
+
+  setStripeClientFactoryForTesting((secretKey) => {
+    assert.equal(secretKey, "sk_test_mock");
+    return {
+      paymentIntents: {
+        create: async (args) => {
+          calls.push(args);
+          return {
+            id: "pi_mock_123",
+            client_secret: "pi_mock_123_secret_456"
+          };
+        }
+      }
+    };
+  });
+
+  const result = await createPaymentIntent({ amount: 2500 });
+
+  assert.deepEqual(calls, [{ amount: 2500, currency: "usd" }]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mock_123",
+    clientSecret: "pi_mock_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent forwards currency and string metadata", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  const calls = [];
+
+  setStripeClientFactoryForTesting(() => ({
+    paymentIntents: {
+      create: async (args) => {
+        calls.push(args);
+        return {
+          id: "pi_with_metadata",
+          client_secret: "pi_with_metadata_secret"
+        };
+      }
+    }
+  }));
+
+  await createPaymentIntent({
+    amount: 1500,
+    currency: "GBP",
+    metadata: {
+      jobId: "job_123",
+      userId: "usr_456"
+    }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      amount: 1500,
+      currency: "gbp",
+      metadata: {
+        jobId: "job_123",
+        userId: "usr_456"
+      }
+    }
+  ]);
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  let called = false;
+
+  setStripeClientFactoryForTesting(() => ({
+    paymentIntents: {
+      create: async () => {
+        called = true;
+      }
+    }
+  }));
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }),
+    /Payment amount is required and must be a positive integer/
+  );
+  assert.equal(called, false);
+});
+
+test("createPaymentIntent preserves Stripe API error messages", async () => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+
+  setStripeClientFactoryForTesting(() => ({
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined.");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  }));
+
+  await assert.rejects(() => createPaymentIntent({ amount: 2500 }), /Your card was declined/);
+});
+
+test("createPaymentIntent live Stripe smoke test", { skip: process.env.STRIPE_PAYMENT_SMOKE !== "true" }, async () => {
+  if (!process.env.STRIPE_SECRET_KEY?.startsWith("sk_test_")) {
+    throw new Error("STRIPE_PAYMENT_SMOKE requires a Stripe test-mode STRIPE_SECRET_KEY");
+  }
+
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: {
+      source: "freelanceflow-smoke-test"
+    }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.1.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Replaced the timestamp-based payment stub with Stripe PaymentIntent creation via the official Stripe Node SDK.
- Validates amount, currency, optional string metadata, and requires STRIPE_SECRET_KEY without hardcoding secrets.
- Returns Stripe's payment intent id and client_secret as paymentId/clientSecret, and preserves Stripe API error messages through the API error handler.
- Added mocked unit coverage plus a guarded live Stripe smoke test gated behind STRIPE_PAYMENT_SMOKE=true and a test-mode STRIPE_SECRET_KEY.

## Tests
- npm test
- npm run build -w apps/web

/claim #1