### PR TITLE
fix(security): add stricter rate limiting for auth endpoints

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,11 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "Too many auth attempts, please try again later" }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
+authRoutes.use(authLimiter);
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);


### PR DESCRIPTION
## Summary

Auth endpoints (login, register, refresh) used the same global rate limit of 200 requests per 15 minutes, leaving them vulnerable to brute-force attacks.

## Vulnerability

There was no differentiated rate limiting for sensitive auth endpoints. Attackers could:
- Attempt 200 login/register attempts per 15 minutes per IP
- Brute-force credential guessing without meaningful throttling
- Perform denial-of-service via rapid auth requests

## Fix

1. Added `authLimiter` in `middleware/rateLimit.js`: 10 requests per 60 seconds
2. Applied `authLimiter` to all auth routes via `authRoutes.use()`
3. Returns clear error message when rate limit is exceeded

## Changes

- `apps/api/src/middleware/rateLimit.js`: Added `authLimiter` with 10 req/min
- `apps/api/src/routes/authRoutes.js`: Imported and applied `authLimiter`