### PR TITLE
Implement admin operations panel

### DIFF
--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,53 @@
 import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import {
+  decideFlaggedJob,
+  getAdminMetrics,
+  getPlatformControls,
+  listAdminUsers,
+  listAuditLog,
+  listDisputes,
+  listFlaggedJobs,
+  ruleOnDispute,
+  setPlatformControl,
+  setUserStatus
+} from "../services/adminService.js";
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function updateUserStatus(req, res) {
+  return ok(res, await setUserStatus(req.params.userId, req.body.status, req.user.sub));
+}
+
+export async function moderationQueue(req, res) {
+  return ok(res, await listFlaggedJobs(req.query));
+}
+
+export async function moderateJob(req, res) {
+  return ok(res, await decideFlaggedJob(req.params.flagId, req.body.decision, req.body.reason, req.user.sub));
+}
+
+export async function disputeQueue(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function resolveDispute(req, res) {
+  return ok(res, await ruleOnDispute(req.params.disputeId, req.body.ruling, req.user.sub));
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function updateControl(req, res) {
+  return ok(res, await setPlatformControl(req.params.control, req.body.enabled, req.user.sub));
+}
+
+export async function audit(req, res) {
+  return ok(res, await listAuditLog(req.query));
 }

--- a/apps/api/src/middleware/adminOnly.js
+++ b/apps/api/src/middleware/adminOnly.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,30 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import {
+  audit,
+  controls,
+  disputeQueue,
+  metrics,
+  moderateJob,
+  moderationQueue,
+  resolveDispute,
+  updateControl,
+  updateUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { adminOnly } from "../middleware/adminOnly.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminOnly);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:userId/status", updateUserStatus);
+adminRoutes.get("/moderation/jobs", moderationQueue);
+adminRoutes.post("/moderation/jobs/:flagId/decision", moderateJob);
+adminRoutes.get("/disputes", disputeQueue);
+adminRoutes.post("/disputes/:disputeId/ruling", resolveDispute);
+adminRoutes.get("/platform-controls", controls);
+adminRoutes.patch("/platform-controls/:control", updateControl);
+adminRoutes.get("/audit-log", audit);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,311 @@
+const users = [
+  {
+    id: "usr_1001",
+    name: "Maya Chen",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-02-14",
+    trustScore: 96,
+    activeJobs: 4,
+    disputes: 0
+  },
+  {
+    id: "usr_1002",
+    name: "Jordan Lee",
+    email: "jordan@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-03-02",
+    trustScore: 89,
+    activeJobs: 2,
+    disputes: 1
+  },
+  {
+    id: "usr_1003",
+    name: "Riley Stone",
+    email: "riley@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-04-11",
+    trustScore: 54,
+    activeJobs: 1,
+    disputes: 2
+  },
+  {
+    id: "usr_1004",
+    name: "Avery Patel",
+    email: "avery@example.com",
+    role: "client",
+    status: "banned",
+    joinedAt: "2026-01-20",
+    trustScore: 18,
+    activeJobs: 0,
+    disputes: 4
+  }
+];
+
+const flaggedJobs = [
+  {
+    id: "flag_2001",
+    jobId: "job_3001",
+    title: "Scrape competitor customer data",
+    client: "Avery Patel",
+    reason: "Potential policy violation",
+    severity: "high",
+    status: "pending",
+    flaggedAt: "2026-05-27T14:21:00.000Z"
+  },
+  {
+    id: "flag_2002",
+    jobId: "job_3002",
+    title: "Rebuild checkout analytics dashboard",
+    client: "Jordan Lee",
+    reason: "Budget anomaly",
+    severity: "medium",
+    status: "pending",
+    flaggedAt: "2026-05-28T09:05:00.000Z"
+  },
+  {
+    id: "flag_2003",
+    jobId: "job_3003",
+    title: "Write landing page copy",
+    client: "Nora Kim",
+    reason: "Repeated report from freelancers",
+    severity: "low",
+    status: "escalated",
+    flaggedAt: "2026-05-29T16:44:00.000Z"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_4001",
+    client: "Jordan Lee",
+    freelancer: "Maya Chen",
+    jobTitle: "API billing integration",
+    amount: 2400,
+    status: "open",
+    updatedAt: "2026-05-29T20:12:00.000Z",
+    evidenceCount: 5,
+    transactionId: "pi_928391",
+    thread: [
+      "Client says milestone 2 is incomplete.",
+      "Freelancer uploaded delivery notes and test evidence.",
+      "Escrow payment is currently held."
+    ],
+    ruling: null
+  },
+  {
+    id: "dsp_4002",
+    client: "Nora Kim",
+    freelancer: "Riley Stone",
+    jobTitle: "Brand refresh deck",
+    amount: 850,
+    status: "under_review",
+    updatedAt: "2026-05-28T11:33:00.000Z",
+    evidenceCount: 3,
+    transactionId: "pi_928407",
+    thread: [
+      "Freelancer missed the revision window.",
+      "Client uploaded the original scope document."
+    ],
+    ruling: null
+  }
+];
+
+const platformControls = {
+  registrations: {
+    enabled: true,
+    label: "New user registrations",
+    updatedBy: "admin_demo",
+    updatedAt: "2026-05-29T19:15:00.000Z"
+  },
+  jobPostings: {
+    enabled: true,
+    label: "New job postings",
+    updatedBy: "admin_demo",
+    updatedAt: "2026-05-29T19:15:00.000Z"
+  }
+};
+
+const auditLog = [
+  {
+    id: "aud_5001",
+    adminId: "admin_demo",
+    action: "user.suspend",
+    target: "usr_1003",
+    details: "Suspended while dispute evidence is reviewed.",
+    createdAt: "2026-05-29T18:41:00.000Z"
+  },
+  {
+    id: "aud_5002",
+    adminId: "admin_demo",
+    action: "job.escalate",
+    target: "flag_2003",
+    details: "Escalated repeated report to senior moderation.",
+    createdAt: "2026-05-29T19:02:00.000Z"
+  }
+];
+
+function recordAudit(adminId, action, target, details) {
+  const entry = {
+    id: `aud_${Date.now()}`,
+    adminId,
+    action,
+    target,
+    details,
+    createdAt: new Date().toISOString()
+  };
+  auditLog.unshift(entry);
+  return entry;
+}
+
+function paginate(items, page = 1, pageSize = 10) {
+  const safePage = Math.max(Number(page) || 1, 1);
+  const safePageSize = Math.min(Math.max(Number(pageSize) || 10, 1), 50);
+  const start = (safePage - 1) * safePageSize;
+
+  return {
+    items: items.slice(start, start + safePageSize),
+    page: safePage,
+    pageSize: safePageSize,
+    total: items.length,
+    totalPages: Math.max(Math.ceil(items.length / safePageSize), 1)
+  };
+}
+
 export async function getAdminMetrics() {
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    totalUsers: users.length,
+    activeJobs: 42,
+    openDisputes: disputes.filter((dispute) => dispute.status !== "resolved").length,
+    flaggedListings: flaggedJobs.filter((job) => job.status !== "approved").length,
+    revenueCurrentPeriod: 128900,
+    trustScoreDistribution: [
+      { range: "0-39", count: users.filter((user) => user.trustScore < 40).length },
+      { range: "40-69", count: users.filter((user) => user.trustScore >= 40 && user.trustScore < 70).length },
+      { range: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+      { range: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+    ]
   };
+}
+
+export async function listAdminUsers(filters = {}) {
+  const search = filters.search?.toLowerCase() ?? "";
+  const filtered = users.filter((user) => {
+    const matchesSearch =
+      !search ||
+      user.name.toLowerCase().includes(search) ||
+      user.email.toLowerCase().includes(search) ||
+      user.id.toLowerCase().includes(search);
+    const matchesRole = !filters.role || user.role === filters.role;
+    const matchesStatus = !filters.status || user.status === filters.status;
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  return paginate(filtered, filters.page, filters.pageSize);
+}
+
+export async function setUserStatus(userId, status, adminId) {
+  if (!["active", "suspended", "banned"].includes(status)) {
+    throw new Error("Unsupported user status");
+  }
+
+  const user = users.find((entry) => entry.id === userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  user.status = status;
+  const action = status === "active" ? "user.reinstate" : `user.${status}`;
+  const audit = recordAudit(adminId, action, userId, `Set user status to ${status}.`);
+  return { user, audit };
+}
+
+export async function listFlaggedJobs(filters = {}) {
+  const filtered = flaggedJobs.filter((job) => !filters.status || job.status === filters.status);
+  return paginate(filtered, filters.page, filters.pageSize);
+}
+
+export async function decideFlaggedJob(flagId, decision, reason, adminId) {
+  if (!["approved", "rejected", "escalated"].includes(decision)) {
+    throw new Error("Unsupported moderation decision");
+  }
+
+  const job = flaggedJobs.find((entry) => entry.id === flagId);
+  if (!job) {
+    throw new Error("Flagged job not found");
+  }
+
+  job.status = decision;
+  job.resolutionReason = reason ?? "";
+  const audit = recordAudit(adminId, `job.${decision}`, flagId, job.resolutionReason);
+  return {
+    job,
+    notification: decision === "rejected" ? `Client ${job.client} notified with reason: ${job.resolutionReason}` : null,
+    audit
+  };
+}
+
+export async function listDisputes(filters = {}) {
+  const filtered = disputes.filter((dispute) => !filters.status || dispute.status === filters.status);
+  return paginate(filtered, filters.page, filters.pageSize);
+}
+
+export async function ruleOnDispute(disputeId, ruling, adminId) {
+  if (!["client", "freelancer", "refund", "escalate"].includes(ruling)) {
+    throw new Error("Unsupported dispute ruling");
+  }
+
+  const dispute = disputes.find((entry) => entry.id === disputeId);
+  if (!dispute) {
+    throw new Error("Dispute not found");
+  }
+
+  dispute.ruling = ruling;
+  dispute.status = ruling === "escalate" ? "under_review" : "resolved";
+  dispute.updatedAt = new Date().toISOString();
+
+  const audit = recordAudit(adminId, `dispute.${ruling}`, disputeId, `Ruling applied to ${dispute.jobTitle}.`);
+  return {
+    dispute,
+    notifications: [`${dispute.client} notified`, `${dispute.freelancer} notified`],
+    audit
+  };
+}
+
+export async function getPlatformControls() {
+  return platformControls;
+}
+
+export async function setPlatformControl(control, enabled, adminId) {
+  if (!platformControls[control]) {
+    throw new Error("Platform control not found");
+  }
+
+  platformControls[control].enabled = Boolean(enabled);
+  platformControls[control].updatedBy = adminId;
+  platformControls[control].updatedAt = new Date().toISOString();
+
+  const audit = recordAudit(
+    adminId,
+    `platform.${control}`,
+    control,
+    `${platformControls[control].label} ${enabled ? "enabled" : "disabled"}.`
+  );
+
+  return { control: platformControls[control], audit };
+}
+
+export async function listAuditLog(filters = {}) {
+  const filtered = auditLog.filter((entry) => {
+    const matchesAdmin = !filters.adminId || entry.adminId === filters.adminId;
+    const matchesAction = !filters.action || entry.action === filters.action;
+    const matchesFrom = !filters.from || entry.createdAt >= filters.from;
+    const matchesTo = !filters.to || entry.createdAt <= filters.to;
+    return matchesAdmin && matchesAction && matchesFrom && matchesTo;
+  });
+
+  return paginate(filtered, filters.page, filters.pageSize);
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminToken() {
+  return signAccessToken({ sub: "admin_test", role: "admin" });
+}
+
+function clientToken() {
+  return signAccessToken({ sub: "client_test", role: "client" });
+}
+
+test("admin routes reject unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("admin routes reject non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: `Bearer ${clientToken()}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Admin access required");
+  });
+});
+
+test("admin metrics returns operational dashboard data for admins", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        authorization: `Bearer ${adminToken()}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.totalUsers, 4);
+    assert.equal(payload.data.openDisputes, 2);
+    assert.equal(payload.data.flaggedListings, 3);
+    assert.equal(payload.data.trustScoreDistribution.length, 4);
+  });
+});
+
+test("admins can update user status and receive an audit entry", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users/usr_1003/status`, {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${adminToken()}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ status: "active" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.user.status, "active");
+    assert.equal(payload.data.audit.action, "user.reinstate");
+    assert.equal(payload.data.audit.adminId, "admin_test");
+  });
+});
+
+test("admins can moderate flagged jobs and notify rejected listing owners", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/moderation/jobs/flag_2002/decision`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken()}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        decision: "rejected",
+        reason: "Budget anomaly confirmed during review."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.job.status, "rejected");
+    assert.match(payload.data.notification, /notified/);
+    assert.equal(payload.data.audit.action, "job.rejected");
+  });
+});
+
+test("admins can change platform controls with audit coverage", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/platform-controls/registrations`, {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${adminToken()}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ enabled: false })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.control.enabled, false);
+    assert.equal(payload.data.audit.action, "platform.registrations");
+  });
+});

--- a/apps/web/app/admin/AdminPanelClient.tsx
+++ b/apps/web/app/admin/AdminPanelClient.tsx
@@ -1,0 +1,640 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type {
+  AdminDispute,
+  AdminPanelData,
+  AdminUser,
+  AuditEntry,
+  FlagStatus,
+  PlatformControl,
+  UserRole,
+  UserStatus
+} from "../../lib/adminMock";
+
+type TabId = "overview" | "users" | "moderation" | "disputes" | "controls" | "audit";
+type RoleFilter = "all" | UserRole;
+type StatusFilter = "all" | UserStatus;
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: "overview", label: "Overview" },
+  { id: "users", label: "Users" },
+  { id: "moderation", label: "Moderation" },
+  { id: "disputes", label: "Disputes" },
+  { id: "controls", label: "Controls" },
+  { id: "audit", label: "Audit" }
+];
+
+export function AdminPanelClient({ initialData }: { initialData: AdminPanelData }) {
+  const [activeTab, setActiveTab] = useState<TabId>("overview");
+  const [users, setUsers] = useState(initialData.users);
+  const [flaggedJobs, setFlaggedJobs] = useState(initialData.flaggedJobs);
+  const [disputes, setDisputes] = useState(initialData.disputes);
+  const [controls, setControls] = useState(initialData.controls);
+  const [auditLog, setAuditLog] = useState(initialData.auditLog);
+  const [userSearch, setUserSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [moderationStatus, setModerationStatus] = useState<"all" | FlagStatus>("all");
+  const [auditAction, setAuditAction] = useState("all");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const metrics = useMemo(() => {
+    const activeJobs = users.reduce((sum, user) => sum + user.activeJobs, 0);
+    const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+    const flaggedListings = flaggedJobs.filter((job) => job.status !== "approved").length;
+    const trustBands = [
+      { label: "0-39", count: users.filter((user) => user.trustScore < 40).length },
+      { label: "40-69", count: users.filter((user) => user.trustScore >= 40 && user.trustScore < 70).length },
+      { label: "70-89", count: users.filter((user) => user.trustScore >= 70 && user.trustScore < 90).length },
+      { label: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+    ];
+
+    return {
+      totalUsers: users.length,
+      activeJobs,
+      openDisputes,
+      flaggedListings,
+      revenue: "$128.9k",
+      trustBands
+    };
+  }, [users, disputes, flaggedJobs]);
+
+  const filteredUsers = useMemo(() => {
+    const query = userSearch.toLowerCase();
+    return users.filter((user) => {
+      const matchesSearch =
+        !query ||
+        user.name.toLowerCase().includes(query) ||
+        user.email.toLowerCase().includes(query) ||
+        user.id.toLowerCase().includes(query);
+      const matchesRole = roleFilter === "all" || user.role === roleFilter;
+      const matchesStatus = statusFilter === "all" || user.status === statusFilter;
+      return matchesSearch && matchesRole && matchesStatus;
+    });
+  }, [users, userSearch, roleFilter, statusFilter]);
+
+  const filteredFlags = useMemo(
+    () => flaggedJobs.filter((job) => moderationStatus === "all" || job.status === moderationStatus),
+    [flaggedJobs, moderationStatus]
+  );
+
+  const filteredAudit = useMemo(
+    () => auditLog.filter((entry) => auditAction === "all" || entry.action === auditAction),
+    [auditLog, auditAction]
+  );
+
+  const auditActions = useMemo(() => ["all", ...Array.from(new Set(auditLog.map((entry) => entry.action)))], [auditLog]);
+
+  function recordAudit(action: string, target: string, details: string) {
+    const entry: AuditEntry = {
+      id: `aud_${Date.now()}`,
+      adminId: initialData.session.id,
+      action,
+      target,
+      details,
+      createdAt: new Date().toISOString()
+    };
+    setAuditLog((current) => [entry, ...current]);
+  }
+
+  function updateUserStatus(userId: string, status: UserStatus) {
+    setUsers((current) => current.map((user) => (user.id === userId ? { ...user, status } : user)));
+    recordAudit(status === "active" ? "user.reinstate" : `user.${status}`, userId, `Set user status to ${status}.`);
+  }
+
+  function decideFlag(flagId: string, status: FlagStatus) {
+    setFlaggedJobs((current) => current.map((job) => (job.id === flagId ? { ...job, status } : job)));
+    recordAudit(`job.${status}`, flagId, `Moderation decision changed to ${status}.`);
+  }
+
+  function ruleDispute(disputeId: string, ruling: string) {
+    setDisputes((current) =>
+      current.map((dispute) =>
+        dispute.id === disputeId
+          ? { ...dispute, ruling, status: ruling === "escalate" ? "under_review" : "resolved" }
+          : dispute
+      )
+    );
+    recordAudit(`dispute.${ruling}`, disputeId, `Applied ${ruling} ruling and notified both parties.`);
+  }
+
+  function toggleControl(control: PlatformControl) {
+    const nextState = !control.enabled;
+    const confirmed = window.confirm(`${nextState ? "Enable" : "Disable"} ${control.label}?`);
+    if (!confirmed) {
+      return;
+    }
+
+    setControls((current) =>
+      current.map((entry) =>
+        entry.id === control.id
+          ? {
+              ...entry,
+              enabled: nextState,
+              updatedBy: initialData.session.id,
+              updatedAt: new Date().toISOString()
+            }
+          : entry
+      )
+    );
+    recordAudit(`platform.${control.id}`, control.id, `${control.label} ${nextState ? "enabled" : "disabled"}.`);
+  }
+
+  function refreshData() {
+    setIsRefreshing(true);
+    window.setTimeout(() => setIsRefreshing(false), 500);
+    recordAudit("panel.refresh", "admin-panel", "Manual admin panel refresh completed.");
+  }
+
+  return (
+    <section className="admin-panel">
+      <div className="admin-header">
+        <div>
+          <p className="admin-kicker">Admin Console</p>
+          <h2>Trust and Operations</h2>
+        </div>
+        <button className="admin-button admin-button-primary" type="button" onClick={refreshData}>
+          {isRefreshing ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      <div aria-label="Admin views" className="admin-tabs" role="tablist">
+        {tabs.map((tab) => (
+          <button
+            aria-selected={activeTab === tab.id}
+            className={`admin-tab ${activeTab === tab.id ? "admin-tab-active" : ""}`}
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            role="tab"
+            type="button"
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "overview" && <Overview metrics={metrics} controls={controls} />}
+      {activeTab === "users" && (
+        <UsersView
+          roleFilter={roleFilter}
+          statusFilter={statusFilter}
+          userSearch={userSearch}
+          users={filteredUsers}
+          onRoleFilter={setRoleFilter}
+          onSearch={setUserSearch}
+          onStatusFilter={setStatusFilter}
+          onUpdateStatus={updateUserStatus}
+        />
+      )}
+      {activeTab === "moderation" && (
+        <ModerationView
+          flaggedJobs={filteredFlags}
+          moderationStatus={moderationStatus}
+          onDecision={decideFlag}
+          onStatusFilter={setModerationStatus}
+        />
+      )}
+      {activeTab === "disputes" && <DisputesView disputes={disputes} onRuling={ruleDispute} />}
+      {activeTab === "controls" && <ControlsView controls={controls} onToggle={toggleControl} />}
+      {activeTab === "audit" && (
+        <AuditView actionFilter={auditAction} actions={auditActions} auditLog={filteredAudit} onActionFilter={setAuditAction} />
+      )}
+    </section>
+  );
+}
+
+function Overview({
+  controls,
+  metrics
+}: {
+  controls: PlatformControl[];
+  metrics: {
+    totalUsers: number;
+    activeJobs: number;
+    openDisputes: number;
+    flaggedListings: number;
+    revenue: string;
+    trustBands: { label: string; count: number }[];
+  };
+}) {
+  const maxTrustBand = Math.max(...metrics.trustBands.map((band) => band.count), 1);
+
+  return (
+    <div className="admin-stack">
+      <div className="admin-summary-grid">
+        <MetricCard label="Total users" value={metrics.totalUsers} />
+        <MetricCard label="Active jobs" value={metrics.activeJobs} />
+        <MetricCard label="Open disputes" value={metrics.openDisputes} tone="warn" />
+        <MetricCard label="Flagged listings" value={metrics.flaggedListings} tone="danger" />
+        <MetricCard label="Revenue period" value={metrics.revenue} tone="success" />
+      </div>
+
+      <section className="admin-band">
+        <div className="admin-section-heading">
+          <h3>Trust Score Distribution</h3>
+        </div>
+        <div className="admin-chart">
+          {metrics.trustBands.map((band) => (
+            <div className="admin-bar-row" key={band.label}>
+              <span>{band.label}</span>
+              <div className="admin-bar-track">
+                <div className="admin-bar-fill" style={{ width: `${(band.count / maxTrustBand) * 100}%` }} />
+              </div>
+              <strong>{band.count}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="admin-band">
+        <div className="admin-section-heading">
+          <h3>Platform State</h3>
+        </div>
+        <div className="admin-control-grid">
+          {controls.map((control) => (
+            <div className="admin-control-row" key={control.id}>
+              <span>{control.label}</span>
+              <span className={`admin-badge ${control.enabled ? "admin-badge-success" : "admin-badge-danger"}`}>
+                {control.enabled ? "Enabled" : "Disabled"}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function MetricCard({ label, tone = "neutral", value }: { label: string; tone?: string; value: number | string }) {
+  return (
+    <article className={`admin-metric admin-metric-${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function UsersView({
+  onRoleFilter,
+  onSearch,
+  onStatusFilter,
+  onUpdateStatus,
+  roleFilter,
+  statusFilter,
+  userSearch,
+  users
+}: {
+  onRoleFilter: (role: RoleFilter) => void;
+  onSearch: (search: string) => void;
+  onStatusFilter: (status: StatusFilter) => void;
+  onUpdateStatus: (userId: string, status: UserStatus) => void;
+  roleFilter: RoleFilter;
+  statusFilter: StatusFilter;
+  userSearch: string;
+  users: AdminUser[];
+}) {
+  return (
+    <section className="admin-band">
+      <div className="admin-section-heading">
+        <h3>User Management</h3>
+        <div className="admin-filters">
+          <input
+            aria-label="Search users"
+            onChange={(event) => onSearch(event.target.value)}
+            placeholder="Search users"
+            value={userSearch}
+          />
+          <select aria-label="Role filter" onChange={(event) => onRoleFilter(event.target.value as RoleFilter)} value={roleFilter}>
+            <option value="all">All roles</option>
+            <option value="client">Clients</option>
+            <option value="freelancer">Freelancers</option>
+            <option value="admin">Admins</option>
+          </select>
+          <select
+            aria-label="Status filter"
+            onChange={(event) => onStatusFilter(event.target.value as StatusFilter)}
+            value={statusFilter}
+          >
+            <option value="all">All statuses</option>
+            <option value="active">Active</option>
+            <option value="suspended">Suspended</option>
+            <option value="banned">Banned</option>
+          </select>
+        </div>
+      </div>
+
+      {users.length === 0 ? (
+        <EmptyState label="No users match the current filters." />
+      ) : (
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Joined</th>
+                <th>Trust</th>
+                <th>Jobs</th>
+                <th>Disputes</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <strong>{user.name}</strong>
+                    <span>{user.email}</span>
+                  </td>
+                  <td>{user.role}</td>
+                  <td>
+                    <StatusBadge value={user.status} />
+                  </td>
+                  <td>{user.joinedAt}</td>
+                  <td>{user.trustScore}</td>
+                  <td>{user.activeJobs}</td>
+                  <td>{user.disputes}</td>
+                  <td>
+                    <div className="admin-actions">
+                      <button className="admin-button" onClick={() => onUpdateStatus(user.id, "suspended")} type="button">
+                        Suspend
+                      </button>
+                      <button className="admin-button" onClick={() => onUpdateStatus(user.id, "active")} type="button">
+                        Reinstate
+                      </button>
+                      <button className="admin-button admin-button-danger" onClick={() => onUpdateStatus(user.id, "banned")} type="button">
+                        Ban
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ModerationView({
+  flaggedJobs,
+  moderationStatus,
+  onDecision,
+  onStatusFilter
+}: {
+  flaggedJobs: AdminPanelData["flaggedJobs"];
+  moderationStatus: "all" | FlagStatus;
+  onDecision: (flagId: string, status: FlagStatus) => void;
+  onStatusFilter: (status: "all" | FlagStatus) => void;
+}) {
+  return (
+    <section className="admin-band">
+      <div className="admin-section-heading">
+        <h3>Job Moderation</h3>
+        <select
+          aria-label="Moderation status filter"
+          onChange={(event) => onStatusFilter(event.target.value as "all" | FlagStatus)}
+          value={moderationStatus}
+        >
+          <option value="all">All flags</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="escalated">Escalated</option>
+        </select>
+      </div>
+
+      {flaggedJobs.length === 0 ? (
+        <EmptyState label="No listings match this moderation state." />
+      ) : (
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Listing</th>
+                <th>Client</th>
+                <th>Reason</th>
+                <th>Severity</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {flaggedJobs.map((job) => (
+                <tr key={job.id}>
+                  <td>
+                    <strong>{job.title}</strong>
+                    <span>{job.jobId}</span>
+                  </td>
+                  <td>{job.client}</td>
+                  <td>{job.reason}</td>
+                  <td>
+                    <StatusBadge value={job.severity} />
+                  </td>
+                  <td>
+                    <StatusBadge value={job.status} />
+                  </td>
+                  <td>
+                    <div className="admin-actions">
+                      <button className="admin-button" onClick={() => onDecision(job.id, "approved")} type="button">
+                        Approve
+                      </button>
+                      <button className="admin-button admin-button-danger" onClick={() => onDecision(job.id, "rejected")} type="button">
+                        Reject
+                      </button>
+                      <button className="admin-button" onClick={() => onDecision(job.id, "escalated")} type="button">
+                        Escalate
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DisputesView({
+  disputes,
+  onRuling
+}: {
+  disputes: AdminDispute[];
+  onRuling: (disputeId: string, ruling: string) => void;
+}) {
+  return (
+    <section className="admin-band">
+      <div className="admin-section-heading">
+        <h3>Dispute Resolution</h3>
+      </div>
+      <div className="admin-dispute-grid">
+        {disputes.map((dispute) => (
+          <article className="admin-dispute" key={dispute.id}>
+            <div className="admin-dispute-top">
+              <div>
+                <h4>{dispute.jobTitle}</h4>
+                <p>
+                  {dispute.client} vs {dispute.freelancer}
+                </p>
+              </div>
+              <StatusBadge value={dispute.status} />
+            </div>
+            <dl className="admin-definition-grid">
+              <div>
+                <dt>Amount</dt>
+                <dd>${dispute.amount.toLocaleString()}</dd>
+              </div>
+              <div>
+                <dt>Evidence</dt>
+                <dd>{dispute.evidenceCount}</dd>
+              </div>
+              <div>
+                <dt>Transaction</dt>
+                <dd>{dispute.transactionId}</dd>
+              </div>
+            </dl>
+            <div className="admin-thread">
+              {dispute.thread.map((message) => (
+                <p key={message}>{message}</p>
+              ))}
+            </div>
+            <div className="admin-actions">
+              <button className="admin-button" onClick={() => onRuling(dispute.id, "client")} type="button">
+                Client
+              </button>
+              <button className="admin-button" onClick={() => onRuling(dispute.id, "freelancer")} type="button">
+                Freelancer
+              </button>
+              <button className="admin-button" onClick={() => onRuling(dispute.id, "refund")} type="button">
+                Refund
+              </button>
+              <button className="admin-button admin-button-danger" onClick={() => onRuling(dispute.id, "escalate")} type="button">
+                Escalate
+              </button>
+            </div>
+            {dispute.ruling && <p className="admin-note">Ruling: {dispute.ruling}</p>}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ControlsView({
+  controls,
+  onToggle
+}: {
+  controls: PlatformControl[];
+  onToggle: (control: PlatformControl) => void;
+}) {
+  return (
+    <section className="admin-band">
+      <div className="admin-section-heading">
+        <h3>Platform Controls</h3>
+      </div>
+      <div className="admin-control-grid">
+        {controls.map((control) => (
+          <div className="admin-control-row" key={control.id}>
+            <div>
+              <strong>{control.label}</strong>
+              <span>
+                Updated by {control.updatedBy} at {formatDate(control.updatedAt)}
+              </span>
+            </div>
+            <button
+              aria-pressed={control.enabled}
+              className={`admin-toggle ${control.enabled ? "admin-toggle-on" : ""}`}
+              onClick={() => onToggle(control)}
+              type="button"
+            >
+              {control.enabled ? "On" : "Off"}
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AuditView({
+  actionFilter,
+  actions,
+  auditLog,
+  onActionFilter
+}: {
+  actionFilter: string;
+  actions: string[];
+  auditLog: AuditEntry[];
+  onActionFilter: (action: string) => void;
+}) {
+  return (
+    <section className="admin-band">
+      <div className="admin-section-heading">
+        <h3>Audit Log</h3>
+        <select aria-label="Audit action filter" onChange={(event) => onActionFilter(event.target.value)} value={actionFilter}>
+          {actions.map((action) => (
+            <option key={action} value={action}>
+              {action === "all" ? "All actions" : action}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {auditLog.length === 0 ? (
+        <EmptyState label="No audit events match this filter." />
+      ) : (
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Admin</th>
+                <th>Action</th>
+                <th>Target</th>
+                <th>Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {auditLog.map((entry) => (
+                <tr key={entry.id}>
+                  <td>{formatDate(entry.createdAt)}</td>
+                  <td>{entry.adminId}</td>
+                  <td>{entry.action}</td>
+                  <td>{entry.target}</td>
+                  <td>{entry.details}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StatusBadge({ value }: { value: string }) {
+  const tone =
+    value === "active" || value === "approved" || value === "low" || value === "resolved"
+      ? "success"
+      : value === "pending" || value === "medium" || value === "under_review" || value === "suspended"
+        ? "warn"
+        : "danger";
+
+  return <span className={`admin-badge admin-badge-${tone}`}>{value.replace("_", " ")}</span>;
+}
+
+function EmptyState({ label }: { label: string }) {
+  return <p className="admin-empty">{label}</p>;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(value));
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,19 @@
+import { AdminPanelClient } from "./AdminPanelClient";
+import { adminPanelData } from "../../lib/adminMock";
+
 export default function AdminPanelPage() {
+  const session = adminPanelData.session;
+
+  if (session.role !== "admin") {
+    return (
+      <section className="admin-forbidden" role="alert">
+        <h2>403</h2>
+        <p>Admin access required.</p>
+      </section>
+    );
+  }
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
+    <AdminPanelClient initialData={adminPanelData} />
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,68 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.admin-panel { display: grid; gap: 1rem; }
+.admin-header { align-items: center; display: flex; gap: 1rem; justify-content: space-between; }
+.admin-header h2 { font-size: clamp(1.8rem, 3vw, 2.6rem); margin: 0; }
+.admin-kicker { color: #8fd6b4; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.25rem; text-transform: uppercase; }
+.admin-tabs { background: #10182e; border: 1px solid #2a3765; border-radius: 8px; display: flex; gap: 0.35rem; overflow-x: auto; padding: 0.35rem; }
+.admin-tab { background: transparent; border: 0; border-radius: 6px; color: #b8c4e6; cursor: pointer; font: inherit; min-height: 2.25rem; padding: 0.45rem 0.75rem; white-space: nowrap; }
+.admin-tab-active { background: #eef4ff; color: #0d1430; font-weight: 700; }
+.admin-stack { display: grid; gap: 1rem; }
+.admin-summary-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.admin-metric { background: #111a31; border: 1px solid #2a3765; border-left: 4px solid #84a9ff; border-radius: 8px; display: grid; gap: 0.35rem; min-height: 5.5rem; padding: 0.9rem; }
+.admin-metric span { color: #aebbe1; font-size: 0.82rem; }
+.admin-metric strong { font-size: 1.6rem; }
+.admin-metric-success { border-left-color: #7dd3a8; }
+.admin-metric-warn { border-left-color: #f7c948; }
+.admin-metric-danger { border-left-color: #ff8f8f; }
+.admin-band { background: #111a31; border: 1px solid #2a3765; border-radius: 8px; padding: 1rem; }
+.admin-section-heading { align-items: center; display: flex; gap: 1rem; justify-content: space-between; margin-bottom: 0.85rem; }
+.admin-section-heading h3 { font-size: 1.05rem; margin: 0; }
+.admin-filters { display: flex; flex-wrap: wrap; gap: 0.5rem; justify-content: flex-end; }
+.admin-filters input, .admin-filters select, .admin-section-heading select { background: #0b1020; border: 1px solid #344575; border-radius: 6px; color: #f2f5ff; min-height: 2.25rem; padding: 0.45rem 0.6rem; }
+.admin-table-wrap { overflow-x: auto; }
+.admin-table { border-collapse: collapse; min-width: 820px; width: 100%; }
+.admin-table th, .admin-table td { border-bottom: 1px solid #26345f; padding: 0.75rem; text-align: left; vertical-align: middle; }
+.admin-table th { color: #aebbe1; font-size: 0.76rem; text-transform: uppercase; }
+.admin-table td span { color: #aebbe1; display: block; font-size: 0.82rem; margin-top: 0.15rem; }
+.admin-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.admin-button { background: #182541; border: 1px solid #3b4e82; border-radius: 6px; color: #f2f5ff; cursor: pointer; font: inherit; min-height: 2.1rem; padding: 0.4rem 0.65rem; }
+.admin-button-primary { background: #eef4ff; color: #0d1430; font-weight: 700; }
+.admin-button-danger { border-color: #b95b68; color: #ffd7dc; }
+.admin-badge { border: 1px solid currentColor; border-radius: 999px; display: inline-flex; font-size: 0.74rem; font-weight: 700; padding: 0.2rem 0.5rem; text-transform: capitalize; }
+.admin-badge-success { color: #7dd3a8; }
+.admin-badge-warn { color: #f7c948; }
+.admin-badge-danger { color: #ff9aa7; }
+.admin-chart { display: grid; gap: 0.65rem; }
+.admin-bar-row { align-items: center; display: grid; gap: 0.65rem; grid-template-columns: 4rem 1fr 2rem; }
+.admin-bar-track { background: #0b1020; border-radius: 999px; height: 0.75rem; overflow: hidden; }
+.admin-bar-fill { background: linear-gradient(90deg, #7dd3a8, #84a9ff); height: 100%; }
+.admin-control-grid { display: grid; gap: 0.75rem; }
+.admin-control-row { align-items: center; background: #0d1428; border: 1px solid #26345f; border-radius: 8px; display: flex; justify-content: space-between; min-height: 4rem; padding: 0.8rem; }
+.admin-control-row span { color: #aebbe1; display: block; font-size: 0.82rem; margin-top: 0.2rem; }
+.admin-toggle { background: #2c365c; border: 1px solid #50608f; border-radius: 999px; color: #f2f5ff; cursor: pointer; font-weight: 700; min-width: 4rem; padding: 0.45rem 0.75rem; }
+.admin-toggle-on { background: #1f6b4f; border-color: #7dd3a8; }
+.admin-dispute-grid { display: grid; gap: 0.9rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.admin-dispute { background: #0d1428; border: 1px solid #26345f; border-radius: 8px; display: grid; gap: 0.8rem; padding: 1rem; }
+.admin-dispute h4, .admin-dispute p { margin: 0; }
+.admin-dispute-top { align-items: start; display: flex; gap: 0.75rem; justify-content: space-between; }
+.admin-dispute-top p, .admin-note { color: #aebbe1; }
+.admin-definition-grid { display: grid; gap: 0.5rem; grid-template-columns: repeat(3, 1fr); margin: 0; }
+.admin-definition-grid div { background: #111a31; border-radius: 6px; padding: 0.55rem; }
+.admin-definition-grid dt { color: #aebbe1; font-size: 0.72rem; }
+.admin-definition-grid dd { font-weight: 700; margin: 0.2rem 0 0; }
+.admin-thread { display: grid; gap: 0.4rem; }
+.admin-thread p { background: #111a31; border-left: 3px solid #84a9ff; border-radius: 6px; color: #dce6ff; padding: 0.55rem; }
+.admin-empty, .admin-forbidden { background: #111a31; border: 1px solid #2a3765; border-radius: 8px; color: #c5d0ee; padding: 1rem; }
+
+@media (max-width: 720px) {
+  .admin-header, .admin-section-heading, .admin-control-row { align-items: stretch; flex-direction: column; }
+  .admin-filters { justify-content: stretch; }
+  .admin-filters input, .admin-filters select, .admin-section-heading select { width: 100%; }
+  .admin-definition-grid { grid-template-columns: 1fr; }
+}

--- a/apps/web/lib/adminMock.ts
+++ b/apps/web/lib/adminMock.ts
@@ -1,0 +1,223 @@
+export type UserRole = "client" | "freelancer" | "admin";
+export type UserStatus = "active" | "suspended" | "banned";
+export type FlagStatus = "pending" | "approved" | "rejected" | "escalated";
+export type DisputeStatus = "open" | "under_review" | "resolved";
+
+export type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  status: UserStatus;
+  joinedAt: string;
+  trustScore: number;
+  activeJobs: number;
+  disputes: number;
+};
+
+export type FlaggedJob = {
+  id: string;
+  jobId: string;
+  title: string;
+  client: string;
+  reason: string;
+  severity: "low" | "medium" | "high";
+  status: FlagStatus;
+  flaggedAt: string;
+};
+
+export type AdminDispute = {
+  id: string;
+  client: string;
+  freelancer: string;
+  jobTitle: string;
+  amount: number;
+  status: DisputeStatus;
+  evidenceCount: number;
+  transactionId: string;
+  updatedAt: string;
+  thread: string[];
+  ruling: string | null;
+};
+
+export type PlatformControl = {
+  id: "registrations" | "jobPostings";
+  label: string;
+  enabled: boolean;
+  updatedBy: string;
+  updatedAt: string;
+};
+
+export type AuditEntry = {
+  id: string;
+  adminId: string;
+  action: string;
+  target: string;
+  details: string;
+  createdAt: string;
+};
+
+export type AdminPanelData = {
+  session: {
+    id: string;
+    name: string;
+    role: UserRole;
+  };
+  users: AdminUser[];
+  flaggedJobs: FlaggedJob[];
+  disputes: AdminDispute[];
+  controls: PlatformControl[];
+  auditLog: AuditEntry[];
+};
+
+export const adminPanelData: AdminPanelData = {
+  session: {
+    id: "admin_demo",
+    name: "Operations Admin",
+    role: "admin"
+  },
+  users: [
+    {
+      id: "usr_1001",
+      name: "Maya Chen",
+      email: "maya@example.com",
+      role: "freelancer",
+      status: "active",
+      joinedAt: "2026-02-14",
+      trustScore: 96,
+      activeJobs: 4,
+      disputes: 0
+    },
+    {
+      id: "usr_1002",
+      name: "Jordan Lee",
+      email: "jordan@example.com",
+      role: "client",
+      status: "active",
+      joinedAt: "2026-03-02",
+      trustScore: 89,
+      activeJobs: 2,
+      disputes: 1
+    },
+    {
+      id: "usr_1003",
+      name: "Riley Stone",
+      email: "riley@example.com",
+      role: "freelancer",
+      status: "suspended",
+      joinedAt: "2026-04-11",
+      trustScore: 54,
+      activeJobs: 1,
+      disputes: 2
+    },
+    {
+      id: "usr_1004",
+      name: "Avery Patel",
+      email: "avery@example.com",
+      role: "client",
+      status: "banned",
+      joinedAt: "2026-01-20",
+      trustScore: 18,
+      activeJobs: 0,
+      disputes: 4
+    }
+  ],
+  flaggedJobs: [
+    {
+      id: "flag_2001",
+      jobId: "job_3001",
+      title: "Scrape competitor customer data",
+      client: "Avery Patel",
+      reason: "Potential policy violation",
+      severity: "high",
+      status: "pending",
+      flaggedAt: "2026-05-27T14:21:00.000Z"
+    },
+    {
+      id: "flag_2002",
+      jobId: "job_3002",
+      title: "Rebuild checkout analytics dashboard",
+      client: "Jordan Lee",
+      reason: "Budget anomaly",
+      severity: "medium",
+      status: "pending",
+      flaggedAt: "2026-05-28T09:05:00.000Z"
+    },
+    {
+      id: "flag_2003",
+      jobId: "job_3003",
+      title: "Write landing page copy",
+      client: "Nora Kim",
+      reason: "Repeated report from freelancers",
+      severity: "low",
+      status: "escalated",
+      flaggedAt: "2026-05-29T16:44:00.000Z"
+    }
+  ],
+  disputes: [
+    {
+      id: "dsp_4001",
+      client: "Jordan Lee",
+      freelancer: "Maya Chen",
+      jobTitle: "API billing integration",
+      amount: 2400,
+      status: "open",
+      evidenceCount: 5,
+      transactionId: "pi_928391",
+      updatedAt: "2026-05-29T20:12:00.000Z",
+      thread: [
+        "Client says milestone 2 is incomplete.",
+        "Freelancer uploaded delivery notes and test evidence.",
+        "Escrow payment is currently held."
+      ],
+      ruling: null
+    },
+    {
+      id: "dsp_4002",
+      client: "Nora Kim",
+      freelancer: "Riley Stone",
+      jobTitle: "Brand refresh deck",
+      amount: 850,
+      status: "under_review",
+      evidenceCount: 3,
+      transactionId: "pi_928407",
+      updatedAt: "2026-05-28T11:33:00.000Z",
+      thread: ["Freelancer missed the revision window.", "Client uploaded the original scope document."],
+      ruling: null
+    }
+  ],
+  controls: [
+    {
+      id: "registrations",
+      label: "New user registrations",
+      enabled: true,
+      updatedBy: "admin_demo",
+      updatedAt: "2026-05-29T19:15:00.000Z"
+    },
+    {
+      id: "jobPostings",
+      label: "New job postings",
+      enabled: true,
+      updatedBy: "admin_demo",
+      updatedAt: "2026-05-29T19:15:00.000Z"
+    }
+  ],
+  auditLog: [
+    {
+      id: "aud_5001",
+      adminId: "admin_demo",
+      action: "user.suspend",
+      target: "usr_1003",
+      details: "Suspended while dispute evidence is reviewed.",
+      createdAt: "2026-05-29T18:41:00.000Z"
+    },
+    {
+      id: "aud_5002",
+      adminId: "admin_demo",
+      action: "job.escalate",
+      target: "flag_2003",
+      details: "Escalated repeated report to senior moderation.",
+      createdAt: "2026-05-29T19:02:00.000Z"
+    }
+  ]
+};


### PR DESCRIPTION
/claim #29

## Summary
- Replaced the placeholder admin page with a tabbed operations console covering overview, users, job moderation, disputes, platform controls, and audit log.
- Added interactive user search/filtering, suspend/reinstate/ban actions, moderation approve/reject/escalate actions, dispute rulings, confirmation-backed platform toggles, and audit event recording.
- Added mock admin panel data for realistic users, flagged listings, disputes, controls, and audit entries.
- Expanded `/api/admin` with admin-only role enforcement plus users, moderation, disputes, platform controls, and audit-log routes.
- Added append-only in-memory audit entries for admin actions and paginated server responses for admin tables.

## Acceptance Coverage
- Admin role enforcement: `authMiddleware` plus new `adminOnly` middleware on every `/api/admin` route.
- User management: filterable/searchable user table with suspend, reinstate, and ban actions.
- Job moderation: flagged listing queue with approve, reject, and escalate decisions.
- Disputes: queue cards with evidence, transaction detail, thread context, and ruling actions.
- Trust metrics: overview counters and trust-score distribution chart.
- Platform controls: registration/job posting toggles with confirmation and audit entries.
- Audit log: filterable action log populated from user, moderation, dispute, control, and refresh actions.

## Validation
- `node --check apps/api/src/services/adminService.js` -> passed
- `node --check apps/api/src/controllers/adminController.js` -> passed
- `node --check apps/api/src/routes/adminRoutes.js` -> passed
- `node --check apps/api/src/middleware/adminOnly.js` -> passed
- `git diff --check` -> passed

I could not run `npm run build -w apps/web` locally because this environment has Node but no `npm` binary or installed `node_modules`.