### PR TITLE
fix: validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews rejects out-of-range ratings", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_1",
+        revieweeId: "usr_2",
+        rating: 99,
+        comment: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews accepts complete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_1",
+        revieweeId: "usr_2",
+        rating: 5,
+        comment: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.reviewerId, "usr_1");
+    assert.equal(payload.data.revieweeId, "usr_2");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great work");
+    assert.match(payload.data.id, /^rev_/);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().trim().min(1),
+  revieweeId: z.string().trim().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #2081
/claim #743

## Summary
- add a review creation schema requiring `reviewerId`, `revieweeId`, `rating`, and `comment`
- constrain review ratings to integers from 1 through 5
- return HTTP 400 for malformed review payloads
- add endpoint regression coverage for malformed, out-of-range, and complete review creation requests

## Verification
- `node --test apps/api/src/tests/reviewValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/reviewValidation.test.js`
- `git diff --check`