### PR TITLE
Add API benchmark suite for platform endpoints

### DIFF
--- a/.github/workflows/api-benchmark-smoke.yml
+++ b/.github/workflows/api-benchmark-smoke.yml
@@ -1,0 +1,21 @@
+name: API benchmark smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package*.json"
+      - ".github/workflows/api-benchmark-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run benchmark:smoke -- --no-write-results

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { env } from "../config/env.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
+  skip: () => env.nodeEnv === "benchmark",
   standardHeaders: "draft-7",
   legacyHeaders: false
 });

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,23 @@
+# API Benchmarks
+
+This suite benchmarks `/health` plus every mounted `/api/*` route with realistic synthetic request bodies. It records p50, p95, and p99 latency, sustained and peak requests per second, error rate, and time to first byte.
+
+## Commands
+
+```bash
+npm run benchmark
+npm run benchmark:smoke
+npm run benchmark -- --list
+```
+
+If `BENCHMARK_TARGET_URL` is not set, the runner starts the Express app in-process on a random loopback port. To benchmark a running local or staging server, copy `.env.benchmark.example` to `.env.benchmark`, export the values for your shell, and set `BENCHMARK_TARGET_URL`.
+
+Auth-protected routes use `BENCHMARK_AUTH_TOKEN` when provided. If it is omitted, the runner creates a benchmark-only admin token with the repository's local JWT secret.
+
+For local in-process runs, the app uses `NODE_ENV=benchmark` and skips the API rate limiter so endpoint latency is not replaced by anti-abuse 429 responses. External target benchmarks do not change the target server's environment, so provide a dedicated benchmark host or token if rate limiting should be configured differently there.
+
+## Output
+
+Full runs write timestamped JSON results and a Markdown summary under `benchmarks/results/`. Smoke runs use the same threshold checks with lower concurrency and shorter duration, making them suitable for CI regression gates.
+
+Thresholds live in `benchmarks/thresholds.json` so reviewers can adjust p99 latency and error-rate limits per endpoint.

--- a/benchmarks/endpoints.mjs
+++ b/benchmarks/endpoints.mjs
@@ -1,0 +1,214 @@
+function jsonPayload(payload) {
+  return {
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  };
+}
+
+function uploadPayload(iteration) {
+  const boundary = `----freelanceflow-benchmark-${iteration}`;
+  const body = Buffer.from([
+    `--${boundary}`,
+    'content-disposition: form-data; name="file"; filename="portfolio-sample.txt"',
+    "content-type: text/plain",
+    "",
+    "Synthetic benchmark upload for a portfolio attachment.",
+    `--${boundary}--`,
+    ""
+  ].join("\r\n"));
+
+  return {
+    headers: {
+      "content-type": `multipart/form-data; boundary=${boundary}`,
+      "content-length": String(body.length)
+    },
+    body
+  };
+}
+
+export const BENCHMARK_ENDPOINTS = [
+  {
+    name: "health",
+    method: "GET",
+    path: "/health",
+    description: "Platform health check"
+  },
+  {
+    name: "auth-register",
+    method: "POST",
+    path: "/api/auth/register",
+    description: "Client account registration",
+    payload: (iteration) => jsonPayload({
+      email: `benchmark.client.${iteration}@example.com`,
+      password: "benchmark-password-123",
+      role: "client"
+    })
+  },
+  {
+    name: "auth-login",
+    method: "POST",
+    path: "/api/auth/login",
+    description: "Existing client login",
+    payload: (iteration) => jsonPayload({
+      email: `benchmark.client.${iteration}@example.com`,
+      password: "benchmark-password-123"
+    })
+  },
+  {
+    name: "auth-oauth-callback",
+    method: "GET",
+    path: "/api/auth/oauth/github/callback",
+    description: "OAuth provider callback acknowledgement"
+  },
+  {
+    name: "auth-refresh",
+    method: "POST",
+    path: "/api/auth/refresh",
+    description: "Access token refresh"
+  },
+  {
+    name: "users-list",
+    method: "GET",
+    path: "/api/users",
+    description: "User directory listing"
+  },
+  {
+    name: "users-create",
+    method: "POST",
+    path: "/api/users",
+    description: "User profile creation",
+    payload: (iteration) => jsonPayload({
+      email: `freelancer.${iteration}@example.com`,
+      name: "Benchmark Freelancer",
+      role: "freelancer",
+      skills: ["node.js", "api-design", "benchmarking"],
+      hourlyRate: 85
+    })
+  },
+  {
+    name: "jobs-list",
+    method: "GET",
+    path: "/api/jobs",
+    description: "Open jobs listing"
+  },
+  {
+    name: "jobs-create",
+    method: "POST",
+    path: "/api/jobs",
+    description: "Client job posting",
+    payload: () => jsonPayload({
+      title: "Build a secure payments dashboard",
+      description: "Implement an authenticated dashboard with reporting, audit history, and payment status filters.",
+      budgetMin: 1200,
+      budgetMax: 3500,
+      categoryId: "web-development",
+      skills: ["react", "node.js", "payments"]
+    })
+  },
+  {
+    name: "proposals-list",
+    method: "GET",
+    path: "/api/proposals",
+    description: "Proposal listing"
+  },
+  {
+    name: "proposals-create",
+    method: "POST",
+    path: "/api/proposals",
+    description: "Freelancer proposal submission",
+    payload: () => jsonPayload({
+      jobId: "job_benchmark",
+      freelancerId: "usr_benchmark_freelancer",
+      coverLetter: "I can deliver the requested secure payments dashboard with tests and deployment notes.",
+      bidAmount: 2400,
+      estimatedDays: 14
+    })
+  },
+  {
+    name: "payments-create",
+    method: "POST",
+    path: "/api/payments",
+    description: "Payment intent creation",
+    payload: () => jsonPayload({
+      jobId: "job_benchmark",
+      payerId: "usr_benchmark_client",
+      payeeId: "usr_benchmark_freelancer",
+      amount: 2400,
+      currency: "usd"
+    })
+  },
+  {
+    name: "reviews-list",
+    method: "GET",
+    path: "/api/reviews",
+    description: "Review listing"
+  },
+  {
+    name: "reviews-create",
+    method: "POST",
+    path: "/api/reviews",
+    description: "Completed contract review",
+    payload: () => jsonPayload({
+      contractId: "contract_benchmark",
+      reviewerId: "usr_benchmark_client",
+      revieweeId: "usr_benchmark_freelancer",
+      rating: 5,
+      comment: "Excellent communication, secure delivery, and complete documentation."
+    })
+  },
+  {
+    name: "messages-list",
+    method: "GET",
+    path: "/api/messages",
+    description: "Message inbox listing"
+  },
+  {
+    name: "messages-create",
+    method: "POST",
+    path: "/api/messages",
+    description: "Conversation message creation",
+    payload: () => jsonPayload({
+      conversationId: "conversation_benchmark",
+      senderId: "usr_benchmark_client",
+      body: "Please share the next milestone status and any payment blockers."
+    })
+  },
+  {
+    name: "notifications-list",
+    method: "GET",
+    path: "/api/notifications",
+    description: "Notification feed listing"
+  },
+  {
+    name: "notifications-create",
+    method: "POST",
+    path: "/api/notifications",
+    description: "Notification creation",
+    payload: () => jsonPayload({
+      userId: "usr_benchmark_client",
+      type: "proposal_received",
+      title: "New proposal received",
+      body: "A freelancer submitted a proposal for your secure payments dashboard."
+    })
+  },
+  {
+    name: "uploads-create",
+    method: "POST",
+    path: "/api/uploads",
+    description: "Small portfolio attachment upload",
+    payload: uploadPayload
+  },
+  {
+    name: "search",
+    method: "GET",
+    path: "/api/search?q=secure%20payments%20react",
+    description: "Global search query"
+  },
+  {
+    name: "admin-metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    description: "Auth-protected admin metrics",
+    auth: true
+  }
+];

--- a/benchmarks/results/api-benchmark-2026-05-28T16-54-34-361Z.json
+++ b/benchmarks/results/api-benchmark-2026-05-28T16-54-34-361Z.json
@@ -1,0 +1,517 @@
+{
+  "generatedAt": "2026-05-28T16:54:34.361Z",
+  "targetUrl": "http://127.0.0.1:53856",
+  "mode": "full",
+  "config": {
+    "concurrency": 4,
+    "durationMs": 1500,
+    "warmupRequests": 3
+  },
+  "results": [
+    {
+      "name": "health",
+      "method": "GET",
+      "path": "/health",
+      "description": "Platform health check",
+      "requests": 10609,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 7071.79,
+        "peak": 6666
+      },
+      "latencyMs": {
+        "p50": 0.49,
+        "p95": 0.9,
+        "p99": 1.39,
+        "max": 9.08
+      },
+      "ttfbMs": {
+        "p50": 0.48,
+        "p95": 0.88,
+        "p99": 1.35
+      }
+    },
+    {
+      "name": "auth-register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "description": "Client account registration",
+      "requests": 5628,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 3751.73,
+        "peak": 3648
+      },
+      "latencyMs": {
+        "p50": 0.98,
+        "p95": 1.41,
+        "p99": 2.13,
+        "max": 3.73
+      },
+      "ttfbMs": {
+        "p50": 0.97,
+        "p95": 1.4,
+        "p99": 2.11
+      }
+    },
+    {
+      "name": "auth-login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "description": "Existing client login",
+      "requests": 5860,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 3906.25,
+        "peak": 3888
+      },
+      "latencyMs": {
+        "p50": 0.95,
+        "p95": 1.29,
+        "p99": 2.16,
+        "max": 7.15
+      },
+      "ttfbMs": {
+        "p50": 0.94,
+        "p95": 1.27,
+        "p99": 2.14
+      }
+    },
+    {
+      "name": "auth-oauth-callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "description": "OAuth provider callback acknowledgement",
+      "requests": 12524,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8348.43,
+        "peak": 8464
+      },
+      "latencyMs": {
+        "p50": 0.45,
+        "p95": 0.56,
+        "p99": 0.95,
+        "max": 2.51
+      },
+      "ttfbMs": {
+        "p50": 0.44,
+        "p95": 0.55,
+        "p99": 0.94
+      }
+    },
+    {
+      "name": "auth-refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "description": "Access token refresh",
+      "requests": 7160,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 4772.19,
+        "peak": 4776
+      },
+      "latencyMs": {
+        "p50": 0.79,
+        "p95": 0.94,
+        "p99": 1.56,
+        "max": 3.4
+      },
+      "ttfbMs": {
+        "p50": 0.78,
+        "p95": 0.93,
+        "p99": 1.55
+      }
+    },
+    {
+      "name": "users-list",
+      "method": "GET",
+      "path": "/api/users",
+      "description": "User directory listing",
+      "requests": 12658,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8437.18,
+        "peak": 8353
+      },
+      "latencyMs": {
+        "p50": 0.44,
+        "p95": 0.55,
+        "p99": 1.09,
+        "max": 7.09
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.54,
+        "p99": 1.08
+      }
+    },
+    {
+      "name": "users-create",
+      "method": "POST",
+      "path": "/api/users",
+      "description": "User profile creation",
+      "requests": 9818,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6544.05,
+        "peak": 6380
+      },
+      "latencyMs": {
+        "p50": 0.56,
+        "p95": 0.74,
+        "p99": 1.34,
+        "max": 19.41
+      },
+      "ttfbMs": {
+        "p50": 0.55,
+        "p95": 0.72,
+        "p99": 1.33
+      }
+    },
+    {
+      "name": "jobs-list",
+      "method": "GET",
+      "path": "/api/jobs",
+      "description": "Open jobs listing",
+      "requests": 12973,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8647.63,
+        "peak": 8660
+      },
+      "latencyMs": {
+        "p50": 0.43,
+        "p95": 0.5,
+        "p99": 1.02,
+        "max": 3.13
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.49,
+        "p99": 1.01
+      }
+    },
+    {
+      "name": "jobs-create",
+      "method": "POST",
+      "path": "/api/jobs",
+      "description": "Client job posting",
+      "requests": 9680,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6451.6,
+        "peak": 6392
+      },
+      "latencyMs": {
+        "p50": 0.58,
+        "p95": 0.73,
+        "p99": 1.46,
+        "max": 2.41
+      },
+      "ttfbMs": {
+        "p50": 0.57,
+        "p95": 0.72,
+        "p99": 1.44
+      }
+    },
+    {
+      "name": "proposals-list",
+      "method": "GET",
+      "path": "/api/proposals",
+      "description": "Proposal listing",
+      "requests": 12688,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8457.58,
+        "peak": 8415
+      },
+      "latencyMs": {
+        "p50": 0.44,
+        "p95": 0.52,
+        "p99": 0.98,
+        "max": 9.49
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.51,
+        "p99": 0.96
+      }
+    },
+    {
+      "name": "proposals-create",
+      "method": "POST",
+      "path": "/api/proposals",
+      "description": "Freelancer proposal submission",
+      "requests": 9892,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6593.93,
+        "peak": 6480
+      },
+      "latencyMs": {
+        "p50": 0.56,
+        "p95": 0.69,
+        "p99": 1.31,
+        "max": 18.96
+      },
+      "ttfbMs": {
+        "p50": 0.55,
+        "p95": 0.68,
+        "p99": 1.29
+      }
+    },
+    {
+      "name": "payments-create",
+      "method": "POST",
+      "path": "/api/payments",
+      "description": "Payment intent creation",
+      "requests": 10576,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 7049.8,
+        "peak": 7028
+      },
+      "latencyMs": {
+        "p50": 0.54,
+        "p95": 0.61,
+        "p99": 1.04,
+        "max": 2.42
+      },
+      "ttfbMs": {
+        "p50": 0.53,
+        "p95": 0.6,
+        "p99": 1.03
+      }
+    },
+    {
+      "name": "reviews-list",
+      "method": "GET",
+      "path": "/api/reviews",
+      "description": "Review listing",
+      "requests": 12769,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8511.4,
+        "peak": 8483
+      },
+      "latencyMs": {
+        "p50": 0.44,
+        "p95": 0.51,
+        "p99": 1.21,
+        "max": 4.13
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.51,
+        "p99": 1.19
+      }
+    },
+    {
+      "name": "reviews-create",
+      "method": "POST",
+      "path": "/api/reviews",
+      "description": "Completed contract review",
+      "requests": 10331,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6885.88,
+        "peak": 6887
+      },
+      "latencyMs": {
+        "p50": 0.55,
+        "p95": 0.62,
+        "p99": 1.29,
+        "max": 2.65
+      },
+      "ttfbMs": {
+        "p50": 0.54,
+        "p95": 0.61,
+        "p99": 1.27
+      }
+    },
+    {
+      "name": "messages-list",
+      "method": "GET",
+      "path": "/api/messages",
+      "description": "Message inbox listing",
+      "requests": 12215,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8138.21,
+        "peak": 7988
+      },
+      "latencyMs": {
+        "p50": 0.45,
+        "p95": 0.57,
+        "p99": 0.96,
+        "max": 18.95
+      },
+      "ttfbMs": {
+        "p50": 0.44,
+        "p95": 0.56,
+        "p99": 0.95
+      }
+    },
+    {
+      "name": "messages-create",
+      "method": "POST",
+      "path": "/api/messages",
+      "description": "Conversation message creation",
+      "requests": 9693,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6459.67,
+        "peak": 6420
+      },
+      "latencyMs": {
+        "p50": 0.58,
+        "p95": 0.77,
+        "p99": 1.25,
+        "max": 3.33
+      },
+      "ttfbMs": {
+        "p50": 0.57,
+        "p95": 0.76,
+        "p99": 1.24
+      }
+    },
+    {
+      "name": "notifications-list",
+      "method": "GET",
+      "path": "/api/notifications",
+      "description": "Notification feed listing",
+      "requests": 12672,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 8446.85,
+        "peak": 8496
+      },
+      "latencyMs": {
+        "p50": 0.44,
+        "p95": 0.54,
+        "p99": 1.23,
+        "max": 2.57
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.53,
+        "p99": 1.21
+      }
+    },
+    {
+      "name": "notifications-create",
+      "method": "POST",
+      "path": "/api/notifications",
+      "description": "Notification creation",
+      "requests": 10245,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 6828.89,
+        "peak": 6864
+      },
+      "latencyMs": {
+        "p50": 0.55,
+        "p95": 0.65,
+        "p99": 1.46,
+        "max": 3.19
+      },
+      "ttfbMs": {
+        "p50": 0.54,
+        "p95": 0.64,
+        "p99": 1.43
+      }
+    },
+    {
+      "name": "uploads-create",
+      "method": "POST",
+      "path": "/api/uploads",
+      "description": "Small portfolio attachment upload",
+      "requests": 6684,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 4455.63,
+        "peak": 4300
+      },
+      "latencyMs": {
+        "p50": 0.78,
+        "p95": 1.21,
+        "p99": 2.98,
+        "max": 8.72
+      },
+      "ttfbMs": {
+        "p50": 0.77,
+        "p95": 1.2,
+        "p99": 2.97
+      }
+    },
+    {
+      "name": "search",
+      "method": "GET",
+      "path": "/api/search?q=secure%20payments%20react",
+      "description": "Global search query",
+      "requests": 11120,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 7411.64,
+        "peak": 7329
+      },
+      "latencyMs": {
+        "p50": 0.5,
+        "p95": 0.59,
+        "p99": 1.25,
+        "max": 5.65
+      },
+      "ttfbMs": {
+        "p50": 0.5,
+        "p95": 0.58,
+        "p99": 1.23
+      }
+    },
+    {
+      "name": "admin-metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "description": "Auth-protected admin metrics",
+      "requests": 6448,
+      "errors": 0,
+      "errorRatePct": 0,
+      "rps": {
+        "sustained": 4298.1,
+        "peak": 4268
+      },
+      "latencyMs": {
+        "p50": 0.88,
+        "p95": 1.05,
+        "p99": 1.89,
+        "max": 3.57
+      },
+      "ttfbMs": {
+        "p50": 0.87,
+        "p95": 1.04,
+        "p99": 1.88
+      }
+    }
+  ],
+  "thresholdFailures": []
+}

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,0 +1,35 @@
+# API Benchmark Summary
+
+Generated: 2026-05-28T16:54:34.361Z
+Target: http://127.0.0.1:53856
+Mode: full
+Concurrency: 4
+Duration per endpoint: 1500ms
+
+| Endpoint | Route | Requests | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Error rate |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| health | GET /health | 10609 | 7071.79 | 6666 | 0.49 | 0.9 | 1.39 | 0.88 | 0% |
+| auth-register | POST /api/auth/register | 5628 | 3751.73 | 3648 | 0.98 | 1.41 | 2.13 | 1.4 | 0% |
+| auth-login | POST /api/auth/login | 5860 | 3906.25 | 3888 | 0.95 | 1.29 | 2.16 | 1.27 | 0% |
+| auth-oauth-callback | GET /api/auth/oauth/github/callback | 12524 | 8348.43 | 8464 | 0.45 | 0.56 | 0.95 | 0.55 | 0% |
+| auth-refresh | POST /api/auth/refresh | 7160 | 4772.19 | 4776 | 0.79 | 0.94 | 1.56 | 0.93 | 0% |
+| users-list | GET /api/users | 12658 | 8437.18 | 8353 | 0.44 | 0.55 | 1.09 | 0.54 | 0% |
+| users-create | POST /api/users | 9818 | 6544.05 | 6380 | 0.56 | 0.74 | 1.34 | 0.72 | 0% |
+| jobs-list | GET /api/jobs | 12973 | 8647.63 | 8660 | 0.43 | 0.5 | 1.02 | 0.49 | 0% |
+| jobs-create | POST /api/jobs | 9680 | 6451.6 | 6392 | 0.58 | 0.73 | 1.46 | 0.72 | 0% |
+| proposals-list | GET /api/proposals | 12688 | 8457.58 | 8415 | 0.44 | 0.52 | 0.98 | 0.51 | 0% |
+| proposals-create | POST /api/proposals | 9892 | 6593.93 | 6480 | 0.56 | 0.69 | 1.31 | 0.68 | 0% |
+| payments-create | POST /api/payments | 10576 | 7049.8 | 7028 | 0.54 | 0.61 | 1.04 | 0.6 | 0% |
+| reviews-list | GET /api/reviews | 12769 | 8511.4 | 8483 | 0.44 | 0.51 | 1.21 | 0.51 | 0% |
+| reviews-create | POST /api/reviews | 10331 | 6885.88 | 6887 | 0.55 | 0.62 | 1.29 | 0.61 | 0% |
+| messages-list | GET /api/messages | 12215 | 8138.21 | 7988 | 0.45 | 0.57 | 0.96 | 0.56 | 0% |
+| messages-create | POST /api/messages | 9693 | 6459.67 | 6420 | 0.58 | 0.77 | 1.25 | 0.76 | 0% |
+| notifications-list | GET /api/notifications | 12672 | 8446.85 | 8496 | 0.44 | 0.54 | 1.23 | 0.53 | 0% |
+| notifications-create | POST /api/notifications | 10245 | 6828.89 | 6864 | 0.55 | 0.65 | 1.46 | 0.64 | 0% |
+| uploads-create | POST /api/uploads | 6684 | 4455.63 | 4300 | 0.78 | 1.21 | 2.98 | 1.2 | 0% |
+| search | GET /api/search?q=secure%20payments%20react | 11120 | 7411.64 | 7329 | 0.5 | 0.59 | 1.25 | 0.58 | 0% |
+| admin-metrics | GET /api/admin/metrics | 6448 | 4298.1 | 4268 | 0.88 | 1.05 | 1.89 | 1.04 | 0% |
+
+## Threshold Result
+
+- PASS: all configured p99 latency and error-rate thresholds passed.

--- a/benchmarks/run-api-benchmarks.mjs
+++ b/benchmarks/run-api-benchmarks.mjs
@@ -1,0 +1,315 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { BENCHMARK_ENDPOINTS } from "./endpoints.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const args = new Set(process.argv.slice(2));
+const isSmoke = args.has("--smoke");
+const listOnly = args.has("--list");
+const noWriteResults = args.has("--no-write-results");
+const failOnThreshold = !args.has("--no-thresholds");
+
+const config = {
+  targetUrl: process.env.BENCHMARK_TARGET_URL,
+  concurrency: Number(process.env.BENCHMARK_CONCURRENCY ?? (isSmoke ? 1 : 4)),
+  durationMs: Number(process.env.BENCHMARK_DURATION_MS ?? (isSmoke ? 350 : 1500)),
+  warmupRequests: Number(process.env.BENCHMARK_WARMUP_REQUESTS ?? (isSmoke ? 1 : 3)),
+  benchmarkToken: process.env.BENCHMARK_AUTH_TOKEN
+};
+
+let createApp;
+let signAccessToken;
+
+if (listOnly) {
+  console.table(BENCHMARK_ENDPOINTS.map(({ name, method, path, auth }) => ({
+    name,
+    method,
+    path,
+    auth: Boolean(auth)
+  })));
+  process.exit(0);
+}
+
+function percentile(values, rank) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((rank / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+function round(value, digits = 2) {
+  return Number(value.toFixed(digits));
+}
+
+async function startLocalServer() {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "benchmark";
+  ({ createApp } = await import("../apps/api/src/app.js"));
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    })
+  };
+}
+
+function buildRequest(endpoint, baseUrl, iteration, authToken) {
+  const target = new URL(endpoint.path, baseUrl);
+  const payload = endpoint.payload?.(iteration) ?? {};
+  const headers = {
+    "user-agent": "freelanceflow-api-benchmark/1.0",
+    ...payload.headers
+  };
+
+  if (endpoint.auth) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
+  return {
+    url: target,
+    options: {
+      method: endpoint.method,
+      headers
+    },
+    body: payload.body
+  };
+}
+
+function sendRequest(requestConfig) {
+  const transport = requestConfig.url.protocol === "https:" ? https : http;
+  const startedAt = performance.now();
+
+  return new Promise((resolve) => {
+    const req = transport.request(requestConfig.url, requestConfig.options, (res) => {
+      const firstByteAt = performance.now();
+      res.resume();
+      res.on("end", () => {
+        const completedAt = performance.now();
+        resolve({
+          status: res.statusCode ?? 0,
+          ttfbMs: firstByteAt - startedAt,
+          latencyMs: completedAt - startedAt,
+          completedAt,
+          ok: (res.statusCode ?? 500) < 400
+        });
+      });
+    });
+
+    req.setTimeout(10_000, () => {
+      req.destroy(new Error("request timeout"));
+    });
+
+    req.on("error", () => {
+      const completedAt = performance.now();
+      resolve({
+        status: 0,
+        ttfbMs: completedAt - startedAt,
+        latencyMs: completedAt - startedAt,
+        completedAt,
+        ok: false
+      });
+    });
+
+    if (requestConfig.body) {
+      req.write(requestConfig.body);
+    }
+    req.end();
+  });
+}
+
+async function runWarmup(endpoint, baseUrl, authToken) {
+  for (let i = 0; i < config.warmupRequests; i += 1) {
+    await sendRequest(buildRequest(endpoint, baseUrl, i, authToken));
+  }
+}
+
+async function runEndpoint(endpoint, baseUrl, authToken) {
+  await runWarmup(endpoint, baseUrl, authToken);
+
+  const startedAt = performance.now();
+  const deadline = startedAt + config.durationMs;
+  const samples = [];
+  let iteration = 0;
+
+  async function worker(workerId) {
+    while (performance.now() < deadline) {
+      const request = buildRequest(endpoint, baseUrl, iteration + workerId, authToken);
+      iteration += 1;
+      const result = await sendRequest(request);
+      samples.push({ ...result, completedBucket: Math.floor((result.completedAt - startedAt) / 1000) });
+    }
+  }
+
+  await Promise.all(Array.from({ length: config.concurrency }, (_, workerId) => worker(workerId)));
+
+  const elapsedMs = performance.now() - startedAt;
+  const latencies = samples.map((sample) => sample.latencyMs);
+  const ttfbs = samples.map((sample) => sample.ttfbMs);
+  const errors = samples.filter((sample) => !sample.ok).length;
+  const perSecond = new Map();
+
+  for (const sample of samples) {
+    perSecond.set(sample.completedBucket, (perSecond.get(sample.completedBucket) ?? 0) + 1);
+  }
+
+  return {
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    description: endpoint.description,
+    requests: samples.length,
+    errors,
+    errorRatePct: samples.length ? round((errors / samples.length) * 100) : 100,
+    rps: {
+      sustained: round(samples.length / (elapsedMs / 1000)),
+      peak: Math.max(0, ...perSecond.values())
+    },
+    latencyMs: {
+      p50: round(percentile(latencies, 50)),
+      p95: round(percentile(latencies, 95)),
+      p99: round(percentile(latencies, 99)),
+      max: round(Math.max(0, ...latencies))
+    },
+    ttfbMs: {
+      p50: round(percentile(ttfbs, 50)),
+      p95: round(percentile(ttfbs, 95)),
+      p99: round(percentile(ttfbs, 99))
+    }
+  };
+}
+
+async function loadThresholds() {
+  const thresholdPath = path.join(__dirname, "thresholds.json");
+  const raw = await fs.readFile(thresholdPath, "utf8");
+  return JSON.parse(raw);
+}
+
+function evaluateThresholds(results, thresholds) {
+  const failures = [];
+  const defaults = thresholds.defaults ?? {};
+
+  for (const result of results) {
+    const endpointThresholds = thresholds.endpoints?.[result.name] ?? {};
+    const maxP99Ms = endpointThresholds.p99Ms ?? defaults.p99Ms;
+    const maxErrorRatePct = endpointThresholds.maxErrorRatePct ?? defaults.maxErrorRatePct;
+
+    if (Number.isFinite(maxP99Ms) && result.latencyMs.p99 > maxP99Ms) {
+      failures.push(`${result.name} p99 ${result.latencyMs.p99}ms exceeded ${maxP99Ms}ms`);
+    }
+    if (Number.isFinite(maxErrorRatePct) && result.errorRatePct > maxErrorRatePct) {
+      failures.push(`${result.name} error rate ${result.errorRatePct}% exceeded ${maxErrorRatePct}%`);
+    }
+  }
+
+  return failures;
+}
+
+function renderMarkdown(report) {
+  const rows = report.results.map((result) => [
+    result.name,
+    `${result.method} ${result.path}`,
+    result.requests,
+    result.rps.sustained,
+    result.rps.peak,
+    result.latencyMs.p50,
+    result.latencyMs.p95,
+    result.latencyMs.p99,
+    result.ttfbMs.p95,
+    `${result.errorRatePct}%`
+  ]);
+
+  return [
+    "# API Benchmark Summary",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Target: ${report.targetUrl}`,
+    `Mode: ${report.mode}`,
+    `Concurrency: ${report.config.concurrency}`,
+    `Duration per endpoint: ${report.config.durationMs}ms`,
+    "",
+    "| Endpoint | Route | Requests | Sustained RPS | Peak RPS | p50 ms | p95 ms | p99 ms | p95 TTFB ms | Error rate |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ...rows.map((row) => `| ${row.join(" | ")} |`),
+    "",
+    "## Threshold Result",
+    "",
+    report.thresholdFailures.length
+      ? report.thresholdFailures.map((failure) => `- FAIL: ${failure}`).join("\n")
+      : "- PASS: all configured p99 latency and error-rate thresholds passed.",
+    ""
+  ].join("\n");
+}
+
+async function writeResults(report) {
+  const resultsDir = path.join(__dirname, "results");
+  await fs.mkdir(resultsDir, { recursive: true });
+  const stamp = report.generatedAt.replace(/[:.]/g, "-");
+  const jsonPath = path.join(resultsDir, `api-benchmark-${stamp}.json`);
+  const markdownPath = path.join(resultsDir, "latest.md");
+
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(markdownPath, renderMarkdown(report));
+
+  return { jsonPath, markdownPath };
+}
+
+let localServer;
+
+try {
+  localServer = config.targetUrl ? null : await startLocalServer();
+  const baseUrl = config.targetUrl ?? localServer.baseUrl;
+  if (!config.benchmarkToken) {
+    process.env.NODE_ENV = process.env.NODE_ENV ?? "benchmark";
+    ({ signAccessToken } = await import("../apps/api/src/utils/jwt.js"));
+  }
+  const authToken = config.benchmarkToken ?? signAccessToken({
+    sub: "benchmark-admin",
+    role: "admin",
+    scope: "benchmark"
+  });
+  const thresholds = await loadThresholds();
+  const results = [];
+
+  for (const endpoint of BENCHMARK_ENDPOINTS) {
+    process.stdout.write(`Benchmarking ${endpoint.method} ${endpoint.path}... `);
+    const result = await runEndpoint(endpoint, baseUrl, authToken);
+    results.push(result);
+    process.stdout.write(`${result.requests} req, p99 ${result.latencyMs.p99}ms, errors ${result.errorRatePct}%\n`);
+  }
+
+  const thresholdFailures = evaluateThresholds(results, thresholds);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    targetUrl: baseUrl,
+    mode: isSmoke ? "smoke" : "full",
+    config,
+    results,
+    thresholdFailures
+  };
+
+  if (!noWriteResults) {
+    const written = await writeResults(report);
+    console.log(`Wrote JSON results to ${path.relative(repoRoot, written.jsonPath)}`);
+    console.log(`Wrote Markdown summary to ${path.relative(repoRoot, written.markdownPath)}`);
+  }
+
+  if (thresholdFailures.length) {
+    console.error("Benchmark threshold failures:");
+    for (const failure of thresholdFailures) console.error(`- ${failure}`);
+    if (failOnThreshold) process.exitCode = 1;
+  }
+} finally {
+  await localServer?.close();
+}

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,11 @@
+{
+  "defaults": {
+    "p99Ms": 1000,
+    "maxErrorRatePct": 0
+  },
+  "endpoints": {
+    "uploads-create": {
+      "p99Ms": 1500
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api",
+    "benchmark": "node benchmarks/run-api-benchmarks.mjs",
+    "benchmark:smoke": "node benchmarks/run-api-benchmarks.mjs --smoke"
   }
 }


### PR DESCRIPTION
/claim #30

## Summary
- Adds a dependency-light benchmark runner under `benchmarks/` for `/health` plus all 20 mounted `/api/*` routes.
- Uses realistic synthetic JSON and multipart upload payloads, plus a benchmark-only admin token for `/api/admin/metrics`.
- Captures p50/p95/p99 latency, sustained and peak RPS, error rate, and TTFB per endpoint.
- Writes JSON and Markdown results to `benchmarks/results/` and adds reviewable p99/error-rate thresholds.
- Adds `npm run benchmark`, `npm run benchmark:smoke`, and a pull-request CI smoke workflow.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-30-demo.mp4

## Benchmark Environment

**Hardware**
- CPU model & core count: Intel(R) Core(TM) Ultra 9 185H, 16 cores / 22 logical processors
- RAM (total & available during benchmark): about 31.7 GiB total, about 18.6 GiB free before validation
- Storage type (SSD / NVMe / HDD): fixed local SSD/NVMe-class Windows storage
- Network interface (Ethernet / WiFi / loopback): loopback for local in-process benchmark target
- Machine type (local workstation / cloud VM / CI runner — include instance type if cloud): local workstation
- OS & version: Microsoft Windows 11 Home 10.0.26200

**Runtime**
- Node.js version (or relevant runtime): Node.js v24.14.0 for local validation; CI smoke uses Node 22
- Any resource limits applied (Docker memory cap, cgroup limits, etc.): none intentionally applied
- Other significant processes running during benchmark (yes / no — if yes, describe): yes, normal Codex desktop and Windows background processes

**If submitted by or with an AI agent**
- Agent or tool name: OpenAI Codex desktop
- Underlying model and version: GPT-5-based Codex model
- Inference provider: OpenAI
- Orchestration framework if any: none beyond Codex shell/GitHub tooling
- Execution mode: human-initiated, agent-executed
- Did the agent have shell/tool access during execution (yes / no): yes
- Did the agent have internet access during execution (yes / no): yes
- Were benchmark commands run by the agent directly or handed off to the human to run: run directly by the agent against local loopback
- Any known agent constraints or sandboxing that may have affected execution: local in-process runs set `NODE_ENV=benchmark` and skip the app's anti-abuse rate limiter so endpoint latency is not replaced by 429 responses; no production secrets or staging systems used

## Local Benchmark Summary
Generated: 2026-05-28T16:54:34.361Z  
Target: local in-process Express server on loopback  
Mode: full, concurrency 4, 1500ms per endpoint

| Endpoint | Requests | Sustained RPS | p99 ms | p95 TTFB ms | Error rate |
| --- | ---: | ---: | ---: | ---: | ---: |
| health | 10609 | 7071.79 | 1.39 | 0.88 | 0% |
| auth-register | 5628 | 3751.73 | 2.13 | 1.40 | 0% |
| auth-login | 5860 | 3906.25 | 2.16 | 1.27 | 0% |
| uploads-create | 6684 | 4455.63 | 2.98 | 1.20 | 0% |
| admin-metrics | 6448 | 4298.10 | 1.89 | 1.04 | 0% |

Full per-endpoint results are committed in `benchmarks/results/latest.md` and the timestamped JSON file.

## Validation
- `node --check benchmarks/run-api-benchmarks.mjs`
- `node --test apps/api/src/tests/health.test.js`
- `node benchmarks/run-api-benchmarks.mjs --smoke --no-write-results`
- `node benchmarks/run-api-benchmarks.mjs`
- `git diff --check`