### PR TITLE
fix: add input validation to messageController.js

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Message Routes Input Validation", async (t) => {
+  await t.test("POST /api/messages rejects empty payload", async () => {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({})
+      });
+
+      const body = await response.json();
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+      assert.equal(body.message, "Invalid message payload");
+    });
+  });
+
+  await t.test("POST /api/messages rejects missing recipientId", async () => {
+    await withServer(async (baseUrl) => {
+      const payload = {
+        senderId: "usr_sender123",
+        content: "Hello world"
+      };
+
+      const response = await fetch(`${baseUrl}/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json();
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+      assert.equal(body.message, "Invalid message payload");
+    });
+  });
+
+  await t.test("POST /api/messages accepts valid payload and stores it", async () => {
+    await withServer(async (baseUrl) => {
+      const payload = {
+        senderId: "usr_sender123",
+        recipientId: "usr_recipient456",
+        content: "Hello world!"
+      };
+
+      const response = await fetch(`${baseUrl}/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      const body = await response.json();
+      assert.equal(response.status, 201);
+      assert.equal(body.success, true);
+      assert.equal(body.data.senderId, payload.senderId);
+      assert.equal(body.data.recipientId, payload.recipientId);
+      assert.equal(body.data.content, payload.content);
+      assert.ok(body.data.id);
+      assert.ok(body.data.sentAt);
+    });
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().trim().min(1),
+  recipientId: z.string().trim().min(1),
+  content: z.string().trim().min(1).max(5000)
+});


### PR DESCRIPTION
## Summary

Closes #1267

### Problem
The `postMessage` handler in `apps/api/src/controllers/messageController.js` spread/passed the raw `req.body` to the service layer without any schema validation, which accepts empty or malformed payloads.

### Changes
- **`apps/api/src/validators/message.js`**: Create a `createMessageSchema` object using Zod to validate:
  - `senderId` (non-empty string)
  - `recipientId` (non-empty string)
  - `content` (non-empty string, max 5000 characters)
- **`apps/api/src/controllers/messageController.js`**: Use `createMessageSchema.safeParse(req.body)` to validate incoming payloads and return a `400 Bad Request` if invalid.
- **`apps/api/src/tests/message.test.js`**: Add integration tests verifying:
  - Empty payload is rejected (400)
  - Missing fields (like `recipientId`) are rejected (400)
  - Valid payloads are successfully processed (201)

### Testing
Ran tests successfully:
```bash
node --test apps/api/src/tests/message.test.js
```
