### PR TITLE
fix: add RBAC middleware for admin-only endpoints (Issue #947)

### DIFF
--- a/apps/api/src/middleware/rbac.js
+++ b/apps/api/src/middleware/rbac.js
@@ -1,0 +1,25 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Role-based access control middleware.
+ * Must be used AFTER authMiddleware so req.user is populated.
+ *
+ * Usage:
+ *   import { requireRole } from "../middleware/rbac.js";
+ *   adminRoutes.use(requireRole("admin"));
+ *
+ * @param {...string} roles - One or more allowed roles
+ * @returns {Function} Express middleware
+ */
+export function requireRole(...roles) {
+  const allowed = new Set(roles);
+  return function (req, res, next) {
+    if (!req.user) {
+      return fail(res, "Authentication required", 401);
+    }
+    if (!allowed.has(req.user.role)) {
+      return fail(res, "Forbidden — insufficient permissions", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/rbac.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Bounty Claim

**Issue:** #947 — No authorization checks on admin endpoints
**Referenced by:** #743 (Low Hanging Fruit Automation, $700)

## Problem
`/api/admin/*` routes only check if the user is authenticated (has a valid JWT), but do not verify the user's role. Any authenticated user (client, freelancer) can access admin metrics and controls.

## Solution
- Created `apps/api/src/middleware/rbac.js` with `requireRole(...roles)` middleware
  - Checks `req.user.role` against allowed roles
  - Returns 403 Forbidden for unauthorized roles
  - Returns 401 if no user is authenticated
- Applied `requireRole("admin")` to `adminRoutes` after `authMiddleware`

## Files Changed
- `apps/api/src/middleware/rbac.js` (new) — reusable RBAC middleware
- `apps/api/src/routes/adminRoutes.js` — added role check

## Security
This follows the principle of defense in depth: auth middleware validates the token, RBAC middleware validates the role.

**Payout address:** `0x9f0d7b0ae4a9ecfaef02d459dde1ea7fc3a01b8c`