### PR TITLE
fix: admin routes should require admin role, not just authentication

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-role-check.test.js
+++ b/apps/api/src/tests/admin-role-check.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("admin metrics rejects unauthenticated request", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+  const body = await res.json();
+
+  assert.equal(res.status, 401);
+  assert.equal(body.success, false);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("admin metrics rejects non-admin user", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 403);
+  assert.equal(body.success, false);
+  assert.match(body.message, /admin/i);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("admin metrics allows admin user", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(body.data.openJobs !== undefined);
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Add `requireAdmin` middleware to admin routes so that only users with `role: "admin"` can access admin-only endpoints.

## Bug

The admin routes (`/api/admin/metrics`) use `authMiddleware` to verify the JWT token, but never check whether the authenticated user has the `admin` role. Any authenticated user — including `client` or `freelancer` — can access admin-only endpoints.

## Changes

- **`apps/api/src/middleware/admin.js`** (new): `requireAdmin` middleware that checks `req.user.role === "admin"` and returns 403 Forbidden if not
- **`apps/api/src/routes/adminRoutes.js`**: Added `requireAdmin` middleware after `authMiddleware`
- **`apps/api/src/tests/admin-role-check.test.js`** (new): Added 3 tests:
  - Unauthenticated request returns 401
  - Non-admin user returns 403
  - Admin user can access metrics (200)

## Testing

```bash
node --test apps/api/src/tests/admin-role-check.test.js
```

All 3 tests pass. Existing health test also passes.

## Related Issues

Fixes #1640
References #743 (parent bounty)
