### PR TITLE
Validate job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/jobBudgetValidation.test.js
+++ b/apps/api/src/tests/jobBudgetValidation.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJob(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+function validJob(overrides = {}) {
+  return {
+    title: "Build admin reports",
+    description: "Create operational reports for project owners.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "development",
+    skills: ["node"],
+    ...overrides
+  };
+}
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJob(baseUrl, validJob({
+      budgetMin: 1000,
+      budgetMax: 100
+    }));
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/jobs accepts equal and ascending budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const equalBudget = await postJob(baseUrl, validJob({
+      budgetMin: 250,
+      budgetMax: 250
+    }));
+    assert.equal(equalBudget.status, 201);
+
+    const ascendingBudget = await postJob(baseUrl, validJob({
+      budgetMin: 100,
+      budgetMax: 1000
+    }));
+    const payload = await ascendingBudget.json();
+
+    assert.equal(ascendingBudget.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 100);
+    assert.equal(payload.data.budgetMax, 1000);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobFieldsSchema.refine((job) => job.budgetMin <= job.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobFieldsSchema.partial();


### PR DESCRIPTION
/claim #743

## Summary
- Adds a `budgetMin <= budgetMax` refinement for job creation payloads.
- Returns a stable 400 response for invalid job payloads instead of creating inverted budget ranges.
- Keeps `updateJobSchema.partial()` compatible by applying the range refinement only to the create schema.
- Adds regression tests for inverted, equal, and ascending budget ranges.

Fixes #1356.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1356-demo.mp4

## Validation
- `node --check apps/api/src/controllers/jobController.js`
- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/jobBudgetValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobBudgetValidation.test.js`
- `git diff --check`