### PR TITLE
fix: prevent self-admin registration and enforce admin role on admin routes

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -2,7 +2,14 @@ import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
 
+function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return res.status(403).json({ success: false, message: "Forbidden: admin role required" });
+  }
+  return next();
+}
+
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminOnly);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Registered users could set themselves as admin via the registration endpoint. Admin routes were also missing role-based access control.

**Changes:**
- Remove 'admin' option from registration role enum
- Add adminOnly middleware to admin routes

/claim #743