### PR TITLE
Add ledger loom poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger Loom
+
+At dawn the brief is measured out,
+not loud, not dressed in chrome;
+a task becomes a woven route,
+and finds its working home.
+
+The client threads a careful scope,
+the builder knots reply;
+each estimate becomes a rope
+that keeps the promise dry.
+
+The tests are small and patient lamps,
+they burn beside the line;
+when failures mark the folded maps,
+the fix rewrites the sign.
+
+A review clicks through the quiet frame,
+then merge lights up the rail;
+the ledger learns the work by name,
+and trust begins to scale.
+
+At payout, nothing needs to shout;
+the value has been shown.
+A finished craft is carried out,
+and both sides own the known.


### PR DESCRIPTION
/claim #76

Added an original root-level `POEM.md` with five stanzas and 20 poem lines.

Creative note: I chose a ledger-loom form because it connects FreelanceFlow's scoped work, review, merge, trust, and payout steps without turning the poem into generic developer slogans.

Validation:
- `POEM.md` exists at the project root
- Poem structure: 5 stanzas, 20 poem lines
- `git diff --check` passed