### PR TITLE
Fix API test file glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- update the API workspace test script to target `src/tests/**/*.test.js`
- make the root `npm test` command discover the existing test file instead of trying to execute the `src/tests` directory as a module

## Validation
- `npm test` passes from the repository root
- `git diff --check` passes

Fixes #1891
/claim #743