### PR TITLE
Fix registration JWT subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the returned user id as the JWT subject", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #1079 by creating one registration user id and signing that same id as the JWT `sub`.
- Adds a regression test asserting the decoded token subject equals the returned `id`.

## Validation
- Added `apps/api/src/tests/authService.test.js`.
- `node --test apps/api/src/tests/authService.test.js apps/api/src/tests/jobValidator.test.js` passed locally: 4 tests passed.
- The code change is scoped to the registration id/token mismatch.

Fixes #1079

<!-- codex-demo-start -->
## Demo
![Registration JWT subject demo](https://raw.githubusercontent.com/ManuelPuerto/bug-bounty/codex-demo-assets/demos/registration-jwt-subject-demo.gif)

## Validation update
- `node --test apps/api/src/tests/authService.test.js apps/api/src/tests/jobValidator.test.js`
- Result: 4 tests passed.
<!-- codex-demo-end -->
