### PR TITLE
fix: enforce secure JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,5 +1,11 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+if (nodeEnv === "production" && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET is required in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("env.js should throw if JWT_SECRET is missing in production", async () => {
+  // Save original env
+  const origEnv = process.env.NODE_ENV;
+  const origJwt = process.env.JWT_SECRET;
+  
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  try {
+    // Dynamic import to re-evaluate module
+    await import(`../config/env.js?t=${Date.now()}`);
+    assert.fail("Should have thrown an error");
+  } catch (err) {
+    assert.match(err.message, /JWT_SECRET is required/);
+  } finally {
+    process.env.NODE_ENV = origEnv;
+    if (origJwt) process.env.JWT_SECRET = origJwt;
+  }
+});


### PR DESCRIPTION
This PR fixes a critical security misconfiguration where `JWT_SECRET` falls back to a hardcoded string `development-secret` if not explicitly set in the environment variables. 
If deployed to production with a missing environment variable, this default allows attackers to trivially forge valid access tokens and achieve full system compromise.

Scope:
- `config/env.js`: Now strictly checks `NODE_ENV === "production"` and throws a startup error if `JWT_SECRET` is missing.
- `env.test.js`: Added a test to verify that the application refuses to start in production without a secure secret.

This resolves issue #1346.

/claim #743
No payout address, private token, cookie, seed phrase, or API key is included in the PR.