### PR TITLE
Fix freelancer search skill separator

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(" / ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the freelancer search skill separator with an ASCII-safe ` / ` delimiter.
- Keeps the change scoped to `apps/web/app/freelancers/search/page.tsx`.
- Avoids non-ASCII separator rendering noise on the freelancer search cards.

Fixes #1635.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1635-demo.mp4

## Validation
- `node ../../node_modules/next/dist/bin/next build` from `apps/web`
- `git diff --check`