### PR TITLE
fix(api): validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q ?? "";
+  if (typeof query !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query must be 200 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(normalizedQuery));
 }

--- a/apps/api/src/tests/searchController.test.js
+++ b/apps/api/src/tests/searchController.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid query input before searching", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/search?q=${encodeURIComponent("  React  ")}`
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "React");
+  });
+});
+
+test("GET /api/search rejects overly long query input", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(201);
+    const response = await fetch(
+      `${baseUrl}/api/search?q=${encodeURIComponent(query)}`
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be 200 characters or fewer");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=react&q=node`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be a string");
+  });
+});


### PR DESCRIPTION
## Summary\n- validate `q` before passing it to the search service\n- trim valid query strings and reject repeated/non-string query params\n- reject queries longer than 200 characters with a 400 response\n- add regression tests for normalized, too-long, and repeated query inputs\n- make the API test script discover `*.test.js` files\n\nFixes #2130\n\n/claim #743\n\n## Validation\n- `npm test -w apps/api`\n- `node --test apps/api/src/tests/searchController.test.js`