### PR TITLE
feat: add technical poem about Node.js (issue #76)

### DIFF
--- a/assets/poems/nodejs-poem.md
+++ b/assets/poems/nodejs-poem.md
@@ -1,0 +1,28 @@
+# Node.js: The Async Maestro
+
+In event-loop’s gentle sway, I wait,
+Non-blocking I/O, avoiding fate.
+From V8’s engine, JavaScript flies,
+Handling requests under open skies.
+
+`require('http')` lifts the server high,
+A single thread, yet none deny.
+Callbacks queue in a silent dance,
+Promises unlock the next advance.
+
+Streams and buffers, data’s flow,
+`npm install` — the packages grow.
+Middleware chains, a layered art,
+`express` routes play their part.
+
+Through `fs` and `path`, files we read,
+`process.env` for all we need.
+Cluster mode for multi-core might,
+Debugging through the dark of night.
+
+From REST to GraphQL, APIs rise,
+Node’s ecosystem never dies.
+So praise the runtime, lean and fast,
+Making full-stack dreams that last.
+
+— A tribute to Node.js, the heartbeat of modern backend.


### PR DESCRIPTION
在 /assets/poems/ 目录下创建一首关于 Node.js 的技术诗歌文件，满足 Issue 要求：原创、至少12行、技术准确且富有创意。