### PR TITLE
Validate payment intent payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentIntentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentIntentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentValidation.test.js
+++ b/apps/api/src/tests/paymentValidation.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: -10, currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments rejects unsupported currencies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 25, currency: "banana" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments creates a normalized payment intent", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 25, currency: "MXN" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "mxn");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const supportedCurrencies = ["usd", "eur", "mxn", "gbp", "cad", "aud"];
+
+export const createPaymentIntentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .refine((currency) => supportedCurrencies.includes(currency), {
+      message: "Unsupported currency"
+    })
+    .default("usd")
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds a Zod schema for `POST /api/payments` payment-intent payloads.
- Rejects missing, negative, zero, non-numeric, and unsupported-currency payment requests with a stable 400 response.
- Normalizes supported currency codes before calling `createPaymentIntent`.
- Adds HTTP regression coverage for invalid amount, invalid currency, and valid normalized payment flows.

Fixes #1414.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1414-demo.mp4

## Validation
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/validators/payment.js`
- `node --check apps/api/src/tests/paymentValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentValidation.test.js`
- `git diff --check`