### PR TITLE
Restrict admin metrics to admin users

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...roles) {
+  return function roleMiddleware(req, res, next) {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuth.test.js
+++ b/apps/api/src/tests/adminAuth.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/admin/metrics rejects authenticated non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, { success: false, message: "Forbidden" });
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      openJobs: 42,
+      activeFreelancers: 185,
+      flaggedAccounts: 3,
+      monthlyVolume: 128900
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds reusable role authorization middleware after JWT authentication.
- Protects `/api/admin/metrics` so authenticated non-admin users receive `403 Forbidden`.
- Adds regression tests for missing token, client token, and admin token behavior.

Fixes #1417.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1417-demo.mp4

## Validation
- `node --check apps/api/src/middleware/auth.js`
- `node --check apps/api/src/routes/adminRoutes.js`
- `node --check apps/api/src/tests/adminAuth.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/adminAuth.test.js`
- `node --test src/tests/*.test.js` from `apps/api`
- `git diff --check`

Note: `npm test -w apps/api` could not be used in this local Windows environment because the workspace script invokes `node` through `cmd` and returns `Acceso denegado`; the same test files pass with the bundled Node binary directly.