### PR TITLE
fix: prevent memory exhaustion DoS via unbound multer uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ 
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 } // 5MB limit
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
This PR fixes a critical Denial of Service (DoS) vulnerability in the upload route.

**Vulnerability:**
The `uploadRoutes` previously configured `multer` with `memoryStorage()` but failed to specify any file size limits. This allowed an unauthenticated or malicious user to upload an arbitrarily large file (e.g., several gigabytes), causing Node.js to consume all available memory and crash the server with an Out-of-Memory (OOM) error.

**Fix:**
Implemented a `limits: { fileSize: 5 * 1024 * 1024 }` (5MB) configuration option for the multer instance. This forces the middleware to reject oversized files before they can consume excessive memory, protecting the application's availability.

/claim #952
No payout address, private token, cookie, seed phrase, or API key is included in the PR.