### PR TITLE
fix(auth): remove admin from register schema — prevent privilege escalation

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+ email: z.string().email(),
+ password: z.string().min(8),
+ role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #797 — Removes "admin" from the registerSchema role enum. Users can no longer self-assign admin role during registration. Admin accounts must be provisioned separately.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.