### PR TITLE
Fix: automatically load .env environment variables during API startup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,3 +1,13 @@
+try {
+  // Automatically load local .env file natively if it exists
+  process.loadEnvFile();
+} catch (error) {
+  // Ignore missing .env file (ENOENT)
+  if (error && error.code !== "ENOENT") {
+    console.warn("Failed to load .env file:", error.message);
+  }
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const envFilePath = path.join(__dirname, "../../../../.env");
+
+test("native environment loader loads variables from .env file", async () => {
+  // 1. Setup a temporary .env file at the workspace root (where process.cwd() starts)
+  const originalEnvExists = fs.existsSync(envFilePath);
+  let originalEnvContent = "";
+  if (originalEnvExists) {
+    originalEnvContent = fs.readFileSync(envFilePath, "utf8");
+  }
+
+  // Write custom test environment variables
+  fs.writeFileSync(envFilePath, "PORT=12345\nJWT_SECRET=test-secret-env-file-load\nDATABASE_URL=postgres://test-db-url\n");
+
+  try {
+    // 2. Bypass ESM cache by using a cache-busting query parameter on import
+    const { env } = await import(`../config/env.js?cb=${Date.now()}`);
+
+    // 3. Assert values are loaded correctly from .env
+    assert.equal(env.port, 12345);
+    assert.equal(env.jwtSecret, "test-secret-env-file-load");
+    assert.equal(env.databaseUrl, "postgres://test-db-url");
+  } finally {
+    // 4. Restore original .env or clean up
+    if (originalEnvExists) {
+      fs.writeFileSync(envFilePath, originalEnvContent);
+    } else {
+      fs.unlinkSync(envFilePath);
+    }
+  }
+});
+
+test("environment loader defaults to fallbacks when .env is absent", async () => {
+  // Ensure .env does not exist for this test
+  const originalEnvExists = fs.existsSync(envFilePath);
+  let originalEnvContent = "";
+  if (originalEnvExists) {
+    originalEnvContent = fs.readFileSync(envFilePath, "utf8");
+    fs.unlinkSync(envFilePath);
+  }
+
+  // Backup existing process.env variables to avoid interference
+  const oldPort = process.env.PORT;
+  const oldSecret = process.env.JWT_SECRET;
+  delete process.env.PORT;
+  delete process.env.JWT_SECRET;
+
+  try {
+    const { env } = await import(`../config/env.js?cb=${Date.now() + 1}`);
+
+    // Assert it gracefully uses fallbacks without crashing
+    assert.equal(env.port, 4000);
+    assert.equal(env.jwtSecret, "development-secret");
+  } finally {
+    // Restore process.env
+    if (oldPort !== undefined) process.env.PORT = oldPort;
+    if (oldSecret !== undefined) process.env.JWT_SECRET = oldSecret;
+
+    // Restore original .env
+    if (originalEnvExists) {
+      fs.writeFileSync(envFilePath, originalEnvContent);
+    }
+  }
+});


### PR DESCRIPTION
### Problem
Currently, environment variables in the API workspace are defined in `apps/api/src/config/env.js` from `process.env`. However, Node.js does not automatically load a `.env` file unless explicitly commanded. This means that local developers must manually export variables or install an external dependency like `dotenv`.

### Solution
To solve this natively in Node 20.12.0+ and Node 22+ without adding any third-party dependencies:
1. Load the `.env` file in the API using the built-in `process.loadEnvFile()` helper at the top of `apps/api/src/config/env.js`.
2. Wrap it in a `try-catch` block to silently ignore missing files (e.g., `ENOENT`) while warning on other loading errors.
3. Added a new unit test suite in `apps/api/src/tests/env.test.js` to verify that environment variables are correctly loaded and fallback safely when the file is absent.

Closes #1241
/claim #743
