### PR TITLE
fix: require authentication on upload route

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);
+

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+// Ensure process.loadEnvFile is called so JWT_SECRET is loaded if tests run with it,
+// though during test we can mock env.jwtSecret or rely on a fallback/in-memory value.
+// Wait, we need env.jwtSecret to sign and verify.
+// In env.js: jwtSecret: process.env.JWT_SECRET ?? "development-secret"
+// Since we are on main branch, env.js has "development-secret" as fallback, so signing works out of the box.
+
+test("Upload Routes Authorization", async (t) => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("POST /api/uploads without token returns 401", async () => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST"
+    });
+
+    const body = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Unauthorized");
+  });
+
+  await t.test("POST /api/uploads with invalid token returns 401", async () => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer invalid-token-string"
+      }
+    });
+
+    const body = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Invalid token");
+  });
+
+  await t.test("POST /api/uploads with valid token succeeds", async () => {
+    const token = signAccessToken({ sub: "usr_test123", role: "client" });
+
+    // Node fetch doesn't support FormData file uploads natively without FormData.
+    // However, since we just want to test authMiddleware, we can send a multipart/form-data body or empty body.
+    // Let's create a simple multipart boundary body or just call it, since upload.single("file") doesn't throw if file is missing,
+    // it just sets req.file to undefined and calls uploadFile, which returns { status: "no-file" }.
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`
+      }
+    });
+
+    const body = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.status, "no-file");
+  });
+
+  // Clean up server
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1265

### Problem
The file upload endpoint `/api/uploads` was missing `authMiddleware` verification, allowing unauthenticated API clients to post arbitrary files to the server.

### Changes
- **`apps/api/src/routes/uploadRoutes.js`**: Add `authMiddleware` to secure the POST endpoint.
- **`apps/api/src/tests/upload.test.js`**: Add integration tests verifying:
  - Unauthorized uploads (no token) are rejected with a `401 Unauthorized` response.
  - Invalid token uploads are rejected with a `401 Unauthorized` response.
  - Authenticated uploads with a valid token succeed and receive a `201 Created` status.

### Testing
Tests successfully executed and passed:
```bash
node --test apps/api/src/tests/upload.test.js
```
