### PR TITLE
fix: upload and payment routes require authentication

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload-payment-auth.test.js
+++ b/apps/api/src/tests/upload-payment-auth.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("upload route rejects unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST"
+  });
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("payment route rejects unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 100, currency: "usd" })
+  });
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("upload route allows authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("payment route allows authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ amount: 100, currency: "usd" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Add authentication middleware to upload and payment routes.

## Bug

The upload (`/api/uploads`) and payment (`/api/payments`) routes had no authentication middleware. Any unauthenticated user could upload files and create payment intents.

## Changes

- **`apps/api/src/routes/uploadRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/routes/paymentRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/tests/upload-payment-auth.test.js`** (new): 4 tests verifying authentication

## Testing

```bash
node --test apps/api/src/tests/upload-payment-auth.test.js
```

All 4 tests pass.

## Related Issues

Fixes #1648
References #743 (parent bounty)
