### PR TITLE
fix(ui): declare React peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,14 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "devDependencies": {
+        "@types/react": "19.2.2",
+        "react": "19.2.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "node --test src/tests/*.test.mjs"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.2",
+    "react": "19.2.0"
+  }
 }

--- a/packages/ui/src/tests/package-metadata.test.mjs
+++ b/packages/ui/src/tests/package-metadata.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(testDir, "..", "..");
+const packageJson = JSON.parse(
+  await readFile(path.join(packageRoot, "package.json"), "utf8")
+);
+
+test("@freelanceflow/ui declares React as a peer dependency", () => {
+  assert.match(
+    packageJson.peerDependencies?.react ?? "",
+    /\S/,
+    "React should be declared as a peer dependency of the UI package"
+  );
+  assert.equal(
+    packageJson.dependencies?.react,
+    undefined,
+    "React should not be bundled as a direct UI package dependency"
+  );
+});
+
+test("@freelanceflow/ui has local React development metadata", () => {
+  assert.match(
+    packageJson.devDependencies?.react ?? "",
+    /\S/,
+    "React should be available for local UI package development checks"
+  );
+  assert.match(
+    packageJson.devDependencies?.["@types/react"] ?? "",
+    /\S/,
+    "React types should be available for local UI package development checks"
+  );
+});


### PR DESCRIPTION
Closes #1401
/claim #743

## Summary
- Add package-level metadata coverage for `@freelanceflow/ui` so its React contract stays explicit.
- Declare `react` as a peer dependency and add local UI development metadata for `react` and `@types/react`.
- Keep the change scoped to `packages/ui` package metadata and its regression test.

## Validation
- RED before fix: `node --test packages/ui/src/tests/package-metadata.test.mjs` failed with 2 missing React metadata assertions.
- `npm run test -w packages/ui` -> 2 passed, 0 failed.
- `npm ls react -w packages/ui --all` -> reports `@freelanceflow/ui -> react@19.2.0`.
- `git diff --check HEAD~1..HEAD` -> passed.
- `npm run build -w apps/web` -> passed.

## Notes
- Full root `npm test` is still blocked by the existing upstream `node --test src/tests` path issue; this PR adds and runs the focused UI package test instead.
- No payout address, private token, cookie, seed phrase, API key, or hidden runtime metadata is included.