### PR TITLE
Scope message and notification list reads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
-  return ok(res, await listMessages());
+  return ok(res, await listMessages(req.user?.sub));
 }
 
 export async function postMessage(req, res) {

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
-  return ok(res, await listNotifications());
+  return ok(res, await listNotifications(req.user?.sub));
 }
 
 export async function postNotification(req, res) {

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,11 @@
 const messages = [];
 
-export async function listMessages() {
-  return messages;
+export async function listMessages(userId) {
+  if (!userId) {
+    return [];
+  }
+
+  return messages.filter((message) => message.senderId === userId || message.recipientId === userId);
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,11 @@
 const notifications = [];
 
-export async function listNotifications() {
-  return notifications;
+export async function listNotifications(userId) {
+  if (!userId) {
+    return [];
+  }
+
+  return notifications.filter((notification) => notification.userId === userId);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/messageNotificationScope.test.js
+++ b/apps/api/src/tests/messageNotificationScope.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+async function getJson(baseUrl, path, token) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {}
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("message list rejects anonymous reads and scopes messages to the authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_scope_a",
+      recipientId: "usr_scope_b",
+      body: "visible to both users"
+    });
+    await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_scope_c",
+      recipientId: "usr_scope_d",
+      body: "private to other users"
+    });
+
+    const anonymous = await getJson(baseUrl, "/api/messages");
+    assert.equal(anonymous.response.status, 401);
+    assert.deepEqual(anonymous.payload, { success: false, message: "Unauthorized" });
+
+    const token = signAccessToken({ sub: "usr_scope_a", role: "client" });
+    const { response, payload } = await getJson(baseUrl, "/api/messages", token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.length, 1);
+    assert.equal(payload.data[0].body, "visible to both users");
+  });
+});
+
+test("notification list rejects anonymous reads and scopes notifications to the authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_notify_a",
+      type: "proposal.received",
+      message: "You received a proposal"
+    });
+    await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_notify_b",
+      type: "billing.alert",
+      message: "Another user's notification"
+    });
+
+    const anonymous = await getJson(baseUrl, "/api/notifications");
+    assert.equal(anonymous.response.status, 401);
+    assert.deepEqual(anonymous.payload, { success: false, message: "Unauthorized" });
+
+    const token = signAccessToken({ sub: "usr_notify_a", role: "client" });
+    const { response, payload } = await getJson(baseUrl, "/api/notifications", token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.length, 1);
+    assert.equal(payload.data[0].message, "You received a proposal");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Requires authentication before listing messages and notifications.
- Scopes message reads to records where the authenticated user is the sender or recipient.
- Scopes notification reads to records owned by the authenticated user.
- Adds API regression coverage for anonymous rejection and per-user list filtering.

Fixes #1584.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1584-demo.mp4

## Validation
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/controllers/messageController.js`
- `node --check apps/api/src/controllers/notificationController.js`
- `node --check apps/api/src/routes/messageRoutes.js`
- `node --check apps/api/src/routes/notificationRoutes.js`
- `node --check apps/api/src/tests/messageNotificationScope.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/messageNotificationScope.test.js`
- `git diff --check`

## Note
This clone required `npm install --ignore-scripts` before local tests because the normal install hit a Windows `prisma` preinstall permission error. The API tests do not require Prisma scripts.