### PR TITLE
Patch production dependency audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "overrides": {
+        "postcss": "8.5.10"
+      }
     },
     "apps/api": {
       "name": "@freelanceflow/api",
@@ -1672,9 +1675,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1691,9 +1694,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "packages/*"
       ],
       "overrides": {
-        "postcss": "8.5.10"
+        "postcss": "8.5.10",
+        "qs": "6.15.2"
       }
     },
     "apps/api": {
@@ -1736,9 +1737,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "apps/*",
     "packages/*"
   ],
+  "overrides": {
+    "postcss": "8.5.10"
+  },
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "packages/*"
   ],
   "overrides": {
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "qs": "6.15.2"
   },
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",


### PR DESCRIPTION
## Summary
- add root npm overrides for patched `postcss@8.5.10` and `qs@6.15.2`
- refresh the lockfile entries so production dependency auditing no longer reports GHSA-qx2v-qp2m-jg93 or GHSA-q8mj-m7cp-5q26
- keep existing direct dependency versions, including `next@16.2.6`, unchanged

## Validation
- `npm audit --omit=dev` -> `found 0 vulnerabilities`
- `node --test apps\api\src\tests\*.test.js` passes
- `git diff --check` passes

Note: the root `npm test` script still fails on Windows because `node --test src/tests` is treated as a missing file path rather than expanding to the test files. The focused Node test command above exercises the existing API test file successfully.

Fixes #1874
Fixes #1888
/claim #743