### PR TITLE
fix: prevent admin role self-assignment via registration endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## What

Two bug fixes in the auth flow: admin role self-assignment and missing refresh token.

### 1. Registration schema restricted
Removed `"admin"` from the allowed role enum in `registerSchema` so that only `"client"` and `"freelancer"` roles can be assigned during registration.

### 2. Refresh token passed correctly
The `refresh()` controller was calling `refreshToken()` without arguments. Now extracts `token` from `req.body` and passes it to the service.

## Why

- Any user could register as an admin by sending `{"role": "admin"}` in the registration body, granting unauthorized elevated privileges.
- The refresh endpoint was broken because the token from the request body was never forwarded to the service function.

## Testing

- Verified `registerSchema` now rejects `"admin"` role with `Invalid enum value`
- Verified `registerSchema` still accepts `"client"`, `"freelancer"`, and omitting role (defaults to `"client"`)
- Verified `refresh` controller extracts `req.body.token` and passes it to `refreshToken()`
- Fixes issues described in #1823