### PR TITLE
Protect message list reads

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/messageReadAuth.test.js
+++ b/apps/api/src/tests/messageReadAuth.test.js
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("GET /api/messages is protected by auth middleware", async () => {
+  const source = await readFile(new URL("../routes/messageRoutes.js", import.meta.url), "utf8");
+
+  assert.match(source, /import \{ authMiddleware \} from "\.\.\/middleware\/auth\.js";/);
+  assert.match(source, /messageRoutes\.get\("\/",\s*authMiddleware,\s*getMessages\);/);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Require bearer authentication before listing messages from `GET /api/messages`.
- Keep message creation and all other resource routes out of scope to avoid overlapping with PR #1182.
- Add a focused route-table regression test for the message read route.

Fixes #1205
Refs #743

## Verification
- `node --test apps/api/src/tests/messageReadAuth.test.js` -> 1 passed
- `node --check apps/api/src/routes/messageRoutes.js`
- `node --check apps/api/src/tests/messageReadAuth.test.js`
- `git diff --check` -> passed with Windows line-ending warnings only

Note: the clean checkout in this environment has no local npm executable or installed API dependencies, so I used a dependency-free focused regression test plus syntax and diff checks rather than the full Express app suite.