### PR TITLE
Add verification ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Verification Ledger
+
+The brief arrives with careful edges,
+a small square of work under morning light;
+scope pins the corners before anything moves,
+and every promise learns its shape.
+
+A proposal answers without thunder,
+just estimates, notes, and a path through the code;
+the quiet parts matter most here:
+what will be touched, and what will stay still.
+
+Proof gathers in ordinary places,
+green checks, screenshots, a line that now returns true;
+review reads the trace like weather,
+looking for drift before release.
+
+At merge, the room does not erupt;
+it exhales, records the handoff, closes the loop.
+The useful thing is not the applause,
+but that another person can run it again.
+
+Then payout becomes less like a prize
+and more like a receipt for trust made visible:
+brief, build, proof, review,
+all balanced in one verifiable page.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the project root.
- Original poem with five stanzas, written for the FreelanceFlow / bounty workflow context.

## Creative note
I chose a verification-ledger theme because the project turns scoped work, review evidence, and payout into one traceable handoff.

## Validation
- `POEM.md` is in the project root.
- 5 stanzas, exceeding the 3-stanza minimum.
- Scope is limited to the requested Markdown poem.