### PR TITLE
fix: add admin role check to admin routes (Closes #1770)

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,23 @@
-import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+const express = require("express");
+const { authMiddleware } = require("../middleware/authMiddleware");
 
-export const adminRoutes = Router();
+const adminRoutes = express.Router();
+
+/**
+ * Admin middleware — verify user has admin role.
+ * Must be applied AFTER authMiddleware so req.user is populated.
+ */
+function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return res.status(403).json({ error: "Forbidden: admin access required" });
+  }
+  next();
+}
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.use(adminMiddleware);
+adminRoutes.get("/metrics", (req, res) => {
+  res.json({ activeUsers: 42, totalJobs: 128, revenue: "$12,400" });
+});
+
+module.exports = adminRoutes;

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,7 +1,9 @@
-const express = require("express");
-const { authMiddleware } = require("../middleware/authMiddleware");
+import { Router } from "express";
+import { metrics } from "../controllers/adminController.js";
+import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
-const adminRoutes = express.Router();
+export const adminRoutes = Router();
 
 /**
  * Admin middleware — verify user has admin role.
@@ -9,15 +11,11 @@ const adminRoutes = express.Router();
  */
 function adminMiddleware(req, res, next) {
   if (!req.user || req.user.role !== "admin") {
-    return res.status(403).json({ error: "Forbidden: admin access required" });
+    return fail(res, "Forbidden: admin access required", 403);
   }
   next();
 }
 
 adminRoutes.use(authMiddleware);
 adminRoutes.use(adminMiddleware);
-adminRoutes.get("/metrics", (req, res) => {
-  res.json({ activeUsers: 42, totalJobs: 128, revenue: "$12,400" });
-});
-
-module.exports = adminRoutes;
+adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Fix: Admin Role-Based Access Control

### Problem
Admin routes (`/api/admin/*`) only used `authMiddleware` which checked JWT validity but did **not** verify the user has an `admin` role. Any authenticated user could access admin endpoints.

### Solution
Added `adminMiddleware` that runs after `authMiddleware` and returns **403 Forbidden** if `req.user.role !== "admin"`.

### Changes
- **`apps/api/src/routes/adminRoutes.js`**: Added `adminMiddleware` function + applied it to all admin routes

### Testing
- Non-admin users → 403 Forbidden
- Admin users → normal access
- Unauthenticated → 401 (existing authMiddleware behavior)

Closes #1770
