### PR TITLE
fix: validate proposal duration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can complete this safely.",
+  bidAmount: 250,
+  estDuration: "2 weeks"
+};
+
+test("proposal creation requires estimated duration", () => {
+  const { estDuration, ...payload } = validProposal;
+
+  const result = createProposalSchema.safeParse(payload);
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "estDuration");
+});
+
+test("proposal creation rejects blank estimated duration", () => {
+  const result = createProposalSchema.safeParse({
+    ...validProposal,
+    estDuration: ""
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "estDuration");
+});
+
+test("proposal creation accepts estimated duration", () => {
+  const result = createProposalSchema.safeParse(validProposal);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.estDuration, "2 weeks");
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a focused proposal creation schema aligned with required proposal fields
- validate proposal payloads in the controller before creating records
- add schema regression tests for missing, blank, and valid `estDuration`

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalValidation.test.js`
- `node --check apps/api/src/validators/proposal.js apps/api/src/controllers/proposalController.js apps/api/src/tests/proposalValidation.test.js`
- `git diff --check`

/claim #1683
