### PR TITLE
Add auth-specific rate limiting

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,14 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: {
+    success: false,
+    message: "Too many authentication attempts, please try again later"
+  }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
 authRoutes.post("/refresh", refresh);

--- a/apps/api/src/tests/authRateLimit.test.js
+++ b/apps/api/src/tests/authRateLimit.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login is throttled before the generic API limit", async () => {
+  await withServer(async (baseUrl) => {
+    const requestBody = JSON.stringify({
+      email: "client@example.com",
+      password: "correct-password"
+    });
+
+    let response;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      response = await fetch(`${baseUrl}/api/auth/login`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: requestBody
+      });
+    }
+
+    assert.equal(response.status, 200);
+
+    const throttled = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: requestBody
+    });
+    const payload = await throttled.json();
+
+    assert.equal(throttled.status, 429);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /authentication attempts/i);
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds an auth-specific rate limiter for `POST /api/auth/register` and `POST /api/auth/login`.
- Keeps OAuth callback and refresh routes outside this stricter limiter.
- Returns a stable 429 JSON response once auth attempts exceed the focused window.
- Adds HTTP regression coverage proving login is throttled before the generic API limit.

Fixes #1430.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1430-demo.mp4

## Validation
- `node --check apps/api/src/middleware/rateLimit.js`
- `node --check apps/api/src/routes/authRoutes.js`
- `node --check apps/api/src/tests/authRateLimit.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authRateLimit.test.js`
- `git diff --check`

No payout address, private token, cookie, seed phrase, API key, or personal information is included.