### PR TITLE
fix: admin role self-assignment + refresh token passthrough (#1366)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes two security/correctness bugs found in the auth layer.

### Bug 1 — Critical: Admin role self-assignment via registration

The `registerSchema` accepted `"admin"` as a valid role, allowing any user to self-elevate:

```bash
curl -X POST /api/auth/register -d '{"email":"x@x.com","password":"pass1234","role":"admin"}'
# Returns JWT with role:admin
```

**Fix:** Removed `"admin"` from the enum.

### Bug 2 — Refresh token not passed to service

`refreshToken()` was called with no arguments. Token is now read from `req.body.token` and forwarded.

/claim #1366
/claim #743

Closes #1366
Ref: #743