### PR TITLE
fix: add strict rate limiting to auth endpoints to prevent brute force

### DIFF
--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,18 @@
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  message: { error: "Too many requests. Try again later." },
+});
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
 authRoutes.post("/refresh", refresh);


### PR DESCRIPTION
Added 10 requests per 15 minutes rate limit to /auth/login and /auth/register.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`