### PR TITLE
fix: restrict CORS to whitelisted origins only

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,24 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const allowedOrigins = [
+  process.env.FRONTEND_URL ?? "http://localhost:3000"
+];
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("CORS not allowed"));
+      }
+    },
+    credentials: true
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
## Fix for: CORS Wide Open

Replaces `cors()` (allows all origins) with explicit origin whitelist configuration.

### Changes
- `apps/api/src/app.js`: CORS now validates `origin` against `allowedOrigins` list
- Default allows only `FRONTEND_URL` env var or `http://localhost:3000`
- Credentials mode explicitly enabled for same-origin cookie flows
