### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,6 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +8,11 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals stores only validated proposal fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job-101",
+        freelancerId: "maya-dev",
+        coverLetter: "I can build this widget with analytics-ready handoff states.",
+        bidAmount: 1500,
+        status: "approved"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.equal(payload.data.status, undefined);
+    assert.equal(payload.data.jobId, "job-101");
+  });
+});
+
+test("GET /api/proposals includes valid created proposals", async () => {
+  await withServer(async (baseUrl) => {
+    const proposal = {
+      jobId: "job-102",
+      freelancerId: "jordan-ux",
+      coverLetter: "I can map the onboarding flows and prepare a clear handoff.",
+      bidAmount: 900
+    };
+
+    const createResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(proposal)
+    });
+    const createPayload = await createResponse.json();
+    const listResponse = await fetch(`${baseUrl}/api/proposals`);
+    const listPayload = await listResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.ok(listPayload.data.some((item) => item.id === createPayload.data.id));
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(20),
+  bidAmount: z.number().nonnegative()
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds focused validation for `POST /api/proposals` payloads.
- Requires `jobId`, `freelancerId`, `coverLetter`, and nonnegative `bidAmount`.
- Returns a stable 400 response for malformed proposal payloads.
- Passes only validated fields into `createProposal` and adds API regression tests.

Fixes #1563.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1563-demo.mp4

## Validation
- `node --check apps/api/src/controllers/proposalController.js`
- `node --check apps/api/src/validators/proposal.js`
- `node --check apps/api/src/tests/proposalValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalValidation.test.js`
- `git diff --check`

Note: I used explicit test files because the current API package `npm test` script still targets the `src/tests` directory directly, which is tracked separately in #1497/#1502.