### PR TITLE
Reject OAuth callbacks without authorization code

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +15,10 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  if (typeof req.query.code !== "string" || req.query.code.trim() === "") {
+    return fail(res, "OAuth callback requires an authorization code", 400);
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/oauthCallback.test.js
+++ b/apps/api/src/tests/oauthCallback.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { oauthCallback } from "../controllers/authController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("oauthCallback rejects callbacks without an authorization code", async () => {
+  for (const code of [undefined, "", "   "]) {
+    const res = createResponse();
+
+    await oauthCallback({ params: { provider: "github" }, query: { code } }, res);
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      success: false,
+      message: "OAuth callback requires an authorization code"
+    });
+  }
+});
+
+test("oauthCallback accepts callbacks with a non-empty authorization code", async () => {
+  const res = createResponse();
+
+  await oauthCallback({ params: { provider: "github" }, query: { code: "abc123" } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      provider: "github",
+      status: "callback-received"
+    }
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #1109

## Summary
- require a non-empty OAuth authorization `code` before accepting provider callbacks
- return a 400 API error for missing, empty, or whitespace-only callback codes
- add focused node:test coverage for invalid and valid callback code paths

## Validation
- `node --test apps/api/src/tests/oauthCallback.test.js` -> 2 passed
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/oauthCallback.test.js`
- `git diff --check` -> passed with the repository's Windows line-ending warnings

Note: this local runner does not have npm available, so the focused controller test was run with temporary ignored dependency stubs for external packages. No dependency or generated files are committed.