### PR TITLE
fix: add startup environment validation to prevent deploying with defaults

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,27 @@
-export const env = {
+﻿export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+export function validateEnv() {
+  if (env.nodeEnv === "production") {
+    const errors = [];
+    if (!process.env.JWT_SECRET || process.env.JWT_SECRET === "development-secret") {
+      errors.push("JWT_SECRET must be set to a strong secret in production");
+    }
+    if (!process.env.DATABASE_URL) {
+      errors.push("DATABASE_URL must be set in production");
+    }
+    if (!process.env.STRIPE_SECRET_KEY) {
+      errors.push("STRIPE_SECRET_KEY should be set in production");
+    }
+    if (errors.length > 0) {
+      console.error("FATAL: Invalid environment configuration:");
+      errors.forEach(e => console.error("  - " + e));
+      process.exit(1);
+    }
+  }
+}

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,8 +1,9 @@
-import { connectDb } from "./config/db.js";
-import { env } from "./config/env.js";
+﻿import { connectDb } from "./config/db.js";
+import { env, validateEnv } from "./config/env.js";
 import { createApp } from "./app.js";
 
 async function bootstrap() {
+  validateEnv();
   await connectDb();
   const app = createApp();
   app.listen(env.port, () => {


### PR DESCRIPTION
In production, the server silently accepts hardcoded default values (development-secret for JWT, empty database URL) without any warning. Added alidateEnv() that checks JWT_SECRET, DATABASE_URL, and STRIPE_SECRET_KEY are properly configured before server starts. Calls process.exit(1) on misconfiguration. /claim #743