### PR TITLE
Validate review creation requests

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,11 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Invalid review request", 400);
+  }
+
+  return ok(res, await createReview(payload.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects ratings outside the supported range", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        rating: 6,
+        comment: "Great work",
+        reviewerId: "usr_client",
+        revieweeId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/reviews accepts valid review payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Great work",
+        reviewerId: "usr_client",
+        revieweeId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great work");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1),
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- validate review creation payloads before calling the review service
- reject ratings outside the supported 1-5 range with a 400 response
- require non-empty comments and reviewer/reviewee ids for new reviews

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? POST /api/reviews rejects ratings outside the supported range
? POST /api/reviews accepts valid review payloads
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2158.
/claim #743