### PR TITLE
fix: implement proper RBAC and prevent privilege escalation

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: Admins only", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/rbac.test.js
+++ b/apps/api/src/tests/rbac.test.js
@@ -1,0 +1,40 @@
+import { test, mock } from "node:test";
+import assert from "node:assert";
+import { registerSchema } from "../validators/auth.js";
+import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Role-Based Access Control and Privilege Escalation", async (t) => {
+  await t.test("registerSchema should not allow 'admin' role", () => {
+    assert.throws(() => {
+      registerSchema.parse({
+        email: "hacker@example.com",
+        password: "password123",
+        role: "admin"
+      });
+    }, /Invalid enum value/);
+  });
+
+  await t.test("adminMiddleware should reject non-admin users", () => {
+    const req = { user: { role: "client" } };
+    let failed = false;
+    const res = {
+      status: () => ({ json: () => { failed = true; } })
+    };
+    const next = () => {};
+
+    adminMiddleware(req, res, next);
+    assert.strictEqual(failed, true, "Should have failed the request");
+  });
+
+  await t.test("adminMiddleware should allow admin users", () => {
+    const req = { user: { role: "admin" } };
+    let passed = false;
+    const res = {};
+    const next = () => { passed = true; };
+
+    adminMiddleware(req, res, next);
+    assert.strictEqual(passed, true, "Should have called next()");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
This PR resolves two high-severity access control vulnerabilities:

1. **Privilege Escalation during Registration**: The Zod validator for registration explicitly allowed the `role` to be set to `admin`. This allowed any new user to register with full administrative privileges. Fixed by removing `admin` from the allowed roles in `registerSchema`.
2. **Broken Access Control on Admin Routes**: The `adminRoutes.js` endpoints were protected by `authMiddleware` (requiring authentication), but lacked any Role-Based Access Control (RBAC) to ensure the user actually had the `admin` role. Fixed by implementing and applying `adminMiddleware`.

A test suite (`rbac.test.js`) has been added to verify these fixes.

/claim #952
No payout address, private token, cookie, seed phrase, or API key is included in the PR.