### PR TITLE
fix: resolve job details from mock data and return 404 for unknown IDs (Closes #1677)

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,7 +1,16 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+  if (!job) {
+    notFound();
+  }
   return (
     <section className="card">
       <h2>Job Detail</h2>
+      <h3>{job.title}</h3>
+      <p>Budget: {job.budget}</p>
       <p>Viewing details for <strong>{params.id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>


### PR DESCRIPTION
## Summary

Fixes the job detail page to:
1. Look up job by `id` against the mock data in `apps/web/lib/mock.ts`
2. Display job title and budget for known job IDs
3. Call `notFound()` to return a proper 404 for unknown job IDs

## Before
- All URLs like `/jobs/job-101` or `/jobs/not-a-job` showed the same placeholder
- No job details from mock data were displayed
- Invalid job links appeared valid

## After
- `/jobs/job-101` → renders job title "Build an AI customer support widget" with budget "$1,500"
- `/jobs/not-a-job` → returns proper 404 via `notFound()`

## Testing
1. Open `/jobs/job-101` → should show job title + budget
2. Open `/jobs/job-102` → should show "Migrate legacy API to Node.js" / "$2,800"
3. Open `/jobs/job-103` → should show "Design SaaS onboarding flows" / "$900"
4. Open `/jobs/not-a-job` → should return 404 page

Closes #1677