### PR TITLE
fix(auth): prevent admin role self-assignment

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema defaults new users to client role", () => {
+  const payload = registerSchema.parse({
+    email: "new-client@example.com",
+    password: "correct-horse"
+  });
+
+  assert.equal(payload.role, "client");
+});
+
+test("registerSchema allows normal public account roles", () => {
+  assert.equal(
+    registerSchema.parse({
+      email: "builder@example.com",
+      password: "correct-horse",
+      role: "freelancer"
+    }).role,
+    "freelancer"
+  );
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  assert.throws(
+    () =>
+      registerSchema.parse({
+        email: "admin-request@example.com",
+        password: "correct-horse",
+        role: "admin"
+      }),
+    (error) => error.issues?.some((issue) => issue.path?.[0] === "role")
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

Fixes #1755

## Summary
- Removed `admin` from the public registration role enum so callers cannot self-assign administrator privileges during signup.
- Kept the existing default role as `client`.
- Added focused validator tests covering the default role, a valid `freelancer` role, and rejection of `admin`.

## Validation
- `node --check apps/api/src/validators/auth.js` -> passed
- `node --check apps/api/src/tests/authValidator.test.js` -> passed
- Static auth role check confirmed `z.enum(["client", "freelancer"]).default("client")`
- `git diff --check` -> passed

The full validator test is included for normal `npm test -w apps/api` runs; it was not executed in this checkout because dependencies are not installed locally.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.