### PR TITLE
docs: remove generic README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Project
-<img width="663" height="183" alt="Image" src="https://github.com/user-attachments/assets/1a920eb5-e581-44ce-bcef-2ebf0566777f" />
-
 # FreelanceFlow Monorepo
+<img width="663" height="183" alt="Image" src="https://github.com/user-attachments/assets/1a920eb5-e581-44ce-bcef-2ebf0566777f" />
 
 FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern TypeScript-first architecture.
 


### PR DESCRIPTION
## Summary
- remove the generic duplicate `# Project` heading from the README
- keep the existing image under the descriptive `# FreelanceFlow Monorepo` H1
- leave separate README version/separator cleanup issues untouched

Closes #2185
/claim #743

## Validation
- `git diff --check`