### PR TITLE
Defensively snapshot list service records

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return snapshotList(jobs);
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/listSnapshot.js
+++ b/apps/api/src/services/listSnapshot.js
@@ -1,0 +1,12 @@
+export function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}
+
+export function snapshotList(records) {
+  return records.map(snapshotRecord);
+}

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return snapshotList(messages);
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return snapshotList(notifications);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return snapshotList(proposals);
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return snapshotList(reviews);
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "./listSnapshot.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return snapshotList(users);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServiceSnapshots.test.js
+++ b/apps/api/src/tests/listServiceSnapshots.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  ["job", createJob, listJobs],
+  ["message", sendMessage, listMessages],
+  ["notification", createNotification, listNotifications],
+  ["proposal", createProposal, listProposals],
+  ["review", createReview, listReviews],
+  ["user", createUser, listUsers]
+];
+
+for (const [name, createRecord, listRecords] of cases) {
+  test(`${name} list service returns defensive snapshots`, async () => {
+    const originalTitle = `${name} list snapshot test`;
+    const created = await createRecord({
+      title: originalTitle,
+      labels: [`${name}-original`]
+    });
+
+    const listedRecords = await listRecords();
+    const listedRecord = listedRecords.find((record) => record.id === created.id);
+
+    assert.ok(listedRecord);
+
+    listedRecords.push({ id: `${name}-injected`, title: "injected" });
+    listedRecords.length = 0;
+    listedRecord.title = `${name} listed record mutated`;
+    listedRecord.labels.push(`${name}-listed-record-mutated`);
+
+    const storedRecords = await listRecords();
+    const storedRecord = storedRecords.find((record) => record.id === created.id);
+
+    assert.ok(storedRecord);
+    assert.equal(storedRecord.title, originalTitle);
+    assert.deepEqual(storedRecord.labels, [`${name}-original`]);
+    assert.equal(
+      storedRecords.some((record) => record.id === `${name}-injected`),
+      false
+    );
+    assert.notEqual(storedRecords, listedRecords);
+    assert.notEqual(storedRecord, listedRecord);
+    assert.notEqual(storedRecord.labels, listedRecord.labels);
+  });
+}


### PR DESCRIPTION
/claim #743

## Summary
- add a shared `snapshotList()` helper for list-service responses
- return defensive snapshots from job/proposal/review/message/notification/user list services
- copy array-valued record fields in list snapshots so callers cannot mutate backing in-memory state through returned arrays or listed records

## Bounty
- Closes #1434
- Refs #743

## Validation
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --test apps/api/src/tests/listServiceSnapshots.test.js` -> 6 passed
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --test apps/api/src/tests/*.test.js` -> 7 passed
- `PATH=/home/goalie/.local/node-v22/bin:$PATH node --check apps/api/src/services/listSnapshot.js && ... && node --check apps/api/src/tests/listServiceSnapshots.test.js`
- `git diff --check`

## Note
- `PATH=/home/goalie/.local/node-v22/bin:$PATH npm test` still fails on the existing upstream script `node --test src/tests`, which Node resolves as a missing path instead of expanding test files. Direct `node --test apps/api/src/tests/*.test.js` passes for this PR.

No payout address, private token, cookie value, seed phrase, API key, personal information, or hidden runtime metadata is included.