### PR TITLE
Add settlement loom poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Settlement Loom
+
+The brief is laid like thread across the frame,
+each measured line a promise not yet spun.
+A client names the work, the budget, claim,
+and waits for proof that craft has truly begun.
+
+A maker lifts the shuttle through the night,
+with tests for knots and comments for the seams.
+The proposal holds its pattern to the light,
+then turns a scope of wants to working beams.
+
+Escrow keeps the coin inside its hand,
+not cold, but patient, counting every pass.
+It listens for the milestones that were planned,
+and will not loose the weave for smoke or brass.
+
+Reviewers trace the fibers back to source,
+from message, diff, and artifact to trust.
+If claims pull loose, the record shows the course;
+if proof holds firm, the ledger does what it must.
+
+At merge, the cloth is lifted from the loom,
+plain enough for strangers to inspect.
+The payout crosses out the waiting room,
+and leaves behind a handoff checked and correct.


### PR DESCRIPTION
## Summary
- Add an original five-stanza `POEM.md` for issue #76.
- Creative decision: I used a settlement-loom metaphor to tie scope, proposal, escrow, review evidence, and payout into one verified handoff.

## Validation
- `git diff --check`
- `wc -l POEM.md` -> 26 lines

/claim #76