### PR TITLE
Fix: restrict register roles and extract refresh token (Fixes #1823)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,14 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const { token } = req.body || {};
+  if (!token) {
+    return fail(res, "Token required", 401);
+  }
+  try {
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch (err) {
+    return fail(res, err.message, 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,14 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  if (!token) {
+    throw new Error("Token required");
+  }
+  try {
+    const decoded = verifyAccessToken(token);
+    return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
+  } catch (err) {
+    throw new Error("Invalid token");
+  }
 }

--- a/apps/api/src/tests/auth1823.test.js
+++ b/apps/api/src/tests/auth1823.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Bug #1823: registerSchema role restrictions", () => {
+  // Valid roles should not throw
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "client@banana.com",
+      password: "securepassword123",
+      role: "client"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "freelancer@banana.com",
+      password: "securepassword123",
+      role: "freelancer"
+    });
+  });
+
+  // admin role should be rejected and throw a ZodError
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "attacker@banana.com",
+      password: "securepassword123",
+      role: "admin"
+    });
+  });
+});
+
+test("Bug #1823: refresh endpoint validation", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("POST /api/auth/refresh without token fails with 401", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Token required");
+  });
+
+  await t.test("POST /api/auth/refresh with invalid token fails with 401", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "invalid_token_xyz" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token");
+  });
+
+  await t.test("POST /api/auth/refresh with valid token succeeds", async () => {
+    const validToken = signAccessToken({ sub: "usr_123", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: validToken })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.token);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
This PR resolves #1823 by restricting registerSchema role options to client/freelancer and validating/passing the refresh token from req.body to refreshToken().