### PR TITLE
Align registration token subject with returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authRegistrationIdentity.test.js
+++ b/apps/api/src/tests/authRegistrationIdentity.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const originalNow = Date.now;
+  let tick = 1000;
+  Date.now = () => tick++;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      password: "correct-horse-battery-staple",
+      role: "client"
+    });
+
+    const claims = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(claims.sub, result.id);
+    assert.equal(claims.role, result.role);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary
- Generates the registration user id once in `registerUser`.
- Reuses that exact id for both the response `id` and JWT `sub` claim.
- Adds regression coverage that forces successive time reads to diverge and verifies the token subject still matches the returned user id.

Fixes #1630.

## Demo
Short demo GIF: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1630-demo.gif

## Validation
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authRegistrationIdentity.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authRegistrationIdentity.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`