### PR TITLE
docs: normalize README workspace separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` - Next.js 14 App Router frontend
+- `apps/api` - Express.js backend with layered REST API
+- `packages/db` - Prisma schema and database package
+- `packages/ui` - Shared UI components
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- replace non-ASCII workspace-list separators with ASCII hyphens
- keep the README cleanup scoped to the separator rendering issue
- leave the stale Next.js version wording untouched because it is tracked separately in #2008

Closes #2123
/claim #743

## Validation
- `git diff --check`