### PR TITLE
fix: update PostCSS dependency to resolve audit advisory (#2217)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
Fixes #2217

Ran npm audit fix to update PostCSS dependency.

Wallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26