### PR TITLE
fix: require oauth callback code

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +15,12 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { code } = req.query;
+
+  if (typeof code !== "string" || code.trim() === "") {
+    return fail(res, "Missing OAuth authorization code", 400);
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/oauthCode.test.js
+++ b/apps/api/src/tests/oauthCode.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback rejects missing authorization code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Missing OAuth authorization code"
+    });
+  });
+});
+
+test("OAuth callback rejects blank authorization code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Missing OAuth authorization code"
+    });
+  });
+});
+
+test("OAuth callback rejects repeated authorization code values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=one&code=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Missing OAuth authorization code"
+    });
+  });
+});
+
+test("OAuth callback preserves response when authorization code is present", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #2096
/claim #743

## Summary
- reject OAuth callback requests when the authorization `code` is missing, blank, or repeated
- preserve the existing callback response when a single non-empty code is present
- add endpoint regression coverage for invalid and valid callback code values

## Verification
- `node --test apps/api/src/tests/oauthCode.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/oauthCode.test.js`
- `git diff --check`