### PR TITLE
Reject duplicate job skills

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a marketplace API",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_backend"
+};
+
+test("job validation keeps omitted, empty, and unique skills valid", () => {
+  assert.deepEqual(createJobSchema.parse(validJob).skills, []);
+  assert.deepEqual(createJobSchema.parse({ ...validJob, skills: [] }).skills, []);
+  assert.deepEqual(
+    createJobSchema.parse({ ...validJob, skills: ["node", "react"] }).skills,
+    ["node", "react"]
+  );
+});
+
+test("job validation rejects duplicate skills case-insensitively", () => {
+  let error;
+
+  try {
+    createJobSchema.parse({ ...validJob, skills: ["React", "node", "react"] });
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  assert.equal(error.name, "ZodError");
+  assert.equal(error.issues[0].message, "Skills must be unique");
+  assert.deepEqual(error.issues[0].path, ["skills", 2]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,29 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function addUniqueSkillsIssue(payload, ctx) {
+  if (!payload.skills) {
+    return;
+  }
+
+  const seenSkills = new Set();
+
+  payload.skills.forEach((skill, index) => {
+    const normalizedSkill = skill.toLowerCase();
+
+    if (seenSkills.has(normalizedSkill)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Skills must be unique",
+        path: ["skills", index]
+      });
+      return;
+    }
+
+    seenSkills.add(normalizedSkill);
+  });
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +32,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(addUniqueSkillsIssue);
+
+export const updateJobSchema = jobSchema.partial().superRefine(addUniqueSkillsIssue);


### PR DESCRIPTION
/claim #743

Fixes #990.

## Summary
- fix scoped issue #990 by rejecting duplicate `skills` entries during job validation
- compare skill values case-insensitively so `React` and `react` are treated as duplicates
- keep omitted, empty, and unique skills valid
- add focused validator regression coverage

## Validation
- `node --test apps/api/src/tests/job-validator.test.js` - 2 passed
- `git diff --check`