### PR TITLE
feat: add original poem — The Hunt

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,76 @@
+# The Hunt
+
+_A poem for FreelanceFlow — on the craft of security research_
+
+---
+
+## I. The Surface
+
+A marketplace hums beneath its polish —  
+routes open like storefronts,  
+each endpoint a door  
+left slightly ajar.
+
+We are not thieves.  
+We are cartographers,  
+mapping what was built in haste,  
+what was wired by habit,  
+what was trusted by default.
+
+---
+
+## II. The Descent
+
+The login form is ordinary.  
+The JWT is signed — but *how*?  
+The upload route accepts a file —  
+but does it inspect the soul of it?
+
+We send what was not invited:  
+a payload shaped like a question,  
+a boundary pushed one character past comfort,  
+a role claimed that was never granted.
+
+The system flinches.  
+That flinch is data.
+
+---
+
+## III. The Report
+
+We do not celebrate the crack —  
+we close it.
+
+We write it plainly:  
+*here is the door,  
+here is what fits through it,  
+here is the lock you need.*
+
+No drama. No destruction.  
+Only the quiet satisfaction  
+of a system made  
+one degree harder to break.
+
+---
+
+## IV. The Freelancer
+
+She builds in sprints,  
+invoices in arrears,  
+trusts the platform  
+to hold her money  
+for the seventeen days  
+between proposal accepted  
+and payment cleared.
+
+She does not think about  
+SQL injection,  
+IDOR on proposal IDs,  
+or the admin route  
+that forgot to check the role.
+
+That is what we are for.
+
+---
+
+*Written for FreelanceFlow — a marketplace worth protecting.*


### PR DESCRIPTION
Closes #76

## POEM.md — "The Hunt"

An original 4-stanza free verse poem written specifically for FreelanceFlow, themed around security research and the freelancers the platform protects.

**Creative decision:** Contrasted the technical perspective (the security researcher scanning routes and payloads) with the human perspective (the freelancer who trusts the platform with her money). The tension between these two viewpoints gives meaning to the work of securing a marketplace — it is not abstract, it protects real people.

**Form:** Free verse with consistent cadence and section headers for readability.

/claim #76