### PR TITLE
Fix: Add authentication middleware to all API routes (CWE-306)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
+import { authMiddleware } from "./middleware/auth.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -28,15 +29,15 @@ export function createApp() {
   });
 
   app.use("/api/auth", authRoutes);
-  app.use("/api/users", userRoutes);
-  app.use("/api/jobs", jobRoutes);
-  app.use("/api/proposals", proposalRoutes);
-  app.use("/api/payments", paymentRoutes);
-  app.use("/api/reviews", reviewRoutes);
-  app.use("/api/messages", messageRoutes);
-  app.use("/api/notifications", notificationRoutes);
-  app.use("/api/uploads", uploadRoutes);
-  app.use("/api/search", searchRoutes);
+  app.use("/api/users", authMiddleware, userRoutes);
+  app.use("/api/jobs", authMiddleware, jobRoutes);
+  app.use("/api/proposals", authMiddleware, proposalRoutes);
+  app.use("/api/payments", authMiddleware, paymentRoutes);
+  app.use("/api/reviews", authMiddleware, reviewRoutes);
+  app.use("/api/messages", authMiddleware, messageRoutes);
+  app.use("/api/notifications", authMiddleware, notificationRoutes);
+  app.use("/api/uploads", authMiddleware, uploadRoutes);
+  app.use("/api/search", authMiddleware, searchRoutes);
   app.use("/api/admin", adminRoutes);
 
   app.use(errorHandler);


### PR DESCRIPTION
## Problem
Auth middleware was only applied to admin routes. All other API routes were completely public — no authentication required.

## Fix
Applied `authMiddleware` at the app level to all non-auth routes:
`/api/users`, `/api/jobs`, `/api/proposals`, `/api/payments`, `/api/reviews`, `/api/messages`, `/api/notifications`, `/api/uploads`, `/api/search`

Auth routes (`/api/auth`) remain public for login/register/refresh.
Admin routes already had their own auth middleware.

## Verification
```bash
# Before: No auth needed for any endpoint
curl http://localhost:4000/api/jobs  # Returns data without token

# After: Returns 401 without valid token
curl http://localhost:4000/api/jobs  # {success:false,message:Unauthorized}
```

Closes #871