### PR TITLE
fix: prevent self-assignment of admin-level roles (Fixes #1426)

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +6,9 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
+  const { role } = req.body || {};
+  if (role === "admin" || role === "master_admin") {
+    return fail(res, "Admin-level roles cannot be self-assigned.", 403);
+  }
   return ok(res, await createUser(req.body), 201);
 }


### PR DESCRIPTION
Blocked users from setting admin or master_admin role during registration.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`