### PR TITLE
Use collision-resistant service identifiers

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createId } from "../utils/id.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = createId("usr");
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: createId("job"), status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { id: createId("msg"), ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: createId("ntf"), read: false, ...payload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createId } from "../utils/id.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: createId("prp"), ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: createId("rev"), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/id.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: createId("usr"), ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/idGeneration.test.js
+++ b/apps/api/src/tests/idGeneration.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withFrozenClock(callback) {
+  const originalDateNow = Date.now;
+  Date.now = () => 1234567890;
+  try {
+    return await callback();
+  } finally {
+    Date.now = originalDateNow;
+  }
+}
+
+test("service IDs remain unique within the same millisecond", async () => {
+  await withFrozenClock(async () => {
+    const factories = [
+      {
+        prefix: "job",
+        create: () => createJob({ title: "Build API", description: "Build a useful API", budgetMin: 1, budgetMax: 2, categoryId: "cat" }),
+        idOf: (record) => record.id
+      },
+      {
+        prefix: "msg",
+        create: () => sendMessage({ senderId: "usr_a", receiverId: "usr_b", body: "hello" }),
+        idOf: (record) => record.id
+      },
+      {
+        prefix: "ntf",
+        create: () => createNotification({ userId: "usr_a", body: "hello" }),
+        idOf: (record) => record.id
+      },
+      {
+        prefix: "pay",
+        create: () => createPaymentIntent({ amount: 10, currency: "usd" }),
+        idOf: (record) => record.paymentId
+      },
+      {
+        prefix: "prp",
+        create: () => createProposal({ jobId: "job_a", freelancerId: "usr_a", bidAmount: 10 }),
+        idOf: (record) => record.id
+      },
+      {
+        prefix: "rev",
+        create: () => createReview({ reviewerId: "usr_a", revieweeId: "usr_b", rating: 5 }),
+        idOf: (record) => record.id
+      },
+      {
+        prefix: "usr",
+        create: () => createUser({ email: "user@example.com", role: "client" }),
+        idOf: (record) => record.id
+      }
+    ];
+
+    for (const factory of factories) {
+      const first = factory.idOf(await factory.create());
+      const second = factory.idOf(await factory.create());
+
+      assert.match(first, new RegExp(`^${factory.prefix}_`));
+      assert.match(second, new RegExp(`^${factory.prefix}_`));
+      assert.notEqual(first, second);
+    }
+  });
+});
+
+test("registered user token subject matches the generated user id", async () => {
+  await withFrozenClock(async () => {
+    const user = await registerUser({
+      email: "registered@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const tokenPayload = verifyAccessToken(user.token);
+
+    assert.match(user.id, /^usr_/);
+    assert.equal(tokenPayload.sub, user.id);
+  });
+});

--- a/apps/api/src/utils/id.js
+++ b/apps/api/src/utils/id.js
@@ -1,0 +1,5 @@
+import { randomUUID } from "node:crypto";
+
+export function createId(prefix) {
+  return `${prefix}_${randomUUID()}`;
+}


### PR DESCRIPTION
## Summary
- Add a shared `createId(prefix)` helper backed by `crypto.randomUUID()`.
- Replace timestamp-based service IDs across API services.
- Reuse the generated registration user id as the JWT subject.
- Add regression tests that freeze `Date.now()` and verify IDs still remain unique.

Closes #1169

## Verification
- `node --test "src/tests/**/*.js"`
- `git diff --check`
- `rg -n "Date\.now\(\)" apps/api/src` returns no matches