### PR TITLE
Implement Stripe PaymentIntent service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.2.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,18 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  const statusCode = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  if (statusCode >= 500) {
+    console.error("Unhandled API error:", err);
+  }
+
+  if (err.statusCode) {
+    return res.status(statusCode).json({
+      success: false,
+      message: err.message
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,82 @@
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+export class PaymentServiceError extends Error {
+  constructor(message, statusCode = 400) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+  }
+}
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY is required to create payment intents", 500);
+  }
+
+  if (!stripeClient) {
+    stripeClient = new Stripe(env.stripeSecretKey);
+  }
+
+  return stripeClient;
+}
+
 export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
+  const request = buildPaymentIntentRequest(payload);
+  return createValidatedStripePaymentIntent(request, getStripeClient());
+}
+
+export async function createStripePaymentIntent(payload, client) {
+  const request = buildPaymentIntentRequest(payload);
+  return createValidatedStripePaymentIntent(request, client);
+}
+
+async function createValidatedStripePaymentIntent(request, client) {
+  try {
+    const paymentIntent = await client.paymentIntents.create(request);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: request.amount,
+      currency: request.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error?.message ?? "Unknown Stripe error";
+    throw new PaymentServiceError(`Stripe error: ${message}`, 502);
+  }
+}
+
+function buildPaymentIntentRequest(payload = {}) {
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentServiceError(
+      "Payment amount must be a positive integer in the smallest currency unit"
+    );
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || currency.trim() === "") {
+    throw new PaymentServiceError("Payment currency must be a non-empty string");
+  }
+
+  const request = {
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase()
   };
+
+  if (payload.metadata !== undefined) {
+    if (!isPlainObject(payload.metadata)) {
+      throw new PaymentServiceError("Payment metadata must be an object when provided");
+    }
+    request.metadata = payload.metadata;
+  }
+
+  return request;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/api/src/tests/paymentApi.test.js
+++ b/apps/api/src/tests/paymentApi.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments returns validation errors as JSON", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 0 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Payment amount must be a positive integer in the smallest currency unit"
+    });
+  });
+});
+
+test("POST /api/payments requires Stripe configuration after payload validation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "STRIPE_SECRET_KEY is required to create payment intents"
+    });
+  });
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPaymentIntent,
+  createStripePaymentIntent,
+  PaymentServiceError
+} from "../services/paymentService.js";
+
+test("createStripePaymentIntent creates a Stripe PaymentIntent with required fields", async () => {
+  const calls = [];
+  const stripe = {
+    paymentIntents: {
+      async create(args) {
+        calls.push(args);
+        return {
+          id: "pi_mock_123",
+          client_secret: "pi_mock_123_secret_456"
+        };
+      }
+    }
+  };
+
+  const result = await createStripePaymentIntent({ amount: 2500 }, stripe);
+
+  assert.deepEqual(calls, [{ amount: 2500, currency: "usd" }]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mock_123",
+    clientSecret: "pi_mock_123_secret_456",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+  assert.ok(!result.paymentId.startsWith("pay_"));
+});
+
+test("createStripePaymentIntent preserves explicit currency and metadata", async () => {
+  const calls = [];
+  const stripe = {
+    paymentIntents: {
+      async create(args) {
+        calls.push(args);
+        return {
+          id: "pi_mock_metadata",
+          client_secret: "pi_mock_metadata_secret"
+        };
+      }
+    }
+  };
+
+  await createStripePaymentIntent(
+    {
+      amount: 1000,
+      currency: "EUR",
+      metadata: { proposalId: "proposal_123" }
+    },
+    stripe
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 1000,
+      currency: "eur",
+      metadata: { proposalId: "proposal_123" }
+    }
+  ]);
+});
+
+test("createStripePaymentIntent rejects missing or invalid amount", async () => {
+  const stripe = {
+    paymentIntents: {
+      async create() {
+        throw new Error("should not call Stripe for invalid payloads");
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createStripePaymentIntent({ amount: 0 }, stripe),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.statusCode === 400 &&
+      error.message.includes("positive integer")
+  );
+
+  await assert.rejects(
+    () => createStripePaymentIntent({ amount: 12.5 }, stripe),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.statusCode === 400 &&
+      error.message.includes("positive integer")
+  );
+});
+
+test("createStripePaymentIntent rethrows Stripe errors with the original message", async () => {
+  const stripe = {
+    paymentIntents: {
+      async create() {
+        const error = new Error("Invalid API key provided");
+        error.type = "StripeAuthenticationError";
+        throw error;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createStripePaymentIntent({ amount: 1000 }, stripe),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.statusCode === 502 &&
+      error.message.includes("Invalid API key provided")
+  );
+});
+
+test("createPaymentIntent creates a test-mode PaymentIntent when explicitly enabled", async (t) => {
+  if (process.env.RUN_STRIPE_INTEGRATION_TEST !== "true" || !process.env.STRIPE_SECRET_KEY) {
+    t.skip("Set RUN_STRIPE_INTEGRATION_TEST=true and STRIPE_SECRET_KEY to run Stripe smoke test");
+    return;
+  }
+
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { source: "api-smoke-test" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.2.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Replaces the timestamp payment stub with the official Stripe Node SDK PaymentIntent flow.
- Initializes Stripe from `STRIPE_SECRET_KEY` only; no hardcoded secrets or keys.
- Validates amount, currency, and metadata before creating the provider request.
- Maps Stripe `id` and `client_secret` back to `paymentId` and `clientSecret`.
- Preserves Stripe API error messages and routes payment errors through the API JSON error handler.

## Verification
- `npm test`
- `git diff --check`

The live Stripe smoke test is guarded by `RUN_STRIPE_INTEGRATION_TEST=true` plus `STRIPE_SECRET_KEY`, so it is skipped unless a maintainer explicitly supplies a test-mode key.

Closes #1
/claim #1