### PR TITLE
Trim job text fields during validation

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Landing page build",
+  description: "Build a responsive landing page",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["javascript"]
+};
+
+test("createJobSchema rejects whitespace-only job text fields", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    title: "    ",
+    description: "          ",
+    categoryId: "   ",
+    skills: ["   "]
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(
+    result.error.issues.map((issue) => issue.path.join(".")),
+    ["title", "description", "categoryId", "skills.0"]
+  );
+});
+
+test("createJobSchema trims surrounding whitespace before returning parsed payload", () => {
+  const result = createJobSchema.parse({
+    ...validJob,
+    title: "  Landing page build  ",
+    description: "  Build a responsive landing page  ",
+    categoryId: "  web  ",
+    skills: ["  javascript  ", "  css  "]
+  });
+
+  assert.equal(result.title, "Landing page build");
+  assert.equal(result.description, "Build a responsive landing page");
+  assert.equal(result.categoryId, "web");
+  assert.deepEqual(result.skills, ["javascript", "css"]);
+});
+
+test("updateJobSchema rejects whitespace-only fields while still allowing partial updates", () => {
+  assert.equal(updateJobSchema.safeParse({ title: "    " }).success, false);
+  assert.deepEqual(updateJobSchema.parse({ skills: ["  node  "] }), {
+    skills: ["node"]
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+const trimmedString = (minLength) => z.string().trim().min(minLength);
+
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: trimmedString(4),
+  description: trimmedString(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: trimmedString(1),
+  skills: z.array(trimmedString(1)).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #1082 by trimming job text fields before applying minimum length validation.
- Rejects whitespace-only `title`, `description`, `categoryId`, and `skills` values.
- Preserves valid partial updates while normalizing surrounding whitespace.

## Validation
- `node --test apps/api/src/tests/jobValidator.test.js`
- Result: 3 tests passed.

Fixes #1082

<!-- codex-demo-start -->
## Demo
![Job whitespace validation demo](https://raw.githubusercontent.com/ManuelPuerto/bug-bounty/codex-demo-assets/demos/job-whitespace-validation-demo.gif)

## Validation update
- `node --test apps/api/src/tests/authService.test.js apps/api/src/tests/jobValidator.test.js`
- Result: 4 tests passed.
<!-- codex-demo-end -->
