### PR TITLE
Require job client owner

### DIFF
--- a/apps/api/src/tests/job-client-id-validator.test.js
+++ b/apps/api/src/tests/job-client-id-validator.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a marketplace API",
+  budgetMin: 100,
+  budgetMax: 500,
+  clientId: "usr_client_1",
+  categoryId: "cat_backend",
+  skills: ["node"]
+};
+
+test("job validation accepts a non-empty client owner", () => {
+  assert.equal(createJobSchema.parse(validJob).clientId, "usr_client_1");
+});
+
+test("job validation rejects missing client owner", () => {
+  const { clientId: _clientId, ...jobWithoutClient } = validJob;
+  let error;
+
+  try {
+    createJobSchema.parse(jobWithoutClient);
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  assert.equal(error.name, "ZodError");
+  assert.deepEqual(error.issues[0].path, ["clientId"]);
+});
+
+test("job validation rejects empty client owner", () => {
+  let error;
+
+  try {
+    createJobSchema.parse({ ...validJob, clientId: "" });
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  assert.equal(error.name, "ZodError");
+  assert.deepEqual(error.issues[0].path, ["clientId"]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -5,6 +5,7 @@ export const createJobSchema = z.object({
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
+  clientId: z.string().min(1),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
/claim #743

Fixes #993.

## Summary
- require `clientId` in `createJobSchema` so new jobs cannot be ownerless
- keep update validation partial while aligning creation payloads with the Prisma `Job.clientId` requirement
- add focused validator coverage for valid, missing, and empty client owner values

## Validation
- `node --test apps/api/src/tests/job-client-id-validator.test.js` - 3 passed
- `git diff --check`