### PR TITLE
fix: use ASCII freelancer skill separator

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(" / ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
## Summary
- replace the non-ASCII freelancer skill separator with an ASCII-safe delimiter
- keep the change limited to the freelancer search page

Fixes #1674
/claim #1674

## Validation
- `npm run build -w apps/web` -> passed
- `git diff --check` -> passed
