### PR TITLE
Run workspace builds from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "build": "npm run build --workspaces --if-present",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
/claim #743

Closes #1134

## Summary
- Replace the root `npm run build` placeholder echo with workspace build execution.
- Use `--if-present` so workspaces without build scripts are skipped instead of breaking the root build.

## Validation
- `npm run build`
- `git diff --check`

No payout address, private token, cookie, seed phrase, or API key is included in this PR.
