### PR TITLE
fix: npm test fails on Node 22+ due to broken --test directory arg (#766)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
Fix for [BOUNTY 00] SecureBananaLabs/bug-bounty Issue #766

## Root cause
Node.js 22+ treats bare directory arguments to  as a single module path to require, not a discovery root. The original script:

fails with  because Node tries to  as a file.

## Fix
Changed  test script to use a recursive glob pattern:

This works on all Node versions and correctly discovers all  files under .

## Verification


Closes #766