### PR TITLE
fix: keep proposal ids server owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals ignores caller supplied id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "prp_attacker",
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        coverLetter: "Hello",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_\d+$/);
+    assert.notEqual(payload.data.id, "prp_attacker");
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.freelancerId, "usr_1");
+    assert.equal(payload.data.coverLetter, "Hello");
+  });
+});


### PR DESCRIPTION
Closes #2041
/claim #743

## Summary
- ensure proposal creation applies caller payload before the server-generated id
- prevent request bodies from overriding the generated `prp_...` identifier
- add endpoint regression coverage for caller-supplied proposal id values

## Verification
- `node --test apps/api/src/tests/proposal.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposal.test.js`
- `git diff --check`