### PR TITLE
Return JSON for rate limit errors

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/rate-limit.test.js
+++ b/apps/api/src/tests/rate-limit.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("rate limit responses use the API JSON error shape", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+
+    for (let i = 0; i < 201; i += 1) {
+      response = await fetch(`${baseUrl}/api/search`);
+    }
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type"), /^application\/json/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many requests"
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1058

/claim #743

## Summary
- Configure the global API rate limiter to return the shared JSON error shape for `429` responses.
- Preserve existing limiter settings and headers.
- Add a focused regression test that exhausts `/api/search` and asserts JSON content type and payload.

## Validation
```bash
node --test src/tests/*.test.js
```

Result:
```text
✔ GET /health returns ok payload
✔ rate limit responses use the API JSON error shape
ℹ pass 2
ℹ fail 0
```

## Demo
The regression test starts the Express app, sends 201 requests to `/api/search`, and verifies the limited response is HTTP 429 with `Content-Type: application/json` and `{ "success": false, "message": "Too many requests" }`.
