### PR TITLE
fix: require admin role for metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuthorization.test.js
+++ b/apps/api/src/tests/adminAuthorization.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getAdminMetrics(baseUrl, tokenPayload) {
+  const headers = tokenPayload
+    ? { authorization: `Bearer ${signAccessToken(tokenPayload)}` }
+    : {};
+
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers });
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("admin metrics rejects missing bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getAdminMetrics(baseUrl);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("admin metrics rejects authenticated non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getAdminMetrics(baseUrl, {
+      sub: "usr_client",
+      role: "client"
+    });
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, { success: false, message: "Forbidden" });
+  });
+});
+
+test("admin metrics allows authenticated admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getAdminMetrics(baseUrl, {
+      sub: "usr_admin",
+      role: "admin"
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.deepEqual(Object.keys(payload.data).sort(), [
+      "activeFreelancers",
+      "flaggedAccounts",
+      "monthlyVolume",
+      "openJobs"
+    ]);
+  });
+});


### PR DESCRIPTION
/claim #1657

## Summary
- add a reusable `requireAdmin` guard that rejects authenticated non-admin users with 403
- apply the guard after `authMiddleware` on admin routes
- add regression coverage for missing token, non-admin token, and admin token access to `GET /api/admin/metrics`

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/adminAuthorization.test.js` -> 4 passed
- `node --check apps/api/src/middleware/auth.js apps/api/src/routes/adminRoutes.js apps/api/src/tests/adminAuthorization.test.js` -> passed
- `git diff --check` -> passed

Note: root `npm test -w apps/api` still hits the existing upstream script issue where `node --test src/tests` resolves the directory as a missing module. The focused test files above pass when invoked directly.
