### PR TITLE
fix: add admin role check to admin routes (#1770)

### DIFF
--- a/apps/api/src/middleware/adminMiddleware.js
+++ b/apps/api/src/middleware/adminMiddleware.js
@@ -1,0 +1,6 @@
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Forbidden: admin access required' });
+  }
+  next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,13 @@
-import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/adminMiddleware.js";
+import { metrics } from "../controllers/adminController.js";
+import { Router } from "express";
 
-export const adminRoutes = Router();
+const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
+
 adminRoutes.get("/metrics", metrics);
+
+export { adminRoutes };


### PR DESCRIPTION
创建 adminMiddleware 中间件，检查用户角色是否为 admin，并在 adminRoutes 中应用该中间件，确保只有管理员能访问 /api/admin 下的端点。