### PR TITLE
fix: preserve server-owned message fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,18 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { isRead: _ignoredIsRead, sentAt: _ignoredSentAt, createdAt: _ignoredCreatedAt, ...safePayload } =
+    payload ?? {};
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...safePayload,
+    isRead: false,
+    createdAt: new Date().toISOString(),
+  };
   messages.push(message);
   return message;
+}
+
+export function resetMessagesForTests() {
+  messages.length = 0;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, resetMessagesForTests, sendMessage } from "../services/messageService.js";
+
+test.beforeEach(() => {
+  resetMessagesForTests();
+});
+
+test("sendMessage stores server-owned defaults for new messages", async () => {
+  const message = await sendMessage({
+    conversationId: "conv_1",
+    senderId: "usr_1",
+    recipientId: "usr_2",
+    body: "hello",
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.equal(message.conversationId, "conv_1");
+  assert.equal(message.senderId, "usr_1");
+  assert.equal(message.recipientId, "usr_2");
+  assert.equal(message.body, "hello");
+  assert.equal(message.isRead, false);
+  assert.equal(typeof message.createdAt, "string");
+  assert.ok(Number.isFinite(Date.parse(message.createdAt)));
+  assert.equal("sentAt" in message, false);
+
+  const messages = await listMessages();
+  assert.equal(messages.length, 1);
+  assert.deepEqual(messages[0], message);
+});
+
+test("sendMessage ignores caller-owned read and timestamp fields", async () => {
+  const message = await sendMessage({
+    conversationId: "conv_2",
+    senderId: "usr_3",
+    recipientId: "usr_4",
+    body: "secure defaults",
+    isRead: true,
+    sentAt: "2000-01-01T00:00:00.000Z",
+    createdAt: "1999-01-01T00:00:00.000Z",
+  });
+
+  assert.equal(message.isRead, false);
+  assert.notEqual(message.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.equal("sentAt" in message, false);
+});


### PR DESCRIPTION
Closes #1158

## Summary
- ignore caller-owned `isRead`, `sentAt`, and `createdAt` fields in `sendMessage()`
- write server-owned `isRead: false` and `createdAt` defaults for every new message
- add focused regression tests for default creation and caller override attempts
- fix the API workspace test script so the added tests run through `npm test -w apps/api`

## Testing
```bash
npm test -w apps/api
```

/claim #743
Wallet: 2WktXRjaQ4GKhj6FJhUSndTBLVjxrk43TQwyywehneDA