### PR TITLE
Match registration token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const originalNow = Date.now;
+  const timestamps = [1000, 1001, 2000];
+  Date.now = () => timestamps.shift() ?? 2000;
+
+  try {
+    const result = await registerUser({
+      email: "new-client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const claims = verifyAccessToken(result.token);
+
+    assert.equal(claims.sub, result.id);
+    assert.equal(claims.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once and reuse it in the response and JWT subject
- prevent newly registered users from receiving a token whose `sub` can drift from the returned `id`
- add regression coverage with a mocked clock that advances between ID-generation calls

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? registerUser signs a token for the returned user id
? GET /health returns ok payload
? tests 2
? pass 2
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2119.
/claim #743