### PR TITLE
fix(api): normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,13 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
+}
+
+function normalizeCurrency(currency) {
+  return typeof currency === "string" && currency.length > 0
+    ? currency.toUpperCase()
+    : "USD";
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults to uppercase USD", async () => {
+  const intent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(intent.currency, "USD");
+});
+
+test("createPaymentIntent normalizes lowercase currency codes", async () => {
+  const intent = await createPaymentIntent({ amount: 2500, currency: "eur" });
+
+  assert.equal(intent.currency, "EUR");
+});


### PR DESCRIPTION
## Summary
- normalize payment intent currency codes to uppercase values
- default missing currency to Prisma-compatible `USD`
- add focused service tests for default and lowercase input cases

Fixes #2001

/claim #743

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentService.test.js`