### PR TITLE
fix: user and job routes require authentication

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
+jobRoutes.use(authMiddleware);
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/user-job-auth.test.js
+++ b/apps/api/src/tests/user-job-auth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("user routes reject unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/users`);
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("job routes reject unauthenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`);
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("user routes allow authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("job routes allow authenticated requests", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Add authentication middleware to user and job routes.

## Bug

The user (`/api/users`) and job (`/api/jobs`) routes had no authentication middleware. Any unauthenticated user could list all users, create users, list all jobs, and create jobs.

## Changes

- **`apps/api/src/routes/userRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/routes/jobRoutes.js`**: Added `authMiddleware`
- **`apps/api/src/tests/user-job-auth.test.js`** (new): 4 tests verifying authentication

## Testing

```bash
node --test apps/api/src/tests/user-job-auth.test.js
```

All 4 tests pass.

## Related Issues

Fixes #1650
References #743 (parent bounty)
