### PR TITLE
fix: add request body size limit to prevent payload flooding

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "1mb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
Added express.json({ limit: '1mb' }) to prevent large payload attacks.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`