### PR TITLE
fix: proposal, review, and notification services mass-assignment allows id override

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignored, ...safe } = payload;
+  const notification = { ...safe, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safe } = payload;
+  const proposal = { ...safe, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safe } = payload;
+  const review = { ...safe, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/mass-assignment-rest.test.js
+++ b/apps/api/src/tests/mass-assignment-rest.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createNotification } from "../services/notificationService.js";
+
+test("createProposal ignores caller-supplied id", async () => {
+  const proposal = await createProposal({ id: "attacker_id", title: "test" });
+  assert.notEqual(proposal.id, "attacker_id");
+  assert.ok(proposal.id.startsWith("prp_"));
+  assert.equal(proposal.title, "test");
+});
+
+test("createReview ignores caller-supplied id", async () => {
+  const review = await createReview({ id: "attacker_id", rating: 5 });
+  assert.notEqual(review.id, "attacker_id");
+  assert.ok(review.id.startsWith("rev_"));
+  assert.equal(review.rating, 5);
+});
+
+test("createNotification ignores caller-supplied id", async () => {
+  const notification = await createNotification({ id: "attacker_id", message: "test" });
+  assert.notEqual(notification.id, "attacker_id");
+  assert.ok(notification.id.startsWith("ntf_"));
+  assert.equal(notification.message, "test");
+  assert.equal(notification.read, false);
+});


### PR DESCRIPTION
## Summary

Prevent mass-assignment of `id` field in proposal, review, and notification services.

## Bug

The `createProposal()`, `createReview()`, and `createNotification()` services used `{ id: ..., ...payload }` which allowed callers to override the server-generated `id` field.

## Changes

- **`apps/api/src/services/proposalService.js`**: Destructure `id` from payload to ignore it
- **`apps/api/src/services/reviewService.js`**: Destructure `id` from payload to ignore it
- **`apps/api/src/services/notificationService.js`**: Destructure `id` from payload to ignore it
- **`apps/api/src/tests/mass-assignment-rest.test.js`** (new): 3 tests verifying id override is prevented

## Testing

```bash
node --test apps/api/src/tests/mass-assignment-rest.test.js
```

All 3 tests pass.

## Related Issues

Fixes #1660
References #743 (parent bounty)
