### PR TITLE
Require DATABASE_URL before DB connect

### DIFF
--- a/apps/api/src/config/db.js
+++ b/apps/api/src/config/db.js
@@ -1,4 +1,11 @@
+import { env } from "./env.js";
+
 export async function connectDb() {
+  const databaseUrl = (process.env.DATABASE_URL ?? env.databaseUrl).trim();
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required to connect to the database");
+  }
+
   // TODO: wire Prisma client from @freelanceflow/db package
   return { connected: true, driver: "prisma-placeholder" };
 }

--- a/apps/api/src/tests/dbConfig.test.js
+++ b/apps/api/src/tests/dbConfig.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { connectDb } from "../config/db.js";
+
+test("connectDb rejects missing DATABASE_URL", async () => {
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+
+  try {
+    await assert.rejects(
+      connectDb(),
+      /DATABASE_URL is required to connect to the database/
+    );
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
+});
+
+test("connectDb reports success when DATABASE_URL is configured", async () => {
+  const previousDatabaseUrl = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/freelanceflow";
+
+  try {
+    assert.deepEqual(await connectDb(), {
+      connected: true,
+      driver: "prisma-placeholder"
+    });
+  } finally {
+    if (previousDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #1088 by making `connectDb()` fail fast when `DATABASE_URL` is missing or blank.
- Preserves the existing placeholder success shape when a database URL is configured.
- Adds focused node:test coverage for missing and configured database URL behavior.

## Validation
- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `node --check apps/api/src/config/db.js` -> passed
- `node --check apps/api/src/tests/dbConfig.test.js` -> passed
- `git diff --check` -> passed

## Demo
https://raw.githubusercontent.com/Wangnov/bug-bounty/codex-demo-assets/demos/connectdb-database-url-demo.mp4

Fixes #1088
