### PR TITLE
fix: rate limit malformed JSON requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,13 +15,13 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp({ limiter = apiLimiter } = {}) {
   const app = express();
 
   app.use(helmet());
   app.use(cors());
+  app.use(limiter);
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof SyntaxError && err.status === 400 && err.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import rateLimit from "express-rate-limit";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
-  const app = createApp();
+async function withServer(app, callback) {
   const server = app.listen(0);
 
   await new Promise((resolve, reject) => {
@@ -11,14 +11,53 @@ test("GET /health returns ok payload", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+test("GET /health returns ok payload", async () => {
+  await withServer(createApp(), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+test("malformed JSON requests count toward the API rate limit", async () => {
+  const limiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 2,
+    standardHeaders: "draft-7",
+    legacyHeaders: false
+  });
+
+  await withServer(createApp({ limiter }), async (baseUrl) => {
+    const sendMalformedJson = () =>
+      fetch(`${baseUrl}/api/auth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{"
+      });
+
+    const first = await sendMalformedJson();
+    assert.equal(first.status, 400);
+    assert.deepEqual(await first.json(), {
+      success: false,
+      message: "Malformed JSON payload"
+    });
+
+    const second = await sendMalformedJson();
+    assert.equal(second.status, 400);
+
+    const third = await sendMalformedJson();
+    assert.equal(third.status, 429);
   });
 });


### PR DESCRIPTION
## Summary
- apply the global API rate limiter before JSON body parsing so malformed JSON requests still consume quota
- return a structured 400 response for malformed JSON payloads instead of falling through as an unexpected server error
- add an API regression test that sends malformed JSON twice, then confirms the third malformed request is blocked with 429
- make the API test script target test files directly so the suite runs under current Node versions

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-1735-rate-limit-malformed-json-demo.mp4

## Tests
- npm test --workspace apps/api

/claim #1735