### PR TITLE
Use server-owned fields for message creation

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { isRead, sentAt, createdAt, ...messagePayload } = payload;
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...messagePayload,
+    isRead: false,
+    createdAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage applies server-owned unread and createdAt fields", async () => {
+  const message = await sendMessage({
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "hello"
+  });
+
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.receiverId, "usr_receiver");
+  assert.equal(message.body, "hello");
+  assert.equal(message.isRead, false);
+  assert.match(message.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal("sentAt" in message, false);
+});
+
+test("sendMessage ignores caller-owned read and timestamp fields", async () => {
+  const message = await sendMessage({
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "hello",
+    isRead: true,
+    sentAt: "2000-01-01T00:00:00.000Z",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+
+  assert.equal(message.isRead, false);
+  assert.notEqual(message.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.equal("sentAt" in message, false);
+});


### PR DESCRIPTION
## Summary
- Prevent callers from controlling message read state or timestamps during message creation.
- Replace the non-schema `sentAt` output with server-owned `createdAt`.
- Add focused service coverage for default and override cases.

Closes #1157

## Verification
- `node --test "src/tests/**/*.js"`
- `git diff --check`