### PR TITLE
feat(web): add actionable navigation pages

### DIFF
--- a/apps/web/app/dashboard/client/page.tsx
+++ b/apps/web/app/dashboard/client/page.tsx
@@ -1,8 +1,21 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function ClientDashboardPage() {
   return (
-    <section className="card">
-      <h2>Dashboard (Client)</h2>
-      <p>Track jobs, shortlisted freelancers, and payment milestones.</p>
+    <section>
+      <h2>Client Dashboard</h2>
+      <div className="grid">
+        <article className="card">
+          <h3>Open jobs</h3>
+          <p>{jobs.length} active listings</p>
+        </article>
+        <article className="card">
+          <h3>Next action</h3>
+          <p>Review proposals and keep project scopes current.</p>
+          <Link href="/jobs">View jobs</Link>
+        </article>
+      </div>
     </section>
   );
 }

--- a/apps/web/app/dashboard/freelancer/page.tsx
+++ b/apps/web/app/dashboard/freelancer/page.tsx
@@ -1,8 +1,21 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function FreelancerDashboardPage() {
   return (
-    <section className="card">
-      <h2>Dashboard (Freelancer)</h2>
-      <p>Manage proposals, accepted jobs, earnings, and response metrics.</p>
+    <section>
+      <h2>Freelancer Dashboard</h2>
+      <div className="grid">
+        <article className="card">
+          <h3>Matched opportunities</h3>
+          <p>{jobs.length} jobs match marketplace demand.</p>
+        </article>
+        <article className="card">
+          <h3>Next action</h3>
+          <p>Browse open listings and prepare a focused proposal.</p>
+          <Link href="/jobs">Browse jobs</Link>
+        </article>
+      </div>
     </section>
   );
 }

--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -4,12 +4,12 @@ import { freelancers } from "../../../lib/mock";
 export default function FreelancerSearchPage() {
   return (
     <section>
-      <h2>Freelancer Search</h2>
+      <h2>Find Freelancers</h2>
       <div className="grid">
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(", ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
## Summary
- replace placeholder client and freelancer dashboard routes with scannable marketplace summaries
- keep the freelancer search route aligned with the navigation label while preserving profile links
- reuse the existing mock jobs/freelancers data and global card/grid styles

Fixes #1995

/claim #743

## Validation
- `npm run build -w apps/web`