### PR TITLE
Require auth for review listing

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
+reviewRoutes.get("/", authMiddleware, getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/reviewReadAuth.test.js
+++ b/apps/api/src/tests/reviewReadAuth.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/reviews requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/reviews returns reviews for authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_review_reader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #1240.

Scope: protect `GET /api/reviews` with the existing bearer auth middleware so anonymous callers cannot list the review store. `POST /api/reviews` remains out of scope.

Validation:
- `node --test apps/api/src/tests/reviewReadAuth.test.js` -> 2 passed
- `node --check apps/api/src/routes/reviewRoutes.js` -> passed
- `node --check apps/api/src/tests/reviewReadAuth.test.js` -> passed
- `git diff --check` -> passed

Demo/evidence: the new regression test proves anonymous review list requests return `401` and authenticated requests still return the review array.

No payout address, private token, cookie, seed phrase, or API key is included.
