### PR TITLE
Add specification arc project poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Specification Arc
+
+At the edge of a brief, the first line is measured,
+not by promise alone, but by shape and constraint.
+A client names the problem in careful coordinates,
+and the workspace answers with a map that can hold.
+
+Profiles rise like markers on a drafting table,
+each skill a clean point in a widening plan.
+Messages carry context without losing their edges,
+so a proposal can land where the work actually lives.
+
+When the build begins, the proof is not theatrical;
+it is tests, screenshots, notes, and the quiet exactness of scope.
+Review turns the raw trace into shared understanding,
+one correction at a time, until both sides can point.
+
+Payment waits behind the glass of the agreed milestone,
+visible enough to steady the room, guarded enough to matter.
+No invoice has to shout when the evidence is ordered;
+the trail itself becomes the agreement's second signature.
+
+So FreelanceFlow draws its line from ask to acceptance:
+a path for trust to travel without becoming vague.
+Work enters as intention, leaves as something verifiable,
+and the handoff holds because every mark has a reason.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the repository root.
- Wrote an original five-stanza poem specifically for FreelanceFlow, centered on scope, proposal context, review evidence, milestone payment, and verifiable handoff.

## Creative decision
I used a specification-and-coordinate metaphor to frame FreelanceFlow as a path where scoped work becomes trustworthy through review evidence and traceable payout.

## Validation
- `python3` stanza/file check -> `poem_stanzas=5`, `root_file_exists=True`.
- `git diff --check` -> no whitespace errors.
- Confirmed the repository is starred as requested for AI-agent PRs.