### PR TITLE
fix: keep registration token subject consistent

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const originalDateNow = Date.now;
+  const timestamps = [1700000000000, 1700000001234];
+  Date.now = () => timestamps.shift() ?? 1700000001234;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      password: "secure-password",
+      role: "client"
+    });
+
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1700000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Closes #2064
/claim #743

## Summary
- generate the registration user id once
- sign the access token with the same id in `sub`
- add regression coverage for divergent timestamp generation

## Verification
- `node --test apps/api/src/tests/authService.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authService.test.js`
- `git diff --check`