### PR TITLE
Add actionable settings overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,21 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.settings-hero p { color: #bac7e8; max-width: 680px; }
+.settings-eyebrow { color: #facc15; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.35rem; text-transform: uppercase; }
+.settings-summary { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.settings-stat { min-height: 116px; }
+.settings-stat span, .settings-stat small, .settings-panel p { color: #bac7e8; }
+.settings-stat strong { display: block; font-size: 1.8rem; margin: 0.45rem 0 0.2rem; }
+.settings-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.settings-panel { display: grid; gap: 0.85rem; }
+.settings-panel h3, .settings-panel p { margin: 0; }
+.settings-panel-header { display: grid; gap: 0.45rem; }
+.settings-panel-header div { align-items: center; display: flex; flex-wrap: wrap; gap: 0.6rem; justify-content: space-between; }
+.settings-chip { background: #1f2a4b; border: 1px solid #3d4f82; border-radius: 999px; color: #facc15; font-size: 0.78rem; font-weight: 700; padding: 0.25rem 0.55rem; }
+.settings-panel ul { display: grid; gap: 0.55rem; list-style: none; margin: 0; padding: 0; }
+.settings-panel li { background: #0f172d; border: 1px solid #27365f; border-radius: 8px; padding: 0.7rem 0.8rem; }
+.settings-panel button, .settings-actions button { background: #facc15; border: 0; border-radius: 8px; color: #101624; cursor: pointer; font: inherit; font-weight: 800; padding: 0.65rem 0.85rem; text-align: center; }
+.settings-panel button { justify-self: start; }
+.settings-actions div { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.settings-actions button { background: #0f172d; border: 1px solid #3d4f82; color: #dce6ff; }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,91 @@
 export default function SettingsPage() {
+  const sections = [
+    {
+      title: "Account",
+      status: "Public",
+      description: "Profile identity and marketplace visibility",
+      items: ["Public profile: visible", "Primary role: client and freelancer", "Portfolio status: ready"],
+      action: "Edit profile"
+    },
+    {
+      title: "Notifications",
+      status: "On",
+      description: "Inbox, proposal, and payment alerts",
+      items: ["Proposal updates: instant", "Milestone reminders: daily digest", "Payment receipts: enabled"],
+      action: "Manage alerts"
+    },
+    {
+      title: "Security",
+      status: "Review",
+      description: "Session and sign-in controls",
+      items: ["Two-factor auth: recommended", "Active sessions: 2 devices", "Password age: 43 days"],
+      action: "Secure account"
+    },
+    {
+      title: "Payouts",
+      status: "Weekly",
+      description: "Billing defaults and withdrawal preferences",
+      items: ["Default currency: USD", "Auto invoice: enabled", "Payout cadence: weekly"],
+      action: "Review payouts"
+    }
+  ];
+
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section>
+      <div className="card settings-hero">
+        <p className="settings-eyebrow">Account controls</p>
+        <h2>Settings</h2>
+        <p>
+          Review profile visibility, alert preferences, security status, and payout defaults from a single workspace.
+        </p>
+      </div>
+
+      <div className="settings-summary">
+        <article className="card settings-stat">
+          <span>Profile health</span>
+          <strong>86%</strong>
+          <small>3 recommended updates</small>
+        </article>
+        <article className="card settings-stat">
+          <span>Alerts enabled</span>
+          <strong>9</strong>
+          <small>Across jobs and payments</small>
+        </article>
+        <article className="card settings-stat">
+          <span>Security score</span>
+          <strong>Good</strong>
+          <small>2FA not yet enabled</small>
+        </article>
+      </div>
+
+      <div className="settings-grid">
+        {sections.map((section) => (
+          <article className="card settings-panel" key={section.title}>
+            <div className="settings-panel-header">
+              <div>
+                <h3>{section.title}</h3>
+                <span className="settings-chip">{section.status}</span>
+              </div>
+              <p>{section.description}</p>
+            </div>
+            <ul>
+              {section.items.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            <button type="button">{section.action}</button>
+          </article>
+        ))}
+      </div>
+
+      <section className="card settings-actions">
+        <h3>Recommended next steps</h3>
+        <div>
+          <button type="button">Enable two-factor auth</button>
+          <button type="button">Verify payout method</button>
+          <button type="button">Refresh public portfolio</button>
+        </div>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- replaces the `/settings` placeholder with a practical account settings overview
- adds profile health, alert, and security summary cards
- adds account, notification, security, and payout preference panels using static mock data that matches the current app style
- adds status chips and next-action controls while keeping the change API-free
- extends the shared page styles for the overview, chips, and controls

Fixes #1508

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1508-settings-demo.mp4

## Validation
- `npm run build -w apps/web`
- `git diff --check`