### PR TITLE
fix: snapshot listed service records

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return snapshotRecords(jobs);
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return snapshotRecords(messages);
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return snapshotRecords(notifications);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return snapshotRecords(proposals);
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return snapshotRecords(reviews);
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/snapshot.js
+++ b/apps/api/src/services/snapshot.js
@@ -1,0 +1,12 @@
+export function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}
+
+export function snapshotRecords(records) {
+  return records.map(snapshotRecord);
+}

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return snapshotRecords(users);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("list services return arrays that do not mutate the backing store", async () => {
+  const job = await createJob({
+    title: "Immutable List Job",
+    description: "Verify list snapshots",
+    budgetMin: 100,
+    budgetMax: 500,
+    clientId: "usr_list_owner",
+    categoryId: "cat_backend",
+    skills: ["node"]
+  });
+
+  const listed = await listJobs();
+  listed.length = 0;
+
+  const later = await listJobs();
+  assert.ok(later.some((item) => item.id === job.id));
+});
+
+test("list services return record snapshots", async () => {
+  const user = await createUser({
+    email: "snapshot@example.com",
+    role: "client",
+    skills: ["api"]
+  });
+
+  const listed = await listUsers();
+  const listedUser = listed.find((item) => item.id === user.id);
+  listedUser.email = "mutated@example.com";
+  listedUser.skills.push("mutated");
+
+  const later = await listUsers();
+  const laterUser = later.find((item) => item.id === user.id);
+
+  assert.equal(laterUser.email, "snapshot@example.com");
+  assert.deepEqual(laterUser.skills, ["api"]);
+});


### PR DESCRIPTION
## Summary
- add a shared snapshot helper for in-memory service list outputs
- return copied arrays and copied record objects from job, proposal, review, message, notification, and user list services
- add focused service tests proving returned list arrays and listed records cannot mutate backing store state

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/listSnapshots.test.js`
- `node --check apps/api/src/services/snapshot.js apps/api/src/services/jobService.js apps/api/src/services/proposalService.js apps/api/src/services/reviewService.js apps/api/src/services/messageService.js apps/api/src/services/notificationService.js apps/api/src/services/userService.js apps/api/src/tests/listSnapshots.test.js`
- `git diff --check`

/claim #1681
