### PR TITLE
Validate message creation requests

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,11 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Invalid message request", 400);
+  }
+
+  return ok(res, await sendMessage(payload.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects blank message bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        body: "   ",
+        senderId: "usr_client",
+        receiverId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/messages accepts valid message payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        body: "Hello there",
+        senderId: "usr_client",
+        receiverId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.body, "Hello there");
+    assert.equal(payload.data.senderId, "usr_client");
+    assert.equal(payload.data.receiverId, "usr_freelancer");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  body: z.string().trim().min(1),
+  senderId: z.string().min(1),
+  receiverId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- validate message creation payloads before calling the message service
- reject blank message bodies with a 400 response
- require sender and receiver ids for new messages

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? POST /api/messages rejects blank message bodies
? POST /api/messages accepts valid message payloads
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2167.
/claim #743