### PR TITLE
Fix rate limiter ordering for malformed JSON

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,44 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("malformed JSON requests consume global rate limit quota", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    let rateLimitedResponse;
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
+    try {
+      for (let attempt = 0; attempt < 205; attempt += 1) {
+        const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{"
+        });
+
+        if (response.status === 429) {
+          rateLimitedResponse = response;
+          break;
+        }
+      }
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.ok(rateLimitedResponse, "expected malformed JSON requests to eventually hit the rate limiter");
+    assert.equal(rateLimitedResponse.status, 429);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Moves the global API rate limiter before JSON body parsing so malformed JSON requests still consume rate-limit quota.

## Changes

- Register apiLimiter before express.json() in the Express middleware stack.
- Add regression coverage that sends malformed JSON requests and verifies they eventually receive 429 after consuming the configured quota.

## Verification

- [x] node --test apps/api/src/tests/health.test.js

Closes #2138
Related source issue: #1735
Parent bounty: #743