### PR TITLE
Add POEM.md for issue #76

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# FreelanceFlow, Near Midnight
+
+In the blue-lit hush of an almost-finished screen,  
+jobs drift in like paper boats after rain.  
+A client drops a wish into the current,  
+and somewhere a freelancer answers by name.
+
+Threads wake softly in the marketplace dark,  
+messages flicker like windows across a street.  
+Deadlines tap their watch on the edge of the keyboard,  
+while courage and coffee negotiate a fee.
+
+A portfolio opens like a well-kept suitcase:  
+careful lines, bright proofs, a handful of scars.  
+What looks like work is also translation,  
+turning maybe into milestones, silence into stars.
+
+Here proposals are small bridges thrown over distance,  
+built from trust, timestamps, and clear replies.  
+FreelanceFlow keeps the river from breaking apart,  
+giving shape to the promises work can’t always describe.
+
+So let the night fill with invoices and ideas,  
+with drafts that learn the weight of becoming done.  
+By morning the dashboard glows a little warmer:  
+many separate hands, moving forward as one.


### PR DESCRIPTION
﻿Closes #76

Added `POEM.md` in the project root with an original five-stanza poem written specifically for FreelanceFlow.

Creative decision: I used a calm late-night tone to match the feeling of freelance work happening across time zones, while keeping the imagery tied to the product’s marketplace flow.
