### PR TITLE
Fix production JWT secret fallback

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,20 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+const DEVELOPMENT_JWT_SECRET = "development-secret";
+
+export function loadEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret = source.JWT_SECRET?.trim() || DEVELOPMENT_JWT_SECRET;
+
+  if (nodeEnv === "production" && jwtSecret === DEVELOPMENT_JWT_SECRET) {
+    throw new Error("JWT_SECRET must be set to a non-development value in production");
+  }
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret,
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: source.DATABASE_URL ?? ""
+  };
+}
+
+export const env = loadEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url);
+
+test("loadEnv keeps the development JWT fallback outside production", async () => {
+  const { loadEnv } = await importFreshEnvModule();
+
+  const env = loadEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("loadEnv rejects a missing production JWT secret", async () => {
+  const { loadEnv } = await importFreshEnvModule();
+
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production" }),
+    /JWT_SECRET must be set to a non-development value in production/
+  );
+});
+
+test("loadEnv rejects the development JWT secret in production", async () => {
+  const { loadEnv } = await importFreshEnvModule();
+
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", JWT_SECRET: "development-secret" }),
+    /JWT_SECRET must be set to a non-development value in production/
+  );
+});
+
+test("loadEnv accepts a non-default production JWT secret", async () => {
+  const { loadEnv } = await importFreshEnvModule();
+
+  const env = loadEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret-value" });
+
+  assert.equal(env.jwtSecret, "prod-secret-value");
+});
+
+test("module initialization rejects unsafe production environment", async () => {
+  await withProcessEnv({ NODE_ENV: "production" }, async () => {
+    await assert.rejects(
+      () => importFreshEnvModule(),
+      /JWT_SECRET must be set to a non-development value in production/
+    );
+  });
+});
+
+async function importFreshEnvModule() {
+  return import(`${envModuleUrl.href}?case=${Date.now()}-${Math.random()}`);
+}
+
+async function withProcessEnv(overrides, callback) {
+  const original = {
+    NODE_ENV: process.env.NODE_ENV,
+    JWT_SECRET: process.env.JWT_SECRET
+  };
+
+  delete process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+  Object.assign(process.env, overrides);
+
+  try {
+    await callback();
+  } finally {
+    restoreEnvValue("NODE_ENV", original.NODE_ENV);
+    restoreEnvValue("JWT_SECRET", original.JWT_SECRET);
+  }
+}
+
+function restoreEnvValue(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}


### PR DESCRIPTION
## Summary
- Keeps the local development JWT fallback, but rejects a missing, blank, or literal `development-secret` JWT secret in production.
- Adds environment config regression tests for development fallback, production rejection, and valid production secrets.
- Points the API test script at actual test files so `npm test` runs the health and env tests.

Fixes #755

## Context
This is the follow-up fix for the issue generated by the recursive low-hanging-fruit scanner in #756 / #743.

## Validation
- `npm test`
- `node --test apps/api/src/tests/env.test.js`
- `git diff --check`