### PR TITLE
fix: restrict register role and extract refresh token (Fixes #1690)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    next(error);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    next(error);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -22,6 +30,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body || {};
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.name === "ZodError" || err.constructor?.name === "ZodError") {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors || err.issues
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
+export async function refreshToken(token) {
   return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Auth registration role validation and refresh token validation", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  await t.test("POST /api/auth/register with client role succeeds", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        email: "test_client@example.com",
+        password: "securepassword123",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+  });
+
+  await t.test("POST /api/auth/register with freelancer role succeeds", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        email: "test_freelancer@example.com",
+        password: "securepassword123",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "freelancer");
+  });
+
+  await t.test("POST /api/auth/register with admin role fails validation", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        email: "test_admin@example.com",
+        password: "securepassword123",
+        role: "admin"
+      })
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("POST /api/auth/refresh passes token to the service", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        token: "some-existing-refresh-token"
+      })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.token);
+  });
+
+  server.close();
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Restricts registration role options to 'client' and 'freelancer' (removing 'admin'), and extracts the refresh token from 'req.body' to pass it to the 'refreshToken' service, matching requirements for Issue #1690.