### PR TITLE
fix(api): target test files in npm test

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- update the API workspace test script to target actual Node test files instead of the src/tests directory

## Validation
- npm test

Closes #1497
/claim #743