### PR TITLE
fix: rate limiter should return API JSON errors instead of plain text

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -4,5 +4,11 @@ export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({
+      success: false,
+      message: "Too many requests, please try again later"
+    });
+  }
 });

--- a/apps/api/src/tests/rate-limit-json.test.js
+++ b/apps/api/src/tests/rate-limit-json.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+test("rate limiter returns JSON error for 429 responses", async () => {
+  const app = createApp();
+  const server = await startApp(app);
+  const { port } = server.address();
+
+  // Make 201 requests to exceed the limit
+  const results = [];
+  for (let i = 0; i < 201; i++) {
+    const res = await fetch(`http://127.0.0.1:${port}/health`);
+    results.push({ status: res.status, contentType: res.headers.get("content-type") });
+  }
+
+  const lastResult = results[results.length - 1];
+  assert.equal(lastResult.status, 429);
+  assert.match(lastResult.contentType, /json/);
+
+  // Verify the body is valid JSON with the expected shape
+  const res = await fetch(`http://127.0.0.1:${port}/health`);
+  if (res.status === 429) {
+    const body = await res.json();
+    assert.equal(body.success, false);
+    assert.ok(body.message);
+  }
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

Rate limiter now returns JSON error responses matching the API's error contract.

## Bug

When the global API rate limiter is exceeded, `express-rate-limit` returns its default plain-text response instead of the JSON error shape `{ success: false, message: ... }` used by the rest of the API.

## Changes

- **`apps/api/src/middleware/rateLimit.js`**: Added custom `handler` that returns JSON 429 response
- **`apps/api/src/tests/rate-limit-json.test.js`** (new): Test verifying 429 responses are JSON

## Testing

```bash
node --test apps/api/src/tests/rate-limit-json.test.js
```

Test passes.

## Related Issues

Fixes #1653
References #743 (parent bounty)
