### PR TITLE
Validate public user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/users rejects invalid user payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const invalidEmail = await postUser(baseUrl, {
+      email: "not-an-email",
+      password: "strong-password",
+      role: "client"
+    });
+    assert.equal(invalidEmail.status, 400);
+    assert.deepEqual(await invalidEmail.json(), {
+      success: false,
+      message: "Invalid user payload"
+    });
+
+    const adminRole = await postUser(baseUrl, {
+      email: "admin@example.com",
+      password: "strong-password",
+      role: "admin"
+    });
+    assert.equal(adminRole.status, 400);
+  });
+});
+
+test("POST /api/users validates and strips caller-controlled reserved fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      id: "usr_attacker",
+      status: "suspended",
+      email: "freelancer@example.com",
+      password: "strong-password",
+      role: "freelancer",
+      name: "Freelance Builder",
+      skills: ["node"],
+      hourlyRate: 75
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.status, undefined);
+    assert.equal(payload.data.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(["client", "freelancer"]).default("client"),
+  name: z.string().trim().min(1).max(120).optional(),
+  skills: z.array(z.string().trim().min(1)).default([]),
+  hourlyRate: z.number().nonnegative().optional()
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds a Zod schema for the public `POST /api/users` path.
- Rejects invalid email/password payloads and public `role: admin` creation.
- Passes parsed data only into `createUser`, stripping caller-controlled reserved fields like `id` and `status`.
- Adds regression coverage for invalid payloads, admin role rejection, and sanitized successful creation.

Fixes #1354.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1354-demo.mp4

## Validation
- `node --check apps/api/src/controllers/userController.js`
- `node --check apps/api/src/validators/user.js`
- `node --check apps/api/src/tests/userValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/userValidation.test.js`
- `git diff --check`