### PR TITLE
Validate OAuth callback providers

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOAuthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +17,10 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  if (!supportedOAuthProviders.has(req.params.provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/oauthProvider.test.js
+++ b/apps/api/src/tests/oauthProvider.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/auth/oauth/github/callback accepts supported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/not-a-provider/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds a small allowlist for OAuth callback providers.
- Keeps supported provider callbacks working for `github` and `google`.
- Returns a stable 400 response for unsupported provider names.
- Adds API regression tests for accepted and rejected provider paths.

Fixes #1566.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1566-demo.mp4

## Validation
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/oauthProvider.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/oauthProvider.test.js`
- `git diff --check`

Note: I used explicit test files because the current API package `npm test` script still targets the `src/tests` directory directly, which is tracked separately in #1497/#1502.