### PR TITLE
fix: resolve authentication bypass in login — password verification

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "test": "node --test src/tests"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -9,9 +9,13 @@ export async function register(req, res) {
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    return res.status(401).json({ success: false, message: "Invalid credentials" });
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,21 +1,51 @@
 import { signAccessToken } from "../utils/jwt.js";
+import bcrypt from "bcryptjs";
+
+// In-memory user store (mirrors userService.js)
+const users = [];
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
+  const passwordHash = await bcrypt.hash(payload.password, 10);
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash,
+    role: payload.role ?? "CLIENT",
+  };
+  users.push(user);
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role }),
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const user = users.find((u) => u.email === payload.email);
+  // When Prisma is wired, look up from DB; fall back to in-memory store
+  const dbUser = await getDbUserByEmail(payload.email);
+  const foundUser = dbUser ?? user;
+  if (!foundUser) {
+    throw new Error("Invalid credentials");
+  }
+  const passwordHash = foundUser.passwordHash ?? (user ? user.passwordHash : null);
+  if (!passwordHash) {
+    throw new Error("Invalid credentials");
+  }
+  const valid = await bcrypt.compare(payload.password, passwordHash);
+  if (!valid) {
+    throw new Error("Invalid credentials");
+  }
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: foundUser.email,
+    token: signAccessToken({ sub: foundUser.id, role: foundUser.role }),
   };
+}
+
+// Placeholder — replace with Prisma call once DB is wired
+async function getDbUserByEmail(email) {
+  return null;
 }
 
 export async function refreshToken() {

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/login rejects empty password", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Attempt login with a non-existent user — should fail with 401
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "nobody@example.com", password: "anypassword" }),
+  });
+
+  assert.equal(res.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
     "apps/api": {
       "name": "@freelanceflow/api",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",
@@ -793,6 +794,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {


### PR DESCRIPTION
## Summary
Fix for [BOUNTY] Authentication Bypass: Login does not verify password — Issue #1185

## Root cause
The login function in `authService.js` completely ignored the `password` field and always returned a valid JWT token for any email. The bug was a hardcoded fallback that returned `{ sub: "usr_existing", role: "client" }` without any credential check.

## Fix
- Added `bcryptjs` dependency for password hash verification
- `loginUser()` now looks up the user by email and verifies the password hash using `bcrypt.compare()`
- Throws `"Invalid credentials"` (401) when the user is not found or the password does not match
- Added a regression test that confirms 401 is returned when logging in with a non-existent user

## Changes
- `apps/api/src/services/authService.js` — replaced stub with real `bcrypt.compare()` verification
- `apps/api/src/controllers/authController.js` — catch errors from loginUser and return 401
- `apps/api/src/tests/auth.test.js` — regression test for auth bypass

Closes #1185