### PR TITLE
Add release table poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Release Table
+
+A brief arrives with careful edges,
+measured work in a quiet frame.
+Someone names the missing pieces,
+someone signs the scope by name.
+
+The ticket waits beside the ledger,
+not a promise, not a guess.
+Every field becomes a railing,
+every test a steady yes.
+
+Messages cross the narrow channel,
+clear enough to hold their weight.
+Validation trims the noise away,
+leaving what the fields can state.
+
+Reviewers lean above the table,
+reading proof instead of trust.
+If the patch can keep its shape,
+the merge light answers what it must.
+
+Then payout moves without a flourish,
+from accepted work to settled line.
+FreelanceFlow keeps the handoff visible:
+brief, build, proof, release, align.


### PR DESCRIPTION
/claim #76

## Summary
- Added an original project-specific `POEM.md` at the repository root.
- Kept the PR scoped to issue #76 and the requested Markdown poem only.

## Creative note
I used a release-table metaphor so brief, scope, validation, review, and payout read like separate seats in one trusted FreelanceFlow handoff.

## Validation
- `wc -l POEM.md` -> 26 lines.
- The poem has five stanzas, exceeding the minimum three-stanza requirement.
- `git diff --cached --check` passed before commit.