### PR TITLE
Require production JWT secret

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? "";
+
+if (nodeEnv === "production" && jwtSecret.length === 0) {
+  throw new Error("JWT_SECRET is required in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: jwtSecret || "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function loadEnvConfig(name) {
+  return import(`../config/env.js?case=${name}-${Date.now()}`);
+}
+
+test("production config requires JWT_SECRET", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  try {
+    await assert.rejects(
+      loadEnvConfig("missing-production-secret"),
+      /JWT_SECRET is required in production/
+    );
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  }
+});
+
+test("development config keeps the local JWT_SECRET fallback", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "development";
+  delete process.env.JWT_SECRET;
+
+  try {
+    const { env } = await loadEnvConfig("development-fallback");
+    assert.equal(env.jwtSecret, "development-secret");
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- fail fast when `NODE_ENV=production` is missing `JWT_SECRET`
- keep the existing `development-secret` fallback for local development only
- add dynamic import coverage for production failure and development fallback behavior

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? production config requires JWT_SECRET
? development config keeps the local JWT_SECRET fallback
? GET /health returns ok payload
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2145.
/claim #743