### PR TITLE
Fix review service mass assignment

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,13 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    id: `rev_${Date.now()}`,
+    rating: payload.rating,
+    comment: payload.comment,
+    reviewerId: payload.reviewerId,
+    revieweeId: payload.revieweeId
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview whitelists expected fields", async () => {
+  const review = await createReview({
+    rating: 5,
+    comment: "Clear communication and strong delivery.",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    admin: true,
+    createdAt: "1999-01-01T00:00:00.000Z",
+    id: "rev_attacker"
+  });
+
+  assert.ok(review.id.startsWith("rev_"));
+  assert.deepEqual(review, {
+    id: review.id,
+    rating: 5,
+    comment: "Clear communication and strong delivery.",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee"
+  });
+});


### PR DESCRIPTION
﻿Closes #1301

Fixed the review service mass-assignment bug by whitelisting the expected review fields instead of spreading the full request payload.

Validation:
- `node --test apps/api/src/tests/reviewService.test.js`
