### PR TITLE
fix: user and message services mass-assignment allows id override

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignored, ...safe } = payload;
+  const message = { ...safe, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safe } = payload;
+  const user = { ...safe, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/mass-assignment.test.js
+++ b/apps/api/src/tests/mass-assignment.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+import { sendMessage } from "../services/messageService.js";
+
+test("createUser ignores caller-supplied id", async () => {
+  const user = await createUser({ id: "attacker_id", email: "test@test.com" });
+  assert.notEqual(user.id, "attacker_id");
+  assert.ok(user.id.startsWith("usr_"));
+  assert.equal(user.email, "test@test.com");
+});
+
+test("sendMessage ignores caller-supplied id", async () => {
+  const msg = await sendMessage({ id: "attacker_id", text: "hello" });
+  assert.notEqual(msg.id, "attacker_id");
+  assert.ok(msg.id.startsWith("msg_"));
+  assert.equal(msg.text, "hello");
+  assert.ok(msg.sentAt);
+});


### PR DESCRIPTION
## Summary

Prevent mass-assignment of `id` field in user and message services.

## Bug

The `createUser()` and `sendMessage()` services used `{ id: ..., ...payload }` which allowed callers to override the server-generated `id` field.

## Changes

- **`apps/api/src/services/userService.js`**: Destructure `id` from payload to ignore it
- **`apps/api/src/services/messageService.js`**: Destructure `id` from payload to ignore it
- **`apps/api/src/tests/mass-assignment.test.js`** (new): 2 tests verifying id override is prevented

## Testing

```bash
node --test apps/api/src/tests/mass-assignment.test.js
```

All 2 tests pass.

## Related Issues

Fixes #1656
References #743 (parent bounty)
