### PR TITLE
Fix connectDb DATABASE_URL startup guard

### DIFF
--- a/apps/api/src/config/db.js
+++ b/apps/api/src/config/db.js
@@ -1,4 +1,8 @@
 export async function connectDb() {
   // TODO: wire Prisma client from @freelanceflow/db package
+  if (!process.env.DATABASE_URL?.trim()) {
+    throw new Error("DATABASE_URL is required to connect to the database");
+  }
+
   return { connected: true, driver: "prisma-placeholder" };
 }

--- a/apps/api/src/tests/db.test.js
+++ b/apps/api/src/tests/db.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { connectDb } from "../config/db.js";
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+
+test.after(() => {
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+    return;
+  }
+
+  process.env.DATABASE_URL = originalDatabaseUrl;
+});
+
+test("connectDb rejects when DATABASE_URL is missing", async () => {
+  delete process.env.DATABASE_URL;
+
+  await assert.rejects(
+    connectDb(),
+    /DATABASE_URL is required to connect to the database/,
+  );
+});
+
+test("connectDb rejects when DATABASE_URL is empty", async () => {
+  process.env.DATABASE_URL = "   ";
+
+  await assert.rejects(
+    connectDb(),
+    /DATABASE_URL is required to connect to the database/,
+  );
+});
+
+test("connectDb reports the placeholder connection when DATABASE_URL is configured", async () => {
+  process.env.DATABASE_URL = "postgres://example.local/freelanceflow";
+
+  await assert.deepEqual(await connectDb(), {
+    connected: true,
+    driver: "prisma-placeholder",
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #1090

## Summary
- Fail fast in `connectDb()` when `DATABASE_URL` is missing, empty, or whitespace-only.
- Preserve the existing `{ connected: true, driver: prisma-placeholder }` return shape when a URL is configured.
- Add focused Node test coverage for missing, blank, and configured database URL paths.

## Validation
- `node --test apps/api/src/tests/db.test.js` -> 3 passed
- `node --check apps/api/src/config/db.js`
- `node --check apps/api/src/tests/db.test.js`
- `git diff --check`

Note: full `node --test apps/api/src/tests/*.test.js` could not complete in this workspace because dependencies are not installed (`ERR_MODULE_NOT_FOUND: Cannot find package 'cors'` from the existing health test). The new focused DB test runs without external packages and passes.