### PR TITLE
fix: zod validation errors return 400

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    return next(err);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    return next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Zod validation errors return 400 Bad Request instead of 500", async () => {
+  await withServer(async (baseUrl) => {
+    // Send an invalid payload to /api/auth/register (missing email, short password)
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "invalid", password: "123" }) // Should fail zod validation
+    });
+    
+    const payload = await response.json();
+    
+    assert.equal(response.status, 400, `Expected 400 Bad Request, got ${response.status}`);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors, "Expected 'errors' array in response");
+  });
+});


### PR DESCRIPTION
This PR fixes the global error handler so that it intercepts `ZodError` exceptions and returns a `400 Bad Request` with structured validation messages, rather than throwing an unhandled `500 Internal Server Error`.

Scope:
- `errorHandler.js`: Intercept `ZodError` and map it to a 400 response.
- `authController.js`: Wraps endpoints with try/catch to ensure async validation errors correctly bubble up to the global error handler in Express.
- `errorHandler.test.js`: Comprehensive node:test coverage validating the behavior.

This resolves issue #1141.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.