### PR TITLE
Return snapshots from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListSnapshotCannotMutateStore(createRecord, listRecords, payload, injectedId) {
+  const created = await createRecord(payload);
+  const snapshot = await listRecords();
+
+  snapshot.push({ id: injectedId });
+  snapshot.length = 0;
+
+  const freshSnapshot = await listRecords();
+
+  assert.ok(freshSnapshot.some((record) => record.id === created.id));
+  assert.equal(freshSnapshot.some((record) => record.id === injectedId), false);
+}
+
+test("list services return snapshots instead of mutable backing stores", async () => {
+  await assertListSnapshotCannotMutateStore(
+    createJob,
+    listJobs,
+    {
+      title: "Build audit dashboard",
+      description: "Create reporting views for marketplace operators.",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "analytics",
+      skills: ["node"]
+    },
+    "job_injected"
+  );
+
+  await assertListSnapshotCannotMutateStore(
+    createUser,
+    listUsers,
+    { email: "snapshot-user@example.com", name: "Snapshot User", role: "client" },
+    "usr_injected"
+  );
+
+  await assertListSnapshotCannotMutateStore(
+    sendMessage,
+    listMessages,
+    { senderId: "usr_sender", receiverId: "usr_receiver", body: "Hello" },
+    "msg_injected"
+  );
+
+  await assertListSnapshotCannotMutateStore(
+    createNotification,
+    listNotifications,
+    { userId: "usr_notify", type: "proposal", message: "Proposal received" },
+    "ntf_injected"
+  );
+
+  await assertListSnapshotCannotMutateStore(
+    createProposal,
+    listProposals,
+    { jobId: "job_snapshot", freelancerId: "usr_freelancer", coverLetter: "I can help.", bidAmount: 150 },
+    "prp_injected"
+  );
+
+  await assertListSnapshotCannotMutateStore(
+    createReview,
+    listReviews,
+    { reviewerId: "usr_reviewer", revieweeId: "usr_reviewee", rating: 5, comment: "Great work" },
+    "rev_injected"
+  );
+});


### PR DESCRIPTION
## Summary
- Fixes #1000
- Return defensive array copies from each in-memory list service so callers cannot mutate backing stores.
- Add regression coverage for jobs, users, messages, notifications, proposals, and reviews.

## Validation
- `node --test src/tests/*.js`
- `git diff --check`

Note: `npm test -w apps/api` still fails under Node 25 because the package script runs `node --test src/tests`, which Node treats as a module path. That pre-existing script issue is tracked separately in this repo; the direct file-pattern test command above passes.

/claim #743