### PR TITLE
Prevent admin self-assignment on registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.parse(req.body);
+  const result = await refreshToken(payload.token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { refreshToken } from "../services/authService.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+test("registerSchema rejects public admin self-assignment", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "admin-attempt@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  });
+});
+
+test("registerSchema still defaults public registrations to client", () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(payload.role, "client");
+});
+
+test("refreshToken preserves the verified token identity", async () => {
+  const original = signAccessToken({ sub: "usr_123", role: "freelancer" });
+  const refreshed = await refreshToken(original);
+  const payload = verifyAccessToken(refreshed.token);
+
+  assert.equal(payload.sub, "usr_123");
+  assert.equal(payload.role, "freelancer");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,14 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
+});
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
 });


### PR DESCRIPTION
## Summary

- Restricts public registration roles to `client` and `freelancer`, preventing `role: "admin"` self-assignment through `POST /api/auth/register`.
- Validates `req.body.token` in the refresh controller and passes it to the refresh service.
- Verifies the submitted token before minting a replacement token that preserves the verified `sub` and `role`.
- Fixes the API workspace test script so the existing and new `node:test` files run reliably on Windows.
- Adds regression tests for admin role rejection, default client role behavior, and refresh identity preservation.

## Validation

- `npm test -w apps/api`
- `git diff --check`

Fixes #1716
/claim #743
