### PR TITLE
Protect review list route

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
+reviewRoutes.get("/", authMiddleware, getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/reviewListAuth.test.js
+++ b/apps/api/src/tests/reviewListAuth.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/reviews requires authentication", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Require bearer authentication before `GET /api/reviews` returns the review collection.
- Keep review creation behavior unchanged.
- Add a focused regression test for the unauthenticated read case.

Fixes #1218
Refs #743

## Verification
- `node --test src/tests/*.js` from `apps/api`
- `node --check src/routes/reviewRoutes.js`
- `node --check src/tests/reviewListAuth.test.js`
- `git diff --check`

Note: the workspace script `npm run test -w apps/api` currently targets `node --test src/tests`, which Node 24 treats as a module path. The equivalent explicit test-file glob passes.