### PR TITLE
fix: validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals accepts complete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        coverLetter: "I can complete this work.",
+        bidAmount: 1200,
+        estDuration: "2 weeks",
+        jobId: "job_1",
+        freelancerId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.coverLetter, "I can complete this work.");
+    assert.equal(payload.data.bidAmount, 1200);
+    assert.equal(payload.data.estDuration, "2 weeks");
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.freelancerId, "usr_freelancer");
+    assert.match(payload.data.id, /^prp_/);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1),
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #2077
/claim #743

## Summary
- add a proposal creation schema requiring `coverLetter`, `bidAmount`, `estDuration`, `jobId`, and `freelancerId`
- return HTTP 400 for malformed proposal payloads
- add endpoint regression coverage for malformed and complete proposal creation requests

## Verification
- `node --test apps/api/src/tests/proposalValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalValidation.test.js`
- `git diff --check`