### PR TITLE
fix: add validation for payment amount in createPayment endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  const amount = req.body.amount;
+  if (typeof amount !== "number" || amount <= 0) {
+    return fail(res, "Amount must be a positive number", 400);
+  }
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments creates payment with valid amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 100, currency: "usd" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 100);
+  });
+});
+
+test("POST /api/payments rejects negative amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: -50, currency: "usd" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Amount must be a positive number");
+  });
+});
+
+test("POST /api/payments rejects zero amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 0, currency: "usd" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Amount must be a positive number");
+  });
+});
+
+test("POST /api/payments rejects non-numeric amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: "100", currency: "usd" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Amount must be a positive number");
+  });
+});


### PR DESCRIPTION
This PR adds amount validation to the `/api/payments` endpoint, closing the low-hanging fruit issue #1100. It rejects negative, zero, and non-numeric amounts with a `400 Bad Request`.

Scope: Validate `amount` in `paymentController.js` and add comprehensive node:test coverage verifying validation boundaries.

Tests run:
- `node --test apps/api/src/tests/paymentRoutes.test.js` -> 4 passing tests
- `node --test apps/api/src/tests/*.test.js` -> 5 passing tests

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.