### PR TITLE
fix: require auth for refresh endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
 
 export const authRoutes = Router();
@@ -6,4 +7,4 @@ export const authRoutes = Router();
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh refreshes the authenticated user's identity", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_refresh_subject", role: "freelancer" });
+
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const decoded = verifyAccessToken(payload.data.token);
+    assert.equal(decoded.sub, "usr_refresh_subject");
+    assert.equal(decoded.role, "freelancer");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary

Fixes #782 by requiring authentication before `POST /api/auth/refresh` can mint a new access token.

## What changed

- Applies the existing `authMiddleware` to `POST /api/auth/refresh`.
- Passes the authenticated `req.user` identity into the refresh service.
- Signs refreshed tokens from the caller's `sub` and `role` instead of hard-coded `usr_existing` / `client` values.
- Adds regression tests for unauthenticated rejection and authenticated identity preservation.

## Validation

```text
cd apps/api
node --test src/tests/*.test.js

3 passed
0 failed
```

## Demo

Short demo GIF: https://github.com/adliebe/bug-bounty/releases/download/securebanana-pr782-demo-20260527T090214/securebanana-pr782-demo-20260527T090214.gif