### PR TITLE
Return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { fail } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +39,10 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use("/api", (req, res) => {
+    return fail(res, "API route not found", 404);
+  });
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,25 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("unknown API routes return JSON 404 payloads", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.match(response.headers.get("content-type"), /application\/json/);
+  assert.deepEqual(payload, { success: false, message: "API route not found" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- Add an API catch-all handler so unknown `/api/*` paths return the standard JSON error envelope instead of Express' HTML 404 page.
- Add test coverage for `GET /api/does-not-exist`.

Fixes #932
/claim #743

## Validation
- `node --test apps/api/src/tests/*.test.js`

Note: `npm test -w apps/api` still fails on `main` because the existing test script uses `node --test src/tests` on Node 22, which is already covered separately by #766/#767.