### PR TITLE
Codex: Keep new notifications unread

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification starts new notifications unread", async () => {
+  const notification = await createNotification({
+    message: "Welcome to FreelanceFlow",
+    type: "system"
+  });
+
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Welcome to FreelanceFlow");
+  assert.equal(notification.type, "system");
+  assert.match(notification.id, /^ntf_\d+$/);
+});
+
+test("createNotification ignores caller supplied read state", async () => {
+  const notification = await createNotification({
+    message: "New proposal received",
+    read: true
+  });
+
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "New proposal received");
+});


### PR DESCRIPTION
/claim #743

## Summary
- Keep newly-created notifications server-owned as unread by applying `read: false` after the caller payload.
- Preserve normal caller payload fields such as `message` and `type`.
- Add focused regression tests for default unread creation and caller-supplied `read: true` override prevention.

Closes #1997
References #743

## Demo / Evidence
Focused test output:

```text
✔ createNotification starts new notifications unread
✔ createNotification ignores caller supplied read state
```

## Validation
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/tests/notificationService.test.js`
- `node --test apps/api/src/tests/notificationService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Known upstream test-script note: `npm test -w apps/api` still fails because the existing script invokes `node --test src/tests` as a directory path in this checkout. The explicit API test files above pass.