### PR TITLE
fix: keep message ids server owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages ignores caller supplied id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "msg_attacker",
+        fromUserId: "usr_1",
+        toUserId: "usr_2",
+        body: "Hello",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^msg_\d+$/);
+    assert.notEqual(payload.data.id, "msg_attacker");
+    assert.equal(payload.data.fromUserId, "usr_1");
+    assert.equal(payload.data.toUserId, "usr_2");
+    assert.equal(payload.data.body, "Hello");
+    assert.match(payload.data.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
Closes #2050
/claim #743

## Summary
- ensure message creation applies caller payload before the server-generated id
- prevent request bodies from overriding the generated `msg_...` identifier
- keep `sentAt` server-owned and add endpoint regression coverage

## Verification
- `node --test apps/api/src/tests/message.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/message.test.js`
- `git diff --check`