### PR TITLE
Add dispatch room poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Dispatch Room
+
+The brief arrives with coffee rings,
+a small request, a careful scope.
+No trumpet call, no grand machine,
+just work measured against hope.
+
+A ticket waits beneath the lamp,
+its edges marked with proof and doubt.
+We name the risk, we trim the claim,
+then turn the hidden failure out.
+
+The tests come back like weather notes:
+some clean, some sharp, some asking why.
+We fix the seam that should not show
+and leave the louder words to dry.
+
+In review, the room gets quiet.
+The patch is read line after line.
+Trust is not a badge we pin;
+it is the habit of a sign.
+
+When merge light finally settles in,
+the ledger closes, plain and bright.
+The job moves on, the record stays,
+and someone sleeps a little light.


### PR DESCRIPTION
/claim #76

Added an original root-level `POEM.md` with five compact stanzas.

Creative note: I used a quiet dispatch-room frame because it matches the project's task handoff: scope, proof, review, merge, and payout without turning the poem into generic developer slogans.

Validation:
- `POEM.md` exists at the project root
- Local poem check: 5 stanzas, 20 poem lines
- `git diff --check` passed