### PR TITLE
[Ryan] [Bug Fix] Fix admin role self-assignment and refresh token parameter

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #1690

## Summary
Fixes two security bugs in the authentication module:

1. **Admin role self-assignment via registration endpoint**  
   Removed `"admin"` from `z.enum` in `registerSchema` (`apps/api/src/validators/auth.js`), restricting registration roles to `["client", "freelancer"]` only. This prevents any user from self-registering as an admin by including `role: "admin"` in the request body.

2. **Refresh token parameter not passed to service**  
   Updated the `refresh` controller in `authController.js` to extract `token` from `req.body` and pass it to `refreshToken(token)`. Previously `refreshToken()` was called without arguments, preventing proper user identification during token refresh.

## Changes
- `apps/api/src/validators/auth.js`: Removed `"admin"` from role enum
- `apps/api/src/controllers/authController.js`: Extract token from request body and pass to `refreshToken()`