### PR TITLE
fix(api): make npm test work on Node 22+

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #766.

## What

`apps/api/package.json` invoked the Node test runner with a bare directory:

```json
"test": "node --test src/tests"
```

Modern Node (22 / 24) treats that argument as a single module to load, so `npm test` fails before any test files are discovered:

```
Error: Cannot find module '/.../apps/api/src/tests'
  code: 'MODULE_NOT_FOUND'
```

## Fix

Use a recursive glob so the runner picks up every `*.test.js` file under `src/tests/`:

```diff
- "test": "node --test src/tests"
+ "test": "node --test \"src/tests/**/*.test.js\""
```

## Verify

```bash
npm install
npm test
```

```
> node --test "src/tests/**/*.test.js"

✔ GET /health returns ok payload
ℹ tests 1
ℹ pass 1
ℹ fail 0
```

## Scope

- Single-line change in `apps/api/package.json`
- No source code touched
- No new dependencies
- The single existing test still runs and passes
