### PR TITLE
fix: configure CORS with origin allowlist from CORS_ORIGINS env var (#2214)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: process.env.CORS_ORIGINS?.split(",") || ["http://localhost:3000"], credentials: true }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Fixes #2214

Replaced wildcard cors() with origin allowlist from CORS_ORIGINS env var.

Wallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26