### PR TITLE
fix: prevent admin role self-assignment via registration endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary\n\nPrevents users from registering with the admin role.\n\n### Changes\n1. Removed \`admin\` from registerSchema enum (users can no longer self-assign admin)\n2. Fixed refreshToken to pass token from request body\n\nFixes #1823