### PR TITLE
fix: keep registration token subject aligned

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser returns an id that matches the access token subject", async () => {
+  const originalNow = Date.now;
+  let calls = 0;
+  Date.now = () => 1000 + calls++;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const decoded = jwt.decode(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, result.role);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Fixes #770

## Summary

`registerUser` generated the response `id` and JWT `sub` with two separate `Date.now()` calls. If those calls crossed a millisecond boundary, the API could return one user id while the token identified a different subject.

This PR generates the registration `userId` once and reuses it for both:

- response `id`
- access token `sub`

## Demo

![demo](https://github.com/adliebe/bug-bounty/releases/download/securebanana-pr770-demo-20260527T0718/securebanana-pr770-demo-20260527T0718.gif)

## Validation

```bash
cd apps/api
node --test src/tests/*.test.js
```

Result:

```text
2 tests passed
0 failed
```

Note: the root `npm test` script is currently affected by the already-filed Node 22+ directory test-runner issue #766, so the validation above calls the test files directly.