### PR TITLE
Fix: Prevent duplicate email registration — return 409 on existing email

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,11 +1,18 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err.code === "EMAIL_ALREADY_REGISTERED") {
+      return fail(res, err.message, 409);
+    }
+    throw err;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,13 +1,26 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = [];
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const existing = registeredUsers.find(u => u.email === payload.email);
+  if (existing) {
+    const err = new Error("A user with this email already exists");
+    err.code = "EMAIL_ALREADY_REGISTERED";
+    err.status = 409;
+    throw err;
+  }
+
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
+  registeredUsers.push({ id, email: payload.email });
+  return user;
 }
 
 export async function loginUser(payload) {


### PR DESCRIPTION
## Bug
`registerUser()` in `apps/api/src/services/authService.js` does not check if the provided email already exists before creating a new user. This allows multiple accounts to be registered with the same email address.

Closes #1094
Parent bounty: #743

## Changes
1. **`authService.js`**: Added in-memory `registeredUsers` array to track registered emails. Before creating a new user, checks if email already exists — throws `EMAIL_ALREADY_REGISTERED` error with 409 status if found.
2. **`authService.js`**: Fixed the id/JWT sub mismatch bug (also reported in #1093) — now generates `id` once and reuses it for both the response `id` and JWT `sub` claim.
3. **`authController.js`**: Added try/catch to handle `EMAIL_ALREADY_REGISTERED` errors and return proper 409 Conflict response.

## Acceptance Criteria
- [x] Registering with a new email succeeds (201)
- [x] Registering with the same email again returns 409 Conflict
- [x] JWT `sub` matches the response `id` (no more Date.now() race)
- [x] Error response follows API JSON format `{ success: false, message }`