### PR TITLE
fix: prevent admin role self-assignment during registration (Closes #1607)

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { registerSchema } from "../validators/auth.js";
+
+describe("auth validators", () => {
+  it("should fail validation if role is admin", () => {
+    const result = registerSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    assert.strictEqual(result.success, false);
+  });
+
+  it("should pass validation if role is client or freelancer", () => {
+    const r1 = registerSchema.safeParse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    assert.strictEqual(r1.success, true);
+    assert.strictEqual(r1.data.role, "client");
+
+    const r2 = registerSchema.safeParse({
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    assert.strictEqual(r2.success, true);
+    assert.strictEqual(r2.data.role, "freelancer");
+  });
+
+  it("should default role to client if omitted", () => {
+    const result = registerSchema.safeParse({
+      email: "default@example.com",
+      password: "password123"
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.data.role, "client");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Resolves #1607: Prevented admin role self-assignment during user registration by restricting the allowed role enum value to client/freelancer, and added a test suite to verify the validation rules.