### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,18 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications stores only validated notification fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr-client",
+        title: "Proposal update",
+        body: "Maya sent a revised project proposal.",
+        type: "proposal",
+        read: true
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_/);
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.userId, "usr-client");
+  });
+});
+
+test("GET /api/notifications includes valid created notifications", async () => {
+  await withServer(async (baseUrl) => {
+    const notification = {
+      userId: "usr-freelancer",
+      title: "Unread message",
+      body: "A client replied to your latest thread.",
+      type: "message"
+    };
+
+    const createResponse = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(notification)
+    });
+    const createPayload = await createResponse.json();
+    const listResponse = await fetch(`${baseUrl}/api/notifications`);
+    const listPayload = await listResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.ok(listPayload.data.some((item) => item.id === createPayload.data.id));
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  title: z.string().min(3),
+  body: z.string().min(5),
+  type: z.enum(["proposal", "message", "billing", "system"])
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds focused validation for `POST /api/notifications` payloads.
- Requires `userId`, `title`, `body`, and a supported notification `type`.
- Returns a stable 400 response for malformed notification payloads.
- Passes only validated fields into `createNotification` and adds API regression tests.

Fixes #1571.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1571-demo.mp4

## Validation
- `node --check apps/api/src/controllers/notificationController.js`
- `node --check apps/api/src/validators/notification.js`
- `node --check apps/api/src/tests/notificationValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notificationValidation.test.js`
- `git diff --check`

Note: I used explicit test files because the current API package `npm test` script still targets the `src/tests` directory directly, which is tracked separately in #1497/#1502.