### PR TITLE
Add FreelanceFlow ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger of the Brief
+
+A client writes the morning into scope,
+not grandly, just enough to make it real:
+three screens, one form, a budget line of hope,
+and work that wants a careful hand to seal.
+
+Across the board, a freelancer reads the need
+and answers with a proposal, clear and spare:
+time boxed, skill matched, a promise turned to deed,
+the shape of trust beginning in open air.
+
+The platform keeps the middle lantern bright:
+messages threaded, milestones named and seen,
+payment held steady through the working night,
+each status moving from maybe toward clean.
+
+Then comes review, the small and honest gate,
+where finished work is measured, thanked, improved;
+not just a star, but context given weight,
+so future strangers know what care has proved.
+
+FreelanceFlow is quiet when it works:
+a ledger, a handshake, a route through doubt;
+brief into build, and build into earned perks,
+the kind of system people can count out.


### PR DESCRIPTION
/claim #76

## Summary
- add `POEM.md` at the project root
- include an original five-stanza poem written specifically around FreelanceFlow's client brief, proposal, milestone, review, and payout flow

## Creative note
I chose a ledger-style marketplace poem because FreelanceFlow is about turning trust into trackable handoffs from brief to paid work.

## Validation
- `POEM.md` exists at the project root
- local stanza check confirmed 5 stanzas
- `git diff --check`