### PR TITLE
Add actionable dashboard summaries

### DIFF
--- a/apps/web/app/dashboard/client/page.tsx
+++ b/apps/web/app/dashboard/client/page.tsx
@@ -1,8 +1,85 @@
 export default function ClientDashboardPage() {
+  const metrics = [
+    { label: "Open jobs", value: "4" },
+    { label: "Shortlisted", value: "12" },
+    { label: "In escrow", value: "$4.2k" },
+    { label: "Due this week", value: "3" }
+  ];
+
+  const jobs = [
+    { title: "AI support widget", status: "Reviewing proposals", budget: "$1,500", next: "Compare 5 bids" },
+    { title: "Legacy API migration", status: "Milestone active", budget: "$2,800", next: "Approve staging deploy" },
+    { title: "SaaS onboarding flow", status: "Draft", budget: "$900", next: "Publish job brief" }
+  ];
+
+  const milestones = [
+    { name: "Wireframe handoff", amount: "$450", due: "Today" },
+    { name: "API migration phase 1", amount: "$1,200", due: "Jun 3" },
+    { name: "Widget QA pass", amount: "$650", due: "Jun 6" }
+  ];
+
   return (
-    <section className="card">
-      <h2>Dashboard (Client)</h2>
-      <p>Track jobs, shortlisted freelancers, and payment milestones.</p>
+    <section>
+      <div className="card">
+        <p className="eyebrow">Client workspace</p>
+        <h2>Hiring dashboard</h2>
+        <p className="muted">
+          Track active job pipelines, shortlisted freelancers, and payment milestones from one place.
+        </p>
+      </div>
+
+      <div className="grid">
+        {metrics.map((metric) => (
+          <article className="card metric" key={metric.label}>
+            <span>{metric.label}</span>
+            <strong>{metric.value}</strong>
+          </article>
+        ))}
+      </div>
+
+      <div className="dashboard-columns">
+        <section className="card">
+          <h3>Job pipeline</h3>
+          <div className="stack">
+            {jobs.map((job) => (
+              <article className="row-card" key={job.title}>
+                <div>
+                  <strong>{job.title}</strong>
+                  <p>{job.status}</p>
+                </div>
+                <div className="right">
+                  <span>{job.budget}</span>
+                  <small>{job.next}</small>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="card">
+          <h3>Payment milestones</h3>
+          <div className="stack">
+            {milestones.map((milestone) => (
+              <article className="row-card" key={milestone.name}>
+                <div>
+                  <strong>{milestone.name}</strong>
+                  <p>{milestone.due}</p>
+                </div>
+                <span>{milestone.amount}</span>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="card">
+        <h3>Next actions</h3>
+        <div className="actions">
+          <span>Review proposal shortlist</span>
+          <span>Release approved milestone</span>
+          <span>Invite two saved freelancers</span>
+        </div>
+      </section>
     </section>
   );
 }

--- a/apps/web/app/dashboard/freelancer/page.tsx
+++ b/apps/web/app/dashboard/freelancer/page.tsx
@@ -1,8 +1,82 @@
 export default function FreelancerDashboardPage() {
+  const metrics = [
+    { label: "Active proposals", value: "7" },
+    { label: "Accepted jobs", value: "3" },
+    { label: "Pending payout", value: "$2.1k" },
+    { label: "Response rate", value: "94%" }
+  ];
+
+  const proposals = [
+    { title: "AI support widget", client: "Northstar Labs", state: "Interview requested" },
+    { title: "API migration", client: "Cedar Systems", state: "Proposal viewed" },
+    { title: "Onboarding flow", client: "BrightPath", state: "Draft saved" }
+  ];
+
+  const work = [
+    { title: "Analytics dashboard", milestone: "Charts pass", due: "Today" },
+    { title: "Checkout QA", milestone: "Regression report", due: "Jun 2" },
+    { title: "Brand refresh", milestone: "Final files", due: "Jun 5" }
+  ];
+
   return (
-    <section className="card">
-      <h2>Dashboard (Freelancer)</h2>
-      <p>Manage proposals, accepted jobs, earnings, and response metrics.</p>
+    <section>
+      <div className="card">
+        <p className="eyebrow">Freelancer workspace</p>
+        <h2>Work dashboard</h2>
+        <p className="muted">
+          Manage proposals, accepted jobs, earnings, and response metrics without leaving the dashboard.
+        </p>
+      </div>
+
+      <div className="grid">
+        {metrics.map((metric) => (
+          <article className="card metric" key={metric.label}>
+            <span>{metric.label}</span>
+            <strong>{metric.value}</strong>
+          </article>
+        ))}
+      </div>
+
+      <div className="dashboard-columns">
+        <section className="card">
+          <h3>Proposal activity</h3>
+          <div className="stack">
+            {proposals.map((proposal) => (
+              <article className="row-card" key={proposal.title}>
+                <div>
+                  <strong>{proposal.title}</strong>
+                  <p>{proposal.client}</p>
+                </div>
+                <span>{proposal.state}</span>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="card">
+          <h3>Accepted work</h3>
+          <div className="stack">
+            {work.map((item) => (
+              <article className="row-card" key={item.title}>
+                <div>
+                  <strong>{item.title}</strong>
+                  <p>{item.milestone}</p>
+                </div>
+                <span>{item.due}</span>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="card">
+        <h3>Next actions</h3>
+        <div className="actions">
+          <span>Send interview reply</span>
+          <span>Upload milestone proof</span>
+          <span>Refresh availability</span>
+        </div>
+      </section>
     </section>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,16 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.eyebrow { color: #7dd3fc; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.35rem; text-transform: uppercase; }
+.muted, .row-card p { color: #bac7e8; margin: 0.35rem 0 0; }
+.metric { min-height: 104px; }
+.metric span { color: #bac7e8; display: block; font-size: 0.9rem; }
+.metric strong { display: block; font-size: 2rem; margin-top: 0.4rem; }
+.dashboard-columns { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.stack { display: grid; gap: 0.75rem; }
+.row-card { align-items: center; background: #0f172d; border: 1px solid #27365f; border-radius: 8px; display: flex; gap: 1rem; justify-content: space-between; padding: 0.85rem; }
+.row-card span { color: #dce6ff; text-align: right; }
+.right { display: grid; gap: 0.25rem; justify-items: end; text-align: right; }
+small { color: #93a4ca; }
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.actions span { background: #0f172d; border: 1px solid #27365f; border-radius: 999px; color: #dce6ff; padding: 0.55rem 0.8rem; }


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the client dashboard placeholder with hiring metrics, job pipeline cards, payment milestones, and next actions.
- Replaces the freelancer dashboard placeholder with proposal metrics, accepted work cards, pending payout/response metrics, and next actions.
- Adds shared dashboard styling in the existing global stylesheet.

Fixes #1506.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1506-demo.mp4

## Validation
- `npm run build -w apps/web`
- Browser check: `/dashboard/client` renders Hiring dashboard, Job pipeline, Payment milestones, with no horizontal overflow
- Browser check: `/dashboard/freelancer` renders Work dashboard, Proposal activity, Accepted work, with no horizontal overflow
- `git diff --check`