### PR TITLE
fix: validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ fromUserId: "usr_1" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages accepts complete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        fromUserId: "usr_1",
+        toUserId: "usr_2",
+        body: "Hello"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fromUserId, "usr_1");
+    assert.equal(payload.data.toUserId, "usr_2");
+    assert.equal(payload.data.body, "Hello");
+    assert.match(payload.data.id, /^msg_/);
+    assert.match(payload.data.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  fromUserId: z.string().trim().min(1),
+  toUserId: z.string().trim().min(1),
+  body: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #2067
/claim #743

## Summary
- add a message creation schema requiring `fromUserId`, `toUserId`, and `body`
- return HTTP 400 for malformed message payloads
- add endpoint regression coverage for malformed and complete message creation requests

## Verification
- `node --test apps/api/src/tests/messageValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/messageValidation.test.js`
- `git diff --check`