### PR TITLE
fix: enforce admin role validation on admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: Admins only", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Admin routes should block non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_123", role: "client" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { "Authorization": `Bearer ${token}` }
+    });
+    assert.equal(response.status, 403, `Expected 403 Forbidden, got ${response.status}`);
+  });
+});
+
+test("Admin routes should allow admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { "Authorization": `Bearer ${token}` }
+    });
+    assert.equal(response.status, 200, `Expected 200 OK, got ${response.status}`);
+  });
+});


### PR DESCRIPTION
This PR fixes a Broken Access Control (Privilege Escalation) vulnerability on the administrative endpoints.

Scope:
- `auth.js`: Added `adminMiddleware` to enforce that `req.user.role === "admin"`.
- `adminRoutes.js`: Applied `adminMiddleware` to all admin routes.
- `adminRoutes.test.js`: Added comprehensive node:test coverage validating the RBAC enforcement.

This resolves issue #1146.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.