### PR TITLE
fix: prevent admin role registration and handle validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.name === "ZodError" || err.constructor?.name === "ZodError") {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors || err.issues
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../utils/async.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/tests/register.test.js
+++ b/apps/api/src/tests/register.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Registration — admin role prevention", async (t) => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("POST /api/auth/register — rejects admin role", async () => {
+    const payload = {
+      email: "attacker@example.com",
+      password: "password123",
+      role: "admin"
+    };
+
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Validation failed");
+  });
+
+  await t.test("POST /api/auth/register — accepts client role", async () => {
+    const payload = {
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    };
+
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "client");
+  });
+
+  await t.test("POST /api/auth/register — accepts freelancer role", async () => {
+    const payload = {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    };
+
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "freelancer");
+  });
+
+  await t.test("POST /api/auth/register — defaults to client when no role specified", async () => {
+    const payload = {
+      email: "default@example.com",
+      password: "password123"
+    };
+
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "client");
+  });
+
+  // Clean up server
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/async.js
+++ b/apps/api/src/utils/async.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Closes #1183

### Problem
The public registration endpoint (`/api/auth/register`) accepted the `admin` role in the request payload, which allows self-assigning admin privileges (Role Escalation vulnerability). Additionally, validation errors (ZodErrors) inside async controller methods were not handled correctly due to Express 4 not catching rejected promises.

### Changes
1. **`apps/api/src/validators/auth.js`**:
   - Restrict role parameter in `registerSchema` to `["client", "freelancer"]`.
2. **`apps/api/src/routes/authRoutes.js`**:
   - Wrap auth controllers with `asyncHandler` so validation errors (and other unhandled rejections) propagate correctly to Express error middleware.
3. **`apps/api/src/middleware/errorHandler.js`**:
   - Intercept `ZodError` to format the validation issues and return a standard `400 Bad Request` response instead of triggering an internal `500 Server Error`.
4. **`apps/api/src/tests/register.test.js`**:
   - Add integration tests for registration to verify:
     - Attempts to register with the `admin` role are rejected.
     - Registration with `client` or `freelancer` role succeeds.
     - Lack of role defaults to `client`.

### Verification
Ran tests successfully:
```bash
node --test apps/api/src/tests/register.test.js
```
