### PR TITLE
fix(upload): return 400 when no file is provided (#1499)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    size: req.file.size,
+    mimetype: req.file.mimetype
   }, 201);
 }


### PR DESCRIPTION
## Summary

Fixes #1499 - Upload endpoint returns 201 success when no file is provided.

## Problem

`POST /api/uploads` returned HTTP 201 "Created" with `{ status: "no-file", filename: null }` when no file was attached. This:
- Returned a success status for a failed upload
- Could confuse clients expecting a file to be stored
- Was inconsistent with REST semantics

## Fix

- Returns **400 Bad Request** with message "No file provided" when `req.file` is missing
- Enhanced success response to include `size` and `mimetype` for client-side validation

## Changes

- `apps/api/src/controllers/uploadController.js`: Added file presence check, improved response