### PR TITLE
fix: add rate limiting to proposal creation endpoint

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,16 @@
 import { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+
+
+const proposalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 30,
+  standardHeaders: "draft-7",
+  message: { error: "Too many requests. Try again later." },
+});
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", proposalLimiter, postProposal);


### PR DESCRIPTION
Added rate limiting (30 requests per 15 min) to POST /api/proposals.

**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`