### PR TITLE
Validate payment amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  if (!Number.isFinite(req.body?.amount) || req.body.amount <= 0) {
+    return fail(res, "Amount must be a positive number", 400);
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, amount) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ amount })
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("payment creation rejects negative amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, -100);
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Amount must be a positive number"
+    });
+  });
+});
+
+test("payment creation rejects zero amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, 0);
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Amount must be a positive number"
+    });
+  });
+});
+
+test("payment creation rejects non-number amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, "100");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Amount must be a positive number"
+    });
+  });
+});
+
+test("payment creation accepts positive numeric amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, 125);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.provider, "stripe");
+  });
+});


### PR DESCRIPTION
## Summary
- Rejects invalid payment amounts before creating a payment intent.
- Requires `amount` to be a finite number greater than zero.
- Adds route tests for negative, zero, non-number, and valid payment amounts.

## Verification
- `node --test "src/tests/**/*.js"` from `apps/api`
- `git diff --check`

Closes #1121
Refs #743