### PR TITLE
fix: validate refresh token before minting new token (#2204)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const token = req.body?.refreshToken || req.headers["x-refresh-token"];
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,10 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  if (!token) {
+    throw new Error("Refresh token is required");
+  }
+  const decoded = verifyToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }


### PR DESCRIPTION
Fixes #2204

Refresh endpoint now validates the refresh token via JWT verification before minting a new access token.

Wallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26