### PR TITLE
Fix: Validate API PORT configuration at startup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,15 @@
+function parsePort(value) {
+  if (value === undefined || value === null) return 4000;
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(\`Invalid PORT configuration: "\${value}". Must be an integer between 1 and 65535.\`);
+  }
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Problem
`Number(process.env.PORT ?? 4000)` allows NaN values to flow through when PORT is non-numeric, negative, fractional, or out of range. This causes silent crashes at `app.listen()`.

## Fix
Added `parsePort()` function:
- Returns `4000` when PORT is unset/null
- Validates the parsed integer is between 1-65535
- Throws a clear error for invalid values at startup

```
Invalid PORT configuration: "not-a-number". Must be an integer between 1 and 65535.
```

Closes #873