### PR TITLE
feat: add actionable settings overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,23 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
+button { font: inherit; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.settings-hero { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.settings-hero p { margin-bottom: 0; color: #b8c3e6; }
+.settings-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.settings-panel { display: flex; flex-direction: column; gap: 1rem; min-height: 100%; }
+.settings-panel__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; }
+.settings-panel h3 { margin: 0; font-size: 1.05rem; }
+.settings-list { display: grid; gap: 0.75rem; margin: 0; }
+.settings-list__row { display: grid; gap: 0.25rem; }
+.settings-list dt { color: #b8c3e6; font-size: 0.85rem; }
+.settings-list dd { margin: 0; font-weight: 600; }
+.settings-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: auto; }
+.status-chip { border-radius: 999px; padding: 0.25rem 0.6rem; white-space: nowrap; font-size: 0.78rem; font-weight: 700; }
+.status-chip--ready { background: #163f34; color: #8ff0c8; border: 1px solid #2d8268; }
+.status-chip--warning { background: #4c3216; color: #ffd08a; border: 1px solid #9a6a2f; }
+.button { border: 1px solid #7aa2ff; border-radius: 8px; padding: 0.5rem 0.75rem; color: #f2f5ff; background: #315ac5; cursor: pointer; }
+.button--secondary { background: transparent; color: #c9d5ff; border-color: #4b5f99; }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,92 @@
 export default function SettingsPage() {
+  const sections = [
+    {
+      title: "Account and profile",
+      status: "Public profile",
+      rows: [
+        ["Display name", "Maya Chen"],
+        ["Primary role", "Client"],
+        ["Profile visibility", "Visible to verified freelancers"]
+      ],
+      actions: ["Edit profile", "Preview"]
+    },
+    {
+      title: "Notifications",
+      status: "Digest enabled",
+      rows: [
+        ["Proposal updates", "Email and in-app"],
+        ["Message alerts", "In-app only"],
+        ["Billing notices", "Email required"]
+      ],
+      actions: ["Manage alerts", "Send test"]
+    },
+    {
+      title: "Security",
+      status: "Needs review",
+      rows: [
+        ["Two-factor auth", "Not enabled"],
+        ["Password age", "Updated 42 days ago"],
+        ["Active sessions", "2 trusted devices"]
+      ],
+      actions: ["Enable 2FA", "Review sessions"]
+    },
+    {
+      title: "Billing and payouts",
+      status: "Ready",
+      rows: [
+        ["Default payment", "USDC escrow"],
+        ["Payout cadence", "Manual release"],
+        ["Tax profile", "Not required for mock account"]
+      ],
+      actions: ["Update method", "View invoices"]
+    }
+  ];
+
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section>
+      <div className="card settings-hero">
+        <div>
+          <h2>Settings</h2>
+          <p>Review account defaults, profile visibility, security posture, and payout preferences.</p>
+        </div>
+        <span className="status-chip status-chip--ready">Account active</span>
+      </div>
+
+      <div className="settings-grid">
+        {sections.map((section) => (
+          <article className="card settings-panel" key={section.title}>
+            <div className="settings-panel__header">
+              <h3>{section.title}</h3>
+              <span
+                className={
+                  section.status === "Needs review"
+                    ? "status-chip status-chip--warning"
+                    : "status-chip status-chip--ready"
+                }
+              >
+                {section.status}
+              </span>
+            </div>
+
+            <dl className="settings-list">
+              {section.rows.map(([label, value]) => (
+                <div key={label} className="settings-list__row">
+                  <dt>{label}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            <div className="settings-actions">
+              {section.actions.map((action, index) => (
+                <button className={index === 0 ? "button" : "button button--secondary"} key={action} type="button">
+                  {action}
+                </button>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes #1834.

## Summary
- replace the `/settings` placeholder with a static account settings overview
- add account/profile, notifications, security, and billing/payout preference sections
- add status chips and next-action controls while keeping all data mocked and frontend-only

## Verification
- `npm run build -w apps/web` -> passed
- `git diff --check` -> clean