### PR TITLE
Add API benchmark suite

### DIFF
--- a/.github/workflows/api-benchmark-smoke.yml
+++ b/.github/workflows/api-benchmark-smoke.yml
@@ -1,0 +1,35 @@
+name: API benchmark smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/api-benchmark-smoke.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/api-benchmark-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run benchmark:smoke -- --no-write-results

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -3,6 +3,7 @@ import rateLimit from "express-rate-limit";
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
+  skip: () => process.env.NODE_ENV === "benchmark",
   standardHeaders: "draft-7",
   legacyHeaders: false
 });

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,50 @@
+# API Benchmark Suite
+
+This benchmark suite covers every mounted `/api/*` route plus `/health`.
+It uses only Node.js standard runtime APIs and can run against either:
+
+- an in-process local Express app, when `BENCHMARK_TARGET_URL` is not set
+- an already-running local or staging API, when `BENCHMARK_TARGET_URL` is set
+
+## Commands
+
+```bash
+npm run benchmark
+npm run benchmark:smoke
+```
+
+`benchmark:smoke` uses low request counts and is suitable for CI.
+
+## Configuration
+
+Copy `benchmarks/.env.benchmark.example` into your shell environment or export the values you need:
+
+```bash
+BENCHMARK_TARGET_URL=http://127.0.0.1:4000
+BENCHMARK_CONCURRENCY=4
+BENCHMARK_REQUESTS=25
+BENCHMARK_RESULTS_DIR=benchmarks/results
+```
+
+If `BENCHMARK_TARGET_URL` is omitted, the runner starts the API in-process on an ephemeral local port.
+
+## Output
+
+Full benchmark runs write:
+
+- timestamped JSON to `benchmarks/results/`
+- timestamped Markdown summaries to `benchmarks/results/`
+
+Smoke runs validate thresholds but do not write results unless `--write-results` is passed.
+
+## Metrics
+
+Each endpoint report includes:
+
+- p50, p95, and p99 latency in milliseconds
+- p95 time-to-first-byte in milliseconds
+- sustained and peak requests per second
+- HTTP status distribution
+- error rate percentage
+
+Thresholds are configured in `benchmarks/thresholds.json`.

--- a/benchmarks/api-benchmark.mjs
+++ b/benchmarks/api-benchmark.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createApp } from "../apps/api/src/app.js";
+import { signAccessToken } from "../apps/api/src/utils/jwt.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+const args = new Set(process.argv.slice(2));
+const smoke = args.has("--smoke");
+const shouldWriteResults = !args.has("--no-write-results") && (!smoke || args.has("--write-results"));
+
+const requestCount = Number(process.env[smoke ? "BENCHMARK_SMOKE_REQUESTS" : "BENCHMARK_REQUESTS"] ?? (smoke ? 3 : 25));
+const concurrency = Number(process.env[smoke ? "BENCHMARK_SMOKE_CONCURRENCY" : "BENCHMARK_CONCURRENCY"] ?? (smoke ? 1 : 4));
+const resultsDir = path.resolve(repoRoot, process.env.BENCHMARK_RESULTS_DIR ?? "benchmarks/results");
+const benchmarkRunId = Date.now();
+const authToken = signAccessToken({ sub: "benchmark_admin", role: "admin" });
+
+const endpoints = [
+  { name: "GET /health", method: "GET", path: "/health" },
+  { name: "POST /api/auth/register", method: "POST", path: "/api/auth/register", json: i => ({ email: `bench-${benchmarkRunId}-${i}@example.com`, password: "benchmark-pass", role: "client" }) },
+  { name: "POST /api/auth/login", method: "POST", path: "/api/auth/login", json: i => ({ email: `login-${benchmarkRunId}-${i}@example.com`, password: "benchmark-pass" }) },
+  { name: "GET /api/auth/oauth/github/callback", method: "GET", path: "/api/auth/oauth/github/callback" },
+  { name: "POST /api/auth/refresh", method: "POST", path: "/api/auth/refresh" },
+  { name: "GET /api/users", method: "GET", path: "/api/users" },
+  { name: "POST /api/users", method: "POST", path: "/api/users", json: i => ({ email: `user-${benchmarkRunId}-${i}@example.com`, name: `Benchmark User ${i}`, role: "freelancer" }) },
+  { name: "GET /api/jobs", method: "GET", path: "/api/jobs" },
+  { name: "POST /api/jobs", method: "POST", path: "/api/jobs", json: i => ({ title: `Benchmark job ${i}`, description: "Benchmark job payload used by the API performance suite.", budgetMin: 100, budgetMax: 500, categoryId: "development", skills: ["node", "api"] }) },
+  { name: "GET /api/proposals", method: "GET", path: "/api/proposals" },
+  { name: "POST /api/proposals", method: "POST", path: "/api/proposals", json: i => ({ jobId: `job_${i}`, freelancerId: `usr_${i}`, coverLetter: "Benchmark proposal payload", amount: 250 }) },
+  { name: "POST /api/payments", method: "POST", path: "/api/payments", json: i => ({ amount: 25000 + i, currency: "usd", proposalId: `prp_${i}` }) },
+  { name: "GET /api/reviews", method: "GET", path: "/api/reviews" },
+  { name: "POST /api/reviews", method: "POST", path: "/api/reviews", json: i => ({ reviewerId: `usr_${i}`, revieweeId: `usr_${i + 1}`, rating: 5, comment: "Benchmark review payload" }) },
+  { name: "GET /api/messages", method: "GET", path: "/api/messages" },
+  { name: "POST /api/messages", method: "POST", path: "/api/messages", json: i => ({ threadId: `thr_${i}`, senderId: `usr_${i}`, body: "Benchmark message payload" }) },
+  { name: "GET /api/notifications", method: "GET", path: "/api/notifications" },
+  { name: "POST /api/notifications", method: "POST", path: "/api/notifications", json: i => ({ userId: `usr_${i}`, type: "benchmark", message: "Benchmark notification payload" }) },
+  { name: "POST /api/uploads", method: "POST", path: "/api/uploads", multipart: i => ({ fileName: `benchmark-${i}.txt`, content: `benchmark upload ${i}` }) },
+  { name: "GET /api/search", method: "GET", path: "/api/search?q=developer" },
+  { name: "GET /api/admin/metrics", method: "GET", path: "/api/admin/metrics", headers: { Authorization: `Bearer ${authToken}` } }
+];
+
+async function main() {
+  const server = await startServerIfNeeded();
+  const baseUrl = process.env.BENCHMARK_TARGET_URL ?? server.baseUrl;
+
+  try {
+    const thresholds = await readThresholds();
+    const startedAt = new Date();
+    const endpointResults = [];
+
+    for (const endpoint of endpoints) {
+      endpointResults.push(await benchmarkEndpoint(baseUrl, endpoint));
+    }
+
+    const finishedAt = new Date();
+    const report = {
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      mode: smoke ? "smoke" : "full",
+      baseUrl,
+      requestCount,
+      concurrency,
+      endpoints: endpointResults
+    };
+
+    const failures = validateThresholds(report, thresholds);
+    printSummary(report, failures);
+
+    if (shouldWriteResults) {
+      await writeResults(report, failures);
+    }
+
+    if (failures.length > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await server.close?.();
+  }
+}
+
+async function startServerIfNeeded() {
+  if (process.env.BENCHMARK_TARGET_URL) {
+    return {};
+  }
+
+  process.env.NODE_ENV = "benchmark";
+  const app = createApp();
+  const server = http.createServer(app);
+
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise(resolve => server.close(resolve))
+  };
+}
+
+async function benchmarkEndpoint(baseUrl, endpoint) {
+  await sendRequest(baseUrl, endpoint, -1);
+
+  const latencies = [];
+  const ttfbs = [];
+  const statuses = new Map();
+  const started = performance.now();
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < requestCount) {
+      const requestIndex = cursor++;
+      const result = await sendRequest(baseUrl, endpoint, requestIndex);
+      latencies.push(result.latencyMs);
+      ttfbs.push(result.ttfbMs);
+      statuses.set(result.status, (statuses.get(result.status) ?? 0) + 1);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, requestCount) }, () => worker()));
+  const durationSeconds = Math.max((performance.now() - started) / 1000, 0.001);
+  const errors = [...statuses.entries()].reduce((sum, [status, count]) => status >= 400 ? sum + count : sum, 0);
+  const sortedLatencies = latencies.toSorted((a, b) => a - b);
+  const sortedTtfbs = ttfbs.toSorted((a, b) => a - b);
+
+  return {
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    requests: latencies.length,
+    p50Ms: percentile(sortedLatencies, 50),
+    p95Ms: percentile(sortedLatencies, 95),
+    p99Ms: percentile(sortedLatencies, 99),
+    ttfbP95Ms: percentile(sortedTtfbs, 95),
+    sustainedRps: round(latencies.length / durationSeconds),
+    peakRps: round(1000 / Math.max(Math.min(...latencies), 1)),
+    errorRatePct: round((errors / latencies.length) * 100),
+    statuses: Object.fromEntries([...statuses.entries()].sort(([a], [b]) => a - b))
+  };
+}
+
+async function sendRequest(baseUrl, endpoint, requestIndex) {
+  const headers = { ...(endpoint.headers ?? {}) };
+  const options = { method: endpoint.method, headers };
+
+  if (endpoint.json) {
+    headers["Content-Type"] = "application/json";
+    options.body = JSON.stringify(endpoint.json(requestIndex));
+  }
+
+  if (endpoint.multipart) {
+    const data = endpoint.multipart(requestIndex);
+    const formData = new FormData();
+    formData.set("file", new Blob([data.content], { type: "text/plain" }), data.fileName);
+    options.body = formData;
+  }
+
+  const started = performance.now();
+  const response = await fetch(`${baseUrl}${endpoint.path}`, options);
+  const firstByteAt = performance.now();
+  await response.arrayBuffer();
+  const completedAt = performance.now();
+
+  return {
+    status: response.status,
+    ttfbMs: round(firstByteAt - started),
+    latencyMs: round(completedAt - started)
+  };
+}
+
+async function readThresholds() {
+  const content = await fs.readFile(path.join(__dirname, "thresholds.json"), "utf8");
+  return JSON.parse(content);
+}
+
+function validateThresholds(report, thresholds) {
+  const failures = [];
+
+  for (const endpoint of report.endpoints) {
+    const threshold = {
+      ...thresholds.defaults,
+      ...(thresholds.endpoints?.[endpoint.name] ?? {})
+    };
+
+    if (endpoint.p99Ms > threshold.p99Ms) {
+      failures.push(`${endpoint.name} p99 ${endpoint.p99Ms}ms exceeds ${threshold.p99Ms}ms`);
+    }
+
+    if (endpoint.errorRatePct > threshold.errorRatePct) {
+      failures.push(`${endpoint.name} error rate ${endpoint.errorRatePct}% exceeds ${threshold.errorRatePct}%`);
+    }
+  }
+
+  return failures;
+}
+
+async function writeResults(report, failures) {
+  await fs.mkdir(resultsDir, { recursive: true });
+  const stamp = report.startedAt.replaceAll(/[:.]/g, "-");
+  await fs.writeFile(path.join(resultsDir, `${stamp}.json`), `${JSON.stringify({ ...report, failures }, null, 2)}\n`);
+  await fs.writeFile(path.join(resultsDir, `${stamp}.md`), toMarkdown(report, failures));
+}
+
+function printSummary(report, failures) {
+  console.table(report.endpoints.map(endpoint => ({
+    endpoint: endpoint.name,
+    p50: endpoint.p50Ms,
+    p95: endpoint.p95Ms,
+    p99: endpoint.p99Ms,
+    ttfbP95: endpoint.ttfbP95Ms,
+    rps: endpoint.sustainedRps,
+    errors: endpoint.errorRatePct
+  })));
+
+  if (failures.length > 0) {
+    console.error(`Threshold failures:\n- ${failures.join("\n- ")}`);
+  }
+}
+
+function toMarkdown(report, failures) {
+  const rows = report.endpoints.map(endpoint => (
+    `| ${endpoint.name} | ${endpoint.requests} | ${endpoint.p50Ms} | ${endpoint.p95Ms} | ${endpoint.p99Ms} | ${endpoint.ttfbP95Ms} | ${endpoint.sustainedRps} | ${endpoint.errorRatePct}% |`
+  ));
+
+  return `# API Benchmark Report
+
+- Started: ${report.startedAt}
+- Finished: ${report.finishedAt}
+- Mode: ${report.mode}
+- Base URL: ${report.baseUrl}
+- Requests per endpoint: ${report.requestCount}
+- Concurrency: ${report.concurrency}
+
+| Endpoint | Requests | p50 ms | p95 ms | p99 ms | TTFB p95 ms | Sustained RPS | Error Rate |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+${rows.join("\n")}
+
+## Thresholds
+
+${failures.length === 0 ? "All thresholds passed." : failures.map(failure => `- ${failure}`).join("\n")}
+`;
+}
+
+function percentile(sortedValues, pct) {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+
+  const index = Math.ceil((pct / 100) * sortedValues.length) - 1;
+  return round(sortedValues[Math.min(Math.max(index, 0), sortedValues.length - 1)]);
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/benchmarks/results/2026-05-28T21-08-14-403Z.json
+++ b/benchmarks/results/2026-05-28T21-08-14-403Z.json
@@ -1,0 +1,347 @@
+{
+  "startedAt": "2026-05-28T21:08:14.403Z",
+  "finishedAt": "2026-05-28T21:08:14.702Z",
+  "mode": "full",
+  "baseUrl": "http://127.0.0.1:55392",
+  "requestCount": 25,
+  "concurrency": 4,
+  "endpoints": [
+    {
+      "name": "GET /health",
+      "method": "GET",
+      "path": "/health",
+      "requests": 25,
+      "p50Ms": 3.2,
+      "p95Ms": 8.94,
+      "p99Ms": 8.98,
+      "ttfbP95Ms": 8.91,
+      "sustainedRps": 977.81,
+      "peakRps": 819.67,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/auth/register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "requests": 25,
+      "p50Ms": 2.64,
+      "p95Ms": 16.93,
+      "p99Ms": 17.47,
+      "ttfbP95Ms": 16.9,
+      "sustainedRps": 769.18,
+      "peakRps": 847.46,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "POST /api/auth/login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "requests": 25,
+      "p50Ms": 1.91,
+      "p95Ms": 3.38,
+      "p99Ms": 3.48,
+      "ttfbP95Ms": 3.35,
+      "sustainedRps": 1753.28,
+      "peakRps": 775.19,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "GET /api/auth/oauth/github/callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/github/callback",
+      "requests": 25,
+      "p50Ms": 1.38,
+      "p95Ms": 2.85,
+      "p99Ms": 3.02,
+      "ttfbP95Ms": 2.8,
+      "sustainedRps": 2463.01,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/auth/refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "requests": 25,
+      "p50Ms": 1.2,
+      "p95Ms": 2.13,
+      "p99Ms": 2.15,
+      "ttfbP95Ms": 2.1,
+      "sustainedRps": 2650.79,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "GET /api/users",
+      "method": "GET",
+      "path": "/api/users",
+      "requests": 25,
+      "p50Ms": 0.94,
+      "p95Ms": 2.17,
+      "p99Ms": 2.22,
+      "ttfbP95Ms": 2.15,
+      "sustainedRps": 3274.02,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/users",
+      "method": "POST",
+      "path": "/api/users",
+      "requests": 25,
+      "p50Ms": 1.55,
+      "p95Ms": 1.79,
+      "p99Ms": 1.8,
+      "ttfbP95Ms": 1.76,
+      "sustainedRps": 2703.01,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/jobs",
+      "method": "GET",
+      "path": "/api/jobs",
+      "requests": 25,
+      "p50Ms": 1.11,
+      "p95Ms": 1.8,
+      "p99Ms": 1.86,
+      "ttfbP95Ms": 1.76,
+      "sustainedRps": 3212.8,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/jobs",
+      "method": "POST",
+      "path": "/api/jobs",
+      "requests": 25,
+      "p50Ms": 1.12,
+      "p95Ms": 2.35,
+      "p99Ms": 2.47,
+      "ttfbP95Ms": 2.33,
+      "sustainedRps": 2900.64,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/proposals",
+      "method": "GET",
+      "path": "/api/proposals",
+      "requests": 25,
+      "p50Ms": 1.12,
+      "p95Ms": 2.02,
+      "p99Ms": 2.03,
+      "ttfbP95Ms": 2,
+      "sustainedRps": 3218.52,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/proposals",
+      "method": "POST",
+      "path": "/api/proposals",
+      "requests": 25,
+      "p50Ms": 1.12,
+      "p95Ms": 1.9,
+      "p99Ms": 2.01,
+      "ttfbP95Ms": 1.88,
+      "sustainedRps": 2960.68,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "POST /api/payments",
+      "method": "POST",
+      "path": "/api/payments",
+      "requests": 25,
+      "p50Ms": 1.17,
+      "p95Ms": 1.52,
+      "p99Ms": 1.64,
+      "ttfbP95Ms": 1.5,
+      "sustainedRps": 3272.73,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/reviews",
+      "method": "GET",
+      "path": "/api/reviews",
+      "requests": 25,
+      "p50Ms": 0.85,
+      "p95Ms": 1.58,
+      "p99Ms": 1.6,
+      "ttfbP95Ms": 1.55,
+      "sustainedRps": 3980.89,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/reviews",
+      "method": "POST",
+      "path": "/api/reviews",
+      "requests": 25,
+      "p50Ms": 1.33,
+      "p95Ms": 2.54,
+      "p99Ms": 2.55,
+      "ttfbP95Ms": 2.51,
+      "sustainedRps": 2601.05,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/messages",
+      "method": "GET",
+      "path": "/api/messages",
+      "requests": 25,
+      "p50Ms": 0.77,
+      "p95Ms": 1.33,
+      "p99Ms": 1.35,
+      "ttfbP95Ms": 1.31,
+      "sustainedRps": 4430.95,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/messages",
+      "method": "POST",
+      "path": "/api/messages",
+      "requests": 25,
+      "p50Ms": 1.63,
+      "p95Ms": 2.61,
+      "p99Ms": 2.71,
+      "ttfbP95Ms": 2.58,
+      "sustainedRps": 2234.22,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/notifications",
+      "method": "GET",
+      "path": "/api/notifications",
+      "requests": 25,
+      "p50Ms": 1.13,
+      "p95Ms": 2.82,
+      "p99Ms": 2.91,
+      "ttfbP95Ms": 2.78,
+      "sustainedRps": 2948.94,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "POST /api/notifications",
+      "method": "POST",
+      "path": "/api/notifications",
+      "requests": 25,
+      "p50Ms": 0.96,
+      "p95Ms": 2.74,
+      "p99Ms": 2.95,
+      "ttfbP95Ms": 2.72,
+      "sustainedRps": 2629.36,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "POST /api/uploads",
+      "method": "POST",
+      "path": "/api/uploads",
+      "requests": 25,
+      "p50Ms": 2.66,
+      "p95Ms": 3.53,
+      "p99Ms": 3.54,
+      "ttfbP95Ms": 3.5,
+      "sustainedRps": 1425.32,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "201": 25
+      }
+    },
+    {
+      "name": "GET /api/search",
+      "method": "GET",
+      "path": "/api/search?q=developer",
+      "requests": 25,
+      "p50Ms": 1.11,
+      "p95Ms": 5.24,
+      "p99Ms": 5.53,
+      "ttfbP95Ms": 4.94,
+      "sustainedRps": 1908.69,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    },
+    {
+      "name": "GET /api/admin/metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "requests": 25,
+      "p50Ms": 1.17,
+      "p95Ms": 4.08,
+      "p99Ms": 4.09,
+      "ttfbP95Ms": 4.04,
+      "sustainedRps": 2540.84,
+      "peakRps": 1000,
+      "errorRatePct": 0,
+      "statuses": {
+        "200": 25
+      }
+    }
+  ],
+  "failures": []
+}

--- a/benchmarks/results/2026-05-28T21-08-14-403Z.md
+++ b/benchmarks/results/2026-05-28T21-08-14-403Z.md
@@ -1,0 +1,36 @@
+# API Benchmark Report
+
+- Started: 2026-05-28T21:08:14.403Z
+- Finished: 2026-05-28T21:08:14.702Z
+- Mode: full
+- Base URL: http://127.0.0.1:55392
+- Requests per endpoint: 25
+- Concurrency: 4
+
+| Endpoint | Requests | p50 ms | p95 ms | p99 ms | TTFB p95 ms | Sustained RPS | Error Rate |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| GET /health | 25 | 3.2 | 8.94 | 8.98 | 8.91 | 977.81 | 0% |
+| POST /api/auth/register | 25 | 2.64 | 16.93 | 17.47 | 16.9 | 769.18 | 0% |
+| POST /api/auth/login | 25 | 1.91 | 3.38 | 3.48 | 3.35 | 1753.28 | 0% |
+| GET /api/auth/oauth/github/callback | 25 | 1.38 | 2.85 | 3.02 | 2.8 | 2463.01 | 0% |
+| POST /api/auth/refresh | 25 | 1.2 | 2.13 | 2.15 | 2.1 | 2650.79 | 0% |
+| GET /api/users | 25 | 0.94 | 2.17 | 2.22 | 2.15 | 3274.02 | 0% |
+| POST /api/users | 25 | 1.55 | 1.79 | 1.8 | 1.76 | 2703.01 | 0% |
+| GET /api/jobs | 25 | 1.11 | 1.8 | 1.86 | 1.76 | 3212.8 | 0% |
+| POST /api/jobs | 25 | 1.12 | 2.35 | 2.47 | 2.33 | 2900.64 | 0% |
+| GET /api/proposals | 25 | 1.12 | 2.02 | 2.03 | 2 | 3218.52 | 0% |
+| POST /api/proposals | 25 | 1.12 | 1.9 | 2.01 | 1.88 | 2960.68 | 0% |
+| POST /api/payments | 25 | 1.17 | 1.52 | 1.64 | 1.5 | 3272.73 | 0% |
+| GET /api/reviews | 25 | 0.85 | 1.58 | 1.6 | 1.55 | 3980.89 | 0% |
+| POST /api/reviews | 25 | 1.33 | 2.54 | 2.55 | 2.51 | 2601.05 | 0% |
+| GET /api/messages | 25 | 0.77 | 1.33 | 1.35 | 1.31 | 4430.95 | 0% |
+| POST /api/messages | 25 | 1.63 | 2.61 | 2.71 | 2.58 | 2234.22 | 0% |
+| GET /api/notifications | 25 | 1.13 | 2.82 | 2.91 | 2.78 | 2948.94 | 0% |
+| POST /api/notifications | 25 | 0.96 | 2.74 | 2.95 | 2.72 | 2629.36 | 0% |
+| POST /api/uploads | 25 | 2.66 | 3.53 | 3.54 | 3.5 | 1425.32 | 0% |
+| GET /api/search | 25 | 1.11 | 5.24 | 5.53 | 4.94 | 1908.69 | 0% |
+| GET /api/admin/metrics | 25 | 1.17 | 4.08 | 4.09 | 4.04 | 2540.84 | 0% |
+
+## Thresholds
+
+All thresholds passed.

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,11 @@
+{
+  "defaults": {
+    "p99Ms": 1000,
+    "errorRatePct": 0
+  },
+  "endpoints": {
+    "GET /health": { "p99Ms": 250, "errorRatePct": 0 },
+    "GET /api/admin/metrics": { "p99Ms": 500, "errorRatePct": 0 },
+    "POST /api/uploads": { "p99Ms": 1500, "errorRatePct": 0 }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "benchmark": "node benchmarks/api-benchmark.mjs",
+    "benchmark:smoke": "node benchmarks/api-benchmark.mjs --smoke",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
## Summary
- Add a pure Node.js benchmark runner covering `/health` and every mounted `/api/*` route.
- Add JSON/Markdown result output under `benchmarks/results/`, configurable thresholds, `.env.benchmark.example`, and benchmark docs.
- Add `npm run benchmark`, `npm run benchmark:smoke`, and a CI smoke workflow.
- Skip API rate limiting only when `NODE_ENV=benchmark` so local benchmark measurements are not rate-limit contaminated.

/claim #30

## Validation
- `npm test`
- `npm run benchmark:smoke -- --no-write-results`
- `npm run benchmark`
- `node --check benchmarks/api-benchmark.mjs`
- `git diff --check`

## Benchmark Environment

**Hardware**
- CPU model & core count: Apple Silicon local workstation; exact core topology not required by the benchmark runner.
- RAM: local workstation memory.
- Storage type: local SSD/NVMe-class storage.
- Network interface: loopback for local in-process benchmark target.
- Machine type: local workstation.
- OS & version: macOS local development environment.

**Runtime**
- Node.js version: v25.9.0 locally; CI smoke uses Node 22.
- Resource limits applied: none intentionally applied.
- Other significant processes running during benchmark: normal local development background processes.

**If submitted by or with an AI agent**
- Agent or tool name: OpenAI Codex desktop.
- Underlying model and version: GPT-5-based Codex coding agent.
- Inference provider: OpenAI.
- Orchestration framework if any: none beyond Codex shell/GitHub tooling.
- Execution mode: human-initiated, agent-executed.
- Did the agent have shell/tool access during execution: yes.
- Did the agent have internet access during execution: yes.
- Were benchmark commands run by the agent directly or handed off to the human to run: run directly by the agent.
- Any known agent constraints or sandboxing that may have affected execution: no production/staging secrets; benchmark ran against a local in-process Express app on loopback.