### PR TITLE
Return 404 for unknown detail routes

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,19 @@
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((item) => item.username === params.username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Rate: {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{job.title}</strong>.</p>
+      <p>Budget: {job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
/claim #743

Closes #1038.

## Summary

- Look up job detail route params against the mock job list before rendering.
- Look up freelancer profile route params against the mock freelancer list before rendering.
- Return the Next.js `notFound()` path for unknown job IDs or freelancer usernames instead of echoing arbitrary route params as valid data.
- Render matched mock job/freelancer data for valid detail pages.

## Verification

- `npx tsc -p apps/web/tsconfig.json --noEmit`
- `npm run build -w apps/web` could not complete locally because Turbopack panicked on the non-ASCII workspace path before evaluating this change.
