### PR TITLE
Add Circuit of Trust poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Circuit of Trust
+
+At dawn the board is quiet,
+but every task has a trace:
+a title, a promise, a handoff,
+a name in the ledger of grace.
+
+The client brings a question,
+the builder brings a plan;
+between them runs a workflow
+that turns intent into span.
+
+No gate should trust a whisper,
+no token drift from its claim;
+the cleanest path through commerce
+is proof attached to a name.
+
+So keep the checks in daylight,
+keep every contract plain;
+when work and payment meet there,
+trust becomes a maintained domain.


### PR DESCRIPTION
## Summary
- Add an original 4-stanza poem in root `POEM.md`
- Creative note: I used an escrow-and-verification frame to connect freelance work, identity, and payment proof.

## Validation
- `git diff --cached --check` passed before commit

/claim #76