### PR TITLE
fix(security): add input validation to search endpoint (#1501)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchQuerySchema.parse(req.query);
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().max(200).optional().default(""),
+});


### PR DESCRIPTION
## Summary

Fixes #1501 - Search endpoint accepts malformed and oversized query values.

## Vulnerability

The `GET /api/search?q=...` endpoint passed `req.query.q` directly to the search service without any validation. Attackers could:
- Send extremely long query strings causing resource exhaustion (DoS)
- Inject malformed characters for potential code injection attacks
- Trigger unexpected behavior with whitespace-padded or empty inputs

## Fix

1. Created `validators/search.js` with `searchQuerySchema` using Zod:
   - `trim()` to strip whitespace
   - `max(200)` to limit query length
   - `optional().default("\ ")` for graceful handling of missing query
2. Applied `searchQuerySchema.parse()` in `searchController`

## Changes

- `apps/api/src/validators/search.js`: New Zod schema for search query validation
- `apps/api/src/controllers/searchController.js`: Added schema validation