### PR TITLE
fix: use canonical login role claim

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -14,7 +14,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "CLIENT" })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("loginUser signs access tokens with canonical client role casing", async () => {
+  const result = await loginUser({
+    email: "client@example.com",
+    password: "correct-horse-battery"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, "usr_existing");
+  assert.equal(decoded.role, "CLIENT");
+});


### PR DESCRIPTION
## Summary
- update the stubbed login service to sign `CLIENT` instead of lowercase `client`
- add a focused service regression that verifies the decoded login JWT role claim
- keep the scope limited to login-token role casing

Closes #2183
/claim #743

## Validation
- `node --test src/tests/authService.test.js src/tests/health.test.js` from `apps/api`
- `git diff --check`