### PR TITLE
Ignore arbitrary job fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,17 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { title, description, budgetMin, budgetMax, categoryId, skills = [] } = payload;
+  const job = {
+    id: `job_${Date.now()}`,
+    status: "open",
+    title,
+    description,
+    budgetMin,
+    budgetMax,
+    categoryId,
+    skills
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobServiceMassAssignment.test.js
+++ b/apps/api/src/tests/jobServiceMassAssignment.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+function validJobPayload(overrides = {}) {
+  return {
+    title: "Build secure API",
+    description: "Build a marketplace API with clear regression coverage.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_backend",
+    skills: ["node"],
+    ...overrides
+  };
+}
+
+test("createJob ignores caller-controlled reserved and arbitrary fields", async () => {
+  const job = await createJob(validJobPayload({
+    id: "job_attacker",
+    status: "COMPLETED",
+    adminApproved: true,
+    featured: true,
+    internalNotes: "trusted"
+  }));
+
+  assert.notEqual(job.id, "job_attacker");
+  assert.equal(job.status, "open");
+  assert.equal(Object.hasOwn(job, "adminApproved"), false);
+  assert.equal(Object.hasOwn(job, "featured"), false);
+  assert.equal(Object.hasOwn(job, "internalNotes"), false);
+});
+
+test("createJob preserves expected job fields", async () => {
+  const payload = validJobPayload({ skills: ["node", "security"] });
+  const job = await createJob(payload);
+
+  assert.equal(job.title, payload.title);
+  assert.equal(job.description, payload.description);
+  assert.equal(job.budgetMin, payload.budgetMin);
+  assert.equal(job.budgetMax, payload.budgetMax);
+  assert.equal(job.categoryId, payload.categoryId);
+  assert.deepEqual(job.skills, payload.skills);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Updates `jobService.createJob()` to build persisted jobs from an explicit allowlist instead of spreading the full caller payload.
- Preserves the server-generated `id` and default `status: open` even when direct callers pass reserved fields.
- Drops arbitrary caller-controlled fields like `adminApproved`, `featured`, and `internalNotes`.
- Adds service regression coverage for the attack case and the expected job fields.

Fixes #1600.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1600-demo.mp4

## Validation
- `node --check apps/api/src/services/jobService.js`
- `node --check apps/api/src/tests/jobServiceMassAssignment.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobServiceMassAssignment.test.js`
- `git diff --check`