### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,20 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+
+  if (Array.isArray(rawQuery) || typeof rawQuery !== "string") {
+    return fail(res, "Search query must be a string");
+  }
+
+  const query = rawQuery.trim();
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query must be 200 characters or fewer");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims a valid search query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20engineer%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "engineer");
+  });
+});
+
+test("GET /api/search rejects search queries longer than 200 characters", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Validate `/api/search` query input before calling the search service
- Trim valid query strings and reject non-string or over-200-character values with HTTP 400
- Add focused API regression coverage for normal trimmed searches and oversized-query rejection

Closes #1993
/claim #743

## Validation
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/search.test.js`

## Demo Evidence
API-level demo is captured by the regression tests above: the first run failed on `main` because the controller returned the untrimmed query and accepted a 201-character query with HTTP 200; after the fix, the same tests pass with trimmed query output and HTTP 400 for the oversized query.

## Note
The repository-level `npm test -w apps/api` script currently fails before test discovery because it invokes `node --test src/tests` as a directory path on this Node runtime. I kept this PR scoped to #1993 and used explicit test-file paths for validation.