### PR TITLE
Require authentication for core resource creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/coreResourceAuth.test.js
+++ b/apps/api/src/tests/coreResourceAuth.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const postCases = [
+  ["/api/jobs", { title: "Build API", description: "Build a useful API", budgetMin: 1, budgetMax: 2, categoryId: "cat" }],
+  ["/api/proposals", { jobId: "job_1", freelancerId: "usr_1", bidAmount: 100 }],
+  ["/api/reviews", { reviewerId: "usr_1", revieweeId: "usr_2", rating: 5 }],
+  ["/api/messages", { senderId: "usr_1", receiverId: "usr_2", body: "hello" }],
+  ["/api/notifications", { userId: "usr_1", title: "Update", body: "hello" }]
+];
+
+test("core resource creation routes reject missing bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    for (const [path, body] of postCases) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 401, path);
+      assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+    }
+  });
+});
+
+test("authenticated clients can still create core resources", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+
+    for (const [path, body] of postCases) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 201, path);
+      assert.equal(payload.success, true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Require `authMiddleware` on core resource POST creation routes.
- Keep existing GET/list routes unchanged.
- Add route coverage proving missing bearer tokens are rejected and authenticated POSTs still succeed.

Protected POST routes:
- `/api/jobs`
- `/api/proposals`
- `/api/reviews`
- `/api/messages`
- `/api/notifications`

Closes #1181

## Verification
- `node --test "src/tests/**/*.js"`
- `git diff --check`