### PR TITLE
fix: reject public admin registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects public admin role assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "admin@example.com",
+        password: "password123",
+        role: "admin",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid registration payload",
+    });
+  });
+});
+
+test("POST /api/auth/register still allows default client registration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.role, "client");
+    assert.equal(typeof payload.data.token, "string");
+  });
+});
+
+test("POST /api/auth/register still allows freelancer registration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "freelancer@example.com",
+        password: "password123",
+        role: "freelancer",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "freelancer@example.com");
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(typeof payload.data.token, "string");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #2019
/claim #743

## Summary
- remove `admin` from public registration role choices
- return the existing API failure envelope for invalid registration payloads
- add endpoint regression tests for admin rejection plus client/freelancer registration

## Verification
- `node --test apps/api/src/tests/auth.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/auth.test.js`
- `git diff --check`