### PR TITLE
Add proof grid project poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Proof Grid
+
+The brief arrives with measured light,
+a title pinned to work made plain;
+scope draws its border through the night,
+and keeps the promise from the strain.
+
+A message crosses pane to pane,
+with context packed in careful lines;
+no guesswork hides inside the chain,
+no silent clause rewrites the signs.
+
+The reviewer lifts the evidence,
+lets tests and notes agree or part;
+each failing edge finds residence
+before the merge can claim a heart.
+
+The payment waits behind the gate,
+not hurried, lost, or left to chance;
+when done is done, the ledgers state
+the work may take its forward stance.
+
+So trust is built in rows we see:
+brief, signal, proof, release, and name;
+a project learns what it can be
+when every hand can trace the same.


### PR DESCRIPTION
/claim #76

Adds an original root-level `POEM.md` with five stanzas written for this project.

One-line creative note: I used a proof-grid structure so the poem follows the marketplace workflow from brief to message, review, payment, and traceable trust.

Validation:
- Confirmed `POEM.md` is at the project root
- Confirmed 5 stanzas, above the 3-stanza minimum
- `git diff --check`