### PR TITLE
fix: add auth middleware to upload route (#1771)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,8 @@
-import { Router } from "express";
-import multer from "multer";
-import { uploadFile } from "../controllers/uploadController.js";
-
-const upload = multer({ storage: multer.memoryStorage() });
+import { Router } from 'express';
+import { upload } from '../middleware/upload.js';
+import { uploadFile } from '../controllers/uploadController.js';
+import { authMiddleware } from '../middleware/auth.js';
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
在 /api/uploads 的 POST 路由中添加 authMiddleware，防止未经身份验证的文件上传