### PR TITLE
fix: align dynamic pages with async params

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,14 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{username}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,14 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #2005
/claim #743

## Summary
- update dynamic job and freelancer pages to await async app-router `params`
- preserve the existing rendered route content
- keep `next-env.d.ts` aligned with the production route types emitted by `next build`

## Verification
- `npm install --ignore-scripts --no-audit`
- `npm run build -w apps/web`
- `git diff --check`

## Note
`next build` passes. It still warns about a parent-directory lockfile influencing Turbopack root detection, which is separate from this PageProps build failure.