### PR TITLE
fix: prevent field override via explicit destructuring in create services (#1175)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,17 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { title, description, budgetMin, budgetMax, categoryId, skills } = payload;
+  const job = {
+    title,
+    description,
+    budgetMin,
+    budgetMax,
+    categoryId,
+    skills: skills ?? [],
+    id: `job_${Date.now()}`,
+    status: "open",
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,14 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { senderId, receiverId, content } = payload;
+  const message = {
+    senderId,
+    receiverId,
+    content,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString(),
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,15 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { userId, type, message } = payload;
+  const notification = {
+    userId,
+    type,
+    message,
+    id: `ntf_${Date.now()}`,
+    read: false,
+    createdAt: new Date().toISOString(),
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,14 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { jobId, coverLetter, budget } = payload;
+  const proposal = {
+    jobId,
+    coverLetter,
+    budget,
+    id: `prp_${Date.now()}`,
+    status: "pending",
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,14 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { jobId, rating, comment } = payload;
+  const review = {
+    jobId,
+    rating,
+    comment,
+    id: `rev_${Date.now()}`,
+    createdAt: new Date().toISOString(),
+  };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
## Fix for #1175: Spread Operator Allows Reserved Field Override

### Problem
All create service functions used `...payload` spread operator AFTER setting reserved fields, allowing callers to override `id`, `status`, `createdAt` etc. through the request body.

### Solution
- Replaced spread operator with explicit field destructuring
- Only expected fields are extracted from payload
- Reserved fields (id, status, timestamps) are hardcoded and cannot be overridden

### Files Changed
- `apps/api/src/services/jobService.js`
- `apps/api/src/services/proposalService.js`
- `apps/api/src/services/reviewService.js`
- `apps/api/src/services/messageService.js`
- `apps/api/src/services/notificationService.js`

This PR is linked to issue #1175 which is limited only to me as the issue creator.