### PR TITLE
Resolve job detail pages from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,18 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>{job.budget}</p>
+      <p>Responsibilities, milestones, and proposals for <strong>{job.id}</strong>.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Resolve `/jobs/[id]` against the existing mock job list instead of rendering a generic placeholder.
- Return the app router 404 page for unknown job ids.
- Show the matching job title, budget, and id for known mock jobs.

## Issue
Fixes #1677
/claim #743

## Demo evidence
- `/jobs/job-101` now renders `Build an AI customer support widget` and `$1,500`.
- `/jobs/not-a-job` now reaches `notFound()` instead of a successful placeholder page.

## Validation
- `npm run build -w apps/web` -> passed
- `git diff --check` -> passed

No payout address, private token, cookie, seed phrase, API key, personal information, or hidden runtime metadata is included.