### PR TITLE
fix(auth): prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/validators.test.js
+++ b/apps/api/src/tests/validators.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  assert.throws(() => {
+    registerSchema.parse({ email: "a@b.com", password: "12345678", role: "admin" });
+  }, /Invalid enum value/);
+});
+
+test("registerSchema allows client role", () => {
+  const result = registerSchema.parse({ email: "a@b.com", password: "12345678", role: "client" });
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema allows freelancer role", () => {
+  const result = registerSchema.parse({ email: "a@b.com", password: "12345678", role: "freelancer" });
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerSchema defaults to client when role omitted", () => {
+  const result = registerSchema.parse({ email: "a@b.com", password: "12345678" });
+  assert.equal(result.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## What

Removes `"admin"` from the `registerSchema` role enum so public registration only accepts `"client"` and `"freelancer"`. The default role remains `"client"`.

## Why

Without this restriction, any unauthenticated caller can self-assign the admin role by including `role: "admin"` in the registration payload, gaining unauthorized administrative access.

## Testing

- `admin` role in request → Zod throws `Invalid enum value`
- `client` and `freelancer` roles → accepted
- Omitted role → defaults to `client`

```
npm test
# 4 tests passed
```

Closes #1871