### PR TITLE
fix: validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid user payload"
+    });
+  });
+});
+
+test("POST /api/users accepts complete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "user@example.com",
+        fullName: "Test User",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "user@example.com");
+    assert.equal(payload.data.fullName, "Test User");
+    assert.equal(payload.data.role, "freelancer");
+    assert.match(payload.data.id, /^usr_/);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+}).passthrough();


### PR DESCRIPTION
Closes #2072
/claim #743

## Summary
- add a user creation schema requiring `email`, `fullName`, and supported `role`
- return HTTP 400 for malformed user payloads
- add endpoint regression coverage for malformed and complete user creation requests

## Verification
- `node --test apps/api/src/tests/userValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/userValidation.test.js`
- `git diff --check`