### PR TITLE
fix: add OAuth callback provider validation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const ALLOWED_PROVIDERS = ["google", "github"];
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,17 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+
+  if (!ALLOWED_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
+
+  // TODO: exchange authorization code for tokens with the provider
+  // TODO: verify state parameter to prevent CSRF
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }


### PR DESCRIPTION
## Fix for: OAuth Callback Accepts Any Provider (#1192)

Validates the `provider` parameter against a whitelist (`google`, `github`) before processing the callback. Unknown providers receive a 400 error.

### Changes
- `apps/api/src/controllers/authController.js`: Added `ALLOWED_PROVIDERS` whitelist, validate provider before responding
