### PR TITLE
fix: add Content-Type validation middleware for JSON endpoints

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
+import { jsonContentType } from "./middleware/contentType.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,6 +22,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
+  app.use(jsonContentType);
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/contentType.js
+++ b/apps/api/src/middleware/contentType.js
@@ -1,0 +1,13 @@
+import { fail } from "../utils/response.js";
+
+const JSON_METHODS = new Set(["POST", "PUT", "PATCH"]);
+
+export function jsonContentType(req, res, next) {
+  if (JSON_METHODS.has(req.method)) {
+    const ct = (req.headers["content-type"] || "").toLowerCase();
+    if (!ct.includes("application/json")) {
+      return fail(res, "Content-Type must be application/json", 415);
+    }
+  }
+  return next();
+}


### PR DESCRIPTION
Added middleware that enforces application/json Content-Type for POST, PUT, and PATCH requests.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`