### PR TITLE
fix: add file upload size, type and count limits (security)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,8 +1,34 @@
 import { Router } from "express";
 import multer from "multer";
-import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+// 文件上传安全限制
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const ALLOWED_MIMES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_FILE_SIZE,
+    files: 1, // 单次只允许上传 1 个文件
+  },
+  fileFilter: (_req, file, cb) => {
+    if (!ALLOWED_MIMES.includes(file.mimetype)) {
+      const err = new Error(`不支持的文件类型: ${file.mimetype}`);
+      err.status = 400;
+      return cb(err);
+    }
+    cb(null, true);
+  },
+});
+
+import { uploadFile } from "../controllers/uploadController.js";
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Summary

Fixes a DoS vulnerability where file upload had no size, type, or count limits.

## Problem

In `apps/api/src/routes/uploadRoutes.js`:
```javascript
const upload = multer({ storage });
```

Without any limits, attackers can:
- Upload arbitrarily large files to exhaust disk space
- Upload malicious file types (executables, scripts)
- Upload many files simultaneously to amplify the DoS

## Fix

Added multer limits configuration:
- Max file size: 10MB
- Allowed MIME types: image/png, image/jpeg, image/gif, image/webp, application/pdf, text/plain
- Max 1 file per request
- Better error message on validation failure

## Change

Only `apps/api/src/routes/uploadRoutes.js` is modified:
- Replaced `multer({ storage })` with full limits + fileFilter configuration