### PR TITLE
fix: return json rate limit errors

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("API rate limiter returns JSON failure envelope", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+    for (let i = 0; i < 201; i += 1) {
+      response = await fetch(`${baseUrl}/api/users`);
+    }
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many requests",
+    });
+  });
+});


### PR DESCRIPTION
Closes #2061
/claim #743

## Summary
- configure the API rate limiter with a custom error handler
- return the existing JSON failure envelope for HTTP 429 responses
- add a regression test that exhausts the limiter and verifies JSON output

## Verification
- `node --test apps/api/src/tests/rateLimit.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/rateLimit.test.js`
- `git diff --check`