### PR TITLE
fix: prevent admin role self-assignment on registration

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects 'admin' role during registration", () => {
+  assert.throws(
+    () => registerSchema.parse({
+      email: "admin@test.com",
+      password: "password123",
+      role: "admin"
+    }),
+    /Invalid enum value/,
+    "Should reject admin role assignment"
+  );
+});
+
+test("registerSchema defaults to 'client' when no role is provided", () => {
+  const result = registerSchema.parse({
+    email: "user@test.com",
+    password: "password123"
+  });
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema accepts valid roles", () => {
+  const client = registerSchema.parse({
+    email: "client@test.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.equal(client.role, "client");
+
+  const freelancer = registerSchema.parse({
+    email: "freelancer@test.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(freelancer.role, "freelancer");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Description

Removes the `"admin"` role from `registerSchema` in the auth validator to prevent users from self-assigning admin privileges during registration.

## Changes

- Removed `"admin"` from `z.enum()` in `apps/api/src/validators/auth.js`
- Added test coverage for registration role validation (3 tests)

## Testing

All 4 tests pass (3 new auth tests + existing health test):
- registerSchema rejects 'admin' role during registration ✓
- registerSchema defaults to 'client' when no role is provided ✓
- registerSchema accepts valid roles (client, freelancer) ✓
- GET /health returns ok payload ✓

Closes #1823