### PR TITLE
fix: enforce unread notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification starts notifications unread by default", async () => {
+  const notification = await createNotification({
+    message: "Welcome",
+    type: "system",
+    userId: "usr_1",
+  });
+
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Welcome");
+  assert.equal(notification.type, "system");
+  assert.equal(notification.userId, "usr_1");
+});
+
+test("createNotification ignores caller supplied read state", async () => {
+  const notification = await createNotification({
+    message: "Welcome",
+    read: true,
+    userId: "usr_2",
+  });
+
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Welcome");
+  assert.equal(notification.userId, "usr_2");
+});


### PR DESCRIPTION
Closes #2010
/claim #743

## Summary
- ensure notification creation applies caller payload before server-owned fields
- keep new notifications unread even when the request body includes `read: true`
- add focused regression coverage for default and caller-supplied read states

## Verification
- `node --test apps/api/src/tests/notification.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notification.test.js`
- `git diff --check`