### PR TITLE
Reject non-positive payment amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+    const result = await createPaymentIntent(req.body);
+
+  if (result.error) {
+        return fail(res, result.error, 400);
+  }
+
+  return ok(res, result, 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,15 @@
 export async function createPaymentIntent(payload) {
+  if (
+    !payload ||
+    typeof payload.amount !== "number" ||
+    !Number.isFinite(payload.amount) ||
+    payload.amount <= 0
+  ) {
+    return {
+      error: "Amount must be a positive number"
+    };
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPayment } from "../controllers/paymentController.js";
+
+function mockRes() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    }
+  };
+}
+
+test("createPayment rejects non-positive amounts", async () => {
+  const res = mockRes();
+
+  await createPayment({ body: { amount: -1, currency: "usd" } }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Amount must be a positive number"
+  });
+});
+
+test("createPayment accepts positive numeric amounts", async () => {
+  const res = mockRes();
+
+  await createPayment({ body: { amount: 120, currency: "usd" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.amount, 120);
+  assert.equal(res.body.data.currency, "usd");
+  assert.equal(res.body.data.provider, "stripe");
+  assert.equal(res.body.data.paymentId.startsWith("pay_"), true);
+});


### PR DESCRIPTION
/claim #743

Closes #1177.

Summary
- Reject payment intent requests when amount is missing, non-numeric, zero, or negative.
- - Return a 400 response for invalid payment amounts instead of a successful intent payload.
- - Add focused controller tests for invalid and valid payment amounts.
Verification
- npm test -w apps/api