### PR TITLE
fix: restrict admin metrics to admin role

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,15 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...allowedRoles) {
+  const allowed = new Set(allowedRoles);
+
+  return function requireRoleMiddleware(req, res, next) {
+    if (!req.user || !allowed.has(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-auth.test.js
+++ b/apps/api/src/tests/admin-auth.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { metrics } from "../controllers/adminController.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+async function requestAdminMetrics(role) {
+  const token = role ? signAccessToken({ sub: `usr_${role}`, role }) : null;
+  const req = {
+    headers: token ? { authorization: `Bearer ${token}` } : {}
+  };
+  const res = createMockResponse();
+
+  let authenticated = false;
+  authMiddleware(req, res, () => {
+    authenticated = true;
+  });
+
+  if (!authenticated) {
+    return res;
+  }
+
+  let authorized = false;
+  requireRole("admin")(req, res, () => {
+    authorized = true;
+  });
+
+  if (!authorized) {
+    return res;
+  }
+
+  await metrics(req, res);
+  return res;
+}
+
+test("admin metrics rejects requests without a token", async () => {
+  const res = await requestAdminMetrics();
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.body, { success: false, message: "Unauthorized" });
+});
+
+test("admin metrics rejects authenticated non-admin users", async () => {
+  const res = await requestAdminMetrics("client");
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("admin metrics allows admin users", async () => {
+  const res = await requestAdminMetrics("admin");
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.openJobs, 42);
+});


### PR DESCRIPTION
/claim #743

Fixes #774

## Summary
- add a reusable `requireRole` middleware for authenticated route role checks
- apply `requireRole("admin")` to `/api/admin/*` routes so client/freelancer JWTs cannot read admin metrics
- add focused regression tests for missing token, non-admin token, and admin token access

## Demo
https://github.com/tiago918/bug-bounty/releases/download/securebanana-pr774-demo-20260527T1134Z/securebanana-pr774-demo.mp4

## Validation
```bash
node --test apps/api/src/tests/*.test.js
git diff --check
ffprobe -v error -show_entries stream=codec_name,width,height,duration -of default=noprint_wrappers=1 /tmp/securebanana-pr774-demo.mp4
```

Result:
```text
4 tests passed
0 failed
codec_name=h264
width=1280
height=720
duration=14.000000
```

Note: `npm test -w apps/api` is currently affected by the already-filed Node 22+ test directory issue #766, so validation calls the test files directly.