### PR TITLE
feat: add original poem 'The Merge' (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Merge
+
+In the glow of terminal green, we write our vows,
+each commit a promise pushed across the wire —
+branch by branch, we build what no one allows
+until the CI passes, and the tests don't tire.
+
+We name our bugs like constellations in the dark,
+trace their orbits through a thousand nested calls,
+hunt them down through forests cold and stark,
+and pin them to the board behind glass walls.
+
+Open source is trust laid bare in diffs,
+a stranger's logic folded into ours.
+We read each function like a hieroglyph
+and wonder at the architecture of stars.
+
+Pull requests are letters never sent with ease —
+each review a quiet act of faith.
+We argue syntax, intent, and APIs,
+then merge, and something new escapes the lathe.
+
+So here we are: half poets, half machines,
+translating thought to syntax, dream to thread.
+The compiler doesn't care what any of it means.
+We do. That's why we write the code instead.


### PR DESCRIPTION
Adds an original poem titled *The Merge* as  in the project root.

**Creative decision:** I chose free verse with a consistent rhyme scheme to mirror the tension between structure (code) and freedom (creativity) — the poem explores open-source collaboration and bug hunting as acts of shared authorship, fitting for a project built on community contribution.

/claim #76