### PR TITLE
Add project-specific FreelanceFlow poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# FreelanceFlow at the Checkout
+
+A brief is pinned beneath the morning light,
+where builders scan the work that needs a name;
+a client measures trust against the night,
+and every bid arrives with quiet aim.
+
+The dashboard hums with messages and proof,
+with milestones waiting for a careful hand;
+from profile page to payment, root to roof,
+the marketplace begins to understand.
+
+No flourish pays the invoice on its own,
+no clever line can make a promise true;
+the strongest systems make the labor known,
+then let the honest ledger carry through.
+
+So ship the page, protect the final mile,
+let escrow, review, and service move as one;
+where freelancers find a fairer workflow style,
+the project turns from placeholder into done.


### PR DESCRIPTION
Closes #76

## Summary
- Added `POEM.md` at the repository root.
- Wrote an original four-stanza poem for FreelanceFlow, referencing the marketplace, dashboards, milestones, escrow, review, and payment flow.

## Creative decision
I used a restrained technical lyric style so the poem feels specific to a freelance marketplace without distracting from the product context.

## Validation
- Root `POEM.md` only.
- Minimum 3 stanzas satisfied with 4 stanzas.
- No code or unrelated files changed.
