### PR TITLE
fix: validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects an empty message payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid message payload");
+  });
+});
+
+test("POST /api/messages stores a valid message payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_sender",
+        receiverId: "usr_receiver",
+        body: "Hello from a valid message"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.senderId, "usr_sender");
+    assert.equal(payload.data.receiverId, "usr_receiver");
+    assert.equal(payload.data.body, "Hello from a valid message");
+    assert.equal(payload.data.isRead, false);
+    assert.match(payload.data.id, /^msg_/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().min(1),
+  receiverId: z.string().min(1),
+  body: z.string().trim().min(1),
+  isRead: z.boolean().default(false)
+});


### PR DESCRIPTION
/claim #743

Fixes #789

## Summary

`POST /api/messages` accepted `{}` and stored a successful message with no sender, receiver, or body. This PR keeps the fix narrow:

- add `createMessageSchema` requiring `senderId`, `receiverId`, and non-empty `body`
- reject invalid message creation requests with HTTP 400
- preserve valid message creation and default `isRead` to `false`
- add focused API regression tests for invalid and valid message creation

## Demo

![message validation demo](https://github.com/adliebe/bug-bounty/releases/download/securebanana-message-validation-demo-20260527T1330Z/securebanana-message-validation-demo-20260527T1330Z.gif)

## Validation

```bash
node --test apps/api/src/tests/health.test.js apps/api/src/tests/message.test.js
node --check apps/api/src/controllers/messageController.js
node --check apps/api/src/validators/message.js
node --check apps/api/src/tests/message.test.js
git diff --check
```

Result:

```text
3 tests passed
0 failed
```