### PR TITLE
Fix: require admin role for admin metrics endpoint (Fixes #1764)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,12 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return (req, res, next) => {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
 
 test("registerSchema role validation", () => {
   // Valid roles
@@ -35,4 +37,17 @@ test("registerSchema role validation", () => {
       role: "admin"
     });
   });
+});
+
+test("registerUser token sub matches returned user id", async () => {
+  const payload = {
+    email: "test@example.com",
+    role: "client"
+  };
+  const result = await registerUser(payload);
+  assert.ok(result.id);
+  assert.ok(result.token);
+  
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, result.id, "JWT subject must match the returned user id exactly");
 });

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema role validation", () => {
+  // Valid roles
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123"
+    });
+  });
+
+  // Invalid role: admin should fail validation
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  });
+});

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { registerSchema } from "../validators/auth.js";
 import { registerUser } from "../services/authService.js";
 import { verifyAccessToken } from "../utils/jwt.js";
+import { requireRole } from "../middleware/auth.js";
 
 test("registerSchema role validation", () => {
   // Valid roles
@@ -50,4 +51,49 @@ test("registerUser token sub matches returned user id", async () => {
   
   const decoded = verifyAccessToken(result.token);
   assert.equal(decoded.sub, result.id, "JWT subject must match the returned user id exactly");
+});
+
+test("requireRole middleware allows correct role", () => {
+  const middleware = requireRole("admin");
+  const req = { user: { role: "admin" } };
+  let calledNext = false;
+  const res = {
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      return this;
+    }
+  };
+  const next = () => { calledNext = true; };
+
+  middleware(req, res, next);
+  assert.ok(calledNext);
+});
+
+test("requireRole middleware rejects incorrect role", () => {
+  const middleware = requireRole("admin");
+  const req = { user: { role: "client" } };
+  let calledNext = false;
+  let responseStatus = 0;
+  let responseBody = null;
+  const res = {
+    status(code) {
+      responseStatus = code;
+      return this;
+    },
+    json(data) {
+      responseBody = data;
+      return this;
+    }
+  };
+  const next = () => { calledNext = true; };
+
+  middleware(req, res, next);
+  assert.ok(!calledNext);
+  assert.equal(responseStatus, 403);
+  assert.equal(responseBody.success, false);
+  assert.equal(responseBody.message, "Forbidden");
 });

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposalSchema } from "../validators/proposal.js";
+
+test("createProposalSchema accepts valid payload", () => {
+  assert.doesNotThrow(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250,
+      estDuration: "5 days"
+    });
+  });
+});
+
+test("createProposalSchema rejects missing or blank estDuration", () => {
+  // Missing estDuration
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250
+    });
+  });
+
+  // Blank estDuration
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250,
+      estDuration: ""
+    });
+  });
+});
+
+test("createProposalSchema rejects missing or invalid required fields", () => {
+  // Missing jobId
+  assert.throws(() => {
+    createProposalSchema.parse({
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250,
+      estDuration: "5 days"
+    });
+  });
+
+  // Missing freelancerId
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250,
+      estDuration: "5 days"
+    });
+  });
+
+  // Missing coverLetter
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      bidAmount: 250,
+      estDuration: "5 days"
+    });
+  });
+
+  // Missing or negative bidAmount
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      estDuration: "5 days"
+    });
+  });
+
+  assert.throws(() => {
+    createProposalSchema.parse({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: -10,
+      estDuration: "5 days"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1)
+});


### PR DESCRIPTION
## Description

Adds a `requireRole` authorization middleware that checks if `req.user.role` matches the expected role. Enforces that only users with the `admin` role can access the `/api/admin/metrics` endpoint under `adminRoutes`.

## Changes
- Added `requireRole(role)` middleware in `apps/api/src/middleware/auth.js`.
- Enforced `requireRole('admin')` in `apps/api/src/routes/adminRoutes.js`.
- Added unit tests for the role verification middleware in `apps/api/src/tests/auth.test.js`.

Closes #1764