### PR TITLE
Implement dynamic job and freelancer detail routes

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,36 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { freelancers, getFreelancerByUsername } from "../../../lib/mock";
+
+type FreelancerPageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export function generateStaticParams() {
+  return freelancers.map((freelancer) => ({ username: freelancer.username }));
+}
+
+export default async function FreelancerDetailPage({ params }: FreelancerPageProps) {
+  const { username } = await params;
+  const freelancer = getFreelancerByUsername(username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>{freelancer.username}</p>
+      <h2>{freelancer.name}</h2>
+      <h3>{freelancer.headline}</h3>
+      <p>{freelancer.bio}</p>
+      <p>
+        <strong>Rate:</strong> {freelancer.rate}
+      </p>
+      <p>
+        <strong>Skills:</strong> {freelancer.skills.join(", ")}
+      </p>
+      <Link href="/freelancers/search">Back to freelancer search</Link>
     </section>
   );
 }

--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(", ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,35 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getJobById, jobs } from "../../../lib/mock";
+
+type JobPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export function generateStaticParams() {
+  return jobs.map((job) => ({ id: job.id }));
+}
+
+export default async function JobDetailPage({ params }: JobPageProps) {
+  const { id } = await params;
+  const job = getJobById(id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <p>{job.category}</p>
+      <h2>{job.title}</h2>
+      <p>{job.description}</p>
+      <p>
+        <strong>Budget:</strong> {job.budget}
+      </p>
+      <p>
+        <strong>Skills:</strong> {job.skills.join(", ")}
+      </p>
+      <Link href="/jobs">Back to jobs</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,10 +1,53 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    category: "Engineering",
+    description: "Create an embeddable support widget with a small admin flow, conversation history, and API hooks.",
+    skills: ["Next.js", "OpenAI", "TypeScript"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    category: "Backend",
+    description: "Move a legacy REST API into a Node.js service while preserving existing auth and reporting behavior.",
+    skills: ["Node.js", "Express", "PostgreSQL"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    category: "Design",
+    description: "Design a compact onboarding experience for teams, invitations, billing setup, and first project creation.",
+    skills: ["Figma", "UX Research", "Product Design"]
+  }
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    headline: "Full-stack product engineer",
+    bio: "Builds polished SaaS features across Next.js, API design, and pragmatic AI integrations.",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr"
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Lee",
+    headline: "UX researcher and interface designer",
+    bio: "Turns ambiguous product ideas into clear flows, prototypes, and user-tested interface patterns.",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr"
+  }
 ];
+
+export function getJobById(id: string) {
+  return jobs.find((job) => job.id === id);
+}
+
+export function getFreelancerByUsername(username: string) {
+  return freelancers.find((freelancer) => freelancer.username === username);
+}


### PR DESCRIPTION
/claim #743

## Summary
- Replaces placeholder dynamic job and freelancer pages with record-backed detail views.
- Adds lookup helpers and richer mock records for job/category/skills and freelancer name/headline/bio data.
- Adds `generateStaticParams()` plus `notFound()` handling so known mock routes are generated and unknown routes get a real 404.
- Normalizes the freelancer search skills separator while keeping the listing link behavior intact.

Fixes #1473.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1473-demo.mp4

## Validation
- `npm run build -w apps/web`
- `git diff --check -- apps/web/app/freelancers/[username]/page.tsx apps/web/app/freelancers/search/page.tsx apps/web/app/jobs/[id]/page.tsx apps/web/lib/mock.ts`
