### PR TITLE
Add actionable settings overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,30 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
+button { font: inherit; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.settings-page { display: grid; gap: 1rem; }
+.settings-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.settings-header h2, .settings-panel h3 { margin: 0; }
+.eyebrow { margin: 0 0 0.35rem; color: #8cc6ff; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.status-pill { display: inline-flex; align-items: center; width: fit-content; border: 1px solid #5aa56f; border-radius: 999px; padding: 0.25rem 0.55rem; color: #c7f7d2; background: #14321f; font-size: 0.8rem; white-space: nowrap; }
+.status-pill.subtle { border-color: #405173; color: #d7e2ff; background: #1c2744; }
+.settings-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; }
+.settings-summary div, .settings-panel { border: 1px solid #2a3765; border-radius: 8px; background: #151c35; padding: 1rem; }
+.settings-summary strong, .settings-summary span { display: block; }
+.settings-summary span, .settings-panel p, .settings-list dt { color: #aebbe0; }
+.settings-grid { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.settings-panel { display: grid; gap: 1rem; }
+.settings-panel-header { display: flex; align-items: start; justify-content: space-between; gap: 1rem; }
+.settings-panel button { border: 1px solid #6f89c9; border-radius: 6px; background: #f2f5ff; color: #10172a; padding: 0.45rem 0.7rem; cursor: pointer; white-space: nowrap; }
+.settings-list { display: grid; gap: 0.8rem; margin: 0; }
+.settings-list div { display: grid; gap: 0.25rem; }
+.settings-list dt { font-size: 0.86rem; }
+.settings-list dd { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; margin: 0; }
+@media (max-width: 720px) {
+  .settings-header, .settings-panel-header, .settings-list dd { align-items: stretch; flex-direction: column; }
+  .settings-summary, .settings-grid { grid-template-columns: 1fr; }
+  .settings-panel button { width: 100%; }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,101 @@
 export default function SettingsPage() {
+  const settingsGroups = [
+    {
+      id: "account-profile",
+      title: "Account profile",
+      description: "Public marketplace identity and profile discovery.",
+      items: [
+        { label: "Profile visibility", value: "Public", status: "Active" },
+        { label: "Primary role", value: "Client and freelancer", status: "Synced" },
+        { label: "Portfolio review", value: "Updated 2 days ago", status: "Current" }
+      ],
+      action: "Review profile"
+    },
+    {
+      id: "notifications",
+      title: "Notifications",
+      description: "Proposal, message, and billing delivery preferences.",
+      items: [
+        { label: "Proposal updates", value: "Email and in-app", status: "On" },
+        { label: "Unread message digest", value: "Daily summary", status: "On" },
+        { label: "Billing alerts", value: "Instant", status: "On" }
+      ],
+      action: "Tune alerts"
+    },
+    {
+      id: "security",
+      title: "Security",
+      description: "Account protection and session health.",
+      items: [
+        { label: "Two-step verification", value: "Authenticator app", status: "Enabled" },
+        { label: "Last password change", value: "18 days ago", status: "Healthy" },
+        { label: "Active sessions", value: "2 trusted devices", status: "Review" }
+      ],
+      action: "Manage access"
+    },
+    {
+      id: "billing-defaults",
+      title: "Billing defaults",
+      description: "Invoice, payout, and tax preference summary.",
+      items: [
+        { label: "Default invoice currency", value: "USD", status: "Set" },
+        { label: "Payout method", value: "Bank account ending 1842", status: "Verified" },
+        { label: "Tax profile", value: "Individual contractor", status: "Complete" }
+      ],
+      action: "Open billing"
+    }
+  ];
+
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section className="settings-page">
+      <div className="settings-header">
+        <div>
+          <p className="eyebrow">Account center</p>
+          <h2>Settings</h2>
+        </div>
+        <span className="status-pill">4 areas configured</span>
+      </div>
+
+      <div className="settings-summary" aria-label="Account settings summary">
+        <div>
+          <strong>Public profile</strong>
+          <span>Visible to marketplace clients</span>
+        </div>
+        <div>
+          <strong>Security score</strong>
+          <span>Strong account posture</span>
+        </div>
+        <div>
+          <strong>Billing status</strong>
+          <span>Payouts ready</span>
+        </div>
+      </div>
+
+      <div className="settings-grid">
+        {settingsGroups.map((group) => (
+          <section className="settings-panel" key={group.id} aria-labelledby={`${group.id}-heading`}>
+            <div className="settings-panel-header">
+              <div>
+                <h3 id={`${group.id}-heading`}>{group.title}</h3>
+                <p>{group.description}</p>
+              </div>
+              <button type="button">{group.action}</button>
+            </div>
+
+            <dl className="settings-list">
+              {group.items.map((item) => (
+                <div key={item.label}>
+                  <dt>{item.label}</dt>
+                  <dd>
+                    <span>{item.value}</span>
+                    <span className="status-pill subtle">{item.status}</span>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- Replaces the `/settings` placeholder card with a static account settings overview.
- Adds account profile, notifications, security, and billing defaults sections with status chips and next-action controls.
- Keeps the change scoped to frontend display only.

Fixes #1795

## Validation
- `git diff --check`
- Static validation with bundled Node.js: checked expected settings content in `apps/web/app/settings/page.tsx`

## Note
- `npm run build -w apps/web` was not run because this environment has no `npm`, `npx`, `pnpm`, or `corepack` executable available.