### PR TITLE
fix(api): restrict cors origins

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,12 +14,24 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { env } from "./config/env.js";
 
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(
+    cors({
+      origin(origin, callback) {
+        if (!origin || env.corsOrigins.includes(origin)) {
+          return callback(null, true);
+        }
+
+        return callback(null, false);
+      },
+      credentials: true
+    })
+  );
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,13 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: parseCorsOrigins(process.env.CORS_ORIGIN)
 };
+
+function parseCorsOrigins(value) {
+  return (value ?? "http://localhost:3000,http://localhost:5173")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS allows trusted local frontend origins", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "http://localhost:3000" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("access-control-allow-origin"),
+      "http://localhost:3000"
+    );
+    assert.equal(response.headers.get("access-control-allow-credentials"), "true");
+  });
+});
+
+test("CORS does not allow untrusted browser origins", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "https://evil.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  });
+});
+
+test("CORS keeps no-origin service requests working", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
## Summary\n- configure API CORS with a trusted-origin allowlist instead of unrestricted `cors()` defaults\n- add `CORS_ORIGIN` parsing with safe localhost web defaults\n- keep no-origin service and health-check requests working\n- add regression tests for allowed, blocked, and no-origin requests\n- make the API test script discover `*.test.js` files\n\nFixes #2127\n\n/claim #743\n\n## Validation\n- `npm test -w apps/api`\n- `node --test apps/api/src/tests/cors.test.js`