### PR TITLE
Harden API CORS origin policy

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { corsOriginGuard, createCorsOptions } from "./config/cors.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -15,11 +16,12 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp(options = {}) {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(corsOriginGuard(options));
+  app.use(cors(createCorsOptions(options)));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/cors.js
+++ b/apps/api/src/config/cors.js
@@ -1,0 +1,47 @@
+import { env } from "./env.js";
+
+function normalizeConfig(options = {}) {
+  return {
+    nodeEnv: options.nodeEnv ?? env.nodeEnv,
+    corsOrigins: options.corsOrigins ?? env.corsOrigins
+  };
+}
+
+function allowsAnyOrigin({ nodeEnv, corsOrigins }) {
+  return corsOrigins.includes("*") || (nodeEnv !== "production" && corsOrigins.length === 0);
+}
+
+export function isCorsOriginAllowed(origin, options = {}) {
+  const config = normalizeConfig(options);
+
+  if (!origin) {
+    return true;
+  }
+
+  if (allowsAnyOrigin(config)) {
+    return true;
+  }
+
+  return config.corsOrigins.includes(origin);
+}
+
+export function corsOriginGuard(options = {}) {
+  return function guardCorsOrigin(req, res, next) {
+    if (isCorsOriginAllowed(req.headers.origin, options)) {
+      return next();
+    }
+
+    return res.status(403).json({
+      success: false,
+      message: "CORS origin not allowed"
+    });
+  };
+}
+
+export function createCorsOptions(options = {}) {
+  return {
+    origin(origin, callback) {
+      callback(null, isCorsOriginAllowed(origin, options));
+    }
+  };
+}

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,9 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: (process.env.CORS_ORIGINS ?? process.env.CORS_ORIGIN ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean)
 };

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(app, callback) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("development CORS reflects browser origins by default", async () => {
+  const app = createApp({ nodeEnv: "development", corsOrigins: [] });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { Origin: "https://local.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "https://local.example");
+  });
+});
+
+test("production CORS allows configured browser origins", async () => {
+  const app = createApp({
+    nodeEnv: "production",
+    corsOrigins: ["https://app.example.com"]
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { Origin: "https://app.example.com" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "https://app.example.com");
+  });
+});
+
+test("production CORS rejects unconfigured browser origins", async () => {
+  const app = createApp({
+    nodeEnv: "production",
+    corsOrigins: ["https://app.example.com"]
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { Origin: "https://evil.example" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "CORS origin not allowed"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #848

## Summary
- Replaces the API-wide default wildcard CORS behavior with an environment-backed origin allowlist.
- Adds a small production guard that returns `403` for browser origins not in the allowlist.
- Keeps development/test convenient when no allowlist is configured.

## Approach
- Added `CORS_ORIGINS` / `CORS_ORIGIN` parsing in API env config.
- Added a focused CORS helper/guard so the policy is isolated from route logic.
- Added API tests for default development behavior, production allowed origin, and production rejected origin.

## Security review
- Reduces production browser-readable API exposure from arbitrary origins.
- Does not change auth, payment, upload, message, notification, or data service behavior.
- No secrets or hardcoded production domains are added; allowed origins stay environment-controlled.

## Verification
- `npm test` from `apps/api` passes: 4/4 tests.
- `git diff --check` passes.