### PR TITLE
fix: add file size limit and security restrictions to file upload

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof multer.MulterError) {
+    const message =
+      err.code === "LIMIT_FILE_SIZE"
+        ? "File too large — maximum size is 5 MB"
+        : `Upload error: ${err.message}`;
+    return res.status(400).json({ success: false, message });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,27 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIMETYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "application/json"
+];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter(_req, file, cb) {
+    if (ALLOWED_MIMETYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`File type ${file.mimetype} is not allowed`));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("upload file size validation", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    // Too-large file → MulterError (LIMIT_FILE_SIZE)
+    const blob = new Blob([Buffer.alloc(6 * 1024 * 1024)], { type: "image/jpeg" });
+    const form = new FormData();
+    form.append("file", blob, "large.jpg");
+    const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    assert.equal(res.status, 400, "file >5MB should be rejected");
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});


### PR DESCRIPTION
## What

Adds security hardening to the file upload endpoint:
- 5 MB file size limit via `multer` configuration
- Allowed MIME type whitelist (JPEG, PNG, GIF, WebP, PDF, plain text, JSON)
- `MulterError` handling in error handler to return `400` instead of `500`

## Why

Without size limits or type filters, the upload endpoint is vulnerable to DoS attacks via arbitrarily large or malicious file uploads.

## Testing

- File > 5 MB → `400 { success: false, message: "File too large..." }`
- Allowed file type + size under limit → routes to controller as before

Closes #1883