### PR TITLE
fix: require admin role for metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function roleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getMetrics(baseUrl, role) {
+  const token = signAccessToken({ sub: `usr_${role}`, role });
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("GET /api/admin/metrics rejects client tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getMetrics(baseUrl, "client");
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Forbidden",
+    });
+  });
+});
+
+test("GET /api/admin/metrics rejects freelancer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getMetrics(baseUrl, "freelancer");
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Forbidden",
+    });
+  });
+});
+
+test("GET /api/admin/metrics allows admin tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getMetrics(baseUrl, "admin");
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+    assert.equal(payload.data.flaggedAccounts, 3);
+  });
+});


### PR DESCRIPTION
Closes #2057
/claim #743

## Summary
- add a small reusable role guard for authenticated routes
- require `role: "admin"` for `/api/admin/metrics`
- add endpoint regression tests for client, freelancer, and admin tokens

## Verification
- `node --test apps/api/src/tests/admin.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/admin.test.js`
- `git diff --check`