### PR TITLE
Add release window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Release Window
+
+At nine, the brief arrives with measured light,
+a problem folded clean inside its thread;
+we name the edge, define the working height,
+and leave no hidden clause beneath the spec unread.
+
+By ten, proposals gather into shape,
+not promises, but paths the hands can test;
+each estimate becomes a narrow map
+where scope and time can argue, then come to rest.
+
+At noon, escrow keeps the table still,
+a quiet lock between the ask and art;
+the builder moves through failing checks until
+the proof is small enough to trust by heart.
+
+By four, review has turned the diff around,
+with comments trimmed to what the product needs;
+the merge light holds a steady, amber sound
+while every changed line answers for its deeds.
+
+At five, the payout leaves a traceable door,
+not thunder, just a receipt that clears the air;
+tomorrow's work can start from something more:
+a record, a release, and trust kept fair.


### PR DESCRIPTION
/claim #76

## Summary
- Adds an original project-specific poem as root-level `POEM.md`.
- Uses five compact stanzas, exceeding the minimum three-stanza requirement.
- Keeps the change scoped to the requested Markdown file.

## Creative note
I chose a release-window structure because it turns FreelanceFlow's brief, proposal, escrow, review, and payout steps into a calm deployment cadence.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-76-release-window-demo.mp4

## Validation
- `POEM.md` exists at the project root
- Stanza count: 5
- `git diff --cached --check`