### PR TITLE
Add beacon build poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Beacon in the Build
+
+At the edge of a quiet repo,
+where tickets hum like distant wire,
+a small green check begins to glow
+and teaches doubt to turn to fire.
+
+The branch is not a bragging thing,
+it only carries proof in flight:
+a test, a note, a cleaner path,
+a narrow beam through ship-it night.
+
+Reviewers read the changed terrain,
+the logs, the diff, the reason why;
+each comment trims the unknown down
+until the merge star clears the sky.
+
+Then payout is not magic gold,
+but trust made visible and bright:
+scope kept small, evidence shown,
+and useful work delivered right.


### PR DESCRIPTION
/claim #76

Summary:
- Adds an original project-specific technical poem in `POEM.md`.
- The poem has 4 stanzas and centers on small scoped work, review evidence, merge readiness, and payout trust.

One-line note: I used a compact build-and-beacon metaphor because this bounty repo is about turning focused proof into useful shipped work.

Validation:
- `POEM.md` is in the repository root
- 4 stanzas, satisfying the 3+ stanza requirement
- `git diff --check`