### PR TITLE
fix: enforce authentication on job creation endpoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -8,5 +8,7 @@ export async function getJobs(req, res) {
 
 export async function postJob(req, res) {
   const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  // Enforce authenticated creator: use user ID from JWT token (issue #1783)
+  const clientId = req.user.sub;
+  return ok(res, await createJob({ ...payload, clientId }), 201);
 }

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job.auth.test.js
+++ b/apps/api/src/tests/job.auth.test.js
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+/**
+ * Tests for issue #1783: Enforce authentication on job creation endpoint
+ *
+ * These tests verify that the POST /api/jobs endpoint requires a valid
+ * JWT token and rejects unauthenticated requests with 401.
+ */
+
+const validJobPayload = {
+  title: "Build a landing page",
+  description: "We need a modern landing page for our SaaS product",
+  budgetMin: 500,
+  budgetMax: 2000,
+  categoryId: "cat_web",
+  skills: ["HTML", "CSS", "JavaScript"]
+};
+
+test("POST /api/jobs without token returns 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validJobPayload)
+    });
+
+    assert.equal(response.status, 401, "Unauthenticated job creation should return 401");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/jobs with invalid token returns 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer invalid-token-here"
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+
+    assert.equal(response.status, 401, "Invalid token should return 401");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/jobs with valid token returns 201 and sets clientId", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const token = signAccessToken({ sub: "usr_test123", role: "client" });
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${token}`
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+
+    assert.equal(response.status, 201, "Authenticated job creation should return 201");
+
+    const body = await response.json();
+    assert.equal(body.success, true, "Response should indicate success");
+    assert.equal(body.data.clientId, "usr_test123", "Job clientId should match authenticated user");
+    assert.equal(body.data.title, validJobPayload.title, "Job title should match payload");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("GET /api/jobs remains public (no auth required)", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`);
+
+    assert.equal(response.status, 200, "GET /api/jobs should remain public");
+
+    const body = await response.json();
+    assert.equal(body.success, true, "Response should indicate success");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Fix for #1783: Enforce authentication on job creation endpoint

### Vulnerability

The `POST /api/jobs` endpoint was missing authentication middleware, allowing **any unauthenticated user** to create jobs. This is a critical security issue as it could allow:

- Spam job creation
- Resource exhaustion
- Attribution bypass (jobs not tied to any real user)

**Reproduction**: Send a POST request to `/api/jobs` with no `Authorization` header — the request succeeds with 201.

### Fix

1. **`apps/api/src/routes/jobRoutes.js`** — Added `authMiddleware` to the `POST /` route
2. **`apps/api/src/controllers/jobController.js`** — Extract `clientId` from `req.user.sub` (the JWT subject claim) and attach it to the job payload, ensuring jobs are always attributed to the authenticated creator
3. **`apps/api/src/tests/job.auth.test.js`** — New test file with 4 test cases:
   - `POST /api/jobs` without token → **401 Unauthorized**
   - `POST /api/jobs` with invalid token → **401 Unauthorized**
   - `POST /api/jobs` with valid token → **201 Created** with `clientId` set from JWT
   - `GET /api/jobs` remains **public** (backward compatible)

### Test Results

```
✓ POST /api/jobs without token returns 401
✓ POST /api/jobs with invalid token returns 401
✓ POST /api/jobs with valid token returns 201 and sets clientId
✓ GET /api/jobs remains public (no auth required)
✓ GET /health returns ok payload

5 tests passed, 0 failed
```

### Backward Compatibility

- `GET /api/jobs` remains publicly accessible (no auth required)
- No changes to the job schema or response format (just adds `clientId` field)
- Other endpoints are unaffected

Fixes #1783