### PR TITLE
Return 404 for missing dynamic detail records

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,30 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { findFreelancerByUsername, freelancers } from "../../../lib/mock";
+
+export function generateStaticParams() {
+  return freelancers.map((freelancer) => ({ username: freelancer.username }));
+}
+
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+  const freelancer = findFreelancerByUsername(username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>{freelancer.summary}</p>
+      <p>{freelancer.skills.join(" · ")}</p>
+      <p>
+        Rate: <strong>{freelancer.rate}</strong>
+      </p>
     </section>
   );
 }

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,29 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { notFound } from "next/navigation";
+import { findJobById, jobs } from "../../../lib/mock";
+
+export function generateStaticParams() {
+  return jobs.map((job) => ({ id: job.id }));
+}
+
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+  const job = findJobById(id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>{job.description}</p>
+      <p>
+        Budget: <strong>{job.budget}</strong>
+      </p>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,10 +1,43 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    description: "Create a lightweight support assistant with handoff flows and analytics."
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    description: "Move an aging REST API to the platform Node.js service layer."
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    description: "Map and prototype onboarding paths for a B2B SaaS dashboard."
+  }
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    summary: "Frontend engineer focused on production-ready React dashboards."
+  },
+  {
+    username: "jordan-ux",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    summary: "Product designer who turns research into clear onboarding flows."
+  }
 ];
+
+export function findJobById(id: string) {
+  return jobs.find((job) => job.id === id);
+}
+
+export function findFreelancerByUsername(username: string) {
+  return freelancers.find((freelancer) => freelancer.username === username);
+}


### PR DESCRIPTION
Closes #876
Refs #743
/claim #743

## Summary
- resolve job and freelancer detail routes against the known mock data before rendering
- return Next.js `notFound()` for unknown job ids or freelancer usernames
- render real mock detail fields for valid records and prebuild known dynamic params

## Evidence
- Issue #876 was created by this account with the required #743 creator-only clause.
- The PR is scoped to that issue and fixes the invalid dynamic detail pages described there.

## Validation
- `npm run build -w apps/web`
- `git diff --check`
- `next start` smoke checks:
  - `GET /jobs/job-101` -> 200
  - `GET /jobs/not-a-real-job` -> 404
  - `GET /freelancers/maya-dev` -> 200
  - `GET /freelancers/not-a-real-user` -> 404

No secrets, private keys, wallet material, production credentials, or payout/off-ramp claims are included.