### PR TITLE
fix: add auth, size limit, and type filter to upload endpoint (#1174)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,30 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Unsupported file type: ${file.mimetype}`));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
## Fix for #1174: Upload Endpoint Lacks Authentication and File Restrictions

### Problem
The upload endpoint had no authentication and no file restrictions, allowing:
- Unauthenticated file uploads
- Arbitrary file types (including malicious scripts)
- No file size limit (memory exhaustion DoS)

### Solution
- Added `authMiddleware` to require authentication
- Added 5MB file size limit via multer `limits`
- Added MIME type whitelist (JPEG, PNG, GIF, WebP, PDF, plain text)
- Files with unsupported types are rejected with a descriptive error

### Files Changed
- `apps/api/src/routes/uploadRoutes.js`

This PR is linked to issue #1174 which is limited only to me as the issue creator.