### PR TITLE
Protect notification list reads with auth

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationReadAuth.test.js
+++ b/apps/api/src/tests/notificationReadAuth.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const routeSource = readFileSync(
+  new URL("../routes/notificationRoutes.js", import.meta.url),
+  "utf8"
+);
+
+test("notification list route requires bearer authentication", () => {
+  assert.match(
+    routeSource,
+    /import \{ authMiddleware \} from "\.\.\/middleware\/auth\.js";/
+  );
+  assert.match(
+    routeSource,
+    /notificationRoutes\.get\("\/", authMiddleware, getNotifications\);/
+  );
+});
+
+test("notification creation route remains unchanged", () => {
+  assert.match(routeSource, /notificationRoutes\.post\("\/", postNotification\);/);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #1399 by requiring bearer authentication before listing notifications.
- Leaves notification creation behavior unchanged.
- Adds focused node:test coverage for the route wiring.

## Demo
![Notification read auth demo](https://raw.githubusercontent.com/ManuelPuerto/bug-bounty/codex-demo-assets/demos/notification-read-auth-demo.gif)

## Validation
- `node --test apps/api/src/tests/notificationReadAuth.test.js apps/api/src/tests/authMiddleware.test.js apps/api/src/tests/authService.test.js apps/api/src/tests/jobValidator.test.js`
- Result: 8 tests passed.
- `node --check apps/api/src/routes/notificationRoutes.js`
- `node --check apps/api/src/tests/notificationReadAuth.test.js`

Fixes #1399
