### PR TITLE
fix(validation): reject job creation with inverted budget ranges (#1467)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,12 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary

Fixes #1467 - Job creation allows budgetMin > budgetMax.

## Vulnerability

The `createJobSchema` validated that both `budgetMin` and `budgetMax` are non-negative numbers, but did not verify that `budgetMax >= budgetMin`. This allowed:
- Creating jobs where minimum budget exceeds maximum budget
- Data integrity issues in the job listing
- Confusing user experience and potential abuse

## Fix

Added `Zod.refine()` to `createJobSchema` that enforces `budgetMax >= budgetMin`. When violated, returns a clear validation error pointing to `budgetMax` field.

## Changes

- `apps/api/src/validators/job.js`: Added `.refine()` validation on `createJobSchema`