### PR TITLE
fix(payments): add Zod schema validation for payment creation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+ const payload = createPaymentSchema.parse(req.body);
+ return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.strictObject({
+ amount: z.number().positive("Amount must be positive").min(0.01, "Minimum amount is 0.01"),
+ currency: z.string().min(3).max(3).default("usd")
+});


### PR DESCRIPTION
Fixes #800 — Adds `createPaymentSchema` (Zod strictObject) that validates amount (positive, min 0.01), currency (3-char, defaults "usd"), and rejects unknown fields. Prevents negative/zero amounts and arbitrary payload injection.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.