### PR TITLE
Redact sensitive user fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,18 @@
 const users = [];
+const SENSITIVE_USER_FIELDS = new Set(["password", "passwordHash", "token", "refreshToken"]);
 
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: `usr_${Date.now()}`, ...stripSensitiveUserFields(payload) };
   users.push(user);
   return user;
+}
+
+function stripSensitiveUserFields(payload = {}) {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([key]) => !SENSITIVE_USER_FIELDS.has(key))
+  );
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser strips sensitive credential fields from the response and store", async () => {
+  const user = await createUser({
+    email: "safe-user@example.com",
+    fullName: "Safe User",
+    role: "CLIENT",
+    password: "plain-text-password",
+    passwordHash: "hashed-password",
+    token: "access-token",
+    refreshToken: "refresh-token"
+  });
+
+  assert.equal(user.email, "safe-user@example.com");
+  assert.equal(user.fullName, "Safe User");
+  assert.equal(user.role, "CLIENT");
+  assert.equal(user.password, undefined);
+  assert.equal(user.passwordHash, undefined);
+  assert.equal(user.token, undefined);
+  assert.equal(user.refreshToken, undefined);
+
+  const users = await listUsers();
+  const storedUser = users.find((entry) => entry.id === user.id);
+
+  assert.ok(storedUser);
+  assert.equal(storedUser.password, undefined);
+  assert.equal(storedUser.passwordHash, undefined);
+  assert.equal(storedUser.token, undefined);
+  assert.equal(storedUser.refreshToken, undefined);
+});


### PR DESCRIPTION
## Summary
- Strips credential and token fields from `createUser()` payloads before storing or returning user records.
- Adds focused coverage proving `password`, `passwordHash`, `token`, and `refreshToken` are absent from both the creation response and later `listUsers()` output.
- Updates the API test script so test files are discovered reliably by `npm test`.

## Verification
- `npm test`
- `git diff --check`

Closes #1066
Related to #743
/claim #743