### PR TITLE
fix: add input validation and query length limit to search endpoint (Fixes #1777)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 256;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = (req.query.q ?? "").trim();
+  
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query too long. Maximum length is ${MAX_QUERY_LENGTH} characters.`, 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Added MAX_QUERY_LENGTH validation to prevent DoS via extremely long query strings.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`