### PR TITLE
Add project audit trail poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Audit Trail
+
+At dawn the build lights wake the wire,
+small services hum behind the glass;
+each route becomes a quiet fire,
+each test records the steps that pass.
+
+A token turns, a gateway listens,
+hashes hold their measured line;
+the warning dashboards flare and glisten,
+then fold their noise into a sign.
+
+We mend the edge before it opens,
+name the fault and close the gate;
+in every log the platform hopes
+to trade in trust, not luck or fate.
+
+So ship the fix with steady hands,
+leave proof where future readers start;
+secure work is a set of plans,
+and careful code is public art.


### PR DESCRIPTION
## Summary
- Adds `POEM.md` at the project root with an original four-stanza technical poem.

One-line note: I chose an audit-trail theme and a steady quatrain form to connect the repository's security work with careful, reviewable craft.

Closes #76
/claim #76