### PR TITLE
fix: Prevent admin role self-assignment via registration endpoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,32 @@
+import { ZodError } from "zod";
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return fail(res, "Validation error: " + err.errors.map((e) => e.message).join("; "), 400);
+    }
+    throw err;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return fail(res, "Validation error: " + err.errors.map((e) => e.message).join("; "), 400);
+    }
+    throw err;
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((e) => ({
+        path: e.path.join("."),
+        message: e.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,16 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+// Default role for all new registrations — never trust client-supplied role
+const DEFAULT_ROLE = "client";
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const role = DEFAULT_ROLE;
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role })
   };
 }
 

--- a/apps/api/src/tests/register.role-prevention.test.js
+++ b/apps/api/src/tests/register.role-prevention.test.js
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+/**
+ * Tests for issue #1823: Admin role self-assignment via registration endpoint
+ *
+ * These tests verify that the registration endpoint does NOT allow users
+ * to set their own role (especially "admin"), preventing privilege escalation.
+ */
+
+test("POST /api/auth/register ignores role field and defaults to client", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    // Attempt to register with role: "admin" — this should be rejected
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "attacker@evil.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+
+    // With strict schema, the role field should cause a validation error
+    assert.equal(response.status, 400, "Registration with role field should be rejected with 400");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+    assert.ok(body.message.includes("Validation") || body.errors, "Should indicate validation error");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/auth/register succeeds with valid payload (no role)", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "normal@example.com",
+        password: "password123"
+      })
+    });
+
+    assert.equal(response.status, 201, "Valid registration should succeed with 201");
+
+    const body = await response.json();
+    assert.equal(body.success, true, "Response should indicate success");
+    assert.equal(body.data.role, "client", "New user should always get 'client' role");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/auth/register with role: freelancer is also rejected", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "user@example.com",
+        password: "password123",
+        role: "freelancer"
+      })
+    });
+
+    assert.equal(response.status, 400, "Registration with any role field should be rejected");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,9 +2,10 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
-});
+  password: z.string().min(8)
+  // role is intentionally excluded from registration input
+  // to prevent privilege escalation (issue #1823)
+}).strict();
 
 export const loginSchema = z.object({
   email: z.string().email(),


### PR DESCRIPTION
## Fix for #1823: Admin role self-assignment via registration endpoint

### Vulnerability Description

The registration endpoint (`POST /api/auth/register`) accepted a `role` field in the request body, allowing any user to self-assign privileged roles including `"admin"`. The vulnerable code was in `apps/api/src/validators/auth.js`:

```js
// BEFORE (vulnerable)
export const registerSchema = z.object({
  email: z.string().email(),
  password: z.string().min(8),
  role: z.enum(["client", "freelancer", "admin"]).default("client")
});
```

An attacker could simply send:
```bash
curl -X POST /api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"attacker@evil.com","password":"password123","role":"admin"}'
```

And the service would create an account with `role: "admin"` and issue a JWT token with admin claims, granting full administrative access.

### Fix Summary

**Defense in depth — three layers of protection:**

1. **Schema-level (validators/auth.js):** Removed `role` from `registerSchema` and added `.strict()` to reject any unexpected fields. Sending `"role"` now results in a validation error (HTTP 400).

2. **Service-level (services/authService.js):** `registerUser()` no longer reads `payload.role`. All new registrations are hardcoded to `"client"` via a `DEFAULT_ROLE` constant. Even if schema validation were bypassed, the service layer would not use a client-supplied role.

3. **Error handling (controllers/authController.js, middleware/errorHandler.js):** Added proper `ZodError` catch blocks in the controller and error middleware so validation errors return clean 400 responses instead of unhandled rejections or 500s.

### Files Changed

| File | Change |
|------|--------|
| `apps/api/src/validators/auth.js` | Removed `role` field, added `.strict()` |
| `apps/api/src/services/authService.js` | Hardcoded `DEFAULT_ROLE = "client"`, no longer reads `payload.role` |
| `apps/api/src/controllers/authController.js` | Added ZodError try/catch for clean error responses |
| `apps/api/src/middleware/errorHandler.js` | Added ZodError handling in error middleware |
| `apps/api/src/tests/register.role-prevention.test.js` | New test file proving the fix works |

### Test Results

```
✓ POST /api/auth/register with role: "admin" → 400 (rejected)
✓ POST /api/auth/register with role: "freelancer" → 400 (rejected)
✓ POST /api/auth/register without role field → 201, role defaults to "client"
```

Closes #1823
