### PR TITLE
fix: enforce 1MB JSON body size limit to prevent memory DoS

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "1mb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
The express.json() call in pp.js did not specify a limit option, allowing attackers to send arbitrarily large JSON bodies that could cause memory exhaustion and denial of service.\n\nThis PR adds { limit: '1mb' } to express.json() to enforce a reasonable body size limit.\n\nCloses #1285\n\n/claim #743