### PR TITLE
Add proof kitchen poem (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Proof Kitchen
+
+The brief comes in like flour on slate,
+measured before the morning heat;
+a name, a need, a budget weight,
+work shaped enough for hands to meet.
+
+A proposal warms the quiet line,
+scope folded clean with time and cost;
+no promise plated past its sign,
+no hidden garnish, nothing lost.
+
+Messages rise in steady steam,
+small proofs passed over polished light;
+each question trims the sharper seam,
+each answer brings the table right.
+
+Review arrives with patient taste,
+tests on the edge of every tray;
+what fails goes back without haste,
+what holds is served into the day.
+
+Then payout clears, the record stands,
+a finished ticket, signed and still;
+FreelanceFlow keeps its open hands,
+turning trust into practiced skill.


### PR DESCRIPTION
/claim #76

Closes #76

## Summary
- Added root `POEM.md` with an original five-stanza poem for FreelanceFlow.
- Kept the patch scoped to the requested creative content file.

## Creative Note
I used a proof-kitchen theme to frame scope, evidence, review, merge, and payout as a quiet service line for marketplace trust.

## Validation
- Confirmed `POEM.md` is present at the project root.
- Confirmed the poem has five stanzas, exceeding the three-stanza minimum.
- Ran `git diff --cached --check` before commit with no whitespace errors.