### PR TITLE
fix: add Zod input validation to user creation endpoint

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  email: z.string().email("Invalid email address"),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});


### PR DESCRIPTION
Add `createUserSchema` validation (name, email, role) to POST /api/users using Zod, consistent with existing registerSchema and createJobSchema patterns.

**New file:** `apps/api/src/validators/user.js`
- `createUserSchema` with name (min:1), email, role (enum)

**Modified:** `apps/api/src/controllers/userController.js`
- Parse `req.body` through `createUserSchema.parse()` before forwarding to service

Fixes #1773

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue.