### PR TITLE
fix: add authMiddleware to notification routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
/attempt #743

## Summary
The notification routes are missing authMiddleware, allowing anyone to read or create notifications without authentication. All other auth-protected routes use authMiddleware but notificationRoutes was overlooked.

## Fix
Added uthMiddleware to the notificationRoutes router so both GET /api/notifications and POST /api/notifications require authentication.

## Impact
Without this fix, any unauthenticated user can access all notification data.

/claim #743