### PR TITLE
Run rate limiter before JSON parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("rate limiter counts malformed JSON before body parsing", async () => {
+  await withServer(async (baseUrl) => {
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      let response;
+
+      for (let index = 0; index < 201; index += 1) {
+        response = await fetch(`${baseUrl}/api/jobs`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{\"title\":"
+        });
+      }
+
+      assert.equal(response.status, 429);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- move the global API rate limiter ahead of `express.json()`
- make malformed JSON requests count toward the same API rate limit as valid requests
- add regression coverage proving the 201st malformed JSON request is rejected with `429`

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? rate limiter counts malformed JSON before body parsing
? tests 2
? pass 2
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2098.
/claim #743