### PR TITLE
fix: Add missing auth middleware to notification and message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
+
+messageRoutes.use(authMiddleware);
 
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
+
+notificationRoutes.use(authMiddleware);
 
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
Closes #1941

Added `authMiddleware` to the following routes:
- Notification Routes
- Message Routes