### PR TITLE
fix: prevent mass assignment in reviewService.createReview

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    id: `rev_${Date.now()}`,
+    content: payload.content,
+    rating: payload.rating,
+  };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
## Summary

The `createReview()` function in `apps/api/src/services/reviewService.js` uses the spread operator `{ ...payload }` to merge the entire request body into the new review object. Combined with `reviewController.postReview` lacking Zod validation, this allows mass assignment of arbitrary properties.

## Location

`apps/api/src/services/reviewService.js`:
```js
const review = { id: `rev_${Date.now()}`, ...payload };
```

## Impact

An attacker can inject arbitrary properties into review objects (e.g., admin, role) by including them in the POST body.

## Fix

Whitelist only expected fields (content, rating) instead of spreading the entire payload.

## Related Issues

Closes #1301
Ref: #743