### PR TITLE
Implement Stripe PaymentIntent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^16.12.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,58 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+const DEFAULT_CURRENCY = "usd";
+
+function validatePaymentPayload(payload = {}) {
+  const amount = payload.amount;
+
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("Payment amount must be a positive integer in the smallest currency unit.");
+  }
+
+  const currency = payload.currency ?? DEFAULT_CURRENCY;
+  if (typeof currency !== "string" || !/^[a-zA-Z]{3}$/.test(currency)) {
+    throw new Error("Payment currency must be a three-letter ISO currency code.");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    amount,
+    currency: currency.toLowerCase(),
+    metadata: payload.metadata && typeof payload.metadata === "object" ? payload.metadata : undefined
   };
 }
+
+function getStripeClient() {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+
+  if (!secretKey) {
+    throw new Error("STRIPE_SECRET_KEY is required to create Stripe payment intents.");
+  }
+
+  return new Stripe(secretKey);
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const { amount, currency, metadata } = validatePaymentPayload(payload);
+  const stripe = options.stripeClient ?? getStripeClient();
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount,
+      currency,
+      ...(metadata ? { metadata } : {})
+    });
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? amount,
+      currency: paymentIntent.currency ?? currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error?.message || "Stripe payment intent creation failed.";
+    throw new Error(`Stripe payment intent creation failed: ${message}`);
+  }
+}
+
+export const __test__ = { validatePaymentPayload };

--- a/apps/api/src/tests/paymentService.smoke.test.js
+++ b/apps/api/src/tests/paymentService.smoke.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent can create a real Stripe test-mode PaymentIntent", async (t) => {
+  if (process.env.RUN_STRIPE_SMOKE_TEST !== "1") {
+    t.skip("Set RUN_STRIPE_SMOKE_TEST=1 and STRIPE_SECRET_KEY to run this smoke test.");
+    return;
+  }
+
+  const result = await createPaymentIntent({
+    amount: 100,
+    currency: "usd",
+    metadata: { smoke: "true" }
+  });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.equal(typeof result.clientSecret, "string");
+  assert.equal(result.provider, "stripe");
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, __test__ } from "../services/paymentService.js";
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated defaults", async () => {
+  const calls = [];
+  const stripeClient = {
+    paymentIntents: {
+      create: async (params) => {
+        calls.push(params);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_abc",
+          amount: params.amount,
+          currency: params.currency
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent(
+    { amount: 2500, metadata: { invoiceId: "inv_001" } },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { invoiceId: "inv_001" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent validates amount before calling Stripe", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        throw new Error("Stripe should not be called");
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    /positive integer/
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined.");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 5000, currency: "mxn" }, { stripeClient }),
+    /Your card was declined/
+  );
+});
+
+test("validatePaymentPayload normalizes currency", () => {
+  assert.deepEqual(__test__.validatePaymentPayload({ amount: 100, currency: "MXN" }), {
+    amount: 100,
+    currency: "mxn",
+    metadata: undefined
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^16.12.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,6 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2052,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2140,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary

- Replaces the stub `pay_${Date.now()}` payment response with a real Stripe `PaymentIntent` flow.
- Uses `STRIPE_SECRET_KEY` from the environment; no keys are hardcoded.
- Validates `amount` as a positive integer in the smallest currency unit.
- Defaults `currency` to `usd`, normalizes explicit currency values, and passes optional metadata through to Stripe.
- Returns `paymentId` from `paymentIntent.id` and `clientSecret` from `paymentIntent.client_secret`.
- Preserves Stripe error messages in rethrown service errors.

## Validation

- `npm.cmd install --ignore-scripts --cache .\.npm-cache`
- `npm.cmd test -w apps/api --cache .\.npm-cache`
- `git diff --check`

Test result: 5 passing, 1 skipped guarded Stripe smoke test.

## Smoke Test

The guarded integration smoke test can be run by maintainers with:

```bash
RUN_STRIPE_SMOKE_TEST=1 STRIPE_SECRET_KEY=sk_test_... npm test -w apps/api
```

It is skipped by default so CI does not require live Stripe credentials.