### PR TITLE
Validate OAuth callback state

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +15,11 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { state } = req.query;
+  if (typeof state !== "string" || state.trim().length === 0) {
+    return fail(res, "OAuth state is required", 400);
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/oauthState.test.js
+++ b/apps/api/src/tests/oauthState.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback rejects missing state", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth state is required" });
+  });
+});
+
+test("OAuth callback rejects repeated state values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/auth/oauth/github/callback?code=abc123&state=first&state=second`
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth state is required" });
+  });
+});
+
+test("OAuth callback accepts a single non-empty state", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=abc123&state=csrf-token`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
﻿/claim #743

## Summary
- Require OAuth callbacks to include a single non-empty `state` query parameter before returning callback success.
- Return the shared 400 JSON response for missing, blank, or repeated state values.
- Add HTTP regression tests for missing state, repeated state, and valid callback preservation.

Fixes #1982.

## Demo
Short demo video: https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1982-oauth-state-demo.mp4

## Validation
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/oauthState.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/oauthState.test.js`
- `git diff --check`

Note: `npm test -w apps/api` still fails on the existing upstream script `node --test src/tests`, which Node resolves as a missing module path in this checkout; the explicit test files above pass.
