### PR TITLE
fix: add input validation on payment creation endpoint (security)

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map(i => i.message).join("; "), 400);
+  }
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive("Amount must be positive"),
+  currency: z.enum(["usd", "eur", "gbp"]).default("usd"),
+  description: z.string().max(500).optional(),
+  metadata: z.record(z.string()).optional()
+});


### PR DESCRIPTION
## Summary

The payment creation endpoint passed `req.body` directly to the service layer without any validation, allowing injection of arbitrary data.

## Problem

In `apps/api/src/controllers/paymentController.js`:
```javascript
return ok(res, await createPaymentIntent(req.body), 201);
```

`req.body` was passed directly with no validation. An attacker could:
- Send negative or zero amounts
- Inject unexpected fields into the payment record
- Send extremely large strings as metadata/description

## Fix

Created a Zod validation schema `createPaymentSchema` that enforces:
- `amount`: required positive number
- `currency`: must be `usd`, `eur`, or `gbp` (defaults to `usd`)
- `description`: optional string, max 500 characters
- `metadata`: optional key-value map (record of strings)

The controller now validates with `safeParse` and returns 400 with specific error messages.

## Changes
- `apps/api/src/validators/payment.js`: new Zod schema
- `apps/api/src/controllers/paymentController.js`: validation + auth middleware import
- `apps/api/src/routes/paymentRoutes.js`: auth middleware added