### PR TITLE
fix: catch unhandled promise rejections in controllers

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", catchAsync(metrics));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", catchAsync(register));
+authRoutes.post("/login", catchAsync(login));
+authRoutes.get("/oauth/:provider/callback", catchAsync(oauthCallback));
+authRoutes.post("/refresh", catchAsync(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", catchAsync(getJobs));
+jobRoutes.post("/", catchAsync(postJob));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", catchAsync(getMessages));
+messageRoutes.post("/", catchAsync(postMessage));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", catchAsync(getNotifications));
+notificationRoutes.post("/", catchAsync(postNotification));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", catchAsync(createPayment));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", catchAsync(getProposals));
+proposalRoutes.post("/", catchAsync(postProposal));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", catchAsync(getReviews));
+reviewRoutes.post("/", catchAsync(postReview));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { search } from "../controllers/searchController.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", catchAsync(search));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
@@ -6,4 +7,4 @@ const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), catchAsync(uploadFile));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { catchAsync } from "../utils/catchAsync.js";
 import { getUsers, postUser } from "../controllers/userController.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", catchAsync(getUsers));
+userRoutes.post("/", catchAsync(postUser));

--- a/apps/api/src/tests/unhandledRejections.test.js
+++ b/apps/api/src/tests/unhandledRejections.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Controllers should catch Zod validation errors and not hang/crash", async () => {
+  await withServer(async (baseUrl) => {
+    // A request with an empty body to postJob will trigger a ZodError inside the controller.
+    // Thanks to catchAsync, this should be caught and returned as a 500 (since the zod error handler is in another branch)
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    
+    // We just want to ensure we get a response (not a hang) and it's a 500 (or 400).
+    assert.ok(response.status === 500 || response.status === 400, `Expected 500 or 400, got ${response.status}`);
+  });
+});

--- a/apps/api/src/utils/catchAsync.js
+++ b/apps/api/src/utils/catchAsync.js
@@ -1,0 +1,3 @@
+export const catchAsync = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};

--- a/fix-async.js
+++ b/fix-async.js
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+const routesDir = 'apps/api/src/routes';
+const files = fs.readdirSync(routesDir).filter(f => f.endsWith('.js'));
+
+for (const file of files) {
+  const filePath = path.join(routesDir, file);
+  let content = fs.readFileSync(filePath, 'utf8');
+  
+  if (!content.includes('catchAsync')) {
+    // Add import after express
+    content = content.replace('import { Router } from "express";', 'import { Router } from "express";\nimport { catchAsync } from "../utils/catchAsync.js";');
+    
+    // Wrap the last argument of any route definition
+    // Matches router.get("/path", handler) or router.post("/path", middleware, handler)
+    content = content.replace(/(\w+Routes\.(get|post|put|delete|patch)\((?:.*?,\s*)+)([\w]+)\);/g, '$1catchAsync($3));');
+    
+    // Specific fix for authRoutes since it doesn't end in Routes. Wait, it is authRoutes.
+    
+    fs.writeFileSync(filePath, content);
+    console.log(`Updated ${file}`);
+  }
+}


### PR DESCRIPTION
This PR fixes a widespread Denial of Service (DoS) vulnerability caused by Unhandled Promise Rejections.

Scope:
- `catchAsync.js`: Created a new utility function to automatically wrap asynchronous route handlers and forward rejected promises to the global `next()` error handler.
- `routes/`: Refactored all API routes (`adminRoutes`, `authRoutes`, `jobRoutes`, etc.) to wrap their asynchronous controller functions with `catchAsync`.
- `unhandledRejections.test.js`: Added a test suite that intentionally triggers an exception (via empty body validation failure) to verify that the server properly catches the exception and returns a response rather than hanging or crashing.

This prevents the node process from crashing or leaking unhandled exception state, significantly improving stability.

This resolves issue #1328.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.