### PR TITLE
fix: return 400 for invalid job payloads

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs returns 400 for invalid payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "bad" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload",
+    });
+  });
+});
+
+test("POST /api/jobs still creates valid jobs", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build landing page",
+        description: "Create a polished marketing page",
+        budgetMin: 100,
+        budgetMax: 500,
+        categoryId: "web",
+        skills: ["design", "react"],
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, "Build landing page");
+    assert.equal(payload.data.status, "open");
+  });
+});


### PR DESCRIPTION
Closes #2017
/claim #743

## Summary
- use `safeParse` for job creation payload validation
- return the existing API failure envelope with HTTP 400 for invalid job payloads
- add endpoint regression tests for invalid and valid job creation

## Verification
- `node --test apps/api/src/tests/job.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/job.test.js`
- `git diff --check`