### PR TITLE
Add actionable messaging inbox

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,19 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.messaging-hero p { color: #bac7e8; max-width: 680px; }
+.messaging-eyebrow { color: #c084fc; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.35rem; text-transform: uppercase; }
+.messaging-summary { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+.message-stat { min-height: 116px; }
+.message-stat span, .message-stat small, .message-card p, .message-card small, .thread-message p { color: #bac7e8; }
+.message-stat strong { display: block; font-size: 1.8rem; margin: 0.45rem 0 0.2rem; }
+.messaging-layout { display: grid; gap: 1rem; grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr); }
+.message-list, .thread { display: grid; gap: 0.75rem; }
+.message-card { align-items: center; background: #0f172d; border: 1px solid #27365f; border-radius: 8px; display: flex; gap: 1rem; justify-content: space-between; padding: 0.85rem; }
+.message-card p, .message-card small, .thread-message p { margin: 0.35rem 0 0; }
+.message-meta { display: grid; gap: 0.25rem; justify-items: end; min-width: 76px; text-align: right; }
+.message-meta span { color: #f2f5ff; font-weight: 700; }
+.thread-message { background: #0f172d; border: 1px solid #27365f; border-radius: 8px; padding: 0.85rem; }
+.message-actions div { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.message-actions span { background: #0f172d; border: 1px solid #27365f; border-radius: 999px; color: #dce6ff; padding: 0.55rem 0.8rem; }
+@media (max-width: 720px) { .messaging-layout { grid-template-columns: 1fr; } }

--- a/apps/web/app/messaging/page.tsx
+++ b/apps/web/app/messaging/page.tsx
@@ -1,8 +1,101 @@
 export default function MessagingPage() {
+  const conversations = [
+    {
+      name: "Maya Chen",
+      project: "AI support widget",
+      preview: "Shared the revised milestone plan and QA checklist.",
+      status: "Unread",
+      time: "8 min"
+    },
+    {
+      name: "Jordan UX",
+      project: "SaaS onboarding flow",
+      preview: "Sent two prototype links for review.",
+      status: "Waiting",
+      time: "42 min"
+    },
+    {
+      name: "Cedar Systems",
+      project: "API migration",
+      preview: "Confirmed staging credentials and deploy window.",
+      status: "Replied",
+      time: "2 hr"
+    }
+  ];
+
+  const thread = [
+    { author: "Maya Chen", body: "I split the widget delivery into discovery, prototype, and QA milestones." },
+    { author: "You", body: "That works. Please add the browser support matrix before we approve the first milestone." },
+    { author: "Maya Chen", body: "Added. I also included risks for the CRM embed and handoff notes." }
+  ];
+
   return (
-    <section className="card">
-      <h2>Messaging</h2>
-      <p>Threaded conversations and real-time chat features are represented here.</p>
+    <section>
+      <div className="card messaging-hero">
+        <p className="messaging-eyebrow">Inbox</p>
+        <h2>Messaging</h2>
+        <p>Track active conversations, unread items, and project context without leaving the marketplace.</p>
+      </div>
+
+      <div className="messaging-summary">
+        <article className="card message-stat">
+          <span>Unread</span>
+          <strong>4</strong>
+          <small>Across 3 projects</small>
+        </article>
+        <article className="card message-stat">
+          <span>Avg response</span>
+          <strong>18m</strong>
+          <small>This week</small>
+        </article>
+        <article className="card message-stat">
+          <span>Open threads</span>
+          <strong>11</strong>
+          <small>5 need follow-up</small>
+        </article>
+      </div>
+
+      <div className="messaging-layout">
+        <section className="card">
+          <h3>Conversation queue</h3>
+          <div className="message-list">
+            {conversations.map((conversation) => (
+              <article className="message-card" key={conversation.name}>
+                <div>
+                  <strong>{conversation.name}</strong>
+                  <p>{conversation.project}</p>
+                  <small>{conversation.preview}</small>
+                </div>
+                <div className="message-meta">
+                  <span>{conversation.status}</span>
+                  <small>{conversation.time}</small>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="card">
+          <h3>Selected thread</h3>
+          <div className="thread">
+            {thread.map((message) => (
+              <article className="thread-message" key={`${message.author}-${message.body}`}>
+                <strong>{message.author}</strong>
+                <p>{message.body}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="card message-actions">
+        <h3>Next actions</h3>
+        <div>
+          <span>Reply to Maya Chen</span>
+          <span>Schedule prototype review</span>
+          <span>Archive resolved API thread</span>
+        </div>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the `/messaging` placeholder with a practical inbox overview.
- Adds unread/response/open-thread summary cards.
- Adds a conversation queue, selected thread panel, and next-action chips using static mock data.
- Adds scoped messaging styles with a responsive layout.

Fixes #1514.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1514-demo.mp4

## Validation
- `npm run build -w apps/web`
- Browser check: `/messaging` renders 14 cards, 3 conversation cards, 3 thread messages, queue/actions, and no horizontal overflow
- `git diff --check`