### PR TITLE
fix: remove hardcoded JWT secret fallback in env.js

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,7 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.JWT_SECRET,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
## Summary

The `apps/api/src/config/env.js` file had a hardcoded fallback value for `jwtSecret`:

```js
jwtSecret: process.env.JWT_SECRET ?? development-secret
```

This means anyone who knows the default value can forge valid JWT tokens and impersonate any user.

## Fix

Removed the hardcoded fallback. The `jwtSecret` now only reads from `process.env.JWT_SECRET`, forcing explicit configuration.

```diff
-  jwtSecret: process.env.JWT_SECRET ?? development-secret,
+  jwtSecret: process.env.JWT_SECRET,
```

## Impact

- Prevents JWT forgery via known default secret
- Forces deployers to explicitly set `JWT_SECRET` environment variable
- Aligns with security best practice: no hardcoded secrets

/claim #743
