### PR TITLE
Protect user list route

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/userListAuth.test.js
+++ b/apps/api/src/tests/userListAuth.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/users requires authentication", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Require bearer authentication before `GET /api/users` returns the user collection.
- Keep user creation behavior unchanged.
- Add a focused regression test for the unauthenticated read case.

Fixes #1210
Refs #743

## Verification
- `node --test src/tests/*.js` from `apps/api`
- `node --check src/routes/userRoutes.js`
- `node --check src/tests/userListAuth.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` currently fails because Node 24 treats the package script target `src/tests` as a module path rather than expanding the directory. The equivalent explicit test-file glob passes.