### PR TITLE
Integrate Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.2.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,9 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: status === 500 ? "Unexpected server error" : err.message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,90 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripe;
+
+export async function createPaymentIntent(payload, client = getStripeClient()) {
+  const currency = String(payload.currency ?? "usd").toLowerCase();
+  const amount = toStripeAmount(payload.amount, currency);
+
+  try {
+    const intent = await client.paymentIntents.create({
+      amount,
+      currency,
+      automatic_payment_methods: { enabled: true },
+      description: payload.description,
+      metadata: compactMetadata({
+        jobId: payload.jobId,
+        proposalId: payload.proposalId,
+        userId: payload.userId
+      })
+    });
+
+    return {
+      paymentId: intent.id,
+      clientSecret: intent.client_secret,
+      amount,
+      currency,
+      provider: "stripe",
+      status: intent.status
+    };
+  } catch (error) {
+    const providerMessage = error?.message ?? "Stripe payment intent failed";
+    throw new PaymentProviderError(providerMessage);
+  }
+}
+
+export function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentProviderError("STRIPE_SECRET_KEY is not configured");
+  }
+
+  stripe ??= new Stripe(env.stripeSecretKey, {
+    apiVersion: "2024-06-20"
+  });
+  return stripe;
+}
+
+export function toStripeAmount(amount, currency = "usd") {
+  const value = Number(amount);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new PaymentProviderError("Payment amount must be greater than zero");
+  }
+
+  const zeroDecimalCurrencies = new Set([
+    "bif",
+    "clp",
+    "djf",
+    "gnf",
+    "jpy",
+    "kmf",
+    "krw",
+    "mga",
+    "pyg",
+    "rwf",
+    "ugx",
+    "vnd",
+    "vuv",
+    "xaf",
+    "xof",
+    "xpf"
+  ]);
+  const multiplier = zeroDecimalCurrencies.has(currency.toLowerCase()) ? 1 : 100;
+  return Math.round(value * multiplier);
+}
+
+function compactMetadata(values) {
+  return Object.fromEntries(
+    Object.entries(values)
+      .filter(([, value]) => value !== undefined && value !== null && value !== "")
+      .map(([key, value]) => [key, String(value)])
+  );
+}
+
+export class PaymentProviderError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentProviderError";
+    this.statusCode = 502;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PaymentProviderError,
+  createPaymentIntent,
+  toStripeAmount
+} from "../services/paymentService.js";
+
+test("createPaymentIntent creates a Stripe payment intent and returns client secret", async () => {
+  const calls = [];
+  const stripe = {
+    paymentIntents: {
+      create: async (payload) => {
+        calls.push(payload);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_abc",
+          status: "requires_payment_method"
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent(
+    {
+      amount: 42.5,
+      currency: "USD",
+      description: "Milestone deposit",
+      jobId: "job_123",
+      proposalId: "prop_456",
+      userId: "user_789"
+    },
+    stripe
+  );
+
+  assert.deepEqual(calls[0], {
+    amount: 4250,
+    currency: "usd",
+    automatic_payment_methods: { enabled: true },
+    description: "Milestone deposit",
+    metadata: {
+      jobId: "job_123",
+      proposalId: "prop_456",
+      userId: "user_789"
+    }
+  });
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_abc",
+    amount: 4250,
+    currency: "usd",
+    provider: "stripe",
+    status: "requires_payment_method"
+  });
+});
+
+test("toStripeAmount handles zero-decimal currencies", () => {
+  assert.equal(toStripeAmount(500, "jpy"), 500);
+  assert.equal(toStripeAmount(12.34, "usd"), 1234);
+});
+
+test("createPaymentIntent wraps provider errors", async () => {
+  const stripe = {
+    paymentIntents: {
+      create: async () => {
+        throw new Error("card network unavailable");
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10 }, stripe),
+    (error) => {
+      assert.equal(error instanceof PaymentProviderError, true);
+      assert.equal(error.message, "card network unavailable");
+      assert.equal(error.statusCode, 502);
+      return true;
+    }
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.2.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Addresses issue #1 by replacing the payment stub with Stripe PaymentIntent creation. Returns the client_secret, converts display amounts to Stripe minor units including zero-decimal currencies, preserves useful metadata, adds provider error handling, and fixes the API test script so node --test runs the test files. Verification: npm test -w apps/api passes.