### PR TITLE
fix: remove stale Next.js version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
+- `apps/web` — Next.js App Router frontend
 - `apps/api` — Express.js backend with layered REST API
 - `packages/db` — Prisma schema and database package
 - `packages/ui` — Shared UI components


### PR DESCRIPTION
Closes #2008
/claim #743

## Summary
- remove stale `Next.js 14` wording from the README workspace summary
- describe the web app as a Next.js App Router frontend so docs do not drift from package metadata

## Verification
- `rg -n "Next\.js 14" README.md` finds no stale README wording
- `node -e "const pkg=require('./apps/web/package.json'); if (pkg.dependencies.next !== '16.2.6') process.exit(1); console.log(pkg.dependencies.next)"`
- `git diff --check`