### PR TITLE
fix: review routes require authentication

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
+reviewRoutes.use(authMiddleware);
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/review-auth.test.js
+++ b/apps/api/src/tests/review-auth.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("review routes reject unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`);
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("review routes allow authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(Array.isArray(body.data));
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Add authentication middleware to review routes.

## Bug

The review routes (`/api/reviews`) had no authentication middleware. Any unauthenticated user could read ALL reviews and create reviews with arbitrary data.

## Changes

- **`apps/api/src/routes/reviewRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/tests/review-auth.test.js`** (new): 2 tests verifying authentication

## Testing

```bash
node --test apps/api/src/tests/review-auth.test.js
```

All 2 tests pass.

## Related Issues

Fixes #1646
References #743 (parent bounty)
