### PR TITLE
fix: prevent mass assignment in userService.createUser

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,11 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = {
+    id: `usr_${Date.now()}`,
+    username: payload.username,
+    email: payload.email,
+  };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

`userService.createUser()` uses `{ id: ..., ...payload }` to merge the entire request body into the new user object, allowing mass assignment of arbitrary properties including privilege fields.

## Location

`apps/api/src/services/userService.js`:
```js
const user = { id: `usr_${Date.now()}`, ...payload };
```

## Impact

- Attacker can set `admin: true`, `role: "superadmin"`, or any privilege-related field
- No Zod validation in controller `postUser`

## Fix

Whitelist only expected fields (username, email).

## Related Issues

Closes #1312
Ref: #743