### PR TITLE
fix(api): accept case-insensitive bearer auth

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,15 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const match = authHeader?.match(/^bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+
+  if (!token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth middleware accepts lowercase bearer scheme", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_existing", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `bearer ${token}` }
+    });
+
+    assert.equal(response.status, 200);
+  });
+});
+
+test("auth middleware tolerates extra bearer whitespace", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_existing", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `BeArEr   ${token}  ` }
+    });
+
+    assert.equal(response.status, 200);
+  });
+});
+
+test("auth middleware rejects missing bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: "bearer   " }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});


### PR DESCRIPTION
## Summary\n- parse the Authorization bearer scheme case-insensitively\n- tolerate extra whitespace between the scheme and token while still rejecting empty tokens\n- add protected-route regression coverage for lowercase bearer, mixed-case bearer with extra whitespace, and missing token\n- make the API test script discover `*.test.js` files\n\nFixes #2141\n\n/claim #743\n\n## Validation\n- `node --test apps/api/src/tests/authMiddleware.test.js`\n- `npm test -w apps/api`