### PR TITLE
fix: strip password from user API responses (#1173)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,17 @@
 const users = [];
 
+function sanitize(user) {
+  const { password, ...safe } = user;
+  return safe;
+}
+
 export async function listUsers() {
-  return users;
+  return users.map(sanitize);
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...meta } = payload;
+  const user = { id: `usr_${Date.now()}`, password, ...meta };
   users.push(user);
-  return user;
+  return sanitize(user);
 }


### PR DESCRIPTION
## Fix for #1173: Sensitive Data Exposure - Plaintext Passwords in API Responses

### Problem
`createUser()` returns the full user object including password. `listUsers()` returns all users with passwords exposed.

### Solution
- Added `sanitize()` helper function that strips the `password` field
- `listUsers()` now maps all users through sanitize
- `createUser()` stores password internally but returns sanitized user

### Files Changed
- `apps/api/src/services/userService.js`

### Testing
- Password is stored internally but never returned in API responses
- Existing user data flow preserved

This PR is linked to issue #1173 which is limited only to me as the issue creator.