### PR TITLE
Normalize registration roles

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,18 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const REGISTRATION_ROLES = {
+  client: "CLIENT",
+  freelancer: "FREELANCER"
+};
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const role = normalizeRegistrationRole(payload.role);
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role })
   };
 }
 
@@ -20,4 +26,13 @@ export async function loginUser(payload) {
 
 export async function refreshToken() {
   return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+}
+
+function normalizeRegistrationRole(role = "client") {
+  const canonicalRole = REGISTRATION_ROLES[role];
+  if (!canonicalRole) {
+    throw new Error("Unsupported registration role");
+  }
+
+  return canonicalRole;
 }

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser returns canonical Prisma UserRole values", async () => {
+  const result = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(result.role, "CLIENT");
+  assert.equal(claims.role, "CLIENT");
+});
+
+test("registerUser normalizes freelancer role claims", async () => {
+  const result = await registerUser({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(result.role, "FREELANCER");
+  assert.equal(claims.role, "FREELANCER");
+});
+
+test("public registration does not accept admin role", () => {
+  assert.throws(() =>
+    registerSchema.parse({
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    })
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- Normalizes public registration roles to canonical Prisma `UserRole` values (`CLIENT`, `FREELANCER`) before returning the user object or signing JWT claims.
- Removes `admin` from the public registration schema so self-registration cannot mint an admin role.
- Adds focused service/schema tests and updates the API test script so the test files are actually discovered by `npm test`.

## Verification
- `npm test`
- `git diff --check`

Closes #1062
Related to #743
/claim #743