### PR TITLE
Reject admin role in public registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,9 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const payload = parsed.data;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }

--- a/apps/api/src/tests/auth-register-role.test.js
+++ b/apps/api/src/tests/auth-register-role.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects public admin role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "admin-claim@example.com",
+        password: "correct-horse-battery-staple",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid registration payload"
+    });
+  });
+});
+
+test("POST /api/auth/register still allows freelancer signup", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "freelancer@example.com",
+        password: "correct-horse-battery-staple",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "freelancer@example.com");
+    assert.equal(payload.data.role, "freelancer");
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- fixes #1002 by removing `admin` from the unauthenticated public registration role schema
- returns a 400 JSON response when public signup submits an admin role
- adds API regression coverage for rejected admin signup and preserved freelancer signup

## Demo
![Admin registration rejection demo](https://raw.githubusercontent.com/fvlaconstancia-lang/bug-bounty/fvlaconstancia-public-register-no-admin-demo-evidence/assets/demos/public-register-no-admin-demo.png)

## Validation
- `node --test apps/api/src/tests/*.test.js` -> 3 passing
- `git diff --check` -> no whitespace errors

Note: `npm test -w apps/api` still fails on the existing `node --test src/tests` directory resolution issue, which is tracked separately in this repository.

/claim #743