### PR TITLE
fix: require authentication for token refresh endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
+import { asyncHandler } from "../utils/async.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", authMiddleware, asyncHandler(refresh));

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,9 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(claims) {
+  if (!claims || !claims.sub) {
+    throw new Error("Valid token claims are required for refresh");
+  }
+  return { token: signAccessToken({ sub: claims.sub, role: claims.role }) };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Token Refresh Endpoint", async (t) => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("POST /api/auth/refresh — rejects request without token", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST"
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(body.success, false);
+  });
+
+  await t.test("POST /api/auth/refresh — rejects invalid token", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer invalid.token.here" }
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(body.success, false);
+  });
+
+  await t.test("POST /api/auth/refresh — issues new token with valid existing token", async () => {
+    const validToken = signAccessToken({ sub: "usr_test123", role: "client" });
+
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${validToken}` }
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.ok(body.data.token);
+    // Verify the returned token is a valid JWT string
+    assert.equal(typeof body.data.token, "string");
+    assert.equal(body.data.token.split(".").length, 3);
+  });
+
+  // Clean up server
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/async.js
+++ b/apps/api/src/utils/async.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1013

### Problem
The `POST /api/auth/refresh` endpoint issued new JWT tokens without any authentication. Anyone could call this endpoint and receive a valid token with hardcoded claims (`sub: "usr_existing", role: "client"`), bypassing authentication entirely.

### Root Cause
- `authRoutes.js`: The `/refresh` route had no `authMiddleware`
- `authController.js`: The `refresh()` handler called `refreshToken()` with no arguments
- `authService.js`: `refreshToken()` accepted no parameters and returned a token with hardcoded claims

### Changes

- **`apps/api/src/routes/authRoutes.js`**: Added `authMiddleware` to the refresh route so a valid Bearer token is required
- **`apps/api/src/controllers/authController.js`**: Pass `req.user` (set by authMiddleware) to `refreshToken()`
- **`apps/api/src/services/authService.js`**: `refreshToken()` now accepts `claims` parameter and validates it has a `sub` field before issuing a new token
- **`apps/api/src/utils/async.js`**: Added `asyncHandler` utility for proper async error forwarding
- **`apps/api/src/tests/refresh.test.js`**: Added tests verifying:
  - No token → 401
  - Invalid token → 401
  - Valid token → 200 with new JWT

### Testing
```
✔ POST /api/auth/refresh — rejects request without token
✔ POST /api/auth/refresh — rejects invalid token
✔ POST /api/auth/refresh — issues new token with valid existing token
```
