### PR TITLE
Add settings account controls

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,84 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.settingsHeader {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.settingsHeader h2,
+.settingsPanel h3 {
+  margin-top: 0;
+}
+.settingsGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+.settingsPanel {
+  display: grid;
+  gap: 0.8rem;
+}
+.settingsPanelHeader,
+.settingsRow {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+.statusBadge {
+  background: #d8f5e1;
+  border-radius: 999px;
+  color: #12351f;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.25rem 0.55rem;
+}
+.statusBadge.warning {
+  background: #ffe8ba;
+  color: #4a3000;
+}
+.fieldGroup {
+  display: grid;
+  gap: 0.35rem;
+}
+.fieldGroup input,
+.fieldGroup select {
+  background: #0f1730;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  color: #f2f5ff;
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+}
+.checkRow {
+  align-items: center;
+  display: flex;
+  gap: 0.55rem;
+}
+.settingsButton {
+  background: #89a4ff;
+  border: 1px solid #89a4ff;
+  border-radius: 8px;
+  color: #081022;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.65rem 0.9rem;
+}
+.settingsButton.secondary {
+  background: transparent;
+  color: #dce6ff;
+}
+@media (max-width: 640px) {
+  .settingsHeader,
+  .settingsPanelHeader,
+  .settingsRow {
+    display: grid;
+  }
+  .settingsButton {
+    width: 100%;
+  }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,93 @@
 export default function SettingsPage() {
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section>
+      <div className="settingsHeader">
+        <div>
+          <h2>Settings</h2>
+          <p>Freelancer profile, notifications, security, and billing defaults.</p>
+        </div>
+        <button className="settingsButton" type="button">Save changes</button>
+      </div>
+
+      <div className="settingsGrid">
+        <article className="card settingsPanel">
+          <div className="settingsPanelHeader">
+            <h3>Profile Visibility</h3>
+            <span className="statusBadge">Public</span>
+          </div>
+          <label className="fieldGroup">
+            Display name
+            <input defaultValue="Maya Dev Studio" />
+          </label>
+          <label className="fieldGroup">
+            Marketplace status
+            <select defaultValue="available">
+              <option value="available">Available for projects</option>
+              <option value="limited">Limited availability</option>
+              <option value="hidden">Hidden from search</option>
+            </select>
+          </label>
+          <label className="checkRow">
+            <input defaultChecked type="checkbox" />
+            Show hourly rate on public profile
+          </label>
+        </article>
+
+        <article className="card settingsPanel">
+          <div className="settingsPanelHeader">
+            <h3>Notifications</h3>
+            <span className="statusBadge">3 enabled</span>
+          </div>
+          <label className="checkRow">
+            <input defaultChecked type="checkbox" />
+            Proposal and shortlist updates
+          </label>
+          <label className="checkRow">
+            <input defaultChecked type="checkbox" />
+            New direct messages
+          </label>
+          <label className="checkRow">
+            <input defaultChecked type="checkbox" />
+            Billing and payout alerts
+          </label>
+        </article>
+
+        <article className="card settingsPanel">
+          <div className="settingsPanelHeader">
+            <h3>Security</h3>
+            <span className="statusBadge warning">Review</span>
+          </div>
+          <div className="settingsRow">
+            <span>Password</span>
+            <strong>Updated 42 days ago</strong>
+          </div>
+          <div className="settingsRow">
+            <span>Two-factor authentication</span>
+            <strong>Not enabled</strong>
+          </div>
+          <button className="settingsButton secondary" type="button">Enable 2FA</button>
+        </article>
+
+        <article className="card settingsPanel">
+          <div className="settingsPanelHeader">
+            <h3>Billing Defaults</h3>
+            <span className="statusBadge">Verified</span>
+          </div>
+          <label className="fieldGroup">
+            Default currency
+            <select defaultValue="usd">
+              <option value="usd">USD</option>
+              <option value="eur">EUR</option>
+              <option value="gbp">GBP</option>
+            </select>
+          </label>
+          <div className="settingsRow">
+            <span>Payout method</span>
+            <strong>Bank ending 4821</strong>
+          </div>
+          <button className="settingsButton secondary" type="button">Update billing</button>
+        </article>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- replace the `/settings` placeholder card with a concrete account settings overview
- add profile visibility, notification preferences, security, and billing defaults panels
- include mock status badges, inputs, selects, checkboxes, and next-action buttons without changing API behavior
- add responsive settings styles that match the current lightweight web app shell

## Validation

```text
$ npm run build -w apps/web
Compiled successfully
Finished TypeScript
Generated static pages successfully

$ git diff --check
(no output; only Windows LF/CRLF warnings)
```

Browser verification on `http://127.0.0.1:3000/settings` confirmed the page renders Profile Visibility, Notifications, Security, Billing Defaults, and Save changes controls.

Fixes #2066.

/claim #743
