### PR TITLE
Implement admin operations panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,61 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  getAdminMetrics,
+  getAdminOverview,
+  getPlatformControls,
+  listAdminUsers,
+  listAuditEvents,
+  listDisputes,
+  listModerationJobs,
+  updateDispute,
+  updateModerationJob,
+  updatePlatformControls,
+  updateUserStatus
+} from "../services/adminService.js";
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function overview(req, res) {
+  return ok(res, await getAdminOverview());
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function setUserStatus(req, res) {
+  const { status, reason } = req.body ?? {};
+  return ok(res, await updateUserStatus(req.params.id, status, req.user, reason));
+}
+
+export async function jobs(req, res) {
+  return ok(res, await listModerationJobs(req.query));
+}
+
+export async function setJobModeration(req, res) {
+  const { status, reason } = req.body ?? {};
+  return ok(res, await updateModerationJob(req.params.id, status, req.user, reason));
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function setDisputeStatus(req, res) {
+  const { status, note } = req.body ?? {};
+  return ok(res, await updateDispute(req.params.id, status, req.user, note));
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function setControls(req, res) {
+  return ok(res, await updatePlatformControls(req.body ?? {}, req.user));
+}
+
+export async function audit(req, res) {
+  return ok(res, await listAuditEvents(req.query));
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,10 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = Number.isInteger(err.status) ? err.status : 500;
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: status >= 500 ? "Unexpected server error" : err.message
   });
 }

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,30 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  audit,
+  controls,
+  disputes,
+  jobs,
+  metrics,
+  overview,
+  setControls,
+  setDisputeStatus,
+  setJobModeration,
+  setUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { adminOnly, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnly);
+adminRoutes.get("/overview", overview);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:id/status", setUserStatus);
+adminRoutes.get("/jobs", jobs);
+adminRoutes.patch("/jobs/:id/moderation", setJobModeration);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.patch("/disputes/:id/ruling", setDisputeStatus);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls", setControls);
+adminRoutes.get("/audit", audit);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,204 @@
+const users = [
+  { id: "usr_101", name: "Maya Chen", email: "maya@example.com", role: "freelancer", status: "active", trustScore: 98, joinedAt: "2026-03-15" },
+  { id: "usr_102", name: "Jordan Lee", email: "jordan@example.com", role: "client", status: "active", trustScore: 91, joinedAt: "2026-03-21" },
+  { id: "usr_103", name: "Priya Raman", email: "priya@example.com", role: "freelancer", status: "review", trustScore: 72, joinedAt: "2026-04-02" },
+  { id: "usr_104", name: "Northstar Labs", email: "ops@northstar.test", role: "client", status: "suspended", trustScore: 48, joinedAt: "2026-04-18" }
+];
+
+const moderationJobs = [
+  { id: "job_201", title: "AI customer support widget", client: "Northstar Labs", status: "flagged", risk: "high", budget: 1500, reason: "External payment request" },
+  { id: "job_202", title: "Node.js API migration", client: "AtlasWorks", status: "queued", risk: "medium", budget: 2800, reason: "Large fixed scope" },
+  { id: "job_203", title: "SaaS onboarding redesign", client: "HaloStart", status: "approved", risk: "low", budget: 900, reason: "Clean listing" }
+];
+
+const disputes = [
+  { id: "dsp_301", jobTitle: "Backend audit", client: "Northstar Labs", freelancer: "Maya Chen", status: "open", amount: 640, openedAt: "2026-05-22" },
+  { id: "dsp_302", jobTitle: "Landing page copy", client: "HaloStart", freelancer: "Priya Raman", status: "evidence", amount: 280, openedAt: "2026-05-24" }
+];
+
+const controls = {
+  registrationOpen: true,
+  jobPostingOpen: true,
+  payoutReviewRequired: true,
+  maintenanceMode: false
+};
+
+const auditEvents = [
+  { id: "aud_001", actor: "system", action: "daily_metrics_refreshed", target: "platform", createdAt: "2026-05-29T08:15:00.000Z" },
+  { id: "aud_002", actor: "admin_1", action: "job_flag_reviewed", target: "job_201", createdAt: "2026-05-29T09:30:00.000Z" }
+];
+
+const userStatuses = new Set(["active", "review", "suspended", "banned"]);
+const jobStatuses = new Set(["queued", "flagged", "approved", "rejected"]);
+const disputeStatuses = new Set(["open", "evidence", "refunded", "released", "escalated"]);
+
+function httpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function paginate(items, { page = 1, pageSize = 10 } = {}) {
+  const normalizedPage = Math.max(1, Number(page) || 1);
+  const normalizedPageSize = Math.min(50, Math.max(1, Number(pageSize) || 10));
+  const start = (normalizedPage - 1) * normalizedPageSize;
+
+  return {
+    items: items.slice(start, start + normalizedPageSize),
+    page: normalizedPage,
+    pageSize: normalizedPageSize,
+    total: items.length,
+    totalPages: Math.max(1, Math.ceil(items.length / normalizedPageSize))
+  };
+}
+
+function includesText(value, needle) {
+  return String(value).toLowerCase().includes(String(needle).toLowerCase());
+}
+
+function recordAudit(actor, action, target) {
+  const event = {
+    id: `aud_${String(auditEvents.length + 1).padStart(3, "0")}`,
+    actor,
+    action,
+    target,
+    createdAt: new Date().toISOString()
+  };
+  auditEvents.unshift(event);
+  return event;
+}
+
+function actorFromUser(user) {
+  return user?.sub ?? "admin";
+}
+
 export async function getAdminMetrics() {
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    openJobs: moderationJobs.filter((job) => job.status !== "rejected").length,
+    activeFreelancers: users.filter((user) => user.role === "freelancer" && user.status === "active").length,
+    flaggedAccounts: users.filter((user) => ["review", "suspended", "banned"].includes(user.status)).length,
+    pendingDisputes: disputes.filter((dispute) => ["open", "evidence"].includes(dispute.status)).length,
+    monthlyVolume: moderationJobs.reduce((sum, job) => sum + job.budget, 0)
   };
+}
+
+export async function getAdminOverview() {
+  return {
+    metrics: await getAdminMetrics(),
+    controls: { ...controls },
+    queues: {
+      usersInReview: users.filter((user) => user.status === "review").length,
+      flaggedJobs: moderationJobs.filter((job) => job.status === "flagged").length,
+      openDisputes: disputes.filter((dispute) => dispute.status === "open").length
+    },
+    recentAudit: auditEvents.slice(0, 5)
+  };
+}
+
+export async function listAdminUsers(query = {}) {
+  const { q = "", role = "all", status = "all" } = query;
+  const filtered = users.filter((user) => {
+    const matchesText = !q || includesText(user.name, q) || includesText(user.email, q);
+    const matchesRole = role === "all" || user.role === role;
+    const matchesStatus = status === "all" || user.status === status;
+    return matchesText && matchesRole && matchesStatus;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function updateUserStatus(id, status, actor, reason = "") {
+  if (!userStatuses.has(status)) {
+    throw httpError(400, "Unsupported user status");
+  }
+
+  const user = users.find((entry) => entry.id === id);
+  if (!user) {
+    throw httpError(404, "User not found");
+  }
+
+  user.status = status;
+  user.reviewNote = reason || undefined;
+  recordAudit(actorFromUser(actor), `user_status_${status}`, id);
+  return user;
+}
+
+export async function listModerationJobs(query = {}) {
+  const { q = "", status = "all", risk = "all" } = query;
+  const filtered = moderationJobs.filter((job) => {
+    const matchesText = !q || includesText(job.title, q) || includesText(job.client, q);
+    const matchesStatus = status === "all" || job.status === status;
+    const matchesRisk = risk === "all" || job.risk === risk;
+    return matchesText && matchesStatus && matchesRisk;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function updateModerationJob(id, status, actor, reason = "") {
+  if (!jobStatuses.has(status)) {
+    throw httpError(400, "Unsupported job moderation status");
+  }
+
+  const job = moderationJobs.find((entry) => entry.id === id);
+  if (!job) {
+    throw httpError(404, "Job not found");
+  }
+
+  job.status = status;
+  job.reason = reason || job.reason;
+  recordAudit(actorFromUser(actor), `job_${status}`, id);
+  return job;
+}
+
+export async function listDisputes(query = {}) {
+  const { q = "", status = "all" } = query;
+  const filtered = disputes.filter((dispute) => {
+    const matchesText = !q || includesText(dispute.jobTitle, q) || includesText(dispute.client, q) || includesText(dispute.freelancer, q);
+    const matchesStatus = status === "all" || dispute.status === status;
+    return matchesText && matchesStatus;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function updateDispute(id, status, actor, note = "") {
+  if (!disputeStatuses.has(status)) {
+    throw httpError(400, "Unsupported dispute status");
+  }
+
+  const dispute = disputes.find((entry) => entry.id === id);
+  if (!dispute) {
+    throw httpError(404, "Dispute not found");
+  }
+
+  dispute.status = status;
+  dispute.adminNote = note || undefined;
+  recordAudit(actorFromUser(actor), `dispute_${status}`, id);
+  return dispute;
+}
+
+export async function getPlatformControls() {
+  return { ...controls };
+}
+
+export async function updatePlatformControls(nextControls, actor) {
+  for (const key of Object.keys(nextControls)) {
+    if (!(key in controls) || typeof nextControls[key] !== "boolean") {
+      throw httpError(400, "Unsupported control value");
+    }
+  }
+
+  Object.assign(controls, nextControls);
+  recordAudit(actorFromUser(actor), "platform_controls_updated", "controls");
+  return { ...controls };
+}
+
+export async function listAuditEvents(query = {}) {
+  const { q = "" } = query;
+  const filtered = auditEvents.filter((event) => (
+    !q || includesText(event.action, q) || includesText(event.actor, q) || includesText(event.target, q)
+  ));
+
+  return paginate(filtered, query);
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminToken() {
+  return signAccessToken({ sub: "admin_1", role: "admin" });
+}
+
+function clientToken() {
+  return signAccessToken({ sub: "client_1", role: "client" });
+}
+
+async function request(baseUrl, path, { method = "GET", token, body } = {}) {
+  const headers = {};
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  if (body) {
+    headers["content-type"] = "application/json";
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined
+  });
+
+  const payload = await response.json();
+  return { response, payload };
+}
+
+test("admin API rejects non-admins and exposes operations data to admins", async () => {
+  await withServer(async (baseUrl) => {
+    const anonymous = await request(baseUrl, "/api/admin/overview");
+    assert.equal(anonymous.response.status, 401);
+
+    const nonAdmin = await request(baseUrl, "/api/admin/overview", { token: clientToken() });
+    assert.equal(nonAdmin.response.status, 403);
+
+    const overview = await request(baseUrl, "/api/admin/overview", { token: adminToken() });
+    assert.equal(overview.response.status, 200);
+    assert.equal(overview.payload.success, true);
+    assert.equal(typeof overview.payload.data.metrics.monthlyVolume, "number");
+    assert.equal(overview.payload.data.queues.flaggedJobs, 1);
+  });
+});
+
+test("admin API supports filtering, status actions, controls, and audit entries", async () => {
+  await withServer(async (baseUrl) => {
+    const token = adminToken();
+
+    const filteredUsers = await request(baseUrl, "/api/admin/users?q=maya", { token });
+    assert.equal(filteredUsers.response.status, 200);
+    assert.equal(filteredUsers.payload.data.total, 1);
+    assert.equal(filteredUsers.payload.data.items[0].id, "usr_101");
+
+    const updatedUser = await request(baseUrl, "/api/admin/users/usr_103/status", {
+      method: "PATCH",
+      token,
+      body: { status: "suspended", reason: "Manual review failed" }
+    });
+    assert.equal(updatedUser.response.status, 200);
+    assert.equal(updatedUser.payload.data.status, "suspended");
+
+    const updatedControls = await request(baseUrl, "/api/admin/controls", {
+      method: "PATCH",
+      token,
+      body: { maintenanceMode: true }
+    });
+    assert.equal(updatedControls.response.status, 200);
+    assert.equal(updatedControls.payload.data.maintenanceMode, true);
+
+    const audit = await request(baseUrl, "/api/admin/audit?q=user_status_suspended", { token });
+    assert.equal(audit.response.status, 200);
+    assert.equal(audit.payload.data.items[0].target, "usr_103");
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type AdminTab = "overview" | "users" | "jobs" | "disputes" | "controls" | "audit";
+type UserStatus = "active" | "review" | "suspended" | "banned";
+type JobStatus = "queued" | "flagged" | "approved" | "rejected";
+type DisputeStatus = "open" | "evidence" | "refunded" | "released" | "escalated";
+
+type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: "client" | "freelancer";
+  status: UserStatus;
+  trustScore: number;
+  joinedAt: string;
+};
+
+type ModerationJob = {
+  id: string;
+  title: string;
+  client: string;
+  status: JobStatus;
+  risk: "low" | "medium" | "high";
+  budget: number;
+  reason: string;
+};
+
+type Dispute = {
+  id: string;
+  jobTitle: string;
+  client: string;
+  freelancer: string;
+  status: DisputeStatus;
+  amount: number;
+  openedAt: string;
+};
+
+type AuditEvent = {
+  id: string;
+  actor: string;
+  action: string;
+  target: string;
+  createdAt: string;
+};
+
+const initialUsers: AdminUser[] = [
+  { id: "usr_101", name: "Maya Chen", email: "maya@example.com", role: "freelancer", status: "active", trustScore: 98, joinedAt: "2026-03-15" },
+  { id: "usr_102", name: "Jordan Lee", email: "jordan@example.com", role: "client", status: "active", trustScore: 91, joinedAt: "2026-03-21" },
+  { id: "usr_103", name: "Priya Raman", email: "priya@example.com", role: "freelancer", status: "review", trustScore: 72, joinedAt: "2026-04-02" },
+  { id: "usr_104", name: "Northstar Labs", email: "ops@northstar.test", role: "client", status: "suspended", trustScore: 48, joinedAt: "2026-04-18" }
+];
+
+const initialJobs: ModerationJob[] = [
+  { id: "job_201", title: "AI customer support widget", client: "Northstar Labs", status: "flagged", risk: "high", budget: 1500, reason: "External payment request" },
+  { id: "job_202", title: "Node.js API migration", client: "AtlasWorks", status: "queued", risk: "medium", budget: 2800, reason: "Large fixed scope" },
+  { id: "job_203", title: "SaaS onboarding redesign", client: "HaloStart", status: "approved", risk: "low", budget: 900, reason: "Clean listing" }
+];
+
+const initialDisputes: Dispute[] = [
+  { id: "dsp_301", jobTitle: "Backend audit", client: "Northstar Labs", freelancer: "Maya Chen", status: "open", amount: 640, openedAt: "2026-05-22" },
+  { id: "dsp_302", jobTitle: "Landing page copy", client: "HaloStart", freelancer: "Priya Raman", status: "evidence", amount: 280, openedAt: "2026-05-24" }
+];
+
+const initialAudit: AuditEvent[] = [
+  { id: "aud_001", actor: "system", action: "daily_metrics_refreshed", target: "platform", createdAt: "2026-05-29T08:15:00.000Z" },
+  { id: "aud_002", actor: "admin_1", action: "job_flag_reviewed", target: "job_201", createdAt: "2026-05-29T09:30:00.000Z" }
+];
+
+const tabs: Array<{ id: AdminTab; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "users", label: "Users" },
+  { id: "jobs", label: "Jobs" },
+  { id: "disputes", label: "Disputes" },
+  { id: "controls", label: "Controls" },
+  { id: "audit", label: "Audit" }
+];
+
+function formatMoney(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+}
+
+function titleCase(value: string) {
+  return value
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function statusClass(status: string) {
+  return `status status-${status}`;
+}
+
 export default function AdminPanelPage() {
+  const [activeTab, setActiveTab] = useState<AdminTab>("overview");
+  const [users, setUsers] = useState(initialUsers);
+  const [jobs, setJobs] = useState(initialJobs);
+  const [disputes, setDisputes] = useState(initialDisputes);
+  const [audit, setAudit] = useState(initialAudit);
+  const [userFilter, setUserFilter] = useState("all");
+  const [jobFilter, setJobFilter] = useState("all");
+  const [controls, setControls] = useState({
+    registrationOpen: true,
+    jobPostingOpen: true,
+    payoutReviewRequired: true,
+    maintenanceMode: false
+  });
+
+  const metrics = useMemo(() => {
+    const activeFreelancers = users.filter((user) => user.role === "freelancer" && user.status === "active").length;
+    const flaggedAccounts = users.filter((user) => ["review", "suspended", "banned"].includes(user.status)).length;
+    const openJobs = jobs.filter((job) => job.status !== "rejected").length;
+    const openDisputes = disputes.filter((dispute) => ["open", "evidence"].includes(dispute.status)).length;
+    const monthlyVolume = jobs.reduce((total, job) => total + job.budget, 0);
+
+    return [
+      { label: "Open Jobs", value: String(openJobs), tone: "teal" },
+      { label: "Active Freelancers", value: String(activeFreelancers), tone: "green" },
+      { label: "Flagged Accounts", value: String(flaggedAccounts), tone: "amber" },
+      { label: "Open Disputes", value: String(openDisputes), tone: "rose" },
+      { label: "Monthly Volume", value: formatMoney(monthlyVolume), tone: "blue" }
+    ];
+  }, [disputes, jobs, users]);
+
+  const visibleUsers = users.filter((user) => userFilter === "all" || user.status === userFilter);
+  const visibleJobs = jobs.filter((job) => jobFilter === "all" || job.status === jobFilter);
+
+  function record(action: string, target: string) {
+    setAudit((events) => [
+      {
+        id: `aud_ui_${Date.now()}`,
+        actor: "admin_1",
+        action,
+        target,
+        createdAt: new Date().toISOString()
+      },
+      ...events
+    ]);
+  }
+
+  function setUserStatus(id: string, status: UserStatus) {
+    setUsers((items) => items.map((user) => (user.id === id ? { ...user, status } : user)));
+    record(`user_status_${status}`, id);
+  }
+
+  function setJobStatus(id: string, status: JobStatus) {
+    setJobs((items) => items.map((job) => (job.id === id ? { ...job, status } : job)));
+    record(`job_${status}`, id);
+  }
+
+  function setDisputeStatus(id: string, status: DisputeStatus) {
+    setDisputes((items) => items.map((dispute) => (dispute.id === id ? { ...dispute, status } : dispute)));
+    record(`dispute_${status}`, id);
+  }
+
+  function toggleControl(key: keyof typeof controls) {
+    setControls((current) => {
+      const next = { ...current, [key]: !current[key] };
+      return next;
+    });
+    record("platform_controls_updated", titleCase(key));
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell">
+      <div className="admin-header">
+        <div>
+          <h2>Admin Operations</h2>
+          <p>Monitor marketplace health, review queues, and govern sensitive platform actions.</p>
+        </div>
+        <div className="admin-health">
+          <span className={controls.maintenanceMode ? "status status-rejected" : "status status-active"}>
+            {controls.maintenanceMode ? "Maintenance" : "Live"}
+          </span>
+          <strong>{audit.length}</strong>
+          <span>audit events</span>
+        </div>
+      </div>
+
+      <div className="admin-tabs" role="tablist" aria-label="Admin sections">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={activeTab === tab.id ? "active" : ""}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="admin-grid">
+        <div className="admin-main">
+          {(activeTab === "overview" || activeTab === "users") && (
+            <>
+              <div className="metric-grid">
+                {metrics.map((metric) => (
+                  <article className={`metric metric-${metric.tone}`} key={metric.label}>
+                    <span>{metric.label}</span>
+                    <strong>{metric.value}</strong>
+                  </article>
+                ))}
+              </div>
+
+              <div className="panel">
+                <div className="panel-heading">
+                  <div>
+                    <h3>User Management</h3>
+                    <p>Filter accounts and apply review actions without leaving the queue.</p>
+                  </div>
+                  <select aria-label="Filter users by status" value={userFilter} onChange={(event) => setUserFilter(event.target.value)}>
+                    <option value="all">All statuses</option>
+                    <option value="active">Active</option>
+                    <option value="review">Review</option>
+                    <option value="suspended">Suspended</option>
+                    <option value="banned">Banned</option>
+                  </select>
+                </div>
+                <div className="table-wrap">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>User</th>
+                        <th>Role</th>
+                        <th>Status</th>
+                        <th>Trust</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visibleUsers.map((user) => (
+                        <tr key={user.id}>
+                          <td>
+                            <strong>{user.name}</strong>
+                            <span>{user.email}</span>
+                          </td>
+                          <td>{titleCase(user.role)}</td>
+                          <td><span className={statusClass(user.status)}>{titleCase(user.status)}</span></td>
+                          <td>{user.trustScore}</td>
+                          <td>
+                            <div className="row-actions">
+                              <button type="button" onClick={() => setUserStatus(user.id, "active")}>Approve</button>
+                              <button type="button" onClick={() => setUserStatus(user.id, "suspended")}>Suspend</button>
+                              <button type="button" onClick={() => setUserStatus(user.id, "banned")}>Ban</button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </>
+          )}
+
+          {(activeTab === "overview" || activeTab === "jobs") && (
+            <div className="panel">
+              <div className="panel-heading">
+                <div>
+                  <h3>Job Moderation</h3>
+                  <p>Review flagged listings and keep risky marketplace posts out of circulation.</p>
+                </div>
+                <select aria-label="Filter jobs by status" value={jobFilter} onChange={(event) => setJobFilter(event.target.value)}>
+                  <option value="all">All jobs</option>
+                  <option value="queued">Queued</option>
+                  <option value="flagged">Flagged</option>
+                  <option value="approved">Approved</option>
+                  <option value="rejected">Rejected</option>
+                </select>
+              </div>
+              <div className="queue-list">
+                {visibleJobs.map((job) => (
+                  <article className="queue-row" key={job.id}>
+                    <div>
+                      <strong>{job.title}</strong>
+                      <span>{job.client} - {formatMoney(job.budget)} - {job.reason}</span>
+                    </div>
+                    <span className={statusClass(job.risk)}>{titleCase(job.risk)}</span>
+                    <span className={statusClass(job.status)}>{titleCase(job.status)}</span>
+                    <div className="row-actions">
+                      <button type="button" onClick={() => setJobStatus(job.id, "approved")}>Approve</button>
+                      <button type="button" onClick={() => setJobStatus(job.id, "rejected")}>Reject</button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {activeTab === "disputes" && (
+            <div className="panel">
+              <div className="panel-heading">
+                <div>
+                  <h3>Dispute Resolution</h3>
+                  <p>Track evidence, resolve escrow outcomes, and document rulings.</p>
+                </div>
+              </div>
+              <div className="queue-list">
+                {disputes.map((dispute) => (
+                  <article className="queue-row" key={dispute.id}>
+                    <div>
+                      <strong>{dispute.jobTitle}</strong>
+                      <span>{dispute.client} vs {dispute.freelancer} - {formatMoney(dispute.amount)}</span>
+                    </div>
+                    <span className={statusClass(dispute.status)}>{titleCase(dispute.status)}</span>
+                    <div className="row-actions">
+                      <button type="button" onClick={() => setDisputeStatus(dispute.id, "released")}>Release</button>
+                      <button type="button" onClick={() => setDisputeStatus(dispute.id, "refunded")}>Refund</button>
+                      <button type="button" onClick={() => setDisputeStatus(dispute.id, "escalated")}>Escalate</button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {activeTab === "controls" && (
+            <div className="panel">
+              <div className="panel-heading">
+                <div>
+                  <h3>Platform Controls</h3>
+                  <p>Change high-impact platform switches with immediate audit logging.</p>
+                </div>
+              </div>
+              <div className="control-grid">
+                {Object.entries(controls).map(([key, enabled]) => (
+                  <label className="control-row" key={key}>
+                    <span>
+                      <strong>{titleCase(key)}</strong>
+                      <small>{enabled ? "Enabled" : "Disabled"}</small>
+                    </span>
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={() => toggleControl(key as keyof typeof controls)}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {activeTab === "audit" && (
+            <div className="panel">
+              <div className="panel-heading">
+                <div>
+                  <h3>Audit Log</h3>
+                  <p>Append-only activity generated by moderation actions and controls.</p>
+                </div>
+              </div>
+              <AuditList events={audit} />
+            </div>
+          )}
+        </div>
+
+        <aside className="panel admin-rail">
+          <div className="panel-heading compact">
+            <div>
+              <h3>Recent Activity</h3>
+              <p>Latest admin actions</p>
+            </div>
+          </div>
+          <AuditList events={audit.slice(0, 6)} />
+        </aside>
+      </div>
     </section>
+  );
+}
+
+function AuditList({ events }: { events: AuditEvent[] }) {
+  return (
+    <ol className="audit-list">
+      {events.map((event) => (
+        <li key={event.id}>
+          <span>{titleCase(event.action)}</span>
+          <strong>{event.target}</strong>
+          <small>{new Date(event.createdAt).toLocaleString()}</small>
+        </li>
+      ))}
+    </ol>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,132 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
-.card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+button, select, input { font: inherit; }
+button, select { color: inherit; }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 1rem; }
+.card { background: #151c35; border: 1px solid #2a3765; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.admin-shell { display: grid; gap: 1rem; }
+.admin-header { display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; }
+.admin-header h2 { margin: 0; font-size: 2rem; line-height: 1.1; }
+.admin-header p, .panel-heading p { color: #aeb9d6; margin: 0.35rem 0 0; line-height: 1.5; }
+.admin-health { min-width: 170px; display: grid; gap: 0.25rem; justify-items: end; color: #aeb9d6; }
+.admin-health strong { font-size: 1.75rem; color: #ffffff; }
+
+.admin-tabs { display: flex; gap: 0.5rem; overflow-x: auto; padding-bottom: 0.15rem; }
+.admin-tabs button, .row-actions button {
+  border: 1px solid #33426f;
+  background: #121a31;
+  border-radius: 8px;
+  padding: 0.55rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+.admin-tabs button.active, .row-actions button:hover { background: #1c7d7a; border-color: #38bdb6; color: #f7ffff; }
+
+.admin-grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 1rem; align-items: start; }
+.admin-main { display: grid; gap: 1rem; min-width: 0; }
+.metric-grid { display: grid; grid-template-columns: repeat(5, minmax(130px, 1fr)); gap: 0.75rem; }
+.metric, .panel {
+  background: #141d33;
+  border: 1px solid #2b3a62;
+  border-radius: 8px;
+  box-shadow: 0 16px 36px rgba(3, 8, 20, 0.18);
+}
+.metric { min-height: 92px; padding: 0.85rem; display: grid; align-content: space-between; }
+.metric span { color: #aeb9d6; font-size: 0.78rem; text-transform: uppercase; }
+.metric strong { font-size: 1.45rem; line-height: 1.1; }
+.metric-teal { border-top: 3px solid #2dd4bf; }
+.metric-green { border-top: 3px solid #4ade80; }
+.metric-amber { border-top: 3px solid #f59e0b; }
+.metric-rose { border-top: 3px solid #fb7185; }
+.metric-blue { border-top: 3px solid #60a5fa; }
+
+.panel { padding: 1rem; }
+.panel-heading { display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; margin-bottom: 0.9rem; }
+.panel-heading.compact { margin-bottom: 0.3rem; }
+.panel-heading h3 { margin: 0; font-size: 1rem; line-height: 1.2; }
+.panel-heading select {
+  background: #0f172a;
+  border: 1px solid #33426f;
+  border-radius: 8px;
+  min-height: 38px;
+  padding: 0 0.7rem;
+}
+
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; min-width: 680px; }
+th, td { text-align: left; padding: 0.75rem; border-bottom: 1px solid #273555; vertical-align: middle; }
+th { color: #8fa0c4; font-size: 0.78rem; text-transform: uppercase; }
+td span { display: block; color: #9aa9c8; margin-top: 0.2rem; }
+.row-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.row-actions button { padding: 0.45rem 0.6rem; font-size: 0.78rem; }
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.75rem;
+  line-height: 1;
+  border: 1px solid #39476d;
+  color: #d9e3ff;
+  background: #111a2f;
+}
+.status-active, .status-approved, .status-low, .status-released { border-color: #2dd4bf; color: #bff8f2; }
+.status-review, .status-queued, .status-medium, .status-evidence { border-color: #f59e0b; color: #ffe4a3; }
+.status-suspended, .status-flagged, .status-high, .status-open, .status-escalated { border-color: #fb7185; color: #ffd0d8; }
+.status-banned, .status-rejected, .status-refunded { border-color: #94a3b8; color: #e2e8f0; }
+
+.queue-list, .audit-list, .control-grid { display: grid; gap: 0.7rem; }
+.queue-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.8rem;
+  border: 1px solid #273555;
+  border-radius: 8px;
+  background: #10182d;
+}
+.queue-row span { color: #9aa9c8; }
+.queue-row > div:first-child span { display: block; margin-top: 0.25rem; }
+
+.control-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem;
+  border: 1px solid #273555;
+  border-radius: 8px;
+  background: #10182d;
+}
+.control-row small { display: block; color: #9aa9c8; margin-top: 0.2rem; }
+.control-row input { width: 42px; height: 22px; accent-color: #2dd4bf; }
+
+.admin-rail { position: sticky; top: 1rem; }
+.audit-list { list-style: none; padding: 0; margin: 0; }
+.audit-list li { padding: 0.75rem 0; border-bottom: 1px solid #273555; }
+.audit-list li:last-child { border-bottom: 0; }
+.audit-list span, .audit-list small { display: block; color: #9aa9c8; }
+.audit-list strong { display: block; margin: 0.2rem 0; }
+
+@media (max-width: 900px) {
+  .admin-header, .panel-heading { display: grid; }
+  .admin-health { justify-items: start; }
+  .admin-grid { grid-template-columns: 1fr; }
+  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .admin-rail { position: static; }
+  .queue-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 540px) {
+  main { padding: 1rem 0.75rem; }
+  .admin-header h2 { font-size: 1.55rem; }
+  .metric-grid { grid-template-columns: 1fr; }
+  .admin-tabs button { min-width: max-content; }
+}


### PR DESCRIPTION
/claim #29

## Summary
- Replaced the `/admin` placeholder with a functional admin operations dashboard: overview metrics, user filtering/actions, job moderation, dispute handling, platform controls, and append-only audit activity.
- Expanded `/api/admin/*` with admin-only role enforcement, paginated/filterable admin endpoints, moderation/control mutations, and audit logging backed by the existing in-memory service style.
- Added focused API coverage for admin authorization, filtering, actions, controls, and audit output.

## Demo / Evidence
- Local rendered flow verified: `/admin` loads, Users tab filters to review accounts, Suspend action moves the user to the suspended queue, Controls toggles Maintenance Mode, Audit tab records both actions.
- Desktop and mobile screenshots were captured locally from the production Next server during QA.

## Validation
- `npm run test -w apps/api` -> passed
- `npm run build -w apps/web` -> passed
- `git diff --check` -> passed
- Playwright smoke flow against `next start -p 3000` using system Chrome -> passed

No payout address, private token, cookie value, seed phrase, API key, or hidden runtime metadata is included.