### PR TITLE
Keep registered user id in JWT subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registration token subject matches the returned user id", async () => {
+  const originalNow = Date.now;
+  let timestamp = 1700000000000;
+
+  Date.now = () => timestamp++;
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const claims = verifyAccessToken(result.token);
+
+    assert.equal(claims.sub, result.id);
+    assert.equal(claims.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #1068

/claim #743

## Summary
- Generate the registered user id once in `registerUser()`.
- Reuse that id for both the API response and the JWT `sub` claim.
- Add a regression test that forces `Date.now()` to advance between calls and verifies the token subject still matches the returned id.

## Verification
- `node --test apps/api/src/tests/authService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `node --check apps/api/src/services/authService.js` -> passed
- `node --check apps/api/src/tests/authService.test.js` -> passed
- `git diff --cached --check` -> passed
- `npm test` attempted; it still fails on the existing upstream script `node --test src/tests` path issue tracked separately in #766. This PR does not change that unrelated script.

No payout address, private token, cookie, seed phrase, or API key is included in the PR.