### PR TITLE
Fix dynamic detail pages, return 404 on invalid slugs

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Skills: <strong>{freelancer.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,17 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{job.title}</strong>.</p>
+      <p>Budget: <strong>{job.budget}</strong></p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
This PR resolves the dynamic detail pages slug 404 bug by checking if the requested ID/username exists in the mock data and calling `notFound()` if not.

Closes #1042