### PR TITLE
fix: add budget range validation to createJobSchema

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,12 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMin"]
+  }
+);
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary

Adds a Zod `.refine()` to `createJobSchema` that validates `budgetMin <= budgetMax`. Previously, any nonnegative number was accepted for both fields independently, allowing invalid ranges like `{ budgetMin: 5000, budgetMax: 100 }`.

## Changes

- `apps/api/src/validators/job.js` — added `.refine()` with message `"budgetMin must be less than or equal to budgetMax"` on path `["budgetMin"]`

## Testing

Run the following in the repo to verify the validation works:

```js
import { createJobSchema } from "./validators/job.js";

// Should pass
createJobSchema.parse({ title: "test job", description: "a ten char desc", budgetMin: 100, budgetMax: 500, categoryId: "cat-1" });

// Should throw — budgetMin > budgetMax
createJobSchema.parse({ title: "test job", description: "a ten char desc", budgetMin: 500, budgetMax: 100, categoryId: "cat-1" });
```

Closes #772