### PR TITLE
fix: respect platform port in web start

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "node scripts/start.mjs"
   },
   "devDependencies": {
     "@types/node": "22.15.19",

--- a/apps/web/scripts/port.mjs
+++ b/apps/web/scripts/port.mjs
@@ -1,0 +1,4 @@
+export function resolvePort(env = process.env) {
+  const configuredPort = env.PORT?.trim();
+  return configuredPort || "3000";
+}

--- a/apps/web/scripts/port.test.mjs
+++ b/apps/web/scripts/port.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolvePort } from "./port.mjs";
+
+test("resolvePort uses the platform PORT value when provided", () => {
+  assert.equal(resolvePort({ PORT: "4173" }), "4173");
+});
+
+test("resolvePort falls back to 3000 when PORT is unset", () => {
+  assert.equal(resolvePort({}), "3000");
+});
+
+test("resolvePort falls back to 3000 when PORT is blank", () => {
+  assert.equal(resolvePort({ PORT: "   " }), "3000");
+});

--- a/apps/web/scripts/start.mjs
+++ b/apps/web/scripts/start.mjs
@@ -1,0 +1,21 @@
+import { spawn } from "node:child_process";
+import { resolvePort } from "./port.mjs";
+
+const child = spawn("next", ["start", "-p", resolvePort()], {
+  stdio: "inherit",
+  shell: process.platform === "win32"
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
Closes #2000
/claim #743

## Summary
- replace the hardcoded `next start -p 3000` web start command with a small Node wrapper
- resolve the production start port from `PORT`, falling back to `3000` for local runs
- add a Node regression test for port resolution

## Verification
- `node --test apps/web/scripts/port.test.mjs`
- `node --check apps/web/scripts/start.mjs && node --check apps/web/scripts/port.mjs`
- `npm pkg get scripts.start -w apps/web`

## Note
- `npm run build -w apps/web` currently fails on an unrelated existing Next page type issue in `app/freelancers/[username]/page.tsx`; no build-generated files are included in this PR.