### PR TITLE
Fix API test script glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
/claim #743

## Summary
- Updates the API workspace test script to target `src/tests/**/*.test.js` instead of the `src/tests` directory.
- Fixes the Windows / Node 24 `MODULE_NOT_FOUND` failure when running the workspace test command.
- Leaves runtime code unchanged.

Fixes #1598.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1598-demo.mp4

## Validation
- Reproduced old failure: `node --test src/tests` -> `MODULE_NOT_FOUND`
- `npm test -w apps/api`
- `node --test apps/api/src/tests/**/*.test.js`
- `git diff --check`