### PR TITLE
fix(auth): reuse generated registration user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const user = await registerUser({
+    email: "client@example.com",
+    role: "client"
+  });
+
+  const claims = verifyAccessToken(user.token);
+
+  assert.equal(claims.sub, user.id);
+  assert.equal(claims.role, "client");
+});


### PR DESCRIPTION
/claim #743

Fixes #1758

## Summary
- Generate the registration user ID once in `registerUser`.
- Reuse that same ID for both the returned user object and the JWT `sub` claim.
- Add a focused auth service test that verifies the token subject matches the returned user ID.

## Validation
- `node --check apps/api/src/services/authService.js` -> passed
- `node --check apps/api/src/tests/authService.test.js` -> passed
- Static check confirmed one `Date.now()` call in `authService.js` and `sub: userId` reuse
- `git diff --check` -> passed

The full auth service test is included for normal dependency-installed test runs; it was not executed in this checkout because `apps/api/node_modules` is not present locally.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.