### PR TITLE
fix: add auth middleware to unprotected routes and add JWT secret production guard

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -5,3 +5,13 @@ export const env = {
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+// Warn in all environments when using default JWT secret
+if (!process.env.JWT_SECRET && env.nodeEnv !== "test") {
+  console.warn("WARNING: Using default JWT_SECRET. Set JWT_SECRET environment variable for production security.");
+}
+
+// In production, require explicit JWT_SECRET
+if (env.nodeEnv === "production" && env.jwtSecret === "development-secret") {
+  throw new Error("FATAL: JWT_SECRET must be explicitly configured in production environment.");
+}

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", authMiddleware, getProposals);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,21 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ 
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const allowed = ["image/jpeg", "image/png", "image/gif", "application/pdf"];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Invalid file type. Allowed: JPEG, PNG, GIF, PDF"));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
## Security Fixes Batch 2

### ✅ Authentication (Fixes #1904)
Added `authMiddleware` to previously unprotected routes:
- `POST /api/jobs`, `POST /api/payments`, `POST /api/proposals`, `PUT /api/proposals` (if any)
- `POST /api/reviews`, `GET /api/proposals`, `GET /api/search`
- `POST /api/uploads` — also added `fileFilter` (JPEG/PNG/GIF/PDF only) + 5MB size limit
- `GET /api/users` (admin-only data)
- Kept open: `POST /api/users` (registration), `GET /api/jobs`, `GET /api/reviews` (public browsing)

### ✅ JWT Secret Production Guard (Fixes #1905)
- Added production check — throws error if `JWT_SECRET` is the hardcoded default
- Added development warning when using default secret

**8 files changed, +37/-9** | CI clean

Part of Low Hanging Fruit Automation bounty (#743).