### PR TITLE
fix: restrict error logging to development only to prevent sensitive data leak

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,5 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  if (process.env.NODE_ENV === "development") { console.error("Unhandled API error:", err); }
   if (res.headersSent) {
     return next(err);
   }


### PR DESCRIPTION
The errorHandler middleware unconditionally logs full error objects to console.error, exposing potentially sensitive information (stack traces, internal paths, user data) in production logs. This PR wraps the console.error call in a NODE_ENV === development check so detailed errors are only logged during development. /claim #743