### PR TITLE
fix: prevent JWT secret fallback to weak default in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,10 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.JWT_SECRET || (() => {
+    if (process.env.NODE_ENV === "production") throw new Error("JWT_SECRET must be defined in production");
+    return "development-secret";
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
This PR resolves a critical vulnerability where the application would silently fallback to a hardcoded JWT secret (`development-secret`) if `process.env.JWT_SECRET` was undefined in production. This allows an attacker who knows the open-source codebase to trivially forge JWT tokens and escalate privileges on production systems.

The fix enforces that the environment variable must be provided in production, throwing a loud error at startup rather than compromising security silently.

/claim #952
No payout address, private token, cookie, seed phrase, or API key is included in the PR.