### PR TITLE
Fix: job service mass-assignment allows id and status override (Fixes #1726)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/health.test.js src/tests/jobService.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id, status, ...safePayload } = payload || {};
+  const job = { ...safePayload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob prevents id and status override via mass-assignment", async () => {
+  const payload = {
+    title: "Vulnerability Fixer",
+    description: "Fixing mass-assignment vulnerabilities",
+    id: "hacked_id_123",
+    status: "COMPLETED"
+  };
+
+  const createdJob = await createJob(payload);
+
+  // Check that the returned job has a server-generated ID and status "open"
+  assert.ok(createdJob.id.startsWith("job_"));
+  assert.notEqual(createdJob.id, "hacked_id_123");
+  assert.equal(createdJob.status, "open");
+
+  // Check that listing jobs returns the correct values too
+  const jobs = await listJobs();
+  const found = jobs.find(j => j.title === "Vulnerability Fixer");
+  assert.ok(found);
+  assert.notEqual(found.id, "hacked_id_123");
+  assert.equal(found.status, "open");
+});


### PR DESCRIPTION
## Problem

The `createJob()` service in `apps/api/src/services/jobService.js` constructed new job objects using:
`const job = { id: job_${Date.now()}, status: "open", ...payload };`

Since `...payload` was placed after the server-generated `id` and default `status` keys, any caller could include custom `id` or `status` values in their payload and override the server-controlled variables. This represents a mass-assignment vulnerability.

## Solution

1. Updated `createJob()` to explicitly destructure `id` and `status` from `payload`, ignoring them.
2. Kept the remaining safe properties by spreading `...safePayload` before the server-generated `id` and `status: "open"`.
3. Created a new comprehensive unit test suite in `apps/api/src/tests/jobService.test.js` verifying that `id` and `status` overrides are strictly ignored.
4. Updated the test runner script to ensure both suites run and pass successfully.

Closes #1726