### PR TITLE
Validate OAuth callback requests

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOauthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,18 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = req.params.provider.toLowerCase();
+  if (!supportedOauthProviders.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
+  const code = typeof req.query.code === "string" ? req.query.code.trim() : "";
+  if (!code) {
+    return fail(res, "Missing authorization code", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauth.test.js
+++ b/apps/api/src/tests/oauth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/slack/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback requires an authorization code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Missing authorization code"
+    });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback accepts supported providers with a code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/GitHub/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an OAuth callback provider allowlist for GitHub and Google
- require a non-empty authorization `code` before returning callback success
- add regression tests for unsupported providers, missing codes, and normalized supported providers

## Validation

```text
$ node --test apps\api\src\tests\*.test.js
pass 4
fail 0

$ git diff --check
(no output)
```

Note: the root `npm test` command still hits the existing API test-directory glob issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #1924.

/claim #743
