### PR TITLE
Fix job creation validator to check budgetMin <= budgetMax

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMin === undefined || data.budgetMax === undefined || data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMin"],
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
This PR resolves the budget validator bug by ensuring `budgetMin <= budgetMax` is verified during job creation and partial updates.

Closes #1045