### PR TITLE
Validate proposal creation requests

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,11 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Invalid proposal request", 400);
+  }
+
+  return ok(res, await createProposal(payload.data), 201);
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects non-positive bid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        coverLetter: "I can help with this project.",
+        bidAmount: -100,
+        estDuration: "1 week",
+        jobId: "job_123",
+        freelancerId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/proposals accepts valid proposal payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        coverLetter: "I can help with this project.",
+        bidAmount: 100,
+        estDuration: "1 week",
+        jobId: "job_123",
+        freelancerId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.bidAmount, 100);
+    assert.equal(payload.data.jobId, "job_123");
+    assert.equal(payload.data.freelancerId, "usr_freelancer");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- validate proposal creation payloads before calling the proposal service
- reject non-positive bid amounts with a 400 response
- require non-empty cover letters, estimated durations, job ids, and freelancer ids

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? POST /api/proposals rejects non-positive bid amounts
? POST /api/proposals accepts valid proposal payloads
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2172.
/claim #743