### PR TITLE
fix(auth): prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/auth-register-validation.test.js
+++ b/apps/api/src/tests/auth-register-validation.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema allows a valid client registration", () => {
+  const result = registerSchema.parse({
+    email: "client@test.com",
+    password: "supersecret123",
+    role: "client",
+  });
+  assert.equal(result.role, "client");
+  assert.equal(result.email, "client@test.com");
+});
+
+test("registerSchema allows a valid freelancer registration", () => {
+  const result = registerSchema.parse({
+    email: "freelancer@test.com",
+    password: "anotherpass456",
+    role: "freelancer",
+  });
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerSchema defaults to client role when omitted", () => {
+  const result = registerSchema.parse({
+    email: "default@test.com",
+    password: "password789",
+  });
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema rejects admin role", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "admin@test.com",
+      password: "adminpass000",
+      role: "admin",
+    });
+  }, /Invalid enum value.*admin/);
+});
+
+test("registerSchema rejects unknown role", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "hacker@test.com",
+      password: "hackpass111",
+      role: "superadmin",
+    });
+  }, /Invalid enum value/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## What

Remove `"admin"` from the `registerSchema` role enum so that a caller cannot self-assign an administrator role during account creation.

**Before:** `z.enum(["client", "freelancer", "admin"]).default("client")`
**After:** `z.enum(["client", "freelancer"]).default("client")`

## Why

A security vulnerability — any unauthenticated caller could register with `role: "admin"` and immediately gain admin privileges. The registration endpoint should only allow public user roles.

## Testing

- 5 new validation tests added to `apps/api/src/tests/auth-register-validation.test.js`
- Tests run via `node --test`
- Valid client, freelancer, default role, admin rejection, and unknown role rejection all pass

Closes #2075