### PR TITLE
Fix freelancer search skill separator

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(" / ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
## Summary
- replace the corrupted freelancer skill separator with an ASCII-safe ` / ` separator
- keep the change limited to the freelancer search UI defect tracked in #1632

## Claim
/claim #743

## Demo
![Freelancer search separator demo](https://raw.githubusercontent.com/taherdhanera/bug-bounty/taher/evidence-securebanana-1634/evidence/securebanana-1634-demo.gif)

## Verification
- `npm run build -w apps/web` passes
- `npm test` currently fails before this change is exercised because the existing API test script invokes `node --test src/tests`, which Node cannot resolve as a test entry point in this checkout

Closes #1632
References #743
