### PR TITLE
fix: scope message and notification list reads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
-  return ok(res, await listMessages());
+  return ok(res, await listMessages(req.user.sub));
 }
 
 export async function postMessage(req, res) {

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
-  return ok(res, await listNotifications());
+  return ok(res, await listNotifications(req.user.sub));
 }
 
 export async function postNotification(req, res) {

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
 const messages = [];
 
-export async function listMessages() {
-  return messages;
+export async function listMessages(userId) {
+  return messages.filter(
+    (message) => message.senderId === userId || message.recipientId === userId
+  );
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
-export async function listNotifications() {
-  return notifications;
+export async function listNotifications(userId) {
+  return notifications.filter((notification) => notification.userId === userId);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/userScopedLists.test.js
+++ b/apps/api/src/tests/userScopedLists.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  assert.equal(response.status, 201);
+  return response.json();
+}
+
+async function getJson(baseUrl, path, userId) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      authorization: `Bearer ${signAccessToken({ sub: userId, role: "client" })}`
+    }
+  });
+
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+test("message and notification list endpoints require authentication", async () => {
+  await withServer(async (baseUrl) => {
+    for (const path of ["/api/messages", "/api/notifications"]) {
+      const response = await fetch(`${baseUrl}${path}`);
+      const payload = await response.json();
+
+      assert.equal(response.status, 401);
+      assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+    }
+  });
+});
+
+test("message lists are scoped to the authenticated sender or recipient", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_alice",
+      recipientId: "usr_bob",
+      body: "visible to alice and bob"
+    });
+    await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_carol",
+      recipientId: "usr_dan",
+      body: "not visible to alice"
+    });
+
+    const payload = await getJson(baseUrl, "/api/messages", "usr_alice");
+
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.length, 1);
+    assert.equal(payload.data[0].body, "visible to alice and bob");
+  });
+});
+
+test("notification lists are scoped to the authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_alice",
+      message: "visible to alice"
+    });
+    await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_bob",
+      message: "not visible to alice"
+    });
+
+    const payload = await getJson(baseUrl, "/api/notifications", "usr_alice");
+
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.length, 1);
+    assert.equal(payload.data[0].message, "visible to alice");
+  });
+});


### PR DESCRIPTION
/claim #1652

## Summary
- require bearer authentication for `GET /api/messages` and `GET /api/notifications`
- scope message list reads to records where the authenticated user is the sender or recipient
- scope notification list reads to records whose `userId` matches the authenticated user
- add API regression coverage for unauthenticated rejection and per-user list isolation

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/userScopedLists.test.js` -> 4 passed
- `node --check` on changed controllers/routes/services/tests -> passed
- `git diff --check` -> passed

Note: root `npm test -w apps/api` still hits the existing upstream script issue where `node --test src/tests` resolves the directory as a missing module. The focused test files above pass when invoked directly.
