### PR TITLE
fix: add authentication to payment routes (#1518)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/payment-auth.test.js
+++ b/apps/api/src/tests/payment-auth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startServer(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0);
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/payments rejects unauthenticated requests with 401", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 100, currency: "usd" }),
+  });
+
+  assert.equal(response.status, 401);
+
+  await closeServer(server);
+});
+
+test("POST /api/payments rejects requests with invalid token", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer invalid-token-here",
+    },
+    body: JSON.stringify({ amount: 100, currency: "usd" }),
+  });
+
+  assert.equal(response.status, 401);
+
+  await closeServer(server);
+});


### PR DESCRIPTION
## Summary
Adds `authMiddleware` to the payment routes to prevent unauthenticated payment intent creation.

## Changes
- Added `authMiddleware` import and `paymentRoutes.use(authMiddleware)` to `paymentRoutes.js`
- Added test file `payment-auth.test.js` verifying:
  - Unauthenticated POST requests are rejected with 401
  - Invalid tokens are rejected with 401

## Problem
Previously, `POST /api/payments` had no authentication. Any anonymous user could create payment intents without being logged in, creating potential for abuse and no audit trail.

## Testing
- Unauthenticated request → 401 Unauthorized ✅
- Invalid token → 401 Unauthorized ✅

Fixes #1518
Refs #743