### PR TITLE
Protect server-managed fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serverFields.test.js
+++ b/apps/api/src/tests/serverFields.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+test("creation services do not allow payloads to override server-managed fields", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 12345;
+
+  try {
+    const user = await createUser({
+      id: "client_user",
+      email: "client@example.com",
+      role: "client"
+    });
+    const job = await createJob({
+      id: "client_job",
+      status: "completed",
+      title: "Website build",
+      description: "Build a responsive marketing website",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "cat_web",
+      skills: ["nextjs"]
+    });
+    const proposal = await createProposal({
+      id: "client_proposal",
+      coverLetter: "I can help with this project.",
+      bidAmount: 250,
+      estDuration: "1 week",
+      jobId: "job_12345",
+      freelancerId: "usr_12345"
+    });
+    const review = await createReview({
+      id: "client_review",
+      rating: 5,
+      comment: "Great work",
+      reviewerId: "usr_client",
+      revieweeId: "usr_freelancer"
+    });
+    const message = await sendMessage({
+      id: "client_message",
+      body: "Hello",
+      senderId: "usr_client",
+      receiverId: "usr_freelancer",
+      sentAt: "2000-01-01T00:00:00.000Z"
+    });
+    const notification = await createNotification({
+      id: "client_notification",
+      userId: "usr_client",
+      title: "Proposal update",
+      body: "A proposal changed",
+      read: true
+    });
+
+    assert.equal(user.id, "usr_12345");
+    assert.equal(job.id, "job_12345");
+    assert.equal(job.status, "open");
+    assert.equal(proposal.id, "prp_12345");
+    assert.equal(review.id, "rev_12345");
+    assert.equal(message.id, "msg_12345");
+    assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+    assert.equal(notification.id, "ntf_12345");
+    assert.equal(notification.read, false);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- assign generated ids after user-controlled payloads in creation services
- keep job status, notification read state, and message timestamps server-managed
- add regression coverage proving payload `id`/`status`/`read`/`sentAt` values cannot override server-managed fields

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? creation services do not allow payloads to override server-managed fields
? tests 2
? pass 2
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2136.
/claim #743