### PR TITLE
fix: prevent DoS on search endpoint via query length limit and input validation

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = (req.query.q ?? "").trim();
+
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/tests/searchController.test.js
+++ b/apps/api/src/tests/searchController.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("search input validation", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    // Empty query → 200 (defaults to "")
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/api/search`);
+      assert.equal(res.status, 200, "empty query should get 200");
+    }
+
+    // Short query → 200
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/api/search?q=react`);
+      assert.equal(res.status, 200, "short query should get 200");
+    }
+
+    // Overly long query → 400
+    {
+      const longQ = "a".repeat(201);
+      const res = await fetch(`http://127.0.0.1:${port}/api/search?q=${longQ}`);
+      assert.equal(res.status, 400, "query >200 chars should get 400");
+      const body = await res.json();
+      assert.equal(body.success, false);
+    }
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});


### PR DESCRIPTION
## What

Adds input validation to the search endpoint: trims whitespace from the query and rejects queries exceeding 200 characters with a `400 Bad Request`.

## Why

The search endpoint passed `req.query.q` directly to the search service without any validation. An attacker could send extremely long query strings to consume server resources.

## Testing

- Empty query (no `?q=`) → `200`
- Short query (`?q=react`) → `200`
- Overly long query (201 chars) → `400 { success: false }`

Closes #1881