### PR TITLE
Strip sensitive fields from user service results

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,16 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { email, name, role, bio, skills, avatarUrl } = payload;
+  const user = {
+    id: `usr_${Date.now()}`,
+    email,
+    name,
+    role,
+    bio,
+    skills,
+    avatarUrl
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+const sensitiveFields = ["password", "passwordHash", "token", "resetToken"];
+
+test("createUser omits sensitive credential fields", async () => {
+  const user = await createUser({
+    email: "user@example.com",
+    name: "Test User",
+    role: "client",
+    password: "secret-password",
+    passwordHash: "hashed-password",
+    token: "access-token",
+    resetToken: "reset-token"
+  });
+
+  assert.equal(user.email, "user@example.com");
+  assert.equal(user.name, "Test User");
+  assert.equal(user.role, "client");
+
+  for (const field of sensitiveFields) {
+    assert.equal(field in user, false);
+  }
+});
+
+test("listUsers does not expose stripped sensitive fields", async () => {
+  const users = await listUsers();
+  const storedUser = users.find((user) => user.email === "user@example.com");
+
+  assert.ok(storedUser);
+  for (const field of sensitiveFields) {
+    assert.equal(field in storedUser, false);
+  }
+});


### PR DESCRIPTION
## Summary
- Strip credential/private fields when creating in-memory users.
- Keep only public user profile fields in the stored and returned user object.
- Add service coverage proving sensitive fields are omitted from create and list results.

Closes #1165

## Verification
- `node --test "src/tests/**/*.js"`
- `git diff --check`