### PR TITLE
Add original project poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Observatory of Finished Work
+
+At dusk the brief lifts from a client's pane,
+a small fixed star above the marketplace;
+freelancers chart its scope, then name the grain
+of hours, proof, and price with steady grace.
+
+The messages blink soft as signal fires,
+each question turning fog to measured line;
+a proposal trims its sail to what requires
+real labor, not the shimmer of "almost fine."
+
+Behind the forms, the guarded secrets sleep:
+keys, cards, and tokens folded out of sight.
+The honest rails make every promise keep
+by leaving dark things dark, and records light.
+
+Review arrives with lenses, not applause:
+it finds the missed edge, thanks the passing test,
+then marks the work against the stated clause
+so trust can rest on evidence, not guess.
+
+When payout moves, no trumpet splits the air;
+one quiet star clicks cleanly into place.
+The dashboard clears; the maker leaves it there:
+a finished orbit with a visible trace.


### PR DESCRIPTION
/claim #76

## Summary
- Added POEM.md at the repository root.
- Wrote an original five-stanza poem specifically around FreelanceFlow's brief, proposal, review, and payout flow.

## Creative decision
I used an observatory/star-chart metaphor to frame scoped freelance work as signals that become trustworthy only when tied to review evidence and payout traceability.

## Validation
- Verified POEM.md exists at the repository root.
- Verified the poem has 5 stanzas, exceeding the 3-stanza minimum.
- Ran git diff --cached --check before commit.