### PR TITLE
Add freelancer search overview

### DIFF
--- a/apps/web/app/freelancers/search/page.module.css
+++ b/apps/web/app/freelancers/search/page.module.css
@@ -1,0 +1,148 @@
+.search {
+  display: grid;
+  gap: 1rem;
+}
+
+.header {
+  align-items: center;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 0.35fr);
+}
+
+.header p {
+  color: #bac7e8;
+  max-width: 680px;
+}
+
+.eyebrow {
+  color: #6ee7b7;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+}
+
+.scorecard,
+.facts div {
+  background: #0f172d;
+  border: 1px solid #27365f;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem;
+}
+
+.scorecard span,
+.scorecard small,
+.metrics span,
+.metrics small,
+.card p,
+.facts span {
+  color: #bac7e8;
+}
+
+.scorecard strong,
+.metrics strong {
+  font-size: 1.65rem;
+}
+
+.metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.metrics article {
+  min-height: 116px;
+}
+
+.metrics strong {
+  display: block;
+  margin: 0.45rem 0 0.2rem;
+}
+
+.filters {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.filters div {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filters span {
+  color: #f2f5ff;
+  font-weight: 700;
+}
+
+.filters button,
+.skills span {
+  background: #0f172d;
+  border: 1px solid #314164;
+  border-radius: 999px;
+  color: #dce6ff;
+  padding: 0.5rem 0.7rem;
+}
+
+.results {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  border-radius: 8px;
+  display: grid;
+  gap: 1rem;
+}
+
+.cardHeader {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.cardHeader span {
+  color: #6ee7b7;
+  font-weight: 700;
+}
+
+.cardHeader h3,
+.card p {
+  margin: 0.35rem 0 0;
+}
+
+.skills,
+.facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.card a {
+  color: #6ee7b7;
+  font-weight: 700;
+}
+
+@media (max-width: 720px) {
+  .header {
+    grid-template-columns: 1fr;
+  }
+
+  .cardHeader {
+    display: grid;
+  }
+}

--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -1,16 +1,110 @@
 import Link from "next/link";
 import { freelancers } from "../../../lib/mock";
+import styles from "./page.module.css";
 
 export default function FreelancerSearchPage() {
+  const talent = freelancers.map((freelancer, index) => {
+    const details = [
+      {
+        availability: "Available this week",
+        rating: "4.9",
+        response: "12m",
+        focus: "Frontend systems",
+        summary: "Builds polished Next.js interfaces, design systems, and analytics-ready product surfaces."
+      },
+      {
+        availability: "Booking next sprint",
+        rating: "4.8",
+        response: "25m",
+        focus: "Product discovery",
+        summary: "Turns research findings into clear flows, prototypes, and client-ready design handoff."
+      }
+    ][index];
+
+    return { ...freelancer, ...details };
+  });
+
   return (
-    <section>
-      <h2>Freelancer Search</h2>
-      <div className="grid">
-        {freelancers.map((freelancer) => (
-          <article className="card" key={freelancer.username}>
-            <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
-            <p>{freelancer.rate}</p>
+    <section className={styles.search}>
+      <div className={`card ${styles.header}`}>
+        <div>
+          <p className={styles.eyebrow}>Talent search</p>
+          <h2>Freelancer Search</h2>
+          <p>Compare available specialists by skill, rate, responsiveness, and project focus.</p>
+        </div>
+        <div className={styles.scorecard}>
+          <span>Recommended match pool</span>
+          <strong>{talent.length}</strong>
+          <small>Profiles ready for outreach</small>
+        </div>
+      </div>
+
+      <div className={styles.metrics}>
+        <article className="card">
+          <span>Avg rating</span>
+          <strong>4.85</strong>
+          <small>From visible talent</small>
+        </article>
+        <article className="card">
+          <span>Fastest reply</span>
+          <strong>12m</strong>
+          <small>Current response signal</small>
+        </article>
+        <article className="card">
+          <span>Skill coverage</span>
+          <strong>4</strong>
+          <small>Core marketplace skills</small>
+        </article>
+      </div>
+
+      <div className={`card ${styles.filters}`}>
+        <div>
+          <span>Skills</span>
+          <button type="button">All</button>
+          <button type="button">Next.js</button>
+          <button type="button">UX Research</button>
+        </div>
+        <div>
+          <span>Availability</span>
+          <button type="button">This week</button>
+          <button type="button">Next sprint</button>
+        </div>
+      </div>
+
+      <div className={styles.results}>
+        {talent.map((freelancer) => (
+          <article className={`card ${styles.card}`} key={freelancer.username}>
+            <div className={styles.cardHeader}>
+              <div>
+                <span>{freelancer.focus}</span>
+                <h3>{freelancer.username}</h3>
+              </div>
+              <strong>{freelancer.rate}</strong>
+            </div>
+
+            <p>{freelancer.summary}</p>
+
+            <div className={styles.skills}>
+              {freelancer.skills.map((skill) => (
+                <span key={skill}>{skill}</span>
+              ))}
+            </div>
+
+            <div className={styles.facts}>
+              <div>
+                <span>Rating</span>
+                <strong>{freelancer.rating}</strong>
+              </div>
+              <div>
+                <span>Reply</span>
+                <strong>{freelancer.response}</strong>
+              </div>
+              <div>
+                <span>Status</span>
+                <strong>{freelancer.availability}</strong>
+              </div>
+            </div>
+
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>
         ))}


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the bare `/freelancers/search` grid with a practical talent discovery overview.
- Adds match-pool, rating, response-time, and skill-coverage summary cards.
- Adds skill/availability filter chips and richer freelancer cards with focus, summary, skills, rating, reply time, availability, and rate.
- Keeps styles route-scoped with a CSS module to avoid touching shared global styling.

Fixes #1544.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1544-demo.mp4

## Validation
- `npm run build -w apps/web`
- Chrome headless check: `/freelancers/search` renders header, metrics, filters, profile links, skills, rates, and desktop/mobile screenshots
- `git diff --check`