### PR TITLE
Add missing navigation links

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
/claim #743

## Summary
- Adds the existing `/jobs/post` route to the shared web navigation.
- Adds the existing `/notifications`, `/billing`, and `/settings` account routes to the shared web navigation.
- Keeps the fix scoped to navigation wiring without changing route behavior or styling.

Fixes #1475.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1475-demo.mp4

## Validation
- `npm run build -w apps/web`
- `git diff --check --cached`