### PR TITLE
fix(upload): add file size limit (5MB) and MIME type allowlist

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,8 +1,27 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = [
+ "image/jpeg",
+ "image/png",
+ "image/gif",
+ "image/webp",
+ "application/pdf"
+];
+
+const upload = multer({
+ storage: multer.memoryStorage(),
+ limits: { fileSize: 5 * 1024 * 1024 }, // 5MB max
+ fileFilter(_req, file, cb) {
+ if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+ cb(null, true);
+ } else {
+ cb(new Error(`Unsupported file type: ${file.mimetype}. Allowed: ${ALLOWED_MIME_TYPES.join(", ")}`));
+ }
+ }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
Fixes #799 — Adds multer file size limit (5MB) and MIME type filter (jpeg, png, gif, webp, pdf only). Prevents arbitrary file upload and memory exhaustion DoS.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.