### PR TITLE
fix: registerUser generates consistent user ID and token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser returns consistent user id and token subject", async () => {
+  const result = await registerUser({
+    email: "test@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  assert.ok(result.id.startsWith("usr_"), "id should start with usr_");
+
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, result.id, "token sub must equal returned id");
+});


### PR DESCRIPTION
## What

Fixes the `registerUser()` service to generate the user ID once and reuse it for both the response `id` field and the JWT `sub` claim.

## Why

`Date.now()` was called twice — once for `id` and once for `sub`. When these calls landed on different milliseconds, the API returned a user whose token pointed to a different subject, breaking downstream auth lookups.

## Testing

- Verified that `result.id` matches `verifyAccessToken(result.token).sub` always
- Existing tests continue to pass

```
node --test src/tests/authService.test.js
# 1 test passed
```

Closes #1885