### PR TITLE
fix: proposal routes require authentication and user scoping

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
-  return ok(res, await listProposals());
+  return ok(res, await listProposals(req.user?.sub));
 }
 
 export async function postProposal(req, res) {

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,6 +1,9 @@
 const proposals = [];
 
-export async function listProposals() {
+export async function listProposals(userId) {
+  if (userId) {
+    return proposals.filter((p) => p.freelancerId === userId || p.clientId === userId);
+  }
   return proposals;
 }
 

--- a/apps/api/src/tests/proposal-auth.test.js
+++ b/apps/api/src/tests/proposal-auth.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("proposal routes reject unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`);
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("proposal routes allow authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(Array.isArray(body.data));
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Add authentication middleware to proposal routes and scope list results to the authenticated user.

## Bug

The proposal routes (`/api/proposals`) had no authentication middleware. Any unauthenticated user could read ALL proposals from all users.

## Changes

- **`apps/api/src/routes/proposalRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/services/proposalService.js`**: `listProposals(userId)` now filters by freelancerId/clientId
- **`apps/api/src/controllers/proposalController.js`**: Pass `req.user.sub` to `listProposals()`
- **`apps/api/src/tests/proposal-auth.test.js`** (new): 2 tests verifying authentication

## Testing

```bash
node --test apps/api/src/tests/proposal-auth.test.js
```

All 2 tests pass.

## Related Issues

Fixes #1644
References #743 (parent bounty)
