### PR TITLE
Protect proposal list route

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
+proposalRoutes.get("/", authMiddleware, getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/tests/proposalListAuth.test.js
+++ b/apps/api/src/tests/proposalListAuth.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/proposals requires authentication", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Require bearer authentication before `GET /api/proposals` returns the proposal collection.
- Keep proposal creation behavior unchanged.
- Add a focused regression test for the unauthenticated read case.

Fixes #1216
Refs #743

## Verification
- `node --test src/tests/*.js` from `apps/api`
- `node --check src/routes/proposalRoutes.js`
- `node --check src/tests/proposalListAuth.test.js`
- `git diff --check`

Note: the workspace script `npm run test -w apps/api` currently targets `node --test src/tests`, which Node 24 treats as a module path. The equivalent explicit test-file glob passes.