### PR TITLE
fix(api): require auth for message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/messageRoutes.test.js
+++ b/apps/api/src/tests/messageRoutes.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const messagePayload = {
+  recipientId: "usr_freelancer",
+  body: "Can we discuss the project timeline?"
+};
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("message routes reject unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const getResponse = await fetch(`${baseUrl}/api/messages`);
+    const getPayload = await getResponse.json();
+
+    assert.equal(getResponse.status, 401);
+    assert.equal(getPayload.success, false);
+    assert.equal(getPayload.message, "Unauthorized");
+
+    const postResponse = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(messagePayload)
+    });
+    const postPayload = await postResponse.json();
+
+    assert.equal(postResponse.status, 401);
+    assert.equal(postPayload.success, false);
+    assert.equal(postPayload.message, "Unauthorized");
+  });
+});
+
+test("message routes allow authenticated send and list requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`
+    };
+
+    const postResponse = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(messagePayload)
+    });
+    const postPayload = await postResponse.json();
+
+    assert.equal(postResponse.status, 201);
+    assert.equal(postPayload.success, true);
+    assert.equal(postPayload.data.body, messagePayload.body);
+    assert.ok(postPayload.data.id);
+
+    const getResponse = await fetch(`${baseUrl}/api/messages`, { headers });
+    const getPayload = await getResponse.json();
+
+    assert.equal(getResponse.status, 200);
+    assert.equal(getPayload.success, true);
+    assert.ok(getPayload.data.some((message) => message.id === postPayload.data.id));
+  });
+});


### PR DESCRIPTION
## Summary
- require `authMiddleware` for all message routes
- prevent unauthenticated clients from listing or creating messages
- add regression coverage for unauthenticated rejection and authenticated send/list success

Fixes #2046

/claim #743

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/messageRoutes.test.js`