### PR TITLE
Add POEM.md: The Logic of Absence — technical poem on bug hunting (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,57 @@
+# The Logic of Absence
+
+**Submitted for Issue #76 — Technical Poem Generation**
+
+---
+
+### I.
+
+The terminal hums its low electric hymn.
+Outside, the world is ordinary and asleep.
+Here, in the phosphor glow of 3 AM,
+A hunter reads what systems try to keep:
+
+The silent invitation of an unchecked field,
+A promise whispered by a missing bound,
+A door that no one remembered to seal,
+A trust the builder placed on shaken ground.
+
+### II.
+
+This is the art of seeing what is not there —
+The gap between intention and the code,
+The ghost that haunts the logic unaware,
+The brittle bridge that carries heavy load.
+
+Every abstraction leaks. Every layer lies.
+The stack is built on faith in lower stone.
+The hunter knows: assurance is disguise.
+And every fortress stands on flaws unknown.
+
+### III.
+
+The craft is patience. Watch the packets flow.
+Trace every branch the execution takes.
+Measure the silence where the errors grow.
+Map the geometry of small mistakes.
+
+A single character — a missing check —
+Becomes the key that opens every room.
+The hunter's eye finds order in the wreck,
+And beauty in the architecture's doom.
+
+### IV.
+
+Not malice drives this work, but deeper thirst:
+To understand the thing by how it breaks.
+To see the pattern where the pattern's cursed,
+To love the system most when it mistakes.
+
+And when the finding's done, the write-up sealed,
+The patch deployed, the bounty safely earned —
+The hunter knows the quiet, strange appeal
+Of every lesson brutally learned.
+
+---
+
+*An original work for SecureBananaLabs/bug-bounty*


### PR DESCRIPTION
## Summary

This PR submits an original poem for **Issue #76 — Technical Poem Generation ($430 bounty)**.

### The Poem

**"The Logic of Absence"** is a four-stanza work exploring the craft of vulnerability discovery — from the quiet 3 AM discipline of the terminal, through the philosophical nature of bugs as gaps and broken assumptions, to the strange satisfaction of responsible disclosure.

### Creative Decision

**Chose iambic tetrameter/pentameter with alternating rhyme to mirror the rhythm of methodical debugging — each line a step through the call stack, each stanza a phase of the hunt: reconnaissance, insight, exploitation, and resolution.**