### PR TITLE
fix(api): validate job budget range

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a landing page",
+  description: "Create a polished landing page for launch.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["javascript"]
+};
+
+test("createJobSchema rejects budgets where max is below min", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 10
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+  assert.equal(result.error.issues[0].message, "budgetMax must be greater than or equal to budgetMin");
+});
+
+test("createJobSchema accepts equal min and max budgets", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 250,
+    budgetMax: 250
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects invalid budget ranges when both values are provided", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 900,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema still accepts partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 900 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 900 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+function hasValidBudgetRange(payload) {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+
+  return payload.budgetMax >= payload.budgetMin;
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- prevent job create/update validation from accepting a `budgetMax` lower than `budgetMin`
- keep partial job updates valid when only one budget field is present
- add `node:test` coverage for invalid, equal, and partial budget ranges

Fixes #778

/claim #743

## Demo / validation evidence
This PR addresses the exact payload from #778:

```json
{
  "title": "Invalid budget range",
  "description": "This job has an impossible budget range.",
  "budgetMin": 1000,
  "budgetMax": 10,
  "categoryId": "web",
  "skills": ["javascript"]
}
```

Expected result after this change: `createJobSchema.safeParse(...)` rejects the payload with the error path `budgetMax` and message `budgetMax must be greater than or equal to budgetMin`.

The added regression coverage demonstrates:
- `createJobSchema` rejects `budgetMax < budgetMin`
- `createJobSchema` accepts equal min/max budgets
- `updateJobSchema` rejects invalid ranges when both values are provided
- `updateJobSchema` still accepts partial budget updates when only one budget field is present

## Validation
- Added focused `node:test` coverage in `apps/api/src/tests/jobValidator.test.js`.
- Not run locally: this environment cannot execute `node.exe` (`Access is denied`) and `npm` is not available in PATH.

## Notes
The failing `update-leaderboard` workflow appears unrelated to this code change: it reached the final `git push` step and GitHub rejected the push with `remote: Internal Server Error`.
