### PR TITLE
fix: require client id for job creation

### DIFF
--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build marketplace API",
+  budgetMin: 100,
+  budgetMax: 500,
+  clientId: "usr_client",
+  categoryId: "cat_backend",
+  skills: ["node"]
+};
+
+test("job creation requires clientId", () => {
+  const { clientId, ...payload } = validJob;
+
+  const result = createJobSchema.safeParse(payload);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "clientId");
+});
+
+test("job creation rejects blank clientId", () => {
+  const result = createJobSchema.safeParse({ ...validJob, clientId: "" });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "clientId");
+});
+
+test("job creation accepts clientId", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.clientId, "usr_client");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -5,6 +5,7 @@ export const createJobSchema = z.object({
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
+  clientId: z.string().min(1),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
## Summary
- require `clientId` in the job creation schema so jobs cannot be created without an owner
- add focused schema regression tests for missing, blank, and valid `clientId`

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobValidation.test.js`
- `node --check apps/api/src/validators/job.js apps/api/src/tests/jobValidation.test.js`
- `git diff --check`

/claim #1679
