### PR TITLE
fix: prevent admin role self-assignment via registration (security)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,8 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  // 注册时不允许自选 admin 角色，防止权限提升
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes a critical privilege escalation vulnerability where any user can self-assign the `admin` role during registration.

## Problem

In `apps/api/src/validators/auth.js`:
```javascript
role: z.enum(["client", "freelancer", "admin"]).default("client")
```

A malicious user can send `role: "admin"` in the registration request to gain full administrative access without authorization.

## Fix

Removed `"admin"` from the allowed role enum in registration schema:
```javascript
role: z.enum(["client", "freelancer"]).default("client")
```

Admin role assignment must now be done through a separate, authorized process (e.g., database-level promotion by existing admin).

## Change

Only `apps/api/src/validators/auth.js` is modified:
- `role` enum: removed `"admin"` option from `registerSchema`