### PR TITLE
fix: remove admin role from registration schema

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test 'src/tests/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "hacker@example.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.success, false);
+});
+
+test("registerSchema allows client role", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.ok(result.success);
+  assert.equal(result.data.role, "client");
+});
+
+test("registerSchema allows freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.ok(result.success);
+  assert.equal(result.data.role, "freelancer");
+});
+
+test("registerSchema defaults to client when no role", () => {
+  const result = registerSchema.safeParse({
+    email: "default@example.com",
+    password: "password123"
+  });
+  assert.ok(result.success);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION

Closes #1479

## Bug
The registration endpoint allowed users to self-assign the 'admin' role
by specifying `role: 'admin'` in the signup payload, creating a
privilege escalation vulnerability.

## Fix
- Removed 'admin' from z.enum() in auth validator
- Only 'client' and 'freelancer' roles are now available at registration
- Added 4 unit tests covering the fix

## Testing
```
npm test → 5/5 pass ✅
```
