### PR TITLE
fix(security): add admin role check to admin routes (#1523)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary

Fixes #1523 - Admin routes only check authentication but not admin role.

## Vulnerability

The `/api/admin/metrics` endpoint required authentication via `authMiddleware`, but did not verify that the authenticated user actually has the `admin` role. Any authenticated user (client, freelancer) could access sensitive admin metrics data.

## Fix

1. Added `adminMiddleware` to `middleware/auth.js` that checks `req.user.role === 'admin'` and returns 403 Forbidden if not
2. Applied `adminMiddleware` to `adminRoutes` after `authMiddleware`

## Changes

- `apps/api/src/middleware/auth.js`: Added `adminMiddleware` function
- `apps/api/src/routes/adminRoutes.js`: Imported and applied `adminMiddleware`