### PR TITLE
Add auth endpoint rate limiting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,14 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: {
+    success: false,
+    message: "Too many authentication attempts, try again later"
+  }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
+
+authRoutes.use(["/register", "/login", "/refresh"], authLimiter);
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);

--- a/apps/api/src/tests/authRateLimit.test.js
+++ b/apps/api/src/tests/authRateLimit.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth endpoints enforce a stricter credential-attempt rate limit", async () => {
+  await withServer(async (baseUrl) => {
+    const body = JSON.stringify({
+      email: "client@example.com",
+      password: "correct-horse-battery"
+    });
+
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const response = await fetch(`${baseUrl}/api/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body
+      });
+
+      assert.equal(response.status, 200);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body
+    });
+    const payload = await limitedResponse.json();
+
+    assert.equal(limitedResponse.status, 429);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many authentication attempts, try again later"
+    });
+  });
+});
+
+test("non-auth API routes remain on the general limiter", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #1977

## Summary
- Added a dedicated `authLimiter` for credential-sensitive auth endpoints.
- Applied the stricter limiter to `POST /api/auth/register`, `POST /api/auth/login`, and `POST /api/auth/refresh` while leaving non-auth routes on the existing general API limiter.
- Updated the API test script to use an explicit `src/tests/*.test.js` glob so the Node test runner executes the test files reliably.
- Added regression coverage proving the 11th login attempt is blocked with HTTP 429 and a structured JSON error.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1977-auth-rate-limit-demo.mp4

## Validation
- `npm test`
  - 3 tests passed
  - includes `authRateLimit.test.js` for the strict auth limiter behavior
- `git diff --check`