### PR TITLE
Fix root lint no-op with JS syntax check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
-    "lint": "echo \"No root lint configured\"",
+    "lint": "node scripts/check-js-syntax.mjs",
     "test": "npm run test -w apps/api"
   }
 }

--- a/scripts/check-js-syntax.mjs
+++ b/scripts/check-js-syntax.mjs
@@ -1,0 +1,56 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const EXCLUDED_DIRS = new Set([
+  ".git",
+  ".next",
+  "coverage",
+  "dist",
+  "node_modules"
+]);
+
+const JS_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
+
+function hasJavaScriptExtension(filePath) {
+  return [...JS_EXTENSIONS].some((extension) => filePath.endsWith(extension));
+}
+
+function collectJavaScriptFiles(directory, files = []) {
+  for (const entry of readdirSync(directory)) {
+    if (EXCLUDED_DIRS.has(entry)) {
+      continue;
+    }
+
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      collectJavaScriptFiles(fullPath, files);
+    } else if (stats.isFile() && hasJavaScriptExtension(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const files = collectJavaScriptFiles(process.cwd());
+let failed = false;
+
+for (const file of files) {
+  const result = spawnSync(process.execPath, ["--check", file], {
+    encoding: "utf8"
+  });
+
+  if (result.status !== 0) {
+    failed = true;
+    process.stderr.write(result.stderr || result.stdout);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log(`Checked JavaScript syntax in ${files.length} files.`);


### PR DESCRIPTION
## Summary
- Replace the root no-op lint command with a dependency-free JavaScript syntax checker.
- Add `scripts/check-js-syntax.mjs` to recursively run `node --check` on `.js`, `.mjs`, and `.cjs` files while skipping generated/vendor directories.

## Issue
Fixes #1406
/claim #743

## Validation
- `npm run lint` -> checked JavaScript syntax in 46 files
- `node --test apps/api/src/tests/*.test.js` -> 1 passed
- `npm run build -w apps/web` -> passed

No payout address, private token, cookie, seed phrase, API key, or hidden runtime metadata is included.