### PR TITLE
fix: prevent JWT secret hardcoded fallback (security)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+import crypto from "crypto";
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  // 开发环境自动生成随机 secret，生产环境必须显式设置 JWT_SECRET
+  jwtSecret:
+    process.env.JWT_SECRET ??
+    (process.env.NODE_ENV !== "production"
+      ? `dev-secret-${crypto.randomUUID()}`
+      : (() => {
+          throw new Error(
+            "FATAL: JWT_SECRET environment variable is required in production mode. " +
+              "Please set JWT_SECRET to a strong random string."
+          );
+        })()),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
 };


### PR DESCRIPTION
## Summary

Fixes a critical security vulnerability where the JWT secret has a hardcoded fallback value `"development-secret"` which could allow token forgery in production.

## Problem

In `apps/api/src/config/env.js`:
```javascript
jwtSecret: process.env.JWT_SECRET ?? "development-secret",
```

If `JWT_SECRET` is not set in production, the server silently uses the well-known default, allowing any attacker to forge valid JWT tokens.

## Fix

- **Development mode**: auto-generates a random secret via `crypto.randomUUID()` for convenience
- **Non-development mode**: throws a clear error message requiring `JWT_SECRET` to be set explicitly

## Change

Only `apps/api/src/config/env.js` is modified:
- Added `import crypto from "crypto"`
- Replaced `"development-secret"` fallback with conditional logic

## Testing

- `NODE_ENV=development`: server starts with auto-generated random secret
- `NODE_ENV=production` without JWT_SECRET: server refuses to start with clear error
- `NODE_ENV=production` with JWT_SECRET: server uses the provided secret