### PR TITLE
Handle async controller validation errors

### DIFF
--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedAsyncHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", asyncHandler(metrics));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", asyncHandler(getMessages));
+messageRoutes.post("/", asyncHandler(postMessage));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", asyncHandler(getNotifications));
+notificationRoutes.post("/", asyncHandler(postNotification));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", asyncHandler(createPayment));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", asyncHandler(getProposals));
+proposalRoutes.post("/", asyncHandler(postProposal));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", asyncHandler(getReviews));
+reviewRoutes.post("/", asyncHandler(postReview));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", asyncHandler(search));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), asyncHandler(uploadFile));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", asyncHandler(getUsers));
+userRoutes.post("/", asyncHandler(postUser));

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,6 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
+async function closeServer(server) {
+  server.closeAllConnections?.();
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
 test("GET /health returns ok payload", async () => {
   const app = createApp();
   const server = app.listen(0);
@@ -18,7 +25,31 @@ test("GET /health returns ok payload", async () => {
   assert.equal(response.status, 200);
   assert.deepEqual(payload, { ok: true, service: "api" });
 
+  await closeServer(server);
+});
+
+test("POST /api/auth/register returns validation errors as 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
   await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    server.once("listening", resolve);
+    server.once("error", reject);
   });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email", password: "short" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Invalid request payload");
+  assert.ok(payload.issues.some((issue) => issue.path === "email"));
+  assert.ok(payload.issues.some((issue) => issue.path === "password"));
+
+  await closeServer(server);
 });


### PR DESCRIPTION
Closes #1035
Refs #743

/claim #743

## Summary

- added an `asyncHandler` wrapper so Express 4 forwards async controller rejections to error middleware
- converted Zod validation failures into structured HTTP 400 responses
- wrapped API route controllers and added regression coverage for invalid auth registration payloads

## Demo / Validation

Short demo video:

https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-743-demo.mp4

Reproduction fixed by this PR:

1. Send `POST /api/auth/register` with an invalid email and a short password.
2. Before this change, the thrown Zod validation error was not converted into a stable client error path for async controllers.
3. After this change, the API responds with HTTP `400`, `success: false`, `message: "Invalid request payload"`, and field-level issues for `email` and `password`.

Local validation:

```text
node --test src/tests/*.test.js

tests 2
pass 2
fail 0
```
