### PR TITLE
fix: prevent DoS on search endpoint via query length limit and input validation

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
+import { z } from "zod";
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const searchQuerySchema = z.object({
+  q: z.string().max(200).transform(v => v.trim())
+});
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchQuerySchema.parse(req.query);
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Description
Add Zod input validation to the search endpoint to prevent DoS via overly long query strings.

- Trim query and limit to 200 chars max
- Consistent with existing Zod validation patterns (registerSchema, createJobSchema, etc.)

## Changes
| File | Change |
|------|--------|
| `apps/api/src/controllers/searchController.js` | Add `searchQuerySchema` with max(200) and trim transform |

Fixes #1781