### PR TITLE
Add notifications action feed

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,83 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.button {
+  border: 1px solid #89a4ff;
+  border-radius: 8px;
+  background: #89a4ff;
+  color: #081022;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.55rem 0.85rem;
+}
+.button.secondary {
+  background: transparent;
+  color: #dce6ff;
+}
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.notificationsHeader {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.notificationsHeader h2,
+.notificationItem h3 {
+  margin-top: 0;
+}
+.segmentedControl {
+  background: #0f1730;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+.segment {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: #dce6ff;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  padding: 0.45rem 0.75rem;
+}
+.segment.active {
+  background: #f2f5ff;
+  color: #0b1020;
+}
+.notificationList {
+  display: grid;
+  gap: 1rem;
+}
+.notificationItem {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.notificationItem.unread {
+  border-color: #89a4ff;
+}
+.notificationMeta {
+  color: #aebbea;
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+}
+@media (max-width: 640px) {
+  .notificationsHeader,
+  .notificationItem {
+    display: grid;
+  }
+  .button {
+    width: 100%;
+  }
+}

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,119 @@
-export default function NotificationsPage() {
+import Link from "next/link";
+
+const notifications = [
+  {
+    id: "proposal-shortlist",
+    type: "Proposal",
+    title: "Maya Dev was shortlisted",
+    body: "Your AI support widget job has a new shortlist recommendation.",
+    time: "8 min ago",
+    unread: true
+  },
+  {
+    id: "message-follow-up",
+    type: "Message",
+    title: "Jordan UX sent a follow-up",
+    body: "The onboarding wireframes are ready for your review.",
+    time: "32 min ago",
+    unread: true
+  },
+  {
+    id: "billing-receipt",
+    type: "Billing",
+    title: "Milestone invoice paid",
+    body: "Invoice INV-1042 was paid from your default billing method.",
+    time: "Yesterday",
+    unread: false
+  },
+  {
+    id: "job-flag",
+    type: "Trust",
+    title: "Job listing needs one clarification",
+    body: "Add deliverable details before publishing the SaaS onboarding project.",
+    time: "Yesterday",
+    unread: false
+  }
+];
+
+type SearchParams = {
+  filter?: string;
+  read?: string;
+};
+
+type NotificationsPageProps = {
+  searchParams?: Promise<SearchParams> | SearchParams;
+};
+
+export default async function NotificationsPage({ searchParams }: NotificationsPageProps) {
+  const params = await Promise.resolve(searchParams ?? {});
+  const filter = params.filter === "unread" ? "unread" : "all";
+  const read = params.read;
+  const notificationState = notifications.map((notification) => ({
+    ...notification,
+    unread: read === "all" || read === notification.id ? false : notification.unread
+  }));
+  const unreadCount = notificationState.filter((notification) => notification.unread).length;
+  const visibleNotifications = notificationState.filter(
+    (notification) => filter === "all" || notification.unread
+  );
+
   return (
-    <section className="card">
-      <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
+    <section>
+      <div className="card">
+        <div className="notificationsHeader">
+          <div>
+            <h2>Notifications</h2>
+            <p>{unreadCount} unread updates across proposals, messages, billing, and trust checks.</p>
+          </div>
+          <form action="/notifications">
+            <input name="read" type="hidden" value="all" />
+            <input name="filter" type="hidden" value={filter} />
+            <button className="button" type="submit" disabled={unreadCount === 0}>
+              Mark all read
+            </button>
+          </form>
+        </div>
+        <div className="segmentedControl" aria-label="Notification filter">
+          <Link className={filter === "all" ? "segment active" : "segment"} href="/notifications">
+            All
+          </Link>
+          <Link className={filter === "unread" ? "segment active" : "segment"} href="/notifications?filter=unread">
+            Unread
+          </Link>
+        </div>
+      </div>
+
+      <div className="notificationList" aria-live="polite">
+        {visibleNotifications.length === 0 ? (
+          <article className="card">
+            <h3>No unread notifications</h3>
+            <p>All caught up for now.</p>
+          </article>
+        ) : (
+          visibleNotifications.map((notification) => (
+            <article
+              className={notification.unread ? "card notificationItem unread" : "card notificationItem"}
+              key={notification.id}
+            >
+              <div>
+                <div className="notificationMeta">
+                  <span>{notification.type}</span>
+                  <span>{notification.time}</span>
+                </div>
+                <h3>{notification.title}</h3>
+                <p>{notification.body}</p>
+              </div>
+              <form action="/notifications">
+                <input name="read" type="hidden" value={notification.id} />
+                <input name="filter" type="hidden" value={filter} />
+                <button className="button secondary" type="submit" disabled={!notification.unread}>
+                  {notification.unread ? "Mark read" : "Read"}
+                </button>
+              </form>
+            </article>
+          ))
+        )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- replace the `/notifications` placeholder with an actionable notification feed
- add representative proposal, message, billing, and trust notifications
- show an unread count plus All/Unread views
- support marking one notification or all notifications as read through query-driven GET forms, avoiding backend or hydration dependencies
- add scoped responsive styles for the feed, segmented control, and action buttons

## Validation

```text
$ npm run build -w apps/web
Compiled successfully
Finished TypeScript
Generated static pages successfully

$ git diff --check
(no output; only Windows LF/CRLF warnings)
```

Browser verification on `http://127.0.0.1:3000/notifications`:

```text
startHasTwoUnread: true
afterAllHasZeroUnread: true
unreadEmpty: true
```

Fixes #2056.

/claim #743
