### PR TITLE
feat: add technical poem 'Ode to Code'

### DIFF
--- a/assets/poems/ode_to_code.md
+++ b/assets/poems/ode_to_code.md
@@ -1,0 +1,67 @@
+# Ode to Code
+
+*A technical poem celebrating the art of software development*
+
+---
+
+In silicon valleys deep and bright,
+Where logic dances with the night,
+A language speaks in ones and zeros—
+The dreamers, builders, and the heroes.
+
+```python
+def create_the_future():
+    while human_spirit.burns():
+        ideas = imagination.gather()
+        code = craft.transform(ideas)
+        world.improve(code)
+```
+
+Functions call like rivers flow,
+Through loops of trial and error's glow,
+Each bug a puzzle, each fix a key,
+Unlocking what was meant to be.
+
+The compiler whispers, "Is this right?"
+The debugger shines its pixel light,
+Stack traces tell their winding tales,
+Of midnight hunts through tangled trails.
+
+From `Hello World` to distributed scale,
+From monoliths to microservices' trail,
+We build the bridges, line by line,
+Between the human and divine.
+
+```javascript
+const tomorrow = await Promise.all([
+  innovation.discover(),
+  collaboration.unite(),
+  persistence.prevail()
+]);
+```
+
+Git commits mark our journey's pace,
+Each branch a fork in time and space,
+Pull requests: our conversations,
+Merging hearts across all nations.
+
+The cloud ascends, containers spin,
+Kubernetes orchestrates within,
+Docker images, light and lean,
+The most elegant machines.
+
+So here's to those who dare to code,
+On every winding mountain road,
+Who turn the abstract into real,
+And build the future that we feel.
+
+```bash
+$ echo "Keep shipping, keep dreaming."
+Keep shipping, keep dreaming.
+$ exit 0
+```
+
+---
+
+*Written with ❤️ and caffeine*
+*For every developer who ever stared at a screen at 3 AM*


### PR DESCRIPTION
Hey! I wrote a technical poem called 'Ode to Code' that celebrates software development. It includes code snippets in Python and JavaScript, and touches on themes every developer can relate to — debugging at 3 AM, git commits, cloud infrastructure, and the joy of shipping.

The poem is in Markdown format under .

Fixes #76

/claim #76