### PR TITLE
Add FreelanceFlow ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The Ledger Keeps the Light
+
+At dawn the board awakens with quiet numbered cards,
+each brief a door, each bid a careful key.
+Freelancers bring their weathered tools and proofs,
+clients bring the work they hope to see.
+
+The router hums through dashboards, jobs, and messages,
+through invoices that wait for honest names.
+A review becomes a lantern in the archive,
+showing where the craft outlasted claims.
+
+Escrow is not thunder, only patient balance,
+held until the promised scope is clear.
+Tests tap softly on the rails of trust,
+catching broken edges before they disappear.
+
+So let the marketplace move without shouting:
+proposal, milestone, handoff, paid.
+When every path is small enough to verify,
+good work can stand in public, unafraid.


### PR DESCRIPTION
## Summary
- Adds an original four-stanza `POEM.md` written specifically for FreelanceFlow.
- Uses a ledger/marketplace metaphor around scoped work, escrow, review evidence, and verifiable handoffs.

## Validation
- Confirmed `POEM.md` exists at the repository root.
- Confirmed the poem has 4 stanzas after the title, satisfying the minimum 3-stanza requirement.

Closes #76

/claim #76