### PR TITLE
fix: require authentication for message list endpoint (#1205)

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/msg_1205.txt
+++ b/msg_1205.txt
@@ -1,0 +1,5 @@
+fix: require authentication for message list endpoint (#1205)
+
+GET /messages now requires valid JWT authentication to prevent
+unauthorized access to all messages.
+Fixes #1205

--- a/pr_body_1210.txt
+++ b/pr_body_1210.txt
@@ -1,0 +1,11 @@
+## Fixes #1210
+
+### Problem
+The `GET /users` endpoint exposes all user data without authentication, allowing anyone to enumerate users.
+
+### Solution
+Added `authMiddleware` to the user list route so only authenticated users can access the user list.
+
+### Testing
+- Unauthenticated GET /users returns 401
+- Authenticated GET /users returns user list


### PR DESCRIPTION
## Fixes #1205

### Problem
The `GET /messages` endpoint exposes all messages without authentication, allowing anyone to read private communications.

### Solution
Added `authMiddleware` to the message list route so only authenticated users can access messages.

### Testing
- Unauthenticated GET /messages returns 401
- Authenticated GET /messages returns message list