### PR TITLE
fix: search endpoint now returns matching stored users and jobs (issue #953)

### DIFF
--- a/apps/api/src/services/searchService.js
+++ b/apps/api/src/services/searchService.js
@@ -1,9 +1,46 @@
+import { listUsers } from "./userService.js";
+import { listJobs } from "./jobService.js";
+
+/**
+ * Case-insensitive substring search with bounding.
+ * @param {string} query
+ * @param {Array} items - items to search through
+ * @param {Array<string>} fields - field names to search in
+ * @returns {Array} matching items
+ */
+function searchItems(query, items, fields) {
+  if (!query || typeof query !== "string") return [];
+  const lowerQuery = query.toLowerCase();
+  return items.filter((item) =>
+    fields.some((field) => {
+      const val = item[field];
+      if (typeof val !== "string") return false;
+      return val.toLowerCase().includes(lowerQuery);
+    })
+  );
+}
+
 export async function globalSearch(query) {
-  // TODO: use PostgreSQL full-text search + ranking.
+  const boundedQuery = query.trim().slice(0, 200);
+
+  // Fetch from in-memory stores
+  const [users, jobs] = await Promise.all([listUsers(), listJobs()]);
+
+  // Search users by email and name
+  const matchedUsers = searchItems(boundedQuery, users, ["email", "name"]);
+
+  // Search jobs by title and description
+  const matchedJobs = searchItems(boundedQuery, jobs, ["title", "description"]);
+
+  // Freelancers are not separately stored — users with role "freelancer"
+  const matchedFreelancers = matchedUsers.filter(
+    (u) => u.role === "freelancer" || u.role === "freelance"
+  );
+
   return {
-    query,
-    users: [],
-    jobs: [],
-    freelancers: []
+    query: boundedQuery,
+    users: matchedUsers,
+    jobs: matchedJobs,
+    freelancers: matchedFreelancers,
   };
 }


### PR DESCRIPTION
## Summary
Fix for [Bug: Search endpoint ignores stored users and jobs](https://github.com/SecureBananaLabs/bug-bounty/issues/953)

## Root cause
The  function in  returned empty arrays for bom bom, , and  regardless of the query — it only had a  comment for PostgreSQL full-text search.

## Fix
1. **Search bounded by in-memory stores**: Added  and  calls to retrieve the actual stored records.
2. **Case-insensitive substring search**: Implemented  helper that iterates over items and matches query substrings in specified fields (email/name for users, title/description for jobs).
3. **Query bounding**: Trim whitespace and cap query length at 200 characters.
4. **Freelancers derived from users**: Filter users with role `freelancer` or `freelance` from the matched users.

## Files changed
-  — full rewrite of 

Closes #953