### PR TITLE
Fix register token subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  const id = `usr_${Date.now()}`;
+
   // TODO: persist new user via Prisma
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const originalDateNow = Date.now;
+  const timestamps = [1000, 2000];
+  Date.now = () => timestamps.shift() ?? 3000;
+
+  try {
+    const result = await registerUser({
+      email: "new.user@example.com",
+      role: "freelancer"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "freelancer");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Fixes #1093
/claim #743

## Summary
- reuse one generated user id for both the registration response and JWT `sub` claim
- add a regression test that forces `Date.now()` to return different values across calls
- #1093 is the scoped issue I created for this fix under parent bounty #743

## Tests
- npm test