### PR TITLE
fix: require authentication for user list endpoint (#1210)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/msg_1210.txt
+++ b/msg_1210.txt
@@ -1,0 +1,5 @@
+fix: require authentication for user list endpoint (#1210)
+
+GET /users now requires valid JWT authentication to prevent
+unauthorized access to the full user list.
+Fixes #1210


### PR DESCRIPTION
## Fixes #1210

### Problem
The `GET /users` endpoint exposes all user data without authentication, allowing anyone to enumerate users.

### Solution
Added `authMiddleware` to the user list route so only authenticated users can access the user list.

### Testing
- Unauthenticated GET /users returns 401
- Authenticated GET /users returns user list