### PR TITLE
fix(packages/ui): add React as peerDependency (closes #1462)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Added `react >=17.0.0` to `peerDependencies` in `packages/ui/package.json`
- Fixes npm v7+ peer dependency warning
- Prevents duplicate React instances at runtime

## Fix Details
**Before:** No `peerDependencies` field
**After:** Declares `react >=17.0.0` as peer dependency

Closes #1462
Closes #1401