### PR TITLE
fix(api): enforce server-owned OPEN job status

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, ...payload, status: "OPEN" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+function validJobPayload(overrides = {}) {
+  return {
+    title: "API integration",
+    description: "Connect the service to a partner API.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_backend",
+    skills: ["node", "api"],
+    ...overrides,
+  };
+}
+
+test("createJob initializes jobs with the OPEN status", async () => {
+  const job = await createJob(validJobPayload());
+
+  assert.equal(job.status, "OPEN");
+});
+
+test("createJob does not allow payload status to override the initial state", async () => {
+  const job = await createJob(validJobPayload({ status: "COMPLETED" }));
+
+  assert.equal(job.status, "OPEN");
+});


### PR DESCRIPTION
## Summary
- make newly-created in-memory jobs use Prisma-compatible `OPEN`
- prevent caller-supplied `status` from overriding the initial server-owned state
- add focused node:test coverage for default and override cases

Fixes #1990

/claim #743

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobService.test.js`