### PR TITLE
fix: add authentication middleware to job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Summary
Adds `authMiddleware` to the `POST /api/jobs` route to require authentication before creating job listings.

## Changes
- Updated `apps/api/src/routes/jobRoutes.js` to apply `authMiddleware` to the POST route

## Issue
Fixes #2163

Ref: #743