### PR TITLE
fix: keep review ids server owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews ignores caller supplied id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "rev_attacker",
+        jobId: "job_1",
+        reviewerId: "usr_1",
+        rating: 5,
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_\d+$/);
+    assert.notEqual(payload.data.id, "rev_attacker");
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.reviewerId, "usr_1");
+    assert.equal(payload.data.rating, 5);
+  });
+});


### PR DESCRIPTION
Closes #2048
/claim #743

## Summary
- ensure review creation applies caller payload before the server-generated id
- prevent request bodies from overriding the generated `rev_...` identifier
- add endpoint regression coverage for caller-supplied review id values

## Verification
- `node --test apps/api/src/tests/review.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/review.test.js`
- `git diff --check`