### PR TITLE
fix(api): Snapshot create service records

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = snapshotRecord({ id: `job_${Date.now()}`, status: "open", ...payload });
   jobs.push(job);
-  return job;
+  return snapshotRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = snapshotRecord({ id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() });
   messages.push(message);
-  return message;
+  return snapshotRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = snapshotRecord({ id: `ntf_${Date.now()}`, read: false, ...payload });
   notifications.push(notification);
-  return notification;
+  return snapshotRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = snapshotRecord({ id: `prp_${Date.now()}`, ...payload });
   proposals.push(proposal);
-  return proposal;
+  return snapshotRecord(proposal);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = snapshotRecord({ id: `rev_${Date.now()}`, ...payload });
   reviews.push(review);
-  return review;
+  return snapshotRecord(review);
 }

--- a/apps/api/src/services/snapshot.js
+++ b/apps/api/src/services/snapshot.js
@@ -1,0 +1,3 @@
+export function snapshotRecord(record) {
+  return structuredClone(record);
+}

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = snapshotRecord({ id: `usr_${Date.now()}`, ...payload });
   users.push(user);
-  return user;
+  return snapshotRecord(user);
 }

--- a/apps/api/src/tests/createServiceSnapshots.test.js
+++ b/apps/api/src/tests/createServiceSnapshots.test.js
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  {
+    name: "jobs",
+    create: createJob,
+    payload: () => ({
+      title: "Build billing flow",
+      description: "Implement billing milestones",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "cat_platform",
+      skills: ["Node.js"],
+    }),
+    list: listJobs,
+    arrayField: "skills",
+    mutableField: "title",
+    expectedMutableValue: "Build billing flow",
+  },
+  {
+    name: "proposals",
+    create: createProposal,
+    payload: () => ({
+      jobId: "job_snapshot",
+      freelancerId: "usr_snapshot",
+      coverLetter: "I can help",
+      milestones: ["draft"],
+    }),
+    list: listProposals,
+    arrayField: "milestones",
+    mutableField: "coverLetter",
+    expectedMutableValue: "I can help",
+  },
+  {
+    name: "reviews",
+    create: createReview,
+    payload: () => ({
+      jobId: "job_snapshot",
+      reviewerId: "usr_snapshot",
+      rating: 5,
+      tags: ["fast"],
+    }),
+    list: listReviews,
+    arrayField: "tags",
+    mutableField: "rating",
+    expectedMutableValue: 5,
+  },
+  {
+    name: "messages",
+    create: sendMessage,
+    payload: () => ({
+      conversationId: "conv_snapshot",
+      senderId: "usr_snapshot",
+      body: "hello",
+      attachments: ["brief.pdf"],
+    }),
+    list: listMessages,
+    arrayField: "attachments",
+    mutableField: "body",
+    expectedMutableValue: "hello",
+  },
+  {
+    name: "notifications",
+    create: createNotification,
+    payload: () => ({
+      userId: "usr_snapshot",
+      message: "new proposal",
+      actions: ["open"],
+    }),
+    list: listNotifications,
+    arrayField: "actions",
+    mutableField: "message",
+    expectedMutableValue: "new proposal",
+  },
+  {
+    name: "users",
+    create: createUser,
+    payload: () => ({
+      email: "snapshot@example.com",
+      name: "Snapshot User",
+      skills: ["JavaScript"],
+    }),
+    list: listUsers,
+    arrayField: "skills",
+    mutableField: "name",
+    expectedMutableValue: "Snapshot User",
+  },
+];
+
+describe("create service snapshots", () => {
+  for (const testCase of cases) {
+    it(`keeps stored ${testCase.name} isolated from returned object and payload array mutations`, async () => {
+      const payload = testCase.payload();
+      const originalArray = [...payload[testCase.arrayField]];
+      const created = await testCase.create(payload);
+
+      payload[testCase.mutableField] = "mutated original payload";
+      payload[testCase.arrayField].push("mutated original payload");
+      created[testCase.mutableField] = "mutated outside service";
+      created[testCase.arrayField].push("mutated outside service");
+
+      const stored = (await testCase.list()).find((record) => record.id === created.id);
+
+      assert.equal(stored[testCase.mutableField], testCase.expectedMutableValue);
+      assert.deepEqual(stored[testCase.arrayField], originalArray);
+      assert.notEqual(stored, created);
+      assert.notEqual(stored[testCase.arrayField], created[testCase.arrayField]);
+    });
+  }
+});


### PR DESCRIPTION
﻿/claim #743

Create service functions now snapshot records before storing them and return separate response snapshots. This prevents callers from mutating in-memory state through either the original payload object or the object returned by a create call.

**Create Service Snapshots**

`createJob`, `createProposal`, `createReview`, `sendMessage`, `createNotification`, and `createUser` now use a shared snapshot helper for the stored record and response object while leaving list-service behavior, validation, persistence, and ID generation unchanged.

**Validation**

- `node --test apps\api\src\tests\createServiceSnapshots.test.js` -> 6 passed
- `node --check` on the new helper, new test, and each touched service -> passed
- `git diff --check` -> passed with line-ending warnings only
- Broader `apps/api/src/tests/*.test.js` run is blocked in this clean checkout because `health.test.js` imports `app.js`, which imports missing package `cors`

Fixes #1166
Refs #1159
Refs #743
