### PR TITLE
Require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,15 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...allowedRoles) {
+  const allowed = new Set(allowedRoles);
+
+  return (req, res, next) => {
+    if (!req.user || !allowed.has(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { requireRole } from "../middleware/auth.js";
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("requireRole blocks authenticated users without the required role", () => {
+  const req = { user: { sub: "usr_client", role: "client" } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireRole("admin")(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireRole allows authenticated admins", () => {
+  const req = { user: { sub: "usr_admin", role: "admin" } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireRole("admin")(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body, null);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #1396 by adding reusable role enforcement middleware.
- Requires the `admin` role before `/api/admin/*` requests can reach admin controllers.
- Adds focused middleware tests for forbidden non-admin access and allowed admin access.

## Demo
![Admin role guard demo](https://raw.githubusercontent.com/ManuelPuerto/bug-bounty/codex-demo-assets/demos/admin-role-guard-demo.gif)

## Validation
- `node --test apps/api/src/tests/authMiddleware.test.js apps/api/src/tests/authService.test.js apps/api/src/tests/jobValidator.test.js`
- Result: 6 tests passed.
- `node --check apps/api/src/middleware/auth.js`
- `node --check apps/api/src/routes/adminRoutes.js`

Fixes #1396
