### PR TITLE
fix: add authentication to payment endpoint (#2201)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
Fixes #2201

Added `authMiddleware` to `POST /payments` route.

Wallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26