### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query.q ?? "");
+  if (!parsed.success) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  return ok(res, await globalSearch(parsed.data));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims a valid search query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20design%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        query: "design",
+        users: [],
+        jobs: [],
+        freelancers: []
+      }
+    });
+  });
+});
+
+test("GET /api/search rejects repeated query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design&q=engineering`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid search query"
+    });
+  });
+});
+
+test("GET /api/search rejects oversized query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(121)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid search query"
+    });
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z
+  .string()
+  .trim()
+  .max(120);


### PR DESCRIPTION
## Summary

- validate `/api/search` query input before calling the search service
- trim valid string queries and reject repeated or oversized query values with HTTP 400
- add regression tests for valid trimming, repeated query parameters, and oversized queries

## Validation

```text
$ node --test apps\api\src\tests\*.test.js
pass 4
fail 0

$ git diff --check
(no output)
```

Note: the root `npm test` command still hits the existing API test-directory glob issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #1965.

/claim #743
