### PR TITLE
Add original FreelanceFlow handoff poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Verified Handoff
+
+A client pins a problem to the board,
+with scope instead of static in the wire.
+A builder reads the trace, names the risk,
+then shapes a bid from evidence and fire.
+
+The contract locks its promise into escrow,
+not as a wall, but as a measured gate.
+Milestones wait like checkpoints in the pipeline,
+where shipped work proves the price of trust was straight.
+
+In FreelanceFlow, the profile is a changelog,
+each review a hash no invoice can rewrite.
+Messages carry context through the sprint room,
+and tests turn midnight guesses into light.
+
+The patch arrives with notes, repro, and reason,
+small enough for reviewers to inspect.
+Approval moves the balance from intent
+to payout, signed by what both sides respect.
+
+So let the market keep its quiet ledger:
+clear scope, fair risk, clean handoff, steady code.
+When trust is built from proof instead of posture,
+good work finds its way across the node.


### PR DESCRIPTION
Closes #76

/claim #76

Creative note: I used a verification-pipeline metaphor because FreelanceFlow turns proposals, escrow, tests, review, and payout into a traceable handoff of trust.

Validation:
- Added `POEM.md` at the repository root.
- Poem is original and written specifically around FreelanceFlow.
- Includes 5 stanzas, exceeding the 3-stanza requirement.