### PR TITLE
feat: add post job draft form

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,12 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.stack { display: grid; gap: 0.7rem; }
+.post-job-layout { align-items: start; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.post-job-field { display: grid; gap: 0.5rem; }
+.post-job-control { width: 100%; border: 1px solid #324574; border-radius: 8px; background: #0f162d; color: #f2f5ff; padding: 0.75rem; }
+.post-job-action { border: 0; border-radius: 8px; background: #5dd6a7; color: #08111f; cursor: pointer; font-weight: 700; padding: 0.8rem 1rem; }
+.post-job-row { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.notice { background: #202b4d; border: 1px solid #415b99; border-radius: 8px; padding: 0.8rem; }
+.skill-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.skill-list span { background: #27345f; border-radius: 999px; padding: 0.35rem 0.7rem; }

--- a/apps/web/app/jobs/post/page.tsx
+++ b/apps/web/app/jobs/post/page.tsx
@@ -1,8 +1,156 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useMemo, useState } from "react";
+
+const categories = ["Engineering", "Design", "Writing", "Growth"];
+
 export default function PostJobPage() {
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState(categories[0]);
+  const [budgetMin, setBudgetMin] = useState("");
+  const [budgetMax, setBudgetMax] = useState("");
+  const [skills, setSkills] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const errors = useMemo(() => {
+    const nextErrors: string[] = [];
+    const min = Number(budgetMin);
+    const max = Number(budgetMax);
+
+    if (!title.trim()) nextErrors.push("Add a project title.");
+    if (!description.trim()) nextErrors.push("Add a project description.");
+    if (!budgetMin || Number.isNaN(min) || min < 0) nextErrors.push("Enter a valid minimum budget.");
+    if (!budgetMax || Number.isNaN(max) || max < 0) nextErrors.push("Enter a valid maximum budget.");
+    if (budgetMin && budgetMax && min > max) nextErrors.push("Minimum budget must be below maximum budget.");
+
+    return nextErrors;
+  }, [budgetMax, budgetMin, description, title]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitted(true);
+  }
+
+  const skillList = skills
+    .split(",")
+    .map((skill) => skill.trim())
+    .filter(Boolean);
+
   return (
-    <section className="card">
-      <h2>Post a Job</h2>
-      <p>Draft title, budget, category, and skill requirements for your project.</p>
+    <section className="grid post-job-layout">
+      <form className="card stack" onSubmit={handleSubmit}>
+        <div>
+          <h2>Post a Job</h2>
+          <p>Draft the key details clients need before publishing a project.</p>
+        </div>
+
+        <label className="post-job-field">
+          Project title
+          <input
+            className="post-job-control"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Build an AI customer support widget"
+          />
+        </label>
+
+        <label className="post-job-field">
+          Category
+          <select
+            className="post-job-control"
+            value={category}
+            onChange={(event) => setCategory(event.target.value)}
+          >
+            {categories.map((option) => (
+              <option key={option}>{option}</option>
+            ))}
+          </select>
+        </label>
+
+        <div className="post-job-row">
+          <label className="post-job-field">
+            Minimum budget
+            <input
+              className="post-job-control"
+              min="0"
+              type="number"
+              value={budgetMin}
+              onChange={(event) => setBudgetMin(event.target.value)}
+              placeholder="500"
+            />
+          </label>
+          <label className="post-job-field">
+            Maximum budget
+            <input
+              className="post-job-control"
+              min="0"
+              type="number"
+              value={budgetMax}
+              onChange={(event) => setBudgetMax(event.target.value)}
+              placeholder="1500"
+            />
+          </label>
+        </div>
+
+        <label className="post-job-field">
+          Skills
+          <input
+            className="post-job-control"
+            value={skills}
+            onChange={(event) => setSkills(event.target.value)}
+            placeholder="React, Node.js, analytics"
+          />
+        </label>
+
+        <label className="post-job-field">
+          Description
+          <textarea
+            className="post-job-control"
+            rows={5}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Describe the project scope, outcomes, and timeline."
+          />
+        </label>
+
+        {submitted && errors.length > 0 ? (
+          <div className="notice" role="alert">
+            <strong>Resolve before publishing</strong>
+            <ul>
+              {errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {submitted && errors.length === 0 ? (
+          <p className="notice" role="status">Draft is ready for API persistence.</p>
+        ) : null}
+
+        <button className="post-job-action" type="submit">Review Draft</button>
+      </form>
+
+      <aside className="card stack" aria-label="Job draft preview">
+        <h2>Draft Preview</h2>
+        <div>
+          <h3>{title.trim() || "Untitled project"}</h3>
+          <p>{category}</p>
+          <p>
+            {budgetMin || "0"} - {budgetMax || "0"} USD
+          </p>
+        </div>
+        <p>{description.trim() || "Project description will appear here."}</p>
+        <div className="skill-list">
+          {skillList.length > 0 ? (
+            skillList.map((skill) => <span key={skill}>{skill}</span>)
+          ) : (
+            <span>No skills added</span>
+          )}
+        </div>
+      </aside>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the `/jobs/post` placeholder with a client-side draft form.
- Adds title, category, budget range, skills, and description controls.
- Adds validation feedback and a live draft preview without changing API behavior.

## Validation
- `npm run build -w apps/web`
- `curl -s http://192.168.75.34:3000/jobs/post | rg -o "Post a Job|Project title|Minimum budget|Maximum budget|Skills|Description|Review Draft|Draft Preview|No skills added"`

Closes #2181

/claim #743
