### PR TITLE
fix: prevent mass assignment in notificationService.createNotification

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    message: payload.message,
+    userId: payload.userId,
+    read: false,
+  };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Summary

`notificationService.createNotification()` uses `{ id: ..., read: false, ...payload }` — the spread after `read: false` allows the payload to override the read status and inject arbitrary properties.

## Location

`apps/api/src/services/notificationService.js`:
``js
const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
```n
## Impact

- Attacker can set `read: true` to bypass notification tracking
- Can inject arbitrary properties (e.g. `userId`, `admin`)
- Controller `postNotification` lacks Zod validation

## Fix

Whitelist expected fields (`message`, `userId`) and explicitly set `read: false` after constructing the object from whitelisted fields only.

## Related Issues

Closes #1311
Ref: #743