### PR TITLE
fix: validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications accepts complete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_1",
+        message: "Proposal updated"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.message, "Proposal updated");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().trim().min(1),
+  message: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #2069
/claim #743

## Summary
- add a notification creation schema requiring `userId` and `message`
- return HTTP 400 for malformed notification payloads
- add endpoint regression coverage for malformed and complete notification creation requests

## Verification
- `node --test apps/api/src/tests/notificationValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notificationValidation.test.js`
- `git diff --check`