### PR TITLE
fix(auth): add role-based access control for admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -2,15 +2,27 @@ import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
-    return fail(res, "Unauthorized", 401);
-  }
+ const authHeader = req.headers.authorization;
+ if (!authHeader?.startsWith("Bearer ")) {
+ return fail(res, "Unauthorized", 401);
+ }
 
-  try {
-    req.user = verifyAccessToken(authHeader.slice(7));
-    return next();
-  } catch {
-    return fail(res, "Invalid token", 401);
-  }
+ try {
+ req.user = verifyAccessToken(authHeader.slice(7));
+ return next();
+ } catch {
+ return fail(res, "Invalid token", 401);
+ }
+}
+
+export function requireRole(...roles) {
+ return (req, res, next) => {
+ if (!req.user) {
+ return fail(res, "Unauthorized", 401);
+ }
+ if (!roles.includes(req.user.role)) {
+ return fail(res, "Forbidden: insufficient role", 403);
+ }
+ return next();
+ };
 }

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary
Fixes #795 — Admin `/api/admin/metrics` endpoint now enforces role-based access control.

## Changes
- Added `requireRole(...roles)` middleware in `auth.js` that checks `req.user.role`
- Applied `requireRole("admin")` to all admin routes
- Non-admin authenticated users now receive 403 Forbidden instead of 200 OK

## Testing
- Client JWT → GET /api/admin/metrics → 403 Forbidden
- Admin JWT → GET /api/admin/metrics → 200 OK
- No JWT → 401 Unauthorized (unchanged)

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.