### PR TITLE
fix: add authentication to payment routes

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
## Fix for: Payment Endpoint Missing Authentication (#1191)

Adds `authMiddleware` to the payment route so only authenticated users can create payment intents.

### Changes
- `apps/api/src/routes/paymentRoutes.js`: Added `authMiddleware` to POST /
