### PR TITLE
fix(api): validate proposal estimated duration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/proposals rejects proposals missing estimated duration", async () => {
+  await withServer(async baseUrl => {
+    const response = await postProposal(baseUrl, {
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals stores validated proposal fields", async () => {
+  await withServer(async baseUrl => {
+    const response = await postProposal(baseUrl, {
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250,
+      estDuration: "2 weeks"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.equal(payload.data.estDuration, "2 weeks");
+    assert.deepEqual(Object.keys(payload.data).sort(), [
+      "bidAmount",
+      "coverLetter",
+      "estDuration",
+      "freelancerId",
+      "id",
+      "jobId"
+    ]);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().trim().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary

/claim #743

- add focused proposal creation validation for required proposal fields, including `estDuration`
- return `400` before service creation when a proposal payload is missing persistence-required duration data
- add API regression coverage for missing-duration rejection and valid proposal creation

Fixes #1668

## Demo / validation

- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\proposalValidation.test.js` -> 3 passed
- `node --check apps\api\src\controllers\proposalController.js`
- `node --check apps\api\src\validators\proposal.js`
- `node --check apps\api\src\tests\proposalValidation.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` still fails on the existing upstream script `node --test src/tests`, which resolves `src/tests` as a module path in this environment.

No payout address, private token, cookie value, seed phrase, API key, personal information, or hidden runtime metadata is included.