### PR TITLE
Validate auth token identity claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,19 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const ALLOWED_ROLES = new Set(["client", "freelancer", "admin"]);
+
+function isValidAccessTokenPayload(payload) {
+  return (
+    payload &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    typeof payload.sub === "string" &&
+    payload.sub.trim().length > 0 &&
+    ALLOWED_ROLES.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +21,12 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!isValidAccessTokenPayload(payload)) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authClaims.test.js
+++ b/apps/api/src/tests/authClaims.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function bearer(payload) {
+  return `Bearer ${jwt.sign(payload, env.jwtSecret)}`;
+}
+
+test("protected routes accept valid access-token identity claims", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: bearer({ sub: "usr_123", role: "client" })
+      }
+    });
+
+    assert.equal(response.status, 200);
+  });
+});
+
+test("protected routes reject signed string JWT payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: bearer("usr_123")
+      }
+    });
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("protected routes reject tokens missing subject claims", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: bearer({ role: "client" })
+      }
+    });
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("protected routes reject tokens with unsupported roles", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: bearer({ sub: "usr_123", role: "owner" })
+      }
+    });
+
+    assert.equal(response.status, 401);
+  });
+});
+


### PR DESCRIPTION
## Problem
Protected routes accepted any JWT that verified with the shared secret, even when the decoded payload was a string or an object without identity claims. That left `req.user` without guaranteed `sub`/`role` fields for protected handlers and future route-level authorization checks.

## Root Cause
`authMiddleware` assigned the raw `verifyAccessToken()` result directly to `req.user` without validating the decoded payload shape.

## Approach
- Require verified access-token payloads to be objects.
- Require a non-empty string `sub` claim.
- Require `role` to be one of `client`, `freelancer`, or `admin`.
- Preserve valid app-issued access tokens.
- Add focused API tests for valid claims, string payloads, missing subject, and unsupported role.

## Security Review
This tightens the auth boundary without changing token signing, token secrets, or route authorization. It does not expose tokens or secrets in logs/tests. Route role authorization remains separate and intentionally out of scope for this small fix.

## Verification
- `npm test -w apps/api` -> 5 passed
- `git diff --check` -> pass with Windows line-ending warnings only

Fixes #921
/claim #743