### PR TITLE
Fix API test script to target test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Fixes the API workspace test script so Node's built-in test runner targets the actual test files instead of the tests directory.

## Problem

Running npm test failed before executing tests because node --test src/tests attempted to resolve the directory as a module path.

## Changes

- Updated apps/api/package.json to run node --test against src/tests/**/*.test.js

## Verification

- [x] npm test

Closes #766