### PR TITLE
Pass native props through shared UI components

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const defaultButtonStyle: React.CSSProperties = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children, style, ...props }: ButtonProps) {
   return (
     <button
-      style={{
-        background: "#5468ff",
-        color: "white",
-        border: "none",
-        borderRadius: 8,
-        padding: "0.6rem 0.9rem",
-        cursor: "pointer"
-      }}
+      style={{ ...defaultButtonStyle, ...style }}
+      {...props}
     >
       {children}
     </button>

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,18 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+};
+
+const defaultCardStyle: React.CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: "1rem"
+};
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section style={{ ...defaultCardStyle, ...style }} {...props}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
## Summary
- Extend shared `Button` props from native button attributes and pass through standard props.
- Extend shared `Card` props from native section attributes and pass through standard props.
- Preserve default styles while allowing caller-provided style overrides to merge cleanly.

Closes #1162

## Verification
- `npx tsc --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --noEmit --skipLibCheck --esModuleInterop packages/ui/src/Button.tsx packages/ui/src/Card.tsx`
- `git diff --check`