### PR TITLE
Add bill of materials poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Bill of Materials for Trust
+
+First, list the scope in plain daylight:
+no polished guesswork, no borrowed glow,
+only the task, its edges, its weight,
+and the quiet line where unknowns should show.
+
+Then count the proofs before the promise:
+a passing check, a message kept,
+a screenshot named, a test repeated,
+evidence folded where doubt once slept.
+
+Review is the hand on the caliper,
+measuring claims against what was done;
+not to slow the work from shipping,
+but to make sure it leaves as one.
+
+Payment waits like a sealed component,
+marked for release when the record is clear;
+value moves best through open ledgers,
+where both sides know why the signal is here.
+
+So build the marketplace from small certainties:
+brief, proposal, merge, and name.
+Trust is not magic in FreelanceFlow;
+it is assembled, checked, and claimed.


### PR DESCRIPTION
/claim #76

## Summary
- Adds an original project-specific poem as root-level `POEM.md`.
- Uses five compact stanzas plus title, satisfying the minimum three-stanza requirement.
- Creative note: I chose a "bill of materials for trust" form because FreelanceFlow is about assembling paid work from scoped tasks, evidence, review, payout, and reputation rather than treating trust as a vague feeling.

## Validation
- `test -f POEM.md` -> `POEM.md exists`
- Stanza check counted 6 non-empty blocks including title, with 5 poem stanzas.
- `wc -l POEM.md` -> `26 POEM.md`
- `git diff --check`

## Preview
The poem follows scope, proof, review, payment, and marketplace reputation as inspectable parts in a trust workflow.
