### PR TITLE
fix: use api test discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #2014
/claim #743

## Summary
- update the API workspace test script to use Node test discovery
- avoid loading `src/tests` as an entry module path
- keep the fix scoped to the API package script

## Verification
- `npm test -w apps/api`
- `node --test` from `apps/api`
- `npm pkg get scripts.test -w apps/api`
- `git diff --check`