### PR TITLE
fix: return validation errors as bad requests

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,23 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+        code: issue.code
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/error-handler.test.js
+++ b/apps/api/src/tests/error-handler.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 for Zod validation errors", () => {
+  const schema = z.object({
+    email: z.string().email()
+  });
+  const res = createMockResponse();
+
+  try {
+    schema.parse({ email: "not-an-email" });
+  } catch (error) {
+    errorHandler(error, {}, res, () => {});
+  }
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, "Validation error");
+  assert.deepEqual(res.body.errors, [
+    {
+      path: "email",
+      message: "Invalid email",
+      code: "invalid_string"
+    }
+  ]);
+});
+
+test("errorHandler keeps unknown errors as 500 responses", () => {
+  const originalError = console.error;
+  const res = createMockResponse();
+
+  console.error = () => {};
+  try {
+    errorHandler(new Error("boom"), {}, res, () => {});
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #776

## Summary
- detect `ZodError` in the global API `errorHandler`
- return HTTP 400 with stable field-level validation details for invalid API input
- keep unknown errors on the existing HTTP 500 path
- add focused regression tests for validation errors and unknown errors

## Demo
https://github.com/tiago918/bug-bounty/releases/download/securebanana-pr776-demo-20260527T1148Z/securebanana-pr776-demo.mp4

## Validation
```bash
node --test apps/api/src/tests/*.test.js
git diff --check
ffprobe -v error -show_entries stream=codec_name,width,height,duration -of default=noprint_wrappers=1 /tmp/securebanana-pr776-demo.mp4
```

Result:
```text
3 tests passed
0 failed
codec_name=h264
width=1280
height=720
duration=13.000000
```

Note: `npm test -w apps/api` is currently affected by the already-filed Node 22+ test directory issue #766, so validation calls the test files directly.