### PR TITLE
Return JSON rate limit errors

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/rateLimitResponse.test.js
+++ b/apps/api/src/tests/rateLimitResponse.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("rate limit responses use the API JSON error shape", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+
+    for (let i = 0; i <= 200; i += 1) {
+      response = await fetch(`${baseUrl}/health`);
+    }
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type") ?? "", /^application\/json\b/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many requests"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Configures the global API rate limiter to return the shared JSON failure shape for 429 responses.
- Keeps the existing limit/window/header behavior unchanged.
- Adds a regression test that exhausts the limiter and asserts status, content type, and payload.

Fixes #1594.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1594-demo.mp4

## Validation
- `node --check apps/api/src/middleware/rateLimit.js`
- `node --check apps/api/src/tests/rateLimitResponse.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/rateLimitResponse.test.js`
- `git diff --check`