### PR TITLE
Add Handoff Ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Handoff Ledger
+
+The brief arrives with edges clean,
+a budget line, a careful scope;
+the board records what both sides mean,
+then turns a small request toward hope.
+
+A proposal folds the risk in light,
+with milestones named and questions plain;
+the thread keeps every promise tight,
+so trust can travel through the chain.
+
+In messages, the proof takes form:
+a screenshot, test, and note of why;
+the work moves steady through the storm,
+with fewer shadows left to hide.
+
+Reviewers read the diff for truth,
+not just the green that dashboards show;
+they weigh the craft, protect the youth
+of code that still has room to grow.
+
+At payout, quiet signals clear:
+the task, the merge, the ledger's line.
+FreelanceFlow keeps the handoff near,
+and makes delivered work align.


### PR DESCRIPTION
/claim #76

Adds `POEM.md` with an original five-stanza poem written for FreelanceFlow.

Creative decision: I used a handoff-ledger theme so the poem follows the platform workflow from brief to proposal, proof, review, and payout.

Validation:
- `POEM.md` exists at the project root
- Local stanza check: `poem_file=True stanzas=5 poem_lines=20`
- `git diff --check` -> clean

No payout address, private token, cookie, seed phrase, API key, or hidden runtime metadata is included.