### PR TITLE
fix(users): validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...safePayload } = payload;
+  const user = { ...safePayload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userController.test.js
+++ b/apps/api/src/tests/userController.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.issues.some((issue) => issue.path === "name"));
+    assert.ok(payload.issues.some((issue) => issue.path === "email"));
+  });
+});
+
+test("POST /api/users rejects client-controlled ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        name: "Mallory",
+        email: "mallory@example.com",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.issues.some((issue) => issue.message.includes("Unrecognized key")));
+  });
+});
+
+test("POST /api/users returns a server-generated id for valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Maya Chen",
+        email: "maya@example.com",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.equal(payload.data.name, "Maya Chen");
+    assert.equal(payload.data.email, "maya@example.com");
+    assert.equal(payload.data.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    email: z.string().email(),
+    role: z.enum(["client", "freelancer"]).default("client")
+  })
+  .strict();


### PR DESCRIPTION
/claim #743

Fixes #1766

## Summary
- Added a strict user creation schema requiring `name` and valid `email`, defaulting public roles to `client`, and rejecting unknown fields such as `id`.
- Updated `/api/users` creation to validate input before calling the service.
- Kept the server-generated `usr_...` ID authoritative in `createUser`, even if the service is called directly with an `id` field.
- Added Zod validation handling in the API error middleware so invalid request payloads return a structured 400 instead of a generic 500.
- Added focused API tests for empty payload rejection, client-controlled ID rejection, and valid server-generated user IDs.

## Validation
- `node --check apps/api/src/validators/user.js` -> passed
- `node --check apps/api/src/controllers/userController.js` -> passed
- `node --check apps/api/src/services/userService.js` -> passed
- `node --check apps/api/src/middleware/errorHandler.js` -> passed
- `node --check apps/api/src/tests/userController.test.js` -> passed
- `git diff --check` -> passed

The full API tests are included for normal `npm test -w apps/api` runs; they were not executed in this checkout because dependencies are not installed locally.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.