### PR TITLE
fix: add admin role authorization check on admin routes

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,17 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
+function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  return next();
+}
+
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminOnly);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+// Run all assertions against a single server instance to avoid
+// port-binding races with Node test runner concurrency.
+test("admin routes authorization", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    // 1. No auth → 401
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+      assert.equal(res.status, 401, "no token should get 401");
+    }
+
+    // 2. Client token → 403
+    {
+      const token = signAccessToken({ sub: "usr_client", role: "client" });
+      const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      assert.equal(res.status, 403, "client role should get 403");
+    }
+
+    // 3. Admin token → 200
+    {
+      const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+      const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      assert.equal(res.status, 200, "admin role should get 200");
+    }
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});


### PR DESCRIPTION
## What

Adds an `adminOnly` middleware to the admin router that checks `req.user.role === "admin"` before allowing access. The existing `authMiddleware` already verifies the JWT is valid — this adds the missing role check on top.

## Why

Without a role check, any authenticated client or freelancer can access `/api/admin/metrics` by presenting a valid JWT. Admin-only endpoints require explicit authorization.

## Testing

- No token → `401`
- Client/freelancer token → `403 Forbidden`
- Admin token → `200 OK`

```
node --test src/tests/adminRoutes.test.js
# 1 test, 3 assertions — all passed
```

Closes #1879