### PR TITLE
Return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof SyntaxError && err.status === 400 && err.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformed-json.test.js
+++ b/apps/api/src/tests/malformed-json.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return a client error", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"title\":"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});


### PR DESCRIPTION
Fixes #926

/claim #743

## Summary
- Detect Express/body-parser `entity.parse.failed` syntax errors in the API error handler.
- Return HTTP 400 with a clear JSON error for malformed request bodies instead of the generic HTTP 500 response.
- Add a focused regression test that posts invalid JSON to `/api/jobs`.

## Validation
```bash
node --test src/tests/*.test.js
```

Result:
```text
✔ GET /health returns ok payload
✔ malformed JSON request bodies return a client error
ℹ pass 2
ℹ fail 0
```

## Demo
The new regression test exercises the full Express app over HTTP by sending `Content-Type: application/json` with body `{"title":` to `/api/jobs` and asserting the response is HTTP 400 with `{ "success": false, "message": "Malformed JSON request body" }`.
