### PR TITLE
Add reproducible API benchmark suite

### DIFF
--- a/.env.benchmark.example
+++ b/.env.benchmark.example
@@ -1,0 +1,11 @@
+# Copy to .env.benchmark for local overrides.
+BENCHMARK_TARGET_URL=local
+BENCHMARK_CONCURRENCY=4
+BENCHMARK_DURATION_MS=1500
+BENCHMARK_WARMUP_REQUESTS=2
+BENCHMARK_OUTPUT_DIR=benchmarks/results
+BENCHMARK_THRESHOLDS=benchmarks/thresholds.json
+BENCHMARK_DISABLE_RATE_LIMIT=1
+
+# Required only when BENCHMARK_TARGET_URL is an external server.
+# BENCHMARK_TOKEN=

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -1,0 +1,22 @@
+name: benchmark-smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/benchmark-smoke.yml"
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run benchmark:smoke

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export const apiLimiter = process.env.BENCHMARK_DISABLE_RATE_LIMIT === "1"
+  ? (req, res, next) => next()
+  : rateLimit({
+      windowMs: 15 * 60 * 1000,
+      limit: 200,
+      standardHeaders: "draft-7",
+      legacyHeaders: false
+    });

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,31 @@
+# API Benchmarks
+
+This suite benchmarks every route mounted under `/api/` and writes reproducible JSON and Markdown reports to `benchmarks/results/`.
+
+## Commands
+
+```bash
+npm run benchmark
+npm run benchmark:smoke
+```
+
+By default, the runner starts the local Express API on loopback and generates a dedicated benchmark bearer token for the protected admin metrics route. Set `BENCHMARK_TARGET_URL` to benchmark an already-running local or staging API instead.
+
+## Configuration
+
+Copy `.env.benchmark.example` to `.env.benchmark` and adjust values as needed.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BENCHMARK_TARGET_URL` | `local` | Use `local` to start the API in-process, or set a URL such as `http://127.0.0.1:4000`. |
+| `BENCHMARK_TOKEN` | generated locally | Bearer token for auth-protected routes when benchmarking an external target. |
+| `BENCHMARK_CONCURRENCY` | `4` full, `1` smoke | Concurrent workers per endpoint. |
+| `BENCHMARK_DURATION_MS` | `1500` full, `250` smoke | Load duration per endpoint. |
+| `BENCHMARK_WARMUP_REQUESTS` | `2` full, `1` smoke | Warmup requests before recording samples. |
+| `BENCHMARK_OUTPUT_DIR` | `benchmarks/results` | Output location for `latest.json` and `latest.md`. |
+| `BENCHMARK_THRESHOLDS` | `benchmarks/thresholds.json` | Threshold file used by the regression gate. |
+| `BENCHMARK_DISABLE_RATE_LIMIT` | `1` | Disables the in-memory API limiter for local benchmark runs. |
+
+## Metrics
+
+Each endpoint report includes p50/p95/p99 total latency, p50/p95/p99 TTFB, sustained RPS, peak one-second RPS, error rate, sample count, and status-code counts. TTFB is measured as Node fetch response-header timing; total latency includes reading the response body.

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -1,0 +1,405 @@
+{
+  "generatedAt": "2026-05-27T20:18:02.648Z",
+  "mode": "full",
+  "target": {
+    "baseUrl": "http://127.0.0.1:52237",
+    "localServerStarted": true
+  },
+  "config": {
+    "concurrency": 4,
+    "durationMs": 1500,
+    "warmupRequests": 2,
+    "requestTimeoutMs": 5000,
+    "outputDir": "benchmarks/results",
+    "thresholdsPath": "benchmarks/thresholds.json"
+  },
+  "environment": {
+    "node": "v25.0.0",
+    "platform": "win32",
+    "arch": "x64",
+    "rateLimitDisabled": true
+  },
+  "endpoints": [
+    {
+      "name": "auth.register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "samples": 2718,
+      "durationMs": 1500.82,
+      "p50LatencyMs": 1.94,
+      "p95LatencyMs": 3.52,
+      "p99LatencyMs": 5.43,
+      "p50TtfbMs": 1.91,
+      "p95TtfbMs": 3.46,
+      "p99TtfbMs": 5.36,
+      "sustainedRps": 1811.01,
+      "peakRps": 1686,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 2718
+      }
+    },
+    {
+      "name": "auth.login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "samples": 3487,
+      "durationMs": 1500.52,
+      "p50LatencyMs": 1.61,
+      "p95LatencyMs": 1.98,
+      "p99LatencyMs": 5.58,
+      "p50TtfbMs": 1.59,
+      "p95TtfbMs": 1.96,
+      "p99TtfbMs": 5.51,
+      "sustainedRps": 2323.85,
+      "peakRps": 2303,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 3487
+      }
+    },
+    {
+      "name": "auth.oauthCallback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "samples": 7584,
+      "durationMs": 1500.22,
+      "p50LatencyMs": 0.69,
+      "p95LatencyMs": 1.09,
+      "p99LatencyMs": 1.85,
+      "p50TtfbMs": 0.68,
+      "p95TtfbMs": 1.07,
+      "p99TtfbMs": 1.81,
+      "sustainedRps": 5055.26,
+      "peakRps": 4942,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 7584
+      }
+    },
+    {
+      "name": "auth.refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "samples": 5000,
+      "durationMs": 1500.32,
+      "p50LatencyMs": 1.09,
+      "p95LatencyMs": 1.51,
+      "p99LatencyMs": 2.29,
+      "p50TtfbMs": 1.08,
+      "p95TtfbMs": 1.49,
+      "p99TtfbMs": 2.27,
+      "sustainedRps": 3332.63,
+      "peakRps": 3336,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 5000
+      }
+    },
+    {
+      "name": "users.list",
+      "method": "GET",
+      "path": "/api/users",
+      "samples": 9439,
+      "durationMs": 1500.38,
+      "p50LatencyMs": 0.56,
+      "p95LatencyMs": 0.86,
+      "p99LatencyMs": 1.22,
+      "p50TtfbMs": 0.55,
+      "p95TtfbMs": 0.85,
+      "p99TtfbMs": 1.21,
+      "sustainedRps": 6291.08,
+      "peakRps": 6160,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 9439
+      }
+    },
+    {
+      "name": "users.create",
+      "method": "POST",
+      "path": "/api/users",
+      "samples": 5484,
+      "durationMs": 1500.34,
+      "p50LatencyMs": 0.98,
+      "p95LatencyMs": 1.3,
+      "p99LatencyMs": 5.42,
+      "p50TtfbMs": 0.97,
+      "p95TtfbMs": 1.28,
+      "p99TtfbMs": 5.41,
+      "sustainedRps": 3655.18,
+      "peakRps": 3646,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5484
+      }
+    },
+    {
+      "name": "jobs.list",
+      "method": "GET",
+      "path": "/api/jobs",
+      "samples": 9922,
+      "durationMs": 1500.28,
+      "p50LatencyMs": 0.53,
+      "p95LatencyMs": 0.82,
+      "p99LatencyMs": 1.25,
+      "p50TtfbMs": 0.52,
+      "p95TtfbMs": 0.8,
+      "p99TtfbMs": 1.23,
+      "sustainedRps": 6613.44,
+      "peakRps": 6616,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 9922
+      }
+    },
+    {
+      "name": "jobs.create",
+      "method": "POST",
+      "path": "/api/jobs",
+      "samples": 5356,
+      "durationMs": 1500.59,
+      "p50LatencyMs": 1.02,
+      "p95LatencyMs": 1.33,
+      "p99LatencyMs": 4.98,
+      "p50TtfbMs": 1.01,
+      "p95TtfbMs": 1.32,
+      "p99TtfbMs": 4.96,
+      "sustainedRps": 3569.25,
+      "peakRps": 3574,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5356
+      }
+    },
+    {
+      "name": "proposals.list",
+      "method": "GET",
+      "path": "/api/proposals",
+      "samples": 10085,
+      "durationMs": 1500.24,
+      "p50LatencyMs": 0.53,
+      "p95LatencyMs": 0.73,
+      "p99LatencyMs": 1.22,
+      "p50TtfbMs": 0.52,
+      "p95TtfbMs": 0.72,
+      "p99TtfbMs": 1.2,
+      "sustainedRps": 6722.25,
+      "peakRps": 6686,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 10085
+      }
+    },
+    {
+      "name": "proposals.create",
+      "method": "POST",
+      "path": "/api/proposals",
+      "samples": 5488,
+      "durationMs": 1500.57,
+      "p50LatencyMs": 0.98,
+      "p95LatencyMs": 1.31,
+      "p99LatencyMs": 5.56,
+      "p50TtfbMs": 0.96,
+      "p95TtfbMs": 1.3,
+      "p99TtfbMs": 5.54,
+      "sustainedRps": 3657.29,
+      "peakRps": 3677,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5488
+      }
+    },
+    {
+      "name": "payments.create",
+      "method": "POST",
+      "path": "/api/payments",
+      "samples": 5827,
+      "durationMs": 1500.46,
+      "p50LatencyMs": 0.92,
+      "p95LatencyMs": 1.23,
+      "p99LatencyMs": 4.28,
+      "p50TtfbMs": 0.91,
+      "p95TtfbMs": 1.21,
+      "p99TtfbMs": 4.26,
+      "sustainedRps": 3883.48,
+      "peakRps": 3912,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5827
+      }
+    },
+    {
+      "name": "reviews.list",
+      "method": "GET",
+      "path": "/api/reviews",
+      "samples": 10148,
+      "durationMs": 1503.67,
+      "p50LatencyMs": 0.53,
+      "p95LatencyMs": 0.73,
+      "p99LatencyMs": 1.14,
+      "p50TtfbMs": 0.52,
+      "p95TtfbMs": 0.72,
+      "p99TtfbMs": 1.13,
+      "sustainedRps": 6748.83,
+      "peakRps": 6640,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 10148
+      }
+    },
+    {
+      "name": "reviews.create",
+      "method": "POST",
+      "path": "/api/reviews",
+      "samples": 5804,
+      "durationMs": 1500.17,
+      "p50LatencyMs": 0.93,
+      "p95LatencyMs": 1.24,
+      "p99LatencyMs": 3.41,
+      "p50TtfbMs": 0.92,
+      "p95TtfbMs": 1.23,
+      "p99TtfbMs": 3.4,
+      "sustainedRps": 3868.89,
+      "peakRps": 3829,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5804
+      }
+    },
+    {
+      "name": "messages.list",
+      "method": "GET",
+      "path": "/api/messages",
+      "samples": 9936,
+      "durationMs": 1500.11,
+      "p50LatencyMs": 0.53,
+      "p95LatencyMs": 0.82,
+      "p99LatencyMs": 1.24,
+      "p50TtfbMs": 0.52,
+      "p95TtfbMs": 0.81,
+      "p99TtfbMs": 1.23,
+      "sustainedRps": 6623.53,
+      "peakRps": 6520,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 9936
+      }
+    },
+    {
+      "name": "messages.create",
+      "method": "POST",
+      "path": "/api/messages",
+      "samples": 5575,
+      "durationMs": 1500.42,
+      "p50LatencyMs": 0.96,
+      "p95LatencyMs": 1.32,
+      "p99LatencyMs": 4.47,
+      "p50TtfbMs": 0.95,
+      "p95TtfbMs": 1.3,
+      "p99TtfbMs": 4.44,
+      "sustainedRps": 3715.61,
+      "peakRps": 3680,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5575
+      }
+    },
+    {
+      "name": "notifications.list",
+      "method": "GET",
+      "path": "/api/notifications",
+      "samples": 10020,
+      "durationMs": 1500.26,
+      "p50LatencyMs": 0.53,
+      "p95LatencyMs": 0.79,
+      "p99LatencyMs": 1.23,
+      "p50TtfbMs": 0.52,
+      "p95TtfbMs": 0.78,
+      "p99TtfbMs": 1.2,
+      "sustainedRps": 6678.86,
+      "peakRps": 6628,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 10020
+      }
+    },
+    {
+      "name": "notifications.create",
+      "method": "POST",
+      "path": "/api/notifications",
+      "samples": 5628,
+      "durationMs": 1500.47,
+      "p50LatencyMs": 0.94,
+      "p95LatencyMs": 1.31,
+      "p99LatencyMs": 3.56,
+      "p50TtfbMs": 0.93,
+      "p95TtfbMs": 1.29,
+      "p99TtfbMs": 3.52,
+      "sustainedRps": 3750.82,
+      "peakRps": 3814,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 5628
+      }
+    },
+    {
+      "name": "uploads.create",
+      "method": "POST",
+      "path": "/api/uploads",
+      "samples": 3084,
+      "durationMs": 1500.37,
+      "p50LatencyMs": 1.73,
+      "p95LatencyMs": 2.54,
+      "p99LatencyMs": 7.73,
+      "p50TtfbMs": 1.72,
+      "p95TtfbMs": 2.51,
+      "p99TtfbMs": 7.69,
+      "sustainedRps": 2055.49,
+      "peakRps": 1968,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 3084
+      }
+    },
+    {
+      "name": "search.global",
+      "method": "GET",
+      "path": "/api/search?q=full-stack%20marketplace%20node%20benchmark",
+      "samples": 8288,
+      "durationMs": 1500.28,
+      "p50LatencyMs": 0.64,
+      "p95LatencyMs": 0.93,
+      "p99LatencyMs": 1.36,
+      "p50TtfbMs": 0.63,
+      "p95TtfbMs": 0.92,
+      "p99TtfbMs": 1.34,
+      "sustainedRps": 5524.28,
+      "peakRps": 5402,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8288
+      }
+    },
+    {
+      "name": "admin.metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "samples": 5130,
+      "durationMs": 1500.55,
+      "p50LatencyMs": 1.08,
+      "p95LatencyMs": 1.41,
+      "p99LatencyMs": 1.77,
+      "p50TtfbMs": 1.07,
+      "p95TtfbMs": 1.4,
+      "p99TtfbMs": 1.76,
+      "sustainedRps": 3418.74,
+      "peakRps": 3372,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 5130
+      }
+    }
+  ],
+  "failures": []
+}

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,0 +1,37 @@
+# API Benchmark Results
+
+- Generated: 2026-05-27T20:18:02.648Z
+- Mode: full
+- Target: http://127.0.0.1:52237
+- Local server started by runner: yes
+- Concurrency: 4
+- Duration per endpoint: 1500 ms
+- Warmup requests per endpoint: 2
+- TTFB note: measured as Node fetch response-header timing; total latency includes body read.
+
+| Endpoint | Method | Path | Samples | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Sustained RPS | Peak RPS | Error % | Gate |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| auth.register | POST | /api/auth/register | 2718 | 1.94 | 3.52 | 5.43 | 3.46 | 1811.01 | 1686 | 0 | pass |
+| auth.login | POST | /api/auth/login | 3487 | 1.61 | 1.98 | 5.58 | 1.96 | 2323.85 | 2303 | 0 | pass |
+| auth.oauthCallback | GET | /api/auth/oauth/github/callback | 7584 | 0.69 | 1.09 | 1.85 | 1.07 | 5055.26 | 4942 | 0 | pass |
+| auth.refresh | POST | /api/auth/refresh | 5000 | 1.09 | 1.51 | 2.29 | 1.49 | 3332.63 | 3336 | 0 | pass |
+| users.list | GET | /api/users | 9439 | 0.56 | 0.86 | 1.22 | 0.85 | 6291.08 | 6160 | 0 | pass |
+| users.create | POST | /api/users | 5484 | 0.98 | 1.3 | 5.42 | 1.28 | 3655.18 | 3646 | 0 | pass |
+| jobs.list | GET | /api/jobs | 9922 | 0.53 | 0.82 | 1.25 | 0.8 | 6613.44 | 6616 | 0 | pass |
+| jobs.create | POST | /api/jobs | 5356 | 1.02 | 1.33 | 4.98 | 1.32 | 3569.25 | 3574 | 0 | pass |
+| proposals.list | GET | /api/proposals | 10085 | 0.53 | 0.73 | 1.22 | 0.72 | 6722.25 | 6686 | 0 | pass |
+| proposals.create | POST | /api/proposals | 5488 | 0.98 | 1.31 | 5.56 | 1.3 | 3657.29 | 3677 | 0 | pass |
+| payments.create | POST | /api/payments | 5827 | 0.92 | 1.23 | 4.28 | 1.21 | 3883.48 | 3912 | 0 | pass |
+| reviews.list | GET | /api/reviews | 10148 | 0.53 | 0.73 | 1.14 | 0.72 | 6748.83 | 6640 | 0 | pass |
+| reviews.create | POST | /api/reviews | 5804 | 0.93 | 1.24 | 3.41 | 1.23 | 3868.89 | 3829 | 0 | pass |
+| messages.list | GET | /api/messages | 9936 | 0.53 | 0.82 | 1.24 | 0.81 | 6623.53 | 6520 | 0 | pass |
+| messages.create | POST | /api/messages | 5575 | 0.96 | 1.32 | 4.47 | 1.3 | 3715.61 | 3680 | 0 | pass |
+| notifications.list | GET | /api/notifications | 10020 | 0.53 | 0.79 | 1.23 | 0.78 | 6678.86 | 6628 | 0 | pass |
+| notifications.create | POST | /api/notifications | 5628 | 0.94 | 1.31 | 3.56 | 1.29 | 3750.82 | 3814 | 0 | pass |
+| uploads.create | POST | /api/uploads | 3084 | 1.73 | 2.54 | 7.73 | 2.51 | 2055.49 | 1968 | 0 | pass |
+| search.global | GET | /api/search?q=full-stack%20marketplace%20node%20benchmark | 8288 | 0.64 | 0.93 | 1.36 | 0.92 | 5524.28 | 5402 | 0 | pass |
+| admin.metrics | GET | /api/admin/metrics | 5130 | 1.08 | 1.41 | 1.77 | 1.4 | 3418.74 | 3372 | 0 | pass |
+
+## Threshold Gate
+
+No threshold failures.

--- a/benchmarks/run-benchmarks.mjs
+++ b/benchmarks/run-benchmarks.mjs
@@ -1,0 +1,554 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const benchmarkDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(benchmarkDir, "..");
+
+loadEnvFile(path.join(repoRoot, ".env.benchmark"));
+
+const args = new Set(process.argv.slice(2));
+const smoke = args.has("--smoke") || process.env.BENCHMARK_SMOKE === "1";
+
+process.env.NODE_ENV ||= "benchmark";
+process.env.BENCHMARK_DISABLE_RATE_LIMIT ||= "1";
+
+const config = {
+  concurrency: toPositiveInt(process.env.BENCHMARK_CONCURRENCY, smoke ? 1 : 4),
+  durationMs: toPositiveInt(process.env.BENCHMARK_DURATION_MS, smoke ? 250 : 1500),
+  warmupRequests: toPositiveInt(process.env.BENCHMARK_WARMUP_REQUESTS, smoke ? 1 : 2),
+  requestTimeoutMs: toPositiveInt(process.env.BENCHMARK_REQUEST_TIMEOUT_MS, 5000),
+  outputDir: process.env.BENCHMARK_OUTPUT_DIR
+    ? path.resolve(repoRoot, process.env.BENCHMARK_OUTPUT_DIR)
+    : path.join(benchmarkDir, "results"),
+  thresholdsPath: process.env.BENCHMARK_THRESHOLDS
+    ? path.resolve(repoRoot, process.env.BENCHMARK_THRESHOLDS)
+    : path.join(benchmarkDir, "thresholds.json")
+};
+
+const localTarget = !process.env.BENCHMARK_TARGET_URL || process.env.BENCHMARK_TARGET_URL === "local";
+let server;
+let baseUrl = process.env.BENCHMARK_TARGET_URL;
+
+if (localTarget) {
+  const { createApp } = await import("../apps/api/src/app.js");
+  const app = createApp();
+  const port = toNonNegativeInt(process.env.BENCHMARK_PORT, 0);
+
+  server = await new Promise((resolve) => {
+    const listener = app.listen(port, "127.0.0.1", () => resolve(listener));
+  });
+
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+}
+
+const benchmarkToken = await getBenchmarkToken(localTarget);
+const routes = createRoutes(benchmarkToken);
+const thresholds = JSON.parse(await readFile(config.thresholdsPath, "utf8"));
+
+try {
+  await mkdir(config.outputDir, { recursive: true });
+
+  const endpoints = [];
+  for (const route of routes) {
+    endpoints.push(await runEndpoint(route, baseUrl, config));
+  }
+
+  const failures = evaluateThresholds(endpoints, thresholds);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    mode: smoke ? "smoke" : "full",
+    target: {
+      baseUrl,
+      localServerStarted: localTarget
+    },
+    config: serializeConfig(config),
+    environment: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      rateLimitDisabled: process.env.BENCHMARK_DISABLE_RATE_LIMIT === "1"
+    },
+    endpoints,
+    failures
+  };
+
+  await writeFile(path.join(config.outputDir, "latest.json"), `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(path.join(config.outputDir, "latest.md"), renderMarkdown(report));
+
+  console.log(renderConsoleSummary(report));
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+} finally {
+  if (server) {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function loadEnvFile(filePath) {
+  if (!existsSync(filePath)) {
+    return;
+  }
+
+  const content = existsSync(filePath) ? requireText(filePath) : "";
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] ??= value;
+  }
+}
+
+function requireText(filePath) {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : "";
+}
+
+async function getBenchmarkToken(isLocal) {
+  if (process.env.BENCHMARK_TOKEN) {
+    return process.env.BENCHMARK_TOKEN;
+  }
+
+  if (!isLocal) {
+    throw new Error("BENCHMARK_TOKEN is required when BENCHMARK_TARGET_URL points at an external server.");
+  }
+
+  const { signAccessToken } = await import("../apps/api/src/utils/jwt.js");
+  return signAccessToken({ sub: "usr_benchmark", role: "admin", purpose: "benchmark" });
+}
+
+function createRoutes(token) {
+  const richDescription = [
+    "Build a full-stack marketplace dashboard with authenticated messaging, payment milestones,",
+    "proposal review, notification routing, and admin reporting for a growing freelance team.",
+    "The project should include reusable components, measurable delivery checkpoints, and clear",
+    "acceptance criteria for frontend, backend, and QA handoff."
+  ].join(" ");
+
+  return [
+    {
+      name: "auth.register",
+      method: "POST",
+      path: "/api/auth/register",
+      json: (requestId) => ({
+        email: `benchmark.register.${requestId}@example.com`,
+        password: "benchmark-password",
+        role: "client"
+      })
+    },
+    {
+      name: "auth.login",
+      method: "POST",
+      path: "/api/auth/login",
+      json: (requestId) => ({
+        email: `benchmark.login.${requestId}@example.com`,
+        password: "benchmark-password"
+      })
+    },
+    {
+      name: "auth.oauthCallback",
+      method: "GET",
+      path: "/api/auth/oauth/github/callback"
+    },
+    {
+      name: "auth.refresh",
+      method: "POST",
+      path: "/api/auth/refresh"
+    },
+    {
+      name: "users.list",
+      method: "GET",
+      path: "/api/users"
+    },
+    {
+      name: "users.create",
+      method: "POST",
+      path: "/api/users",
+      json: (requestId) => ({
+        email: `benchmark.user.${requestId}@example.com`,
+        name: `Benchmark User ${requestId}`,
+        role: "freelancer",
+        skills: ["node", "react", "performance-testing"],
+        hourlyRate: 95
+      })
+    },
+    {
+      name: "jobs.list",
+      method: "GET",
+      path: "/api/jobs"
+    },
+    {
+      name: "jobs.create",
+      method: "POST",
+      path: "/api/jobs",
+      json: (requestId) => ({
+        title: `Benchmark API delivery ${requestId}`,
+        description: richDescription,
+        budgetMin: 2500,
+        budgetMax: 7500,
+        categoryId: "cat_engineering",
+        skills: ["node", "express", "benchmarking", "observability"]
+      })
+    },
+    {
+      name: "proposals.list",
+      method: "GET",
+      path: "/api/proposals"
+    },
+    {
+      name: "proposals.create",
+      method: "POST",
+      path: "/api/proposals",
+      json: (requestId) => ({
+        jobId: `job_benchmark_${requestId}`,
+        freelancerId: "usr_benchmark_freelancer",
+        coverLetter: richDescription,
+        proposedBudget: 4900,
+        estimatedDays: 18,
+        milestones: [
+          { title: "Discovery", amount: 900 },
+          { title: "Implementation", amount: 3000 },
+          { title: "QA and handoff", amount: 1000 }
+        ]
+      })
+    },
+    {
+      name: "payments.create",
+      method: "POST",
+      path: "/api/payments",
+      json: (requestId) => ({
+        proposalId: `prp_benchmark_${requestId}`,
+        amount: 4900,
+        currency: "usd",
+        paymentMethodId: "pm_benchmark_card"
+      })
+    },
+    {
+      name: "reviews.list",
+      method: "GET",
+      path: "/api/reviews"
+    },
+    {
+      name: "reviews.create",
+      method: "POST",
+      path: "/api/reviews",
+      json: (requestId) => ({
+        contractId: `ctr_benchmark_${requestId}`,
+        reviewerId: "usr_benchmark_client",
+        revieweeId: "usr_benchmark_freelancer",
+        rating: 5,
+        comment: "Delivered the benchmark scenario with clear milestones and production-ready notes."
+      })
+    },
+    {
+      name: "messages.list",
+      method: "GET",
+      path: "/api/messages"
+    },
+    {
+      name: "messages.create",
+      method: "POST",
+      path: "/api/messages",
+      json: (requestId) => ({
+        conversationId: `cnv_benchmark_${requestId}`,
+        senderId: "usr_benchmark_client",
+        recipientId: "usr_benchmark_freelancer",
+        body: "Please review the attached milestone notes and confirm the delivery window."
+      })
+    },
+    {
+      name: "notifications.list",
+      method: "GET",
+      path: "/api/notifications"
+    },
+    {
+      name: "notifications.create",
+      method: "POST",
+      path: "/api/notifications",
+      json: (requestId) => ({
+        userId: "usr_benchmark_client",
+        type: "milestone_due",
+        title: "Milestone review needed",
+        body: `Benchmark notification ${requestId} with enough payload size to mirror production copy.`
+      })
+    },
+    {
+      name: "uploads.create",
+      method: "POST",
+      path: "/api/uploads",
+      form: (requestId) => {
+        const form = new FormData();
+        const content = `benchmark upload ${requestId}\n${richDescription}\n`;
+        form.set("file", new Blob([content], { type: "text/plain" }), `benchmark-${requestId}.txt`);
+        return form;
+      }
+    },
+    {
+      name: "search.global",
+      method: "GET",
+      path: "/api/search?q=full-stack%20marketplace%20node%20benchmark"
+    },
+    {
+      name: "admin.metrics",
+      method: "GET",
+      path: "/api/admin/metrics",
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    }
+  ];
+}
+
+async function runEndpoint(route, baseUrl, config) {
+  for (let index = 0; index < config.warmupRequests; index += 1) {
+    await performRequest(route, baseUrl, `warmup-${index}`, config.requestTimeoutMs);
+  }
+
+  const samples = [];
+  const bucketCounts = new Map();
+  const startedAt = performance.now();
+  let sequence = 0;
+
+  await Promise.all(
+    Array.from({ length: config.concurrency }, async () => {
+      while (performance.now() - startedAt < config.durationMs) {
+        sequence += 1;
+        const requestId = `${route.name.replaceAll(".", "-")}-${Date.now()}-${sequence}`;
+        const sample = await performRequest(route, baseUrl, requestId, config.requestTimeoutMs);
+        samples.push(sample);
+
+        const bucket = Math.floor((sample.startedAt - startedAt) / 1000);
+        bucketCounts.set(bucket, (bucketCounts.get(bucket) ?? 0) + 1);
+      }
+    })
+  );
+
+  const elapsedMs = performance.now() - startedAt;
+  const totalRequests = samples.length;
+  const errors = samples.filter((sample) => !sample.ok).length;
+  const latencies = samples.map((sample) => sample.totalMs).sort((a, b) => a - b);
+  const ttfbs = samples.map((sample) => sample.ttfbMs).sort((a, b) => a - b);
+  const statusCounts = countBy(samples, (sample) => String(sample.status ?? "network_error"));
+
+  return {
+    name: route.name,
+    method: route.method,
+    path: route.path,
+    samples: totalRequests,
+    durationMs: round(elapsedMs),
+    p50LatencyMs: percentile(latencies, 50),
+    p95LatencyMs: percentile(latencies, 95),
+    p99LatencyMs: percentile(latencies, 99),
+    p50TtfbMs: percentile(ttfbs, 50),
+    p95TtfbMs: percentile(ttfbs, 95),
+    p99TtfbMs: percentile(ttfbs, 99),
+    sustainedRps: totalRequests === 0 ? 0 : round(totalRequests / (elapsedMs / 1000)),
+    peakRps: Math.max(0, ...bucketCounts.values()),
+    errorRatePercent: totalRequests === 0 ? 100 : round((errors / totalRequests) * 100),
+    statusCounts
+  };
+}
+
+async function performRequest(route, baseUrl, requestId, timeoutMs) {
+  const headers = { ...(route.headers ?? {}) };
+  const init = {
+    method: route.method,
+    headers
+  };
+
+  if (route.json) {
+    headers["content-type"] = "application/json";
+    init.body = JSON.stringify(route.json(requestId));
+  }
+
+  if (route.form) {
+    init.body = route.form(requestId);
+  }
+
+  if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+    init.signal = AbortSignal.timeout(timeoutMs);
+  }
+
+  const startedAt = performance.now();
+  try {
+    const response = await fetch(new URL(route.path, baseUrl), init);
+    const ttfbMs = performance.now() - startedAt;
+    const body = await response.arrayBuffer();
+    const totalMs = performance.now() - startedAt;
+
+    return {
+      startedAt,
+      status: response.status,
+      ok: response.status < 400,
+      totalMs: round(totalMs),
+      ttfbMs: round(ttfbMs),
+      bytes: body.byteLength
+    };
+  } catch (error) {
+    const totalMs = performance.now() - startedAt;
+    return {
+      startedAt,
+      status: null,
+      ok: false,
+      totalMs: round(totalMs),
+      ttfbMs: round(totalMs),
+      error: error.message
+    };
+  }
+}
+
+function evaluateThresholds(endpoints, thresholds) {
+  const defaults = thresholds.defaults ?? {};
+  const endpointThresholds = thresholds.endpoints ?? {};
+  const failures = [];
+
+  for (const endpoint of endpoints) {
+    const rule = { ...defaults, ...(endpointThresholds[endpoint.name] ?? {}) };
+    if (Number.isFinite(rule.maxP99Ms) && endpoint.p99LatencyMs > rule.maxP99Ms) {
+      failures.push({
+        endpoint: endpoint.name,
+        metric: "p99LatencyMs",
+        actual: endpoint.p99LatencyMs,
+        threshold: rule.maxP99Ms
+      });
+    }
+
+    if (Number.isFinite(rule.maxP99TtfbMs) && endpoint.p99TtfbMs > rule.maxP99TtfbMs) {
+      failures.push({
+        endpoint: endpoint.name,
+        metric: "p99TtfbMs",
+        actual: endpoint.p99TtfbMs,
+        threshold: rule.maxP99TtfbMs
+      });
+    }
+
+    if (Number.isFinite(rule.maxErrorRatePercent) && endpoint.errorRatePercent > rule.maxErrorRatePercent) {
+      failures.push({
+        endpoint: endpoint.name,
+        metric: "errorRatePercent",
+        actual: endpoint.errorRatePercent,
+        threshold: rule.maxErrorRatePercent
+      });
+    }
+  }
+
+  return failures;
+}
+
+function renderMarkdown(report) {
+  const rows = report.endpoints
+    .map((endpoint) => [
+      endpoint.name,
+      endpoint.method,
+      endpoint.path,
+      endpoint.samples,
+      endpoint.p50LatencyMs,
+      endpoint.p95LatencyMs,
+      endpoint.p99LatencyMs,
+      endpoint.p95TtfbMs,
+      endpoint.sustainedRps,
+      endpoint.peakRps,
+      endpoint.errorRatePercent,
+      report.failures.some((failure) => failure.endpoint === endpoint.name) ? "fail" : "pass"
+    ])
+    .map((cells) => `| ${cells.join(" | ")} |`)
+    .join("\n");
+
+  const failures = report.failures.length === 0
+    ? "No threshold failures."
+    : report.failures
+        .map((failure) => `- ${failure.endpoint}: ${failure.metric} ${failure.actual} exceeded ${failure.threshold}`)
+        .join("\n");
+
+  return `# API Benchmark Results
+
+- Generated: ${report.generatedAt}
+- Mode: ${report.mode}
+- Target: ${report.target.baseUrl}
+- Local server started by runner: ${report.target.localServerStarted ? "yes" : "no"}
+- Concurrency: ${report.config.concurrency}
+- Duration per endpoint: ${report.config.durationMs} ms
+- Warmup requests per endpoint: ${report.config.warmupRequests}
+- TTFB note: measured as Node fetch response-header timing; total latency includes body read.
+
+| Endpoint | Method | Path | Samples | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Sustained RPS | Peak RPS | Error % | Gate |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+${rows}
+
+## Threshold Gate
+
+${failures}
+`;
+}
+
+function renderConsoleSummary(report) {
+  const result = report.failures.length === 0 ? "passed" : "failed";
+  return [
+    `Benchmark ${result}: ${report.endpoints.length} endpoints, ${report.failures.length} threshold failures.`,
+    `JSON: ${path.join(report.config.outputDir, "latest.json")}`,
+    `Markdown: ${path.join(report.config.outputDir, "latest.md")}`
+  ].join("\n");
+}
+
+function serializeConfig(config) {
+  return {
+    ...config,
+    outputDir: toRepoRelative(config.outputDir),
+    thresholdsPath: toRepoRelative(config.thresholdsPath)
+  };
+}
+
+function toRepoRelative(filePath) {
+  const relative = path.relative(repoRoot, filePath).replaceAll("\\", "/");
+  return relative || ".";
+}
+
+function percentile(values, percent) {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const index = Math.ceil((percent / 100) * values.length) - 1;
+  return round(values[Math.max(0, Math.min(index, values.length - 1))]);
+}
+
+function countBy(items, keyFn) {
+  return items.reduce((counts, item) => {
+    const key = keyFn(item);
+    counts[key] = (counts[key] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function toPositiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function toNonNegativeInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,14 @@
+{
+  "defaults": {
+    "maxP99Ms": 1000,
+    "maxP99TtfbMs": 1000,
+    "maxErrorRatePercent": 0
+  },
+  "endpoints": {
+    "uploads.create": {
+      "maxP99Ms": 1500,
+      "maxP99TtfbMs": 1500,
+      "maxErrorRatePercent": 0
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "packages/*"
   ],
   "scripts": {
+    "benchmark": "node benchmarks/run-benchmarks.mjs",
+    "benchmark:smoke": "node benchmarks/run-benchmarks.mjs --smoke",
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"


### PR DESCRIPTION
/claim #30

## Summary
- Added a reproducible Node benchmark runner under enchmarks/ that covers every route mounted under /api/.
- Added 
pm run benchmark and 
pm run benchmark:smoke for full and low-concurrency smoke runs.
- Added .env.benchmark.example, benchmark docs, JSON/Markdown result output, threshold gates, and a GitHub Actions smoke benchmark workflow.
- Added a benchmark-specific rate-limit bypass controlled by BENCHMARK_DISABLE_RATE_LIMIT=1 so local loopback benchmark results are not dominated by the global API limiter.
- Fixed the API test script to target src/tests/*.test.js, which makes 
pm test work on the current Node test runner.

## Verification
- 
pm test
- 
pm run benchmark:smoke
- 
pm run benchmark

## Latest full benchmark summary

# API Benchmark Results

- Generated: 2026-05-27T20:18:02.648Z
- Mode: full
- Target: http://127.0.0.1:52237
- Local server started by runner: yes
- Concurrency: 4
- Duration per endpoint: 1500 ms
- Warmup requests per endpoint: 2
- TTFB note: measured as Node fetch response-header timing; total latency includes body read.

| Endpoint | Method | Path | Samples | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Sustained RPS | Peak RPS | Error % | Gate |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| auth.register | POST | /api/auth/register | 2718 | 1.94 | 3.52 | 5.43 | 3.46 | 1811.01 | 1686 | 0 | pass |
| auth.login | POST | /api/auth/login | 3487 | 1.61 | 1.98 | 5.58 | 1.96 | 2323.85 | 2303 | 0 | pass |
| auth.oauthCallback | GET | /api/auth/oauth/github/callback | 7584 | 0.69 | 1.09 | 1.85 | 1.07 | 5055.26 | 4942 | 0 | pass |
| auth.refresh | POST | /api/auth/refresh | 5000 | 1.09 | 1.51 | 2.29 | 1.49 | 3332.63 | 3336 | 0 | pass |
| users.list | GET | /api/users | 9439 | 0.56 | 0.86 | 1.22 | 0.85 | 6291.08 | 6160 | 0 | pass |
| users.create | POST | /api/users | 5484 | 0.98 | 1.3 | 5.42 | 1.28 | 3655.18 | 3646 | 0 | pass |
| jobs.list | GET | /api/jobs | 9922 | 0.53 | 0.82 | 1.25 | 0.8 | 6613.44 | 6616 | 0 | pass |
| jobs.create | POST | /api/jobs | 5356 | 1.02 | 1.33 | 4.98 | 1.32 | 3569.25 | 3574 | 0 | pass |
| proposals.list | GET | /api/proposals | 10085 | 0.53 | 0.73 | 1.22 | 0.72 | 6722.25 | 6686 | 0 | pass |
| proposals.create | POST | /api/proposals | 5488 | 0.98 | 1.31 | 5.56 | 1.3 | 3657.29 | 3677 | 0 | pass |
| payments.create | POST | /api/payments | 5827 | 0.92 | 1.23 | 4.28 | 1.21 | 3883.48 | 3912 | 0 | pass |
| reviews.list | GET | /api/reviews | 10148 | 0.53 | 0.73 | 1.14 | 0.72 | 6748.83 | 6640 | 0 | pass |
| reviews.create | POST | /api/reviews | 5804 | 0.93 | 1.24 | 3.41 | 1.23 | 3868.89 | 3829 | 0 | pass |
| messages.list | GET | /api/messages | 9936 | 0.53 | 0.82 | 1.24 | 0.81 | 6623.53 | 6520 | 0 | pass |
| messages.create | POST | /api/messages | 5575 | 0.96 | 1.32 | 4.47 | 1.3 | 3715.61 | 3680 | 0 | pass |
| notifications.list | GET | /api/notifications | 10020 | 0.53 | 0.79 | 1.23 | 0.78 | 6678.86 | 6628 | 0 | pass |
| notifications.create | POST | /api/notifications | 5628 | 0.94 | 1.31 | 3.56 | 1.29 | 3750.82 | 3814 | 0 | pass |
| uploads.create | POST | /api/uploads | 3084 | 1.73 | 2.54 | 7.73 | 2.51 | 2055.49 | 1968 | 0 | pass |
| search.global | GET | /api/search?q=full-stack%20marketplace%20node%20benchmark | 8288 | 0.64 | 0.93 | 1.36 | 0.92 | 5524.28 | 5402 | 0 | pass |
| admin.metrics | GET | /api/admin/metrics | 5130 | 1.08 | 1.41 | 1.77 | 1.4 | 3418.74 | 3372 | 0 | pass |

## Threshold Gate

No threshold failures.


## Benchmark Environment
**Hardware**
- CPU model & core count: 12th Gen Intel(R) Core(TM) i7-12700H, 14 cores / 20 logical processors
- RAM (total & available during benchmark): 16.4 GB total, about 7.2 GB free before benchmark
- Storage type (SSD / NVMe / HDD): NVMe SSD
- Network interface (Ethernet / WiFi / loopback): loopback for local benchmark target
- Machine type (local workstation / cloud VM / CI runner - include instance type if cloud): local workstation
- OS & version: Microsoft Windows 11 Pro 10.0.26200

**Runtime**
- Node.js version (or relevant runtime): v25.0.0
- Any resource limits applied (Docker memory cap, cgroup limits, etc.): none
- Other significant processes running during benchmark (yes / no - if yes, describe): yes, normal desktop background processes only

**If submitted by or with an AI agent**
- Agent or tool name (e.g. Claude Code, Devin, Copilot Workspace, AutoGPT): OpenAI coding assistant in a local desktop environment
- Underlying model and version (e.g. claude-sonnet-4-5, gpt-4o - if known): GPT-5-family coding model
- Inference provider (e.g. Anthropic, OpenAI, Azure, self-hosted): OpenAI
- Orchestration framework if any (e.g. LangChain, AutoGen, custom): none
- Execution mode (fully autonomous / human-supervised / human-initiated per step): human-initiated, autonomous execution within the stated task constraints
- Did the agent have shell/tool access during execution (yes / no): yes
- Did the agent have internet access during execution (yes / no): yes
- Were benchmark commands run by the agent directly or handed off to the human to run: run directly by the agent
- Any known agent constraints or sandboxing that may have affected execution: local Windows desktop environment; benchmark target was run on loopback for the included results