### PR TITLE
Seed jobs API with marketplace listings

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,34 @@
-const jobs = [];
+const jobs = [
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    status: "open"
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    status: "open"
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    status: "open"
+  }
+];
+
+function snapshot(job) {
+  return { ...job };
+}
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map(snapshot);
 }
 
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);
-  return job;
+  return snapshot(job);
 }

--- a/apps/api/src/tests/jobsList.test.js
+++ b/apps/api/src/tests/jobsList.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/jobs returns seeded marketplace jobs", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.deepEqual(
+      payload.data.map((job) => job.id),
+      ["job-101", "job-102", "job-103"]
+    );
+    assert.equal(payload.data[1].title, "Migrate legacy API to Node.js");
+  });
+});
+
+test("POST /api/jobs appends a new job to later list responses", async () => {
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build integration tests",
+        description: "Cover the search and jobs endpoints",
+        budgetMin: 100,
+        budgetMax: 300,
+        categoryId: "engineering",
+        skills: ["Node.js"]
+      })
+    });
+    const createPayload = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.data.status, "open");
+    assert.match(createPayload.data.id, /^job_/);
+
+    const listResponse = await fetch(`${baseUrl}/api/jobs`);
+    const listPayload = await listResponse.json();
+    const created = listPayload.data.find((job) => job.id === createPayload.data.id);
+
+    assert.ok(created);
+    assert.equal(created.title, "Build integration tests");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Seeds `jobService` with the same three baseline marketplace jobs visible in the web app.
- Keeps `POST /api/jobs` appending newly created jobs to the in-memory list.
- Returns defensive job snapshots from list/create paths so API consumers cannot mutate stored records through responses.
- Adds API regression tests for seeded fresh-list behavior and create-then-list behavior.

Fixes #1554.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1554-demo.mp4

## Validation
- `node --check apps/api/src/services/jobService.js`
- `node --check apps/api/src/tests/jobsList.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobsList.test.js`
- `git diff --check`

Note: I used explicit test files because the current API package `npm test` script still targets the `src/tests` directory directly, which is tracked separately in #1497/#1502.