### PR TITLE
fix: prevent information disclosure on messages and notifications

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", authMiddleware, getMessages);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", authMiddleware, getNotifications);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/infoDisclosure.test.js
+++ b/apps/api/src/tests/infoDisclosure.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages and GET /api/notifications should be protected", async () => {
+  await withServer(async (baseUrl) => {
+    const resMsg = await fetch(`${baseUrl}/api/messages`);
+    assert.equal(resMsg.status, 401, `GET /api/messages should return 401, got ${resMsg.status}`);
+
+    const resNotif = await fetch(`${baseUrl}/api/notifications`);
+    assert.equal(resNotif.status, 401, `GET /api/notifications should return 401, got ${resNotif.status}`);
+  });
+});


### PR DESCRIPTION
This PR fixes a critical Information Disclosure and Broken Access Control vulnerability on the messaging and notification APIs.

Scope:
- `routes/messageRoutes.js`: Applied `authMiddleware` to the `GET /` route, preventing unauthenticated users from reading all private messages across the platform.
- `routes/notificationRoutes.js`: Applied `authMiddleware` to the `GET /` route, securing system notifications.
- `infoDisclosure.test.js`: Added a test to verify that unauthenticated `GET` requests to these sensitive endpoints correctly yield a `401 Unauthorized` instead of exposing PII.

This resolves issue #1337.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.