### PR TITLE
fix(api): validate refresh tokens

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,10 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import {
+  registerSchema,
+  loginSchema,
+  refreshTokenSchema
+} from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +26,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const payload = refreshTokenSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(payload.data.refreshToken);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,18 @@
-import { signAccessToken } from "../utils/jwt.js";
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyRefreshToken
+} from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: userId, role: payload.role })
   };
 }
 
@@ -14,10 +20,14 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "client" }),
+    refreshToken: signRefreshToken({ sub: "usr_existing", role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyRefreshToken(token);
+  return {
+    token: signAccessToken({ sub: payload.sub, role: payload.role })
+  };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  const payload = await response.json();
+  return { response, payload };
+}
+
+test("POST /api/auth/refresh validates refresh token and preserves user", async () => {
+  await withServer(async (baseUrl) => {
+    const login = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+
+    assert.equal(login.response.status, 200);
+    assert.equal(typeof login.payload.data.token, "string");
+    assert.equal(typeof login.payload.data.refreshToken, "string");
+
+    const refreshed = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: login.payload.data.refreshToken
+    });
+
+    assert.equal(refreshed.response.status, 200);
+    assert.equal(typeof refreshed.payload.data.token, "string");
+
+    const decoded = verifyAccessToken(refreshed.payload.data.token);
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, "client");
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid and access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await postJson(baseUrl, "/api/auth/refresh", {});
+
+    assert.equal(missing.response.status, 400);
+    assert.equal(missing.payload.success, false);
+
+    const invalid = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: "not-a-token"
+    });
+
+    assert.equal(invalid.response.status, 401);
+    assert.equal(invalid.payload.success, false);
+
+    const accessToken = signAccessToken({ sub: "usr_existing", role: "client" });
+    const accessAsRefresh = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: accessToken
+    });
+
+    assert.equal(accessAsRefresh.response.status, 401);
+    assert.equal(accessAsRefresh.payload.success, false);
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -8,3 +8,24 @@ export function signAccessToken(payload) {
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }
+
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, tokenType: "refresh" }, env.jwtSecret, {
+    expiresIn: "7d"
+  });
+}
+
+export function verifyRefreshToken(token) {
+  const payload = jwt.verify(token, env.jwtSecret);
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    payload.tokenType !== "refresh" ||
+    typeof payload.sub !== "string" ||
+    typeof payload.role !== "string"
+  ) {
+    throw new Error("Invalid refresh token");
+  }
+
+  return payload;
+}

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
## Summary\n- issue signed refresh tokens from login/register responses\n- require and validate `refreshToken` in `POST /api/auth/refresh` before minting a new access token\n- reject missing, malformed, and access-token-as-refresh requests\n- make the API test script discover `*.test.js` files and add refresh flow regression coverage\n\nFixes #2121\n\n/claim #743\n\n## Validation\n- `npm test -w apps/api`