### PR TITLE
fix(api): count malformed json in rate limit

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON requests consume the API rate limit", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      for (let i = 0; i < 201; i += 1) {
+        response = await fetch(`${baseUrl}/api/auth/login`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{"
+        });
+      }
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.equal(response.status, 429);
+  });
+});


### PR DESCRIPTION
## Summary\n- move the global API rate limiter before JSON body parsing\n- ensure malformed JSON requests consume rate-limit quota instead of bypassing it\n- add regression coverage that malformed JSON reaches 429 after the configured limit\n- make the API test script discover `*.test.js` files\n\nFixes #2135\n\n/claim #743\n\n## Validation\n- `node --test apps/api/src/tests/rateLimit.test.js`\n- `npm test -w apps/api`