### PR TITLE
fix: add input validation and length limit to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,9 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = String(req.query.q ?? "").trim().slice(0, MAX_QUERY_LENGTH);
+  return ok(res, await globalSearch(query));
 }


### PR DESCRIPTION
## Summary
The search endpoint was passing raw query input directly to the service layer without any validation or length limits. This fix trims whitespace and enforces a 200 character maximum length to prevent DoS via overly long query strings.

## Changes
- Updated `apps/api/src/controllers/searchController.js` to trim and limit search query to 200 characters

## Issue
Fixes #2164

Ref: #743