### PR TITLE
fix: prevent admin role self-assignment in registration (fixes #797)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## SummaryFix for [BOUNTY] Register endpoint allows self-assignment of admin role privilege escalation Issue #797## Root causeThe registerSchema in apps/api/src/validators/auth.js included admin as a valid enum value for the role field allowing any user to register as an admin.## FixRemoved admin from the role enum. The role field now only allows client and freelancer. Admin accounts can only be created through a separate authorized process.Closes #797