### PR TITLE
fix: enforce admin role authorization for admin metrics endpoint (Fixes #1555)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,16 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(allowedRoles) {
+  return (req, res, next) => {
+    if (!req.user) {
+      return fail(res, "Unauthorized", 401);
+    }
+    const roles = Array.isArray(allowedRoles) ? allowedRoles : [allowedRoles];
+    if (!roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Admin metrics access control", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/admin/metrics`;
+
+  await t.test("GET /api/admin/metrics without auth token returns 401", async () => {
+    const response = await fetch(baseUrl);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+
+  await t.test("GET /api/admin/metrics with invalid auth token returns 401", async () => {
+    const response = await fetch(baseUrl, {
+      headers: {
+        Authorization: "Bearer invalid_token"
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token");
+  });
+
+  await t.test("GET /api/admin/metrics with client role token returns 403 Forbidden", async () => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Forbidden");
+  });
+
+  await t.test("GET /api/admin/metrics with freelancer role token returns 403 Forbidden", async () => {
+    const token = signAccessToken({ sub: "usr_freelancer", role: "freelancer" });
+    const response = await fetch(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Forbidden");
+  });
+
+  await t.test("GET /api/admin/metrics with admin role token returns 200 and metrics payload", async () => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.openJobs, "number");
+    assert.equal(typeof payload.data.activeFreelancers, "number");
+    assert.equal(typeof payload.data.flaggedAccounts, "number");
+    assert.equal(typeof payload.data.monthlyVolume, "number");
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
### Problem
The admin metrics endpoint `/api/admin/metrics` was unprotected against non-admin roles. The `authMiddleware` verified that a user had a valid access token but failed to assert if the user had the correct `admin` role, leaving the endpoint open to privilege escalation by standard `client` or `freelancer` users (Broken Access Control).

### Solution
1. **Role Verification Middleware**: Implemented a reusable `requireRole` middleware in `apps/api/src/middleware/auth.js` that checks `req.user.role` against authorized roles and correctly responds with `403 Forbidden` using the standard `fail` helper.
2. **Admin Route Protection**: Added `requireRole("admin")` to `apps/api/src/routes/adminRoutes.js` right after `authMiddleware` to enforce authorization on all administrative paths.
3. **Comprehensive Tests**: Wrote a dedicated suite in `apps/api/src/tests/admin.test.js` validating all scenarios (missing auth, invalid token, incorrect role like client/freelancer, and valid admin access). Verified 100% success rate under native Node test harness.

Closes #1555