### PR TITLE
Limit in-memory upload size

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "Uploaded file exceeds the maximum allowed size"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,14 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_UPLOAD_SIZE_BYTES
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_UPLOAD_SIZE_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads accepts a small file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads rejects oversized in-memory files", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob([new Uint8Array(MAX_UPLOAD_SIZE_BYTES + 1)]), "too-large.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file exceeds the maximum allowed size"
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1072

/claim #743

## Summary
- Add a 5 MiB file-size limit to the `multer.memoryStorage()` upload route.
- Convert `LIMIT_FILE_SIZE` errors into a clear `413` JSON response.
- Add multipart tests for accepted small uploads and rejected oversized uploads.

## Verification
- `node --test apps/api/src/tests/uploadRoutes.test.js` -> 2 passed
- `node --test apps/api/src/tests/*.test.js` -> 3 passed
- `node --check apps/api/src/routes/uploadRoutes.js` -> passed
- `node --check apps/api/src/middleware/errorHandler.js` -> passed
- `node --check apps/api/src/tests/uploadRoutes.test.js` -> passed
- `git diff --cached --check` -> passed
- `npm test` attempted; it still fails on the existing upstream script `node --test src/tests` path issue tracked separately in #766. This PR does not change that unrelated script.

No payout address, private token, cookie, seed phrase, or API key is included in the PR.