### PR TITLE
fix: prevent admin auth self-assignment

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,9 +1,14 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const payload = parsed.data;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }
@@ -22,6 +27,11 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const parsed = refreshSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  const result = await refreshToken(parsed.data.token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,9 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  return {
+    token: signAccessToken({ sub: decoded.sub, role: decoded.role ?? "client" })
+  };
 }

--- a/apps/api/src/tests/authSecurity.test.js
+++ b/apps/api/src/tests/authSecurity.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/register", {
+      email: "admin-seeker@example.com",
+      password: "correct-horse",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid registration payload");
+  });
+});
+
+test("POST /api/auth/register still allows public client and freelancer roles", async () => {
+  await withServer(async (baseUrl) => {
+    const clientResponse = await postJson(baseUrl, "/api/auth/register", {
+      email: "client@example.com",
+      password: "correct-horse"
+    });
+    const clientPayload = await clientResponse.json();
+
+    assert.equal(clientResponse.status, 201);
+    assert.equal(clientPayload.success, true);
+    assert.equal(clientPayload.data.role, "client");
+
+    const freelancerResponse = await postJson(baseUrl, "/api/auth/register", {
+      email: "freelancer@example.com",
+      password: "correct-horse",
+      role: "freelancer"
+    });
+    const freelancerPayload = await freelancerResponse.json();
+
+    assert.equal(freelancerResponse.status, 201);
+    assert.equal(freelancerPayload.success, true);
+    assert.equal(freelancerPayload.data.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/refresh reissues a token for the submitted subject", async () => {
+  await withServer(async (baseUrl) => {
+    const originalToken = signAccessToken({
+      sub: "usr_refresh_owner",
+      role: "freelancer"
+    });
+
+    const response = await postJson(baseUrl, "/api/auth/refresh", {
+      token: originalToken
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_refresh_owner");
+    assert.equal(decoded.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/refresh requires a token in the request body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/refresh", {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Refresh token is required");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,14 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
+});
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
 });


### PR DESCRIPTION
/claim #743

## Summary
- Restrict public auth registration to the self-service `client` and `freelancer` roles.
- Return a 400 response for registration attempts that submit `role: admin`.
- Require `req.body.token` on `POST /api/auth/refresh`, pass it into the auth service, and reissue the token for the submitted token subject/role.
- Make the API workspace test script run concrete test files and add auth security regression coverage.

Fixes #1720.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1426-demo.mp4

## Validation
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/validators/auth.js`
- `node --check apps/api/src/tests/authSecurity.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authSecurity.test.js`
- `npm test -w apps/api`
- `git diff --check`