### PR TITLE
fix: require authentication on POST /api/users endpoint

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/users without auth token returns 401", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Test User", email: "test@example.com" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("POST /api/users with valid auth token creates user", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  try {
+    const token = signAccessToken({ sub: "user_1", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ name: "Test User", email: "test@example.com" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.id);
+    assert.equal(payload.data.name, "Test User");
+    assert.equal(payload.data.email, "test@example.com");
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #1014

### Problem
The `POST /api/users` endpoint had no authentication middleware, allowing anyone to create users without being authenticated.

### Changes

- **`apps/api/src/routes/userRoutes.js`**: Added `authMiddleware` to the `POST /` route
- **`apps/api/src/tests/user.test.js`**: Added tests verifying:
  - POST without token → 401 Unauthorized
  - POST with valid token → 201 Created

### Testing
```
✔ POST /api/users without auth token returns 401
✔ POST /api/users with valid auth token creates user
```
