### PR TITLE
Add account navigation links

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
## Summary
- add main navigation links for the existing `/jobs/post`, `/notifications`, `/billing`, and `/settings` routes
- make account and post-job workflows discoverable from the app shell
- keep the change scoped to the navigation link list

## Validation
- `npm run build -w apps/web` passes
- `git diff --check` passes

Fixes #1912
/claim #743