### PR TITLE
Use server-owned job status

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, ...payload, status: "OPEN" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobStatus.test.js
+++ b/apps/api/src/tests/jobStatus.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+function jobPayload(overrides = {}) {
+  return {
+    title: "Secure marketplace build",
+    description: "Build a secure marketplace feature with regression coverage.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_status",
+    skills: ["security"],
+    ...overrides
+  };
+}
+
+test("createJob assigns the server-owned OPEN status", async () => {
+  const job = await createJob(jobPayload());
+
+  assert.equal(job.status, "OPEN");
+});
+
+test("createJob ignores caller-provided status overrides", async () => {
+  const job = await createJob(jobPayload({ status: "COMPLETED" }));
+
+  assert.equal(job.status, "OPEN");
+});


### PR DESCRIPTION
/claim #743

## Summary
- Creates new in-memory jobs with Prisma-style `OPEN` status instead of lowercase `open`.
- Applies the server-owned status after the caller payload so direct service callers cannot force terminal states during creation.
- Adds focused service regression tests for default status and caller-provided status overrides.

Fixes #1596.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1596-demo.mp4

## Validation
- `node --check apps/api/src/services/jobService.js`
- `node --check apps/api/src/tests/jobStatus.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobStatus.test.js`
- `git diff --check`