### PR TITLE
Document API environment example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ node_modules
 dist
 .env
 .env.*
+!.env.example
+!**/.env.example
 coverage
 *.log

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+For the API, copy `apps/api/.env.example` to `apps/api/.env` and replace the placeholder values before running the backend outside local-only development.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,14 @@
+# Express API port for local development.
+PORT=4000
+
+# JWT signing secret used by apps/api/src/utils/jwt.js.
+# Replace this value outside local development.
+JWT_SECRET=development-secret
+
+# Stripe secret key used by the payment service when Stripe is wired.
+# Leave empty for local development without Stripe calls.
+STRIPE_SECRET_KEY=
+
+# Database connection string for Prisma-backed persistence.
+# The current API placeholder can run without this in local development.
+DATABASE_URL=


### PR DESCRIPTION
/claim #743

## Summary
- Adds `apps/api/.env.example` with the API variables read by `apps/api/src/config/env.js`.
- Documents safe local placeholders for `PORT`, `JWT_SECRET`, `STRIPE_SECRET_KEY`, and `DATABASE_URL` without committing real secrets.
- Updates the README environment section to point API contributors at the example file.
- Keeps `.env` and `.env.*` ignored while allowing `.env.example` files to be tracked.

Fixes #1700.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1700-demo.mp4

## Validation
- `git diff --check`
- `git diff --cached --check`
- `rg -n "PORT|JWT_SECRET|STRIPE_SECRET_KEY|DATABASE_URL" apps/api/.env.example apps/api/src/config/env.js README.md`
- `git check-ignore -v apps/api/.env apps/api/.env.local apps/api/.env.example`