### PR TITLE
fix: reject malformed search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = req.query;
+
+  if (q === undefined) {
+    return ok(res, await globalSearch(""));
+  }
+
+  if (typeof q !== "string") {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  if (q.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query must be 200 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search accepts a single string query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=designer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects repeated query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a single string"
+    });
+  });
+});
+
+test("GET /api/search rejects oversized query values", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- reject repeated/non-string `q` values on `GET /api/search`
- reject search queries longer than 200 characters
- add focused API coverage for valid, repeated, and oversized search queries

Fixes #1579
/claim #743

## Verification
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/controllers/searchController.js`
- `node --check apps/api/src/tests/search.test.js`
- `git diff --check`

No payout address, private token, cookie, seed phrase, or API key is included in this PR.