### PR TITLE
Scope proposal list reads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
-  return ok(res, await listProposals());
+  return ok(res, await listProposals(req.user?.sub));
 }
 
 export async function postProposal(req, res) {

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
+proposalRoutes.get("/", authMiddleware, getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,11 @@
 const proposals = [];
 
-export async function listProposals() {
-  return proposals;
+export async function listProposals(userId) {
+  if (!userId) {
+    return [];
+  }
+
+  return proposals.filter((proposal) => proposal.freelancerId === userId || proposal.clientId === userId);
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposalScope.test.js
+++ b/apps/api/src/tests/proposalScope.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+async function getProposals(baseUrl, token) {
+  const response = await fetch(`${baseUrl}/api/proposals`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {}
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("proposal list rejects anonymous reads and scopes proposals to the authenticated participant", async () => {
+  await withServer(async (baseUrl) => {
+    await postProposal(baseUrl, {
+      jobId: "job_scope_a",
+      clientId: "usr_client_a",
+      freelancerId: "usr_freelancer_a",
+      coverLetter: "I can deliver this safely.",
+      bidAmount: 500
+    });
+    await postProposal(baseUrl, {
+      jobId: "job_scope_b",
+      clientId: "usr_client_b",
+      freelancerId: "usr_freelancer_b",
+      coverLetter: "Unrelated proposal",
+      bidAmount: 900
+    });
+
+    const anonymous = await getProposals(baseUrl);
+    assert.equal(anonymous.response.status, 401);
+    assert.deepEqual(anonymous.payload, { success: false, message: "Unauthorized" });
+
+    const freelancerToken = signAccessToken({ sub: "usr_freelancer_a", role: "freelancer" });
+    const freelancerResult = await getProposals(baseUrl, freelancerToken);
+    assert.equal(freelancerResult.response.status, 200);
+    assert.equal(freelancerResult.payload.success, true);
+    assert.equal(freelancerResult.payload.data.length, 1);
+    assert.equal(freelancerResult.payload.data[0].jobId, "job_scope_a");
+
+    const clientToken = signAccessToken({ sub: "usr_client_a", role: "client" });
+    const clientResult = await getProposals(baseUrl, clientToken);
+    assert.equal(clientResult.response.status, 200);
+    assert.equal(clientResult.payload.success, true);
+    assert.equal(clientResult.payload.data.length, 1);
+    assert.equal(clientResult.payload.data[0].jobId, "job_scope_a");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Requires authentication for `GET /api/proposals`.
- Scopes proposal list results to records where the authenticated user is either the freelancer or the client.
- Adds a regression test covering anonymous rejection and participant-only visibility.

Fixes #1592.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1592-demo.mp4

## Validation
- `node --check apps/api/src/services/proposalService.js`
- `node --check apps/api/src/controllers/proposalController.js`
- `node --check apps/api/src/routes/proposalRoutes.js`
- `node --check apps/api/src/tests/proposalScope.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalScope.test.js`
- `git diff --check`