### PR TITLE
fix: handle ZodError in errorHandler middleware

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((e) => ({
+        path: e.path.join("."),
+        message: e.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,


### PR DESCRIPTION
## Summary

This PR adds proper `ZodError` handling to the Express error handler middleware. Previously, when Zod validation failed (e.g., invalid request body), the error was caught by the generic handler and returned as a **500 Internal Server Error**, which is misleading.

### Changes

- **`apps/api/src/middleware/errorHandler.js`**: Added `instanceof ZodError` check before the generic error handler
  - Returns **400 Bad Request** with structured validation errors
  - Each error includes `path` and `message` for easy client-side handling
  - Moved `console.error` after the Zod check to avoid logging expected validation failures

### Example Response

```json
{
  "success": false,
  "message": "Validation error",
  "errors": [
    { "path": "email", "message": "Invalid email" },
    { "path": "password", "message": "String must contain at least 8 character(s)" }
  ]
}
```

### Testing

Verified that the existing Zod validators in `authController.js` and `jobController.js` (which call `.parse()`) now surface meaningful 400 errors instead of 500s.

/claim #743