### PR TITLE
fix: enforce authentication on payment endpoints

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Payment endpoints should block unauthenticated users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 100 })
+    });
+    
+    assert.equal(response.status, 401, `Expected 401 Unauthorized, got ${response.status}`);
+  });
+});


### PR DESCRIPTION
This PR fixes a Missing Authentication vulnerability in the `/api/payments` endpoint.

Scope:
- `paymentRoutes.js`: Applied the `authMiddleware` to the `paymentRoutes` router to enforce that all payment endpoints require a valid JWT session. This prevents anonymous users from artificially triggering payment events or accessing sensitive logic.
- `paymentRoutes.test.js`: Added a TDD node:test suite to assert that unauthenticated requests to `/api/payments` are correctly rejected with a `401 Unauthorized` response.

This resolves issue #1153.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.