### PR TITLE
fix: validate auth payloads

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,24 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid register payload", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid login payload", 400);
+  }
+
+  const result = await loginUser(parsed.data);
   return ok(res, result);
 }
 

--- a/apps/api/src/tests/authValidation.test.js
+++ b/apps/api/src/tests/authValidation.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid register payload"
+    });
+  });
+});
+
+test("POST /api/auth/login rejects malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid login payload"
+    });
+  });
+});
+
+test("POST /api/auth/register accepts valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "new-user@example.com",
+        password: "secure-password",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "new-user@example.com");
+    assert.equal(payload.data.role, "client");
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});
+
+test("POST /api/auth/login accepts valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "new-user@example.com",
+        password: "secure-password"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "new-user@example.com");
+    assert.equal(typeof payload.data.token, "string");
+  });
+});


### PR DESCRIPTION
Closes #2084
/claim #743

## Summary
- use safe auth schema parsing for register and login
- return HTTP 400 for malformed register and login payloads
- add endpoint regression coverage for malformed and valid auth payloads

## Verification
- `node --test apps/api/src/tests/authValidation.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authValidation.test.js`
- `git diff --check`