### PR TITLE
fix(jobs): add budgetMax >= budgetMin cross-field validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,15 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+ title: z.string().min(4),
+ description: z.string().min(10),
+ budgetMin: z.number().nonnegative(),
+ budgetMax: z.number().nonnegative(),
+ categoryId: z.string().min(1),
+ skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+ message: "budgetMax must be greater than or equal to budgetMin",
+ path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Fixes #796 — createJobSchema now enforces budgetMax >= budgetMin using Zod .refine(). Returns 400 with descriptive error when violated.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.