### PR TITLE
Guard JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const configuredJwtSecret = process.env.JWT_SECRET?.trim();
+
+if (nodeEnv === "production" && !configuredJwtSecret) {
+  throw new Error("JWT_SECRET must be set in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: configuredJwtSecret || "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url).href;
+
+function importEnvWith(overrides) {
+  return spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import { env } from ${JSON.stringify(envModuleUrl)}; console.log(JSON.stringify(env));`
+    ],
+    {
+      env: { ...process.env, ...overrides },
+      encoding: "utf8"
+    }
+  );
+}
+
+test("env keeps development fallback JWT secret", () => {
+  const result = importEnvWith({ NODE_ENV: "development", JWT_SECRET: "" });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(JSON.parse(result.stdout.trim()), {
+    nodeEnv: "development",
+    port: 4000,
+    jwtSecret: "development-secret",
+    stripeSecretKey: "",
+    databaseUrl: ""
+  });
+});
+
+test("env rejects missing JWT secret in production", () => {
+  const result = importEnvWith({ NODE_ENV: "production", JWT_SECRET: "" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET must be set in production/);
+});


### PR DESCRIPTION
﻿Closes #1195

Guarded the JWT secret configuration so production startup now fails fast when `JWT_SECRET` is missing, while preserving the existing development fallback.

Validation:
- `node --test apps/api/src/tests/env.test.js`
