### PR TITLE
fix: block admin privilege escalation during registration

### DIFF
--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Registration should reject requests attempting to register as admin", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "hacker@evil.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    
+    // We expect it NOT to be 201, because validation should fail.
+    assert.notEqual(response.status, 201, `Expected registration as admin to be rejected, but it succeeded with 201`);
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
This PR fixes a critical Insecure Direct Object Reference (IDOR) / Mass Assignment vulnerability in the user registration flow.

Scope:
- `validators/auth.js`: The `registerSchema` incorrectly allowed the `role` enum to include `"admin"`. This allowed any anonymous user to trivially create a fully authorized administrative account by simply injecting `"role": "admin"` into the registration JSON payload. I have removed `"admin"` from the allowed Zod schema enum so that users can only register as `"client"` or `"freelancer"`.
- `authRegistration.test.js`: Added a TDD node:test suite to assert that attempting to register with the `"admin"` role is successfully rejected during validation.

This ensures the RBAC system cannot be bypassed via mass assignment during registration.

This resolves issue #1333.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.