### PR TITLE
Validate upload files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,14 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "Upload file is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    contentType: req.file.mimetype,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "Upload file is too large"
+    });
+  }
+
+  if (err?.statusCode && err.statusCode >= 400 && err.statusCode < 500) {
+    return res.status(err.statusCode).json({
+      success: false,
+      message: err.message
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/middleware/uploadValidation.js
+++ b/apps/api/src/middleware/uploadValidation.js
@@ -1,0 +1,28 @@
+import multer from "multer";
+
+const allowedMimeTypes = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "text/plain"
+]);
+
+export const maxUploadBytes = 5 * 1024 * 1024;
+
+function fileFilter(req, file, callback) {
+  if (!allowedMimeTypes.has(file.mimetype)) {
+    const error = new Error("Unsupported upload file type");
+    error.statusCode = 400;
+    return callback(error);
+  }
+
+  return callback(null, true);
+}
+
+export const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: maxUploadBytes
+  },
+  fileFilter
+});

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,8 +1,6 @@
 import { Router } from "express";
-import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
-
-const upload = multer({ storage: multer.memoryStorage() });
+import { upload } from "../middleware/uploadValidation.js";
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { maxUploadBytes } from "../middleware/uploadValidation.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function formWithFile({ content, filename, type }) {
+  const form = new FormData();
+  form.append("file", new Blob([content], { type }), filename);
+  return form;
+}
+
+test("POST /api/uploads accepts supported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formWithFile({
+        content: "hello",
+        filename: "note.txt",
+        type: "text/plain"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "note.txt",
+      contentType: "text/plain",
+      size: 5,
+      status: "uploaded"
+    });
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formWithFile({
+        content: "<script>alert(1)</script>",
+        filename: "payload.html",
+        type: "text/html"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported upload file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects oversized files", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formWithFile({
+        content: "a".repeat(maxUploadBytes + 1),
+        filename: "large.txt",
+        type: "text/plain"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Upload file is too large"
+    });
+  });
+});
+
+test("POST /api/uploads rejects missing files", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: new FormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Upload file is required"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an upload validation middleware with a 5 MB in-memory file size limit
- allow only PDF, JPEG, PNG, and plain-text uploads
- return stable 400 responses for unsupported or missing files
- return stable 413 responses for oversized files
- include file metadata in successful upload responses
- add regression tests for accepted, unsupported, oversized, and missing-file uploads

## Validation

```text
$ node --test apps\api\src\tests\*.test.js
pass 5
fail 0

$ git diff --check
(no output; only Windows LF/CRLF warnings)
```

Fixes #2087.

/claim #743
