### PR TITLE
fix(error): return 400 with validation details for ZodErrors (#1469)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors.map((e) => ({
+        path: e.path.join("."),
+        message: e.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"


### PR DESCRIPTION
## Summary

Fixes #1469 - Zod validation errors returned 500 instead of 400.

## Problem

When Zod validation fails (e.g., invalid job data, malformed search query), the `errorHandler` middleware caught the `ZodError` but returned a generic 500 "Unexpected server error". This:
- Confused API consumers with wrong status code
- Hid validation details that would help developers fix their requests
- Made debugging unnecessarily difficult

## Fix

Added `ZodError` detection in `errorHandler`:
- Returns **400 Bad Request** instead of 500
- Includes `errors` array with `path` and `message` for each validation failure
- All other errors still return 500 as before

## Changes

- `apps/api/src/middleware/errorHandler.js`: Added ZodError import and handling branch