### PR TITLE
fix: prevent admin role escalation via registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,8 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  // Only allow client/freelancer - admin created via internal process
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Fix for: Role Escalation via Registration

Removes `admin` from allowed roles in `registerSchema`. Admin accounts should only be provisioned through internal/seeder scripts, never via the public API.

### Changes
- `apps/api/src/validators/auth.js`: `role` enum restricted to `["client", "freelancer"]`
