### PR TITLE
Add actionable notifications feed

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,171 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+button {
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.notifications-shell {
+  background: #11182d;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.notifications-header {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.notifications-header h2,
+.notification-body h3 {
+  margin: 0;
+}
+
+.eyebrow {
+  color: #8fd3ff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+}
+
+.notification-count {
+  align-items: center;
+  background: #17233f;
+  border: 1px solid #2f4777;
+  border-radius: 8px;
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.75rem 0.9rem;
+  white-space: nowrap;
+}
+
+.notification-count strong {
+  color: #f7d774;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.notification-count span {
+  color: #c8d4f6;
+  font-size: 0.85rem;
+}
+
+.notification-toolbar {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.segmented-control {
+  background: #0b1020;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  display: inline-flex;
+  padding: 0.2rem;
+}
+
+.segmented-control button,
+.secondary-button,
+.notification-actions button {
+  color: #f2f5ff;
+}
+
+.segmented-control button {
+  background: transparent;
+  min-width: 5.25rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.segmented-control button.active {
+  background: #2f6fed;
+}
+
+.secondary-button,
+.notification-actions button {
+  background: #24523f;
+  padding: 0.6rem 0.8rem;
+}
+
+.notification-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.notification-row {
+  align-items: start;
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding: 0.9rem;
+}
+
+.notification-row[data-unread="true"] {
+  border-color: #4f8cff;
+}
+
+.notification-marker {
+  background: #56627f;
+  border-radius: 999px;
+  height: 0.65rem;
+  margin-top: 0.45rem;
+  width: 0.65rem;
+}
+
+.notification-row[data-unread="true"] .notification-marker {
+  background: #f7d774;
+}
+
+.notification-meta {
+  color: #9db0dd;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.notification-body p {
+  color: #c8d4f6;
+  line-height: 1.5;
+  margin: 0.35rem 0 0;
+}
+
+.notification-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.notification-actions .ghost-button {
+  background: #2a3765;
+}
+
+@media (max-width: 700px) {
+  .notifications-header,
+  .notification-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .notification-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .notification-actions {
+    grid-column: 2;
+  }
+}

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type NotificationKind = "Proposal" | "Message" | "Billing" | "System";
+
+type NotificationItem = {
+  id: string;
+  kind: NotificationKind;
+  title: string;
+  detail: string;
+  time: string;
+  unread: boolean;
+  action: string;
+};
+
+const initialNotifications: NotificationItem[] = [
+  {
+    id: "ntf-101",
+    kind: "Proposal",
+    title: "New proposal on API migration",
+    detail: "Jordan Miles sent a 4 milestone bid for the Node.js migration brief.",
+    time: "12 min ago",
+    unread: true,
+    action: "Review proposal"
+  },
+  {
+    id: "ntf-102",
+    kind: "Message",
+    title: "Maya Dev replied",
+    detail: "The onboarding flow estimate now includes analytics tagging.",
+    time: "38 min ago",
+    unread: true,
+    action: "Open thread"
+  },
+  {
+    id: "ntf-103",
+    kind: "Billing",
+    title: "Milestone invoice ready",
+    detail: "Invoice FF-2041 is ready for review before payout release.",
+    time: "2 hours ago",
+    unread: false,
+    action: "View billing"
+  },
+  {
+    id: "ntf-104",
+    kind: "System",
+    title: "Profile visibility updated",
+    detail: "Your freelancer search profile is visible to verified clients.",
+    time: "Yesterday",
+    unread: false,
+    action: "Open settings"
+  }
+];
+
 export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState(initialNotifications);
+  const [filter, setFilter] = useState<"all" | "unread">("all");
+
+  const unreadCount = notifications.filter((item) => item.unread).length;
+  const visibleNotifications = useMemo(
+    () => notifications.filter((item) => filter === "all" || item.unread),
+    [filter, notifications]
+  );
+
+  function markRead(id: string) {
+    setNotifications((items) =>
+      items.map((item) => (item.id === id ? { ...item, unread: false } : item))
+    );
+  }
+
+  function markAllRead() {
+    setNotifications((items) => items.map((item) => ({ ...item, unread: false })));
+  }
+
   return (
-    <section className="card">
-      <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
+    <section className="notifications-shell">
+      <div className="notifications-header">
+        <div>
+          <p className="eyebrow">Notifications</p>
+          <h2>Action feed</h2>
+        </div>
+        <div className="notification-count">
+          <strong>{unreadCount}</strong>
+          <span>Unread</span>
+        </div>
+      </div>
+
+      <div className="notification-toolbar" aria-label="Notification filters">
+        <div className="segmented-control">
+          <button
+            className={filter === "all" ? "active" : ""}
+            onClick={() => setFilter("all")}
+            type="button"
+          >
+            All
+          </button>
+          <button
+            className={filter === "unread" ? "active" : ""}
+            onClick={() => setFilter("unread")}
+            type="button"
+          >
+            Unread
+          </button>
+        </div>
+        <button className="secondary-button" onClick={markAllRead} type="button">
+          Mark all read
+        </button>
+      </div>
+
+      <div className="notification-list">
+        {visibleNotifications.map((item) => (
+          <article className="notification-row" data-unread={item.unread} key={item.id}>
+            <div className="notification-marker" aria-hidden="true" />
+            <div className="notification-body">
+              <div className="notification-meta">
+                <span>{item.kind}</span>
+                <span>{item.time}</span>
+              </div>
+              <h3>{item.title}</h3>
+              <p>{item.detail}</p>
+            </div>
+            <div className="notification-actions">
+              <button type="button">{item.action}</button>
+              {item.unread ? (
+                <button className="ghost-button" onClick={() => markRead(item.id)} type="button">
+                  Mark read
+                </button>
+              ) : null}
+            </div>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the `/notifications` placeholder with an actionable local notification feed.
- Adds all/unread filtering, unread count, per-item mark-read, and mark-all-read interactions.
- Presents proposal, message, billing, and system notifications with clear next-action buttons.
- Keeps the change scoped to the web notifications route and shared page styles.

Fixes #1489.

## Demo
Short demo GIF: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1489-demo.gif

## Validation
- `node .\node_modules\next\dist\bin\next build .\apps\web`
- `git diff --check`
- Verified `/notifications` locally in Chrome via Playwright screenshots: all notifications, unread filter, mark one read, mark all read.