### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/auth-register-role.test.js
+++ b/apps/api/src/tests/auth-register-role.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "securepass123",
+    role: "admin"
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.path.includes("role")));
+});
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "securepass123",
+    role: "client"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "securepass123",
+    role: "freelancer"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "freelancer");
+});
+
+test("registerSchema defaults to client when role omitted", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "securepass123"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Remove `"admin"` from the allowed roles in `registerSchema` so that public registration can only create `"client"` or `"freelancer"` accounts.

## Bug

The `registerSchema` in `apps/api/src/validators/auth.js` allows `"admin"` as a valid role during user registration. Any user can send `{ "role": "admin" }` in the registration request and receive an admin JWT token with elevated privileges.

## Changes

- **`apps/api/src/validators/auth.js`**: Changed `z.enum(["client", "freelancer", "admin"])` to `z.enum(["client", "freelancer"])` in the registration schema
- **`apps/api/src/tests/auth-register-role.test.js`** (new): Added 4 tests verifying:
  - `"admin"` role is rejected during registration
  - `"client"` role is accepted
  - `"freelancer"` role is accepted
  - Role defaults to `"client"` when omitted

## Testing

```bash
node --test apps/api/src/tests/auth-register-role.test.js
```

All 4 tests pass. Existing health test also passes.

## Related Issues

Fixes #1637
References #743 (parent bounty)
