### PR TITLE
fix: configure CORS with explicit origin allowlist

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,12 +14,18 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { env } from "./config/env.js";
 
 export function createApp() {
   const app = express();
 
+  const allowedOrigins = env.corsOrigins.split(",").map(o => o.trim());
+
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin: allowedOrigins,
+    credentials: true
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,6 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: process.env.CORS_ORIGINS ?? "http://localhost:3000"
 };


### PR DESCRIPTION
## Summary
Replaces unrestricted `cors()` with an explicit origin allowlist read from the `CORS_ORIGINS` environment variable. Defaults to `http://localhost:3000` for development.

## Changes
- Updated `apps/api/src/config/env.js` to add `corsOrigins` from `CORS_ORIGINS` env var
- Updated `apps/api/src/app.js` to configure CORS with origin allowlist and credentials support

## Issue
Fixes #2161

Ref: #743