### PR TITLE
Fix: prevent admin role self-assignment (Fixes #1737)

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema role validation", () => {
+  // Valid roles
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123"
+    });
+  });
+
+  // Invalid role: admin should fail validation
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Prevents user self-assignment to the admin role via registerSchema. The allowed enum values for registration roles are restricted to client and freelancer.