### PR TITLE
fix: keep user ids server owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users ignores caller supplied id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        email: "user@example.com",
+        name: "User",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.email, "user@example.com");
+    assert.equal(payload.data.name, "User");
+  });
+});


### PR DESCRIPTION
Closes #2032
/claim #743

## Summary
- ensure user creation applies caller payload before the server-generated id
- prevent request bodies from overriding the generated `usr_...` identifier
- add endpoint regression coverage for caller-supplied id values

## Verification
- `node --test apps/api/src/tests/user.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/user.test.js`
- `git diff --check`