### PR TITLE
Return client errors for bad API requests

### DIFF
--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function asyncRoute(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,32 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload"
+    });
+  }
+
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON body"
+    });
+  }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", asyncHandler(metrics));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", asyncHandler(getMessages));
+messageRoutes.post("/", asyncHandler(postMessage));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", asyncHandler(getNotifications));
+notificationRoutes.post("/", asyncHandler(postNotification));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", asyncHandler(createPayment));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", asyncHandler(getProposals));
+proposalRoutes.post("/", asyncHandler(postProposal));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", asyncHandler(getReviews));
+reviewRoutes.post("/", asyncHandler(postReview));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", asyncHandler(search));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), asyncHandler(uploadFile));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", asyncHandler(getUsers));
+userRoutes.post("/", asyncHandler(postUser));

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"title\":"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON body"
+    });
+  });
+});
+
+test("Zod validation errors from async routes return 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "API",
+        description: "too short",
+        budgetMin: -1,
+        budgetMax: 100,
+        categoryId: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an async route wrapper so rejected async controllers are passed to Express error handling
- return safe 400 responses for Zod validation failures
- return safe 400 responses for malformed JSON bodies
- return safe 413 responses for oversized JSON bodies
- add regression coverage for malformed JSON and async-route Zod validation errors

## Validation

```text
$ node --test apps\api\src\tests\*.test.js
pass 3
fail 0

$ git diff --check
(no output; only Windows LF/CRLF warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2076.

/claim #743
