### PR TITLE
Add marketplace trust poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger Of Trust
+
+At first there is only a brief on the screen,
+a client with a deadline, a budget, a doubt.
+The job is a promise not yet made clean,
+until the right hands come forward and sort it out.
+
+Profiles carry proof in a practical light:
+skills, rates, reviews, and the work done before.
+A proposal is more than a number typed right;
+it is a plan laid gently at someone else's door.
+
+Messages keep the project from drifting apart,
+small confirmations where confidence grows.
+Every milestone asks for both craft and heart,
+and every invoice should tell what everyone knows.
+
+Payments should move with a quiet, exact grace,
+held until the agreed work can stand on its own.
+When disputes appear, the system leaves space
+for evidence, fairness, and a human tone.
+
+So FreelanceFlow runs on more than code:
+on clear states, clean records, and promises kept.
+Trust is the route, and the route is the road,
+from the first posted task to the final accept.


### PR DESCRIPTION
/claim #76

Creative decision: I used a marketplace-trust theme so the poem ties directly to FreelanceFlow's proposals, milestones, payments, disputes, reviews, and records.

Changes:
- Added `POEM.md` at the project root.
- Kept the contribution scoped to a single original markdown poem with five stanzas.

Validation:
- `git diff --check`