### PR TITLE
Fix message creation defaults

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { isRead, sentAt, ...messagePayload } = payload;
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...messagePayload,
+    isRead: false,
+    createdAt: new Date().toISOString(),
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("sendMessage creates unread schema-shaped messages", async () => {
+  const before = Date.now();
+
+  const message = await sendMessage({
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "hello",
+  });
+
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.receiverId, "usr_receiver");
+  assert.equal(message.body, "hello");
+  assert.equal(message.isRead, false);
+  assert.equal("sentAt" in message, false);
+
+  const createdAt = Date.parse(message.createdAt);
+  assert.ok(Number.isFinite(createdAt));
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= Date.now());
+});
+
+test("sendMessage ignores caller-controlled read and sent timestamp fields", async () => {
+  const message = await sendMessage({
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "client override attempt",
+    isRead: true,
+    sentAt: "1999-01-01T00:00:00.000Z",
+  });
+
+  assert.equal(message.isRead, false);
+  assert.equal("sentAt" in message, false);
+  assert.match(message.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+
+  const storedMessages = await listMessages();
+  const stored = storedMessages.at(-1);
+
+  assert.equal(stored.id, message.id);
+  assert.equal(stored.isRead, false);
+  assert.equal("sentAt" in stored, false);
+});


### PR DESCRIPTION
/claim #743

Fixes #1026.

## Summary

- Make `sendMessage()` create schema-shaped messages with server-owned defaults.
- Ignore caller-supplied `isRead` and `sentAt` during message creation.
- Return `createdAt` instead of the non-schema `sentAt` field.
- Add focused service tests for the default unread path and caller override attempts.

## Validation

- `node --test apps/api/src/tests/message-service.test.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/tests/message-service.test.js`
- `git diff --check`

## Notes

- The focused test is service-level and dependency-free, so it can run without installing the API package dependencies.
- A full local `node --test apps/api/src/tests/*.test.js` run also tries to execute the existing health test, which imports `cors`; my local worktree does not have `node_modules` installed, so that broader run is blocked by `ERR_MODULE_NOT_FOUND: Cannot find package 'cors'` before reaching this change.
