### PR TITLE
Return defensive copies from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((notification) => ({ ...notification }));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const listServiceCases = [
+  {
+    name: "users",
+    create: () => createUser({ email: "copy-user@example.com", fullName: "Copy User" }),
+    list: listUsers
+  },
+  {
+    name: "jobs",
+    create: () => createJob({ title: "Copy safe job", description: "Protect list response state" }),
+    list: listJobs
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ jobId: "job_copy", freelancerId: "usr_copy", bid: 100 }),
+    list: listProposals
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ reviewerId: "usr_a", revieweeId: "usr_b", rating: 5 }),
+    list: listReviews
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ senderId: "usr_a", recipientId: "usr_b", body: "hello" }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ userId: "usr_a", type: "system", message: "hello" }),
+    list: listNotifications
+  }
+];
+
+for (const serviceCase of listServiceCases) {
+  test(`${serviceCase.name} list responses cannot mutate backing store`, async () => {
+    const created = await serviceCase.create();
+    const firstList = await serviceCase.list();
+
+    firstList[0].id = `${serviceCase.name}_edited`;
+    firstList.push({ id: `${serviceCase.name}_injected` });
+    firstList.pop();
+    firstList.length = 0;
+
+    const secondList = await serviceCase.list();
+    assert.ok(secondList.some((entry) => entry.id === created.id));
+    assert.equal(secondList.some((entry) => entry.id === `${serviceCase.name}_injected`), false);
+  });
+}


### PR DESCRIPTION
## Summary
- Returns defensive object copies from all in-memory list services so callers cannot mutate backing store arrays or record objects.
- Covers users, jobs, proposals, reviews, messages, and notifications.
- Adds regression tests that mutate returned list arrays and returned record IDs, then verify the backing store remains intact.

## Verification
- `node --test "src/tests/**/*.js"` from `apps/api`
- `git diff --check`

Closes #1107
Refs #743