### PR TITLE
fix(auth): prevent admin role self-assignment via registration endpoint (#1690)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #1690 — **Admin role self-assignment via registration endpoint**

Two security vulnerabilities addressed:

### 1. Admin role self-assignment (auth.js)
- **Before**: `registerSchema` accepted `role: z.enum(["client", "freelancer", "admin"])`, allowing any user to register with `"admin"` role
- **After**: `role` restricted to `z.enum(["client", "freelancer"])` only — admin accounts can no longer be created through the public registration endpoint

### 2. Missing token parameter in refresh endpoint (authController.js)
- **Before**: `refreshToken()` was called without arguments, ignoring the token from the request body
- **After**: `token` is extracted from `req.body` and passed to `refreshToken(token)`

## Files Changed
- `apps/api/src/validators/auth.js` — removed `"admin"` from allowed registration roles
- `apps/api/src/controllers/authController.js` — pass refresh token from request body

## Test Plan
- [ ] Verify `POST /auth/register` with `role: "admin"` returns validation error
- [ ] Verify `POST /auth/register` with `role: "client"` or `role: "freelancer"` succeeds
- [ ] Verify `POST /auth/refresh` correctly receives token from request body

## Bounty
Issue #1690 | Bounty: $700 | Creator: @lry3069-afk

🤖 Generated with [Claude Code](https://claude.com/claude-code)