### PR TITLE
Return 400 for Zod validation failures

### DIFF
--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,3 @@
+export function asyncHandler(handler) {
+  return (req, res, next) => Promise.resolve(handler(req, res, next)).catch(next);
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/validation-error.test.js
+++ b/apps/api/src/tests/validation-error.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register returns 400 for invalid request body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "not-an-email",
+        password: "short"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation error");
+    assert.deepEqual(
+      payload.errors.map((error) => error.path).sort(),
+      ["email", "password"]
+    );
+  });
+});
+
+test("POST /api/jobs returns 400 for invalid request body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Dev",
+        description: "too short",
+        budgetMin: -1,
+        budgetMax: 100,
+        categoryId: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation error");
+    assert.deepEqual(
+      payload.errors.map((error) => error.path).sort(),
+      ["budgetMin", "categoryId", "description", "title"]
+    );
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #1329.

Summary
- Return structured 400 responses when Zod request validation fails.
- Add a small async route wrapper so auth/job controller validation errors reach the API error middleware.
- Add API tests for invalid auth registration and job creation request bodies.

Verification
- npm test -w apps/api