### PR TITLE
Preserve native props on shared UI components

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit --jsx react-jsx --moduleResolution bundler --module esnext --target es2020 --strict src/ui-props.test.tsx"
+  }
 }

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, style, ...props }: ButtonProps) {
   return (
     <button
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+};
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...props}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>

--- a/packages/ui/src/ui-props.test.tsx
+++ b/packages/ui/src/ui-props.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Button } from "./Button";
+import { Card } from "./Card";
+
+const button = (
+  <Button
+    aria-label="Save changes"
+    className="primary-action"
+    disabled
+    onClick={() => undefined}
+    style={{ marginTop: 8 }}
+    type="submit"
+  >
+    Save
+  </Button>
+);
+
+const card = (
+  <Card
+    aria-labelledby="profile-card"
+    className="profile-card"
+    data-testid="profile-card"
+    style={{ marginTop: 12 }}
+    title="Profile"
+  >
+    {button}
+  </Card>
+);
+
+void card;


### PR DESCRIPTION
/claim #743

Fixes #888.

## Summary
- widen `Button` to native `button` attributes so consumers can pass `type`, `onClick`, `disabled`, `aria-*`, `className`, `style`, and other standard props
- widen `Card` to native section attributes so consumers can pass `className`, `aria-labelledby`, `data-*`, `style`, and other standard props
- merge caller styles after the existing default styles so the shared components keep their current look while remaining usable in real forms and accessible UI
- add a small type-usage regression covering the expected Button/Card props

## Validation
- `npm run typecheck -w packages/ui`
- `git diff --check`

No secrets, private keys, wallet material, production credentials, private data, or payout/off-ramp claims are included.