### PR TITLE
fix: normalize auth email input

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register normalizes email identity before service use", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "  User.Name+Demo@Example.COM  ",
+        password: "correct-horse-battery",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "user.name+demo@example.com");
+  });
+});
+
+test("POST /api/auth/login normalizes email identity before service use", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "  Existing.User@Example.COM  ",
+        password: "correct-horse-battery"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "existing.user@example.com");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+const emailSchema = z.string().trim().email().transform((email) => email.toLowerCase());
+
 export const registerSchema = z.object({
-  email: z.string().email(),
+  email: emailSchema,
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: emailSchema,
   password: z.string().min(8)
 });


### PR DESCRIPTION
## Summary
- normalize register/login email input with one shared Zod schema helper
- trim surrounding whitespace and lowercase validated auth email addresses before service use
- add API regression coverage for mixed-case register and login payloads

Closes #2118
/claim #743

## Validation
- `node --test src/tests/*.test.js` from `apps/api` (3 tests passed)
- `git diff --check`

Note: `npm test -w apps/api` currently fails on this Windows environment because `node --test src/tests` is treated as a module path rather than discovering test files; the direct file-glob command above passes.