### PR TITLE
Pin web Turbopack root to repository

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,10 @@
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  turbopack: {
+    root: path.resolve(__dirname, "../..")
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
/claim #743

Fixes #924.

Summary:
- Pins the web app Turbopack root to the monorepo root in `apps/web/next.config.js`.
- Prevents Next from inferring a parent directory outside the repository when another lockfile exists above the repo.

Validation:
- `npm run build -w apps/web` passed without the previous workspace-root inference warning.
- `git diff --check` passed.