### PR TITLE
Add marketplace landing overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,23 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.landing { display: grid; gap: 1rem; }
+.landing-hero { align-items: stretch; background: #121a31; border: 1px solid #2a3765; border-radius: 12px; display: grid; gap: 1rem; grid-template-columns: minmax(0, 1.45fr) minmax(220px, 0.55fr); padding: 1.25rem; }
+.landing-hero h2 { font-size: 2rem; line-height: 1.1; margin: 0 0 0.75rem; }
+.landing-hero p { color: #bac7e8; max-width: 720px; }
+.landing-eyebrow { color: #6ee7b7; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.4rem; text-transform: uppercase; }
+.landing-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1rem; }
+.landing-actions a { background: #6ee7b7; border-radius: 8px; color: #07111f; font-weight: 700; padding: 0.7rem 0.9rem; }
+.landing-actions a + a { background: transparent; border: 1px solid #6ee7b7; color: #dffcf0; }
+.landing-snapshot { background: #0f172d; border: 1px solid #314164; border-radius: 8px; display: grid; gap: 0.7rem; padding: 1rem; }
+.landing-snapshot span { color: #dce6ff; }
+.landing-stats, .landing-paths { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
+.landing-stat { min-height: 116px; }
+.landing-stat span, .landing-stat small, .landing-path p, .landing-activity p { color: #bac7e8; }
+.landing-stat strong { display: block; font-size: 1.75rem; margin: 0.45rem 0 0.2rem; }
+.landing-path { border-radius: 8px; display: block; min-height: 132px; }
+.landing-path span { color: #f2f5ff; font-weight: 700; }
+.landing-path p { margin: 0.55rem 0 0; }
+.landing-activity div { display: grid; gap: 0.65rem; }
+.landing-activity p { background: #0f172d; border: 1px solid #27365f; border-radius: 8px; margin: 0; padding: 0.75rem; }
+@media (max-width: 720px) { .landing-hero { grid-template-columns: 1fr; } .landing-hero h2 { font-size: 1.65rem; } }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,86 @@
+import Link from "next/link";
+
 export default function LandingPage() {
+  const stats = [
+    { label: "Open projects", value: "128", detail: "Across product, data, and growth" },
+    { label: "Vetted freelancers", value: "2.4k", detail: "Ready for short and long engagements" },
+    { label: "Median reply", value: "16m", detail: "For active marketplace threads" }
+  ];
+
+  const paths = [
+    {
+      href: "/jobs",
+      title: "Browse active work",
+      copy: "Review curated jobs with budget, skill, and delivery context."
+    },
+    {
+      href: "/freelancers/search",
+      title: "Find specialists",
+      copy: "Compare freelancer profiles by role, skills, rating, and availability."
+    },
+    {
+      href: "/jobs/post",
+      title: "Draft a job",
+      copy: "Shape a clear project brief before inviting matched talent."
+    }
+  ];
+
+  const activity = [
+    "API migration brief matched with 8 backend engineers",
+    "Brand refresh shortlist updated with 5 design portfolios",
+    "QA automation proposal moved into client review"
+  ];
+
   return (
-    <section className="card">
-      <h2>Landing</h2>
-      <p>Hire top freelancers for engineering, design, writing, and growth projects.</p>
+    <section className="landing">
+      <div className="landing-hero">
+        <div>
+          <p className="landing-eyebrow">FreelanceFlow marketplace</p>
+          <h2>Hire focused talent for real project momentum.</h2>
+          <p>
+            Move from brief to shortlist with clear project paths, trusted freelancer signals,
+            and live marketplace activity in one place.
+          </p>
+          <div className="landing-actions">
+            <Link href="/jobs">Explore jobs</Link>
+            <Link href="/freelancers/search">Search freelancers</Link>
+          </div>
+        </div>
+        <aside className="landing-snapshot">
+          <strong>Today</strong>
+          <span>24 proposals reviewed</span>
+          <span>9 milestones approved</span>
+          <span>6 contracts ready to start</span>
+        </aside>
+      </div>
+
+      <div className="landing-stats">
+        {stats.map((stat) => (
+          <article className="card landing-stat" key={stat.label}>
+            <span>{stat.label}</span>
+            <strong>{stat.value}</strong>
+            <small>{stat.detail}</small>
+          </article>
+        ))}
+      </div>
+
+      <div className="landing-paths">
+        {paths.map((path) => (
+          <Link className="card landing-path" href={path.href} key={path.href}>
+            <span>{path.title}</span>
+            <p>{path.copy}</p>
+          </Link>
+        ))}
+      </div>
+
+      <section className="card landing-activity">
+        <h3>Marketplace activity</h3>
+        <div>
+          {activity.map((item) => (
+            <p key={item}>{item}</p>
+          ))}
+        </div>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the generic root landing placeholder with a practical marketplace overview.
- Adds hero copy, marketplace stat cards, route-linked action/path cards, and recent activity cues.
- Keeps the implementation static and scoped to the landing page plus responsive CSS.

Fixes #1528.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1528-demo.mp4

## Validation
- `npm run build -w apps/web`
- Chrome headless check: `/` renders hero content, job/search links, desktop and mobile screenshots
- `git diff --check`