### PR TITLE
fix: validate budgetMin <= budgetMax in job creation schema

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.name === "ZodError" || err.constructor?.name === "ZodError") {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors || err.issues
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../utils/async.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Job API — budget validation", async (t) => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("POST /api/jobs — rejects budgetMin > budgetMax", async () => {
+    const payload = {
+      title: "Test Job Title",
+      description: "A detailed job description for testing",
+      budgetMin: 5000,
+      budgetMax: 1000,
+      categoryId: "cat_1",
+      skills: ["javascript"]
+    };
+
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Validation failed");
+    assert.ok(body.errors);
+  });
+
+  await t.test("POST /api/jobs — accepts budgetMin <= budgetMax", async () => {
+    const payload = {
+      title: "Valid Job",
+      description: "A valid job description for testing",
+      budgetMin: 1000,
+      budgetMax: 5000,
+      categoryId: "cat_1",
+      skills: ["javascript"]
+    };
+
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.title, "Valid Job");
+    assert.equal(body.data.budgetMin, 1000);
+    assert.equal(body.data.budgetMax, 5000);
+  });
+
+  await t.test("POST /api/jobs — accepts budgetMin equal to budgetMax", async () => {
+    const payload = {
+      title: "Equal Budget Job",
+      description: "A job where min equals max budget",
+      budgetMin: 3000,
+      budgetMax: 3000,
+      categoryId: "cat_2",
+      skills: []
+    };
+
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.budgetMin, 3000);
+    assert.equal(body.data.budgetMax, 3000);
+  });
+
+  // Clean up server
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/async.js
+++ b/apps/api/src/utils/async.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = z.object(jobFields).refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMin"]
+  }
+);
+
+export const updateJobSchema = z.object(jobFields).partial();


### PR DESCRIPTION
## Summary

Closes #1015

### Problem
The `createJobSchema` validator did not check that `budgetMin <= budgetMax`, allowing jobs to be created with invalid budget ranges (e.g., budgetMin: 5000, budgetMax: 1000).

### Changes

- **`apps/api/src/validators/job.js`**: Added `.refine()` to `createJobSchema` to reject payloads where `budgetMin > budgetMax`
- **`apps/api/src/routes/jobRoutes.js`**: Added `asyncHandler` wrapper to `postJob` route so Zod validation errors are properly forwarded to the error handler
- **`apps/api/src/middleware/errorHandler.js`**: Added `ZodError` detection to return `400` with structured error details instead of generic `500`
- **`apps/api/src/utils/async.js`**: Added `asyncHandler` utility for catching async route errors
- **`apps/api/src/tests/job.test.js`**: Added tests verifying:
  - `budgetMin > budgetMax` → 400 validation error
  - `budgetMin <= budgetMax` → 201 success
  - `budgetMin === budgetMax` → 201 success

### Testing
All tests pass:
```
✔ POST /api/jobs — rejects budgetMin > budgetMax
✔ POST /api/jobs — accepts budgetMin <= budgetMax
✔ POST /api/jobs — accepts budgetMin equal to budgetMax
```
