### PR TITLE
Keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("register returns a token subject matching the returned user id", async () => {
+  const originalDateNow = Date.now;
+  let timestamp = 1700000000000;
+  Date.now = () => timestamp++;
+
+  try {
+    const user = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+
+    const token = verifyAccessToken(user.token);
+    assert.equal(token.sub, user.id);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Fixes #1743
/claim #743

Summary:
- Generate the registration user id once.
- Reuse the same id in the response and in the JWT subject.
- Add a regression test that decodes the token and checks that `sub` matches the returned user id.

Verification:
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/auth.test.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/auth.test.js`
- `git diff --check`

Note:
- `npm test -w apps/api` still fails because the existing script runs `node --test src/tests`, which Node treats as a missing module path on this setup. The explicit test command above runs the real test files and passes.