### PR TITLE
Fix freelancer skill separator

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(" / ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
## Summary

- replace the mojibake-looking freelancer skill separator with a readable ASCII separator
- keep the `/freelancers/search` page scoped to its current mock-data rendering

## Validation

```text
$ npm run build -w apps/web
Compiled successfully
Finished TypeScript
Generated static pages successfully

$ git diff --check
(no output; only Windows LF/CRLF warnings)
```

Local render check on `http://127.0.0.1:3000/freelancers/search` confirmed the HTML now contains `Next.js / TypeScript`.

Fixes #2060.

/claim #743
