### PR TITLE
Handle upload parser errors as client errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof multer.MulterError) {
+    return res.status(400).json({
+      success: false,
+      message: err.message
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/uploadErrorHandler.test.js
+++ b/apps/api/src/tests/uploadErrorHandler.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unexpected upload file fields return a client error response", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("avatar", new Blob(["not important"], { type: "text/plain" }), "avatar.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unexpected field"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Handles Multer parser errors before the generic 500 fallback.
- Returns the shared API error shape with HTTP 400 for malformed multipart upload input.
- Avoids logging handled upload parser errors as unexpected server failures.
- Adds a regression test for an unexpected upload file field.

Fixes #1590.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1590-demo.mp4

## Validation
- `node --check apps/api/src/middleware/errorHandler.js`
- `node --check apps/api/src/tests/uploadErrorHandler.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/uploadErrorHandler.test.js`
- `git diff --check`

## Note
This clone required `npm install --ignore-scripts` before local tests because the normal install hit a Windows `prisma` preinstall permission error. The API tests do not require Prisma scripts.