### PR TITLE
Use runtime PORT for web start script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p ${PORT:-3000}",
+    "test": "node scripts/check-start-script.mjs"
   },
   "devDependencies": {
     "@types/node": "22.15.19",

--- a/apps/web/scripts/check-start-script.mjs
+++ b/apps/web/scripts/check-start-script.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packagePath = path.join(scriptDir, "..", "package.json");
+const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+const startScript = packageJson.scripts?.start ?? "";
+
+assert.match(startScript, /\$\{PORT:-3000\}/, "start script must use the platform PORT with a local 3000 fallback");
+assert.doesNotMatch(startScript, /next start -p 3000$/, "start script must not hardcode only port 3000");


### PR DESCRIPTION
/claim #743

Closes #1115

## Summary
- Update `apps/web` production start script to bind to `${PORT:-3000}` instead of hardcoding port 3000.
- Add a lightweight web package regression check so the start script keeps using the platform-provided PORT with local fallback.

## Validation
- `npm run test -w apps/web`
- `node --check apps/web/scripts/check-start-script.mjs`
- `git diff --check`

No payout address, private token, cookie, seed phrase, or API key is included in this PR.
