### PR TITLE
Scope proposal list to authenticated participants

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,8 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
-  return ok(res, await listProposals());
+  const userId = req.user?.sub;
+  if (typeof userId !== "string" || userId.trim() === "") {
+    return fail(res, "Unauthorized", 401);
+  }
+
+  return ok(res, await listProposals(userId));
 }
 
 export async function postProposal(req, res) {

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
+proposalRoutes.get("/", authMiddleware, getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,12 @@
 const proposals = [];
 
-export async function listProposals() {
-  return proposals;
+export async function listProposals(userId) {
+  return proposals
+    .filter(
+      (proposal) =>
+        proposal.freelancerId === userId || proposal.clientId === userId,
+    )
+    .map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposalListScope.test.js
+++ b/apps/api/src/tests/proposalListScope.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function postProposal(baseUrl, proposal) {
+  const response = await fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(proposal),
+  });
+
+  assert.equal(response.status, 201);
+  return response.json();
+}
+
+async function getProposals(baseUrl, token) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
+  });
+}
+
+test("GET /api/proposals requires auth and returns only participant proposals", async () => {
+  const server = await startServer();
+
+  try {
+    await postProposal(server.baseUrl, {
+      jobId: "job_private_a",
+      freelancerId: "usr_a",
+      clientId: "client_x",
+      bidAmount: 100,
+      coverLetter: "Private proposal A",
+    });
+    await postProposal(server.baseUrl, {
+      jobId: "job_private_b",
+      freelancerId: "usr_b",
+      clientId: "usr_a",
+      bidAmount: 200,
+      coverLetter: "Private proposal B",
+    });
+    await postProposal(server.baseUrl, {
+      jobId: "job_private_c",
+      freelancerId: "usr_c",
+      clientId: "client_y",
+      bidAmount: 300,
+      coverLetter: "Private proposal C",
+    });
+
+    const anonymousResponse = await getProposals(server.baseUrl);
+    assert.equal(anonymousResponse.status, 401);
+
+    const missingSubjectResponse = await getProposals(
+      server.baseUrl,
+      signAccessToken({ role: "freelancer" }),
+    );
+    assert.equal(missingSubjectResponse.status, 401);
+
+    const userAResponse = await getProposals(
+      server.baseUrl,
+      signAccessToken({ sub: "usr_a", role: "freelancer" }),
+    );
+    const userAPayload = await userAResponse.json();
+
+    assert.equal(userAResponse.status, 200);
+    assert.deepEqual(
+      userAPayload.data.map((proposal) => proposal.jobId).sort(),
+      ["job_private_a", "job_private_b"],
+    );
+
+    const userCResponse = await getProposals(
+      server.baseUrl,
+      signAccessToken({ sub: "usr_c", role: "freelancer" }),
+    );
+    const userCPayload = await userCResponse.json();
+
+    assert.equal(userCResponse.status, 200);
+    assert.deepEqual(
+      userCPayload.data.map((proposal) => proposal.jobId),
+      ["job_private_c"],
+    );
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary
- Protects `GET /api/proposals` with `authMiddleware`.
- Rejects verified tokens that do not contain a usable `sub` instead of falling back to a broad list.
- Scopes proposal list results to records where the authenticated user is either the freelancer or client participant.
- Adds regression coverage for anonymous rejection, missing-subject tokens, and participant-only proposal visibility.

Fixes #1592.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1592-demo.mp4

## Validation
- `node --check apps/api/src/routes/proposalRoutes.js`
- `node --check apps/api/src/controllers/proposalController.js`
- `node --check apps/api/src/services/proposalService.js`
- `node --check apps/api/src/tests/proposalListScope.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalListScope.test.js`
- `git diff --check`