### PR TITLE
Ignore caller-owned proposal and review ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...proposalPayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...proposalPayload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id, ...reviewPayload } = payload;
+  const review = { id: `rev_${Date.now()}`, ...reviewPayload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/serviceOwnedIds.test.js
+++ b/apps/api/src/tests/serviceOwnedIds.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+
+test("createProposal ignores caller-controlled id", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker",
+    jobId: "job_123",
+    freelancerId: "usr_123",
+    bidAmount: 100
+  });
+
+  assert.match(proposal.id, /^prp_/);
+  assert.notEqual(proposal.id, "prp_attacker");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_123");
+});
+
+test("createReview ignores caller-controlled id", async () => {
+  const review = await createReview({
+    id: "rev_attacker",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5
+  });
+
+  assert.match(review.id, /^rev_/);
+  assert.notEqual(review.id, "rev_attacker");
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+});


### PR DESCRIPTION
## Summary
- Strip caller-supplied `id` from proposal creation payloads before creating the record.
- Strip caller-supplied `id` from review creation payloads before creating the record.
- Add focused service tests proving service-generated IDs win.

Closes #1171

## Verification
- `node --test "src/tests/**/*.js"`
- `git diff --check`