### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages rejects blank content", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_client",
+        recipientId: "usr_freelancer",
+        content: "   "
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/messages stores validated message payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_client",
+        recipientId: "usr_freelancer",
+        content: "Please send the latest milestone update."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.senderId, "usr_client");
+    assert.equal(payload.data.recipientId, "usr_freelancer");
+    assert.equal(payload.data.content, "Please send the latest milestone update.");
+    assert.match(payload.data.id, /^msg_/);
+    assert.match(payload.data.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().trim().min(1),
+  recipientId: z.string().trim().min(1),
+  content: z.string().trim().min(1).max(5000)
+});


### PR DESCRIPTION
/claim #743

Fixes #1226.

## Summary

- Added a Zod schema for message creation payloads.
- Validate senderId, recipientId, and trimmed content before storing messages.
- Return the existing JSON error shape with HTTP 400 for malformed message payloads.
- Added API regression tests for empty payloads, blank content, and a valid message.

## Verification

- `node --test apps/api/src/tests/*.test.js`

Note: `npm test -w apps/api` currently fails because Node 26 treats `node --test src/tests` as a file path instead of discovering test files from the directory. The direct test-file command above passes.
