### PR TITLE
Return 413 for oversized JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,13 +1,12 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
   if (res.headersSent) {
     return next(err);
   }
 
-  if (err?.type === "entity.too.large" || err?.status === 413) {
-    return res.status(413).json({
-      success: false,
-      message: "Request body too large"
-    });
+  if (err?.type === "entity.too.large") {
+    return fail(res, "Request body too large", 413);
   }
 
   console.error("Unhandled API error:", err);

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.too.large" || err?.status === 413) {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/body-limit.test.js
+++ b/apps/api/src/tests/body-limit.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("oversized JSON bodies return 413 instead of a server error", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Oversized request body",
+        description: "x".repeat(120_000),
+        budgetMin: 10,
+        budgetMax: 20,
+        categoryId: "cat_1",
+        skills: []
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Request body too large"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Return a stable JSON `413 Request body too large` response for Express/body-parser `entity.too.large` errors.
- Reuse the shared `fail(res, message, status)` response helper and keep the handler scoped to oversized JSON body errors.
- Add a focused regression test covering oversized JSON posted to `/api/jobs`.

Closes #1018
/claim #743

## Demo
- Short demo video: https://github.com/JinRudy/bug-bounty/releases/download/pr-1019-demo/bug-bounty-pr-1019-demo.mp4

## Validation
- `node --test apps/api/src/tests/body-limit.test.js` (red before fix: 500 instead of 413; green after fix)
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/middleware/errorHandler.js`
- `ffprobe bug-bounty-pr-1019-demo.mp4` -> H.264, 1280x720, 22s
- `npm run lint` (repository has no root lint configured)

## Note
- `npm test` still fails on current `main` because `apps/api/package.json` uses `node --test src/tests`, which is tracked separately in #766 / PR #767. This PR intentionally does not change that unrelated script wiring.

## Evidence
- The regression test exercises the request path end-to-end through `createApp()` and confirms the oversized JSON response status and body.
- The demo video contains no payout address, private token, cookie, seed phrase, or API key.