### PR TITLE
fix: restrict CORS to allowed origin instead of wildcard

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: process.env.CORS_ORIGIN || 'http://localhost:3000', credentials: true }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Default cors() allows any origin. Restrict via CORS_ORIGIN env var with localhost fallback. /claim #743