### PR TITLE
Defensively snapshot create service records

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = snapshotRecord({ id: `job_${Date.now()}`, status: "open", ...payload });
   jobs.push(job);
-  return job;
+  return snapshotRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = snapshotRecord({ id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() });
   messages.push(message);
-  return message;
+  return snapshotRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = snapshotRecord({ id: `ntf_${Date.now()}`, read: false, ...payload });
   notifications.push(notification);
-  return notification;
+  return snapshotRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = snapshotRecord({ id: `prp_${Date.now()}`, ...payload });
   proposals.push(proposal);
-  return proposal;
+  return snapshotRecord(proposal);
 }

--- a/apps/api/src/services/recordSnapshot.js
+++ b/apps/api/src/services/recordSnapshot.js
@@ -1,0 +1,8 @@
+export function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = snapshotRecord({ id: `rev_${Date.now()}`, ...payload });
   reviews.push(review);
-  return review;
+  return snapshotRecord(review);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./recordSnapshot.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = snapshotRecord({ id: `usr_${Date.now()}`, ...payload });
   users.push(user);
-  return user;
+  return snapshotRecord(user);
 }

--- a/apps/api/src/tests/createServiceSnapshots.test.js
+++ b/apps/api/src/tests/createServiceSnapshots.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  ["job", createJob, listJobs],
+  ["message", sendMessage, listMessages],
+  ["notification", createNotification, listNotifications],
+  ["proposal", createProposal, listProposals],
+  ["review", createReview, listReviews],
+  ["user", createUser, listUsers]
+];
+
+for (const [name, createRecord, listRecords] of cases) {
+  test(`${name} create service returns defensive snapshots`, async () => {
+    const labels = [`${name}-original`];
+    const created = await createRecord({
+      title: `${name} snapshot test`,
+      labels
+    });
+
+    labels.push(`${name}-payload-mutated`);
+    created.title = `${name} response mutated`;
+    created.labels.push(`${name}-response-mutated`);
+
+    const stored = (await listRecords()).find((record) => record.id === created.id);
+
+    assert.ok(stored);
+    assert.notEqual(stored, created);
+    assert.equal(stored.title, `${name} snapshot test`);
+    assert.deepEqual(stored.labels, [`${name}-original`]);
+    assert.notEqual(stored.labels, labels);
+    assert.notEqual(stored.labels, created.labels);
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared `snapshotRecord()` helper for create-service records
- store defensive snapshots in job/proposal/review/message/notification/user create services
- return separate response snapshots so callers cannot mutate backing in-memory state through returned records or payload array references

## Bounty
- Closes #1427
- Refs #743

## Validation
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --test apps/api/src/tests/createServiceSnapshots.test.js` -> 6 passed
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --test apps/api/src/tests/*.test.js` -> 7 passed
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --check apps/api/src/services/recordSnapshot.js && ... && node --check apps/api/src/tests/createServiceSnapshots.test.js`
- `git diff --check`

## Note
- `PATH=/home/goalie/.local/node-v22/bin:$PATH npm test` still fails on the existing upstream script `node --test src/tests`, which Node resolves as a missing path instead of expanding test files. Direct `node --test apps/api/src/tests/*.test.js` passes for this PR.
