### PR TITLE
fix: validate user creation input and prevent client-controlled IDs

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
+import { ZodError } from "zod";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({ success: false, message: "Validation error", errors: err.errors });
+    }
+    throw err;
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,15 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Server always generates the ID — never trust client-supplied id
+  const { email, name, role, bio } = payload;
+  const user = {
+    id: `usr_${Date.now()}`,
+    email,
+    name,
+    role,
+    ...(bio !== undefined && { bio })
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-creation-validation.test.js
+++ b/apps/api/src/tests/user-creation-validation.test.js
@@ -1,0 +1,208 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+/**
+ * Tests for issue #1766: user creation accepts empty payloads and client-controlled ids
+ *
+ * The POST /api/users endpoint should:
+ * 1. Require email and name fields
+ * 2. Reject unknown fields like 'id' (preventing client-controlled IDs)
+ * 3. Only allow safe roles (client, freelancer), not admin
+ * 4. Server-generate the ID regardless of any id in the payload
+ */
+
+test("POST /api/users with empty body returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+
+    assert.equal(response.status, 400, "Empty body should return 400");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/users with missing name returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "test@example.com" })
+    });
+
+    assert.equal(response.status, 400, "Missing name should return 400");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/users with client-controlled id field returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker_controlled",
+        email: "attacker@evil.com",
+        name: "Attacker"
+      })
+    });
+
+    assert.equal(response.status, 400, "Client-controlled id should be rejected by strict schema");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/users with admin role returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "attacker@evil.com",
+        name: "Attacker",
+        role: "admin"
+      })
+    });
+
+    assert.equal(response.status, 400, "Admin role should be rejected");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/users with valid payload returns 201 with server-generated id", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "valid@example.com",
+        name: "Valid User",
+        role: "freelancer",
+        bio: "A test bio"
+      })
+    });
+
+    assert.equal(response.status, 201, "Valid payload should return 201");
+
+    const body = await response.json();
+    assert.equal(body.success, true, "Response should indicate success");
+    assert.ok(body.data.id.startsWith("usr_"), "ID should be server-generated");
+    assert.equal(body.data.email, "valid@example.com");
+    assert.equal(body.data.name, "Valid User");
+    assert.equal(body.data.role, "freelancer");
+    assert.equal(body.data.bio, "A test bio");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/users with invalid email returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "not-an-email",
+        name: "Test User"
+      })
+    });
+
+    assert.equal(response.status, 400, "Invalid email should return 400");
+
+    const body = await response.json();
+    assert.equal(body.success, false, "Response should indicate failure");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/**
+ * Schema for creating a user via POST /api/users
+ * 
+ * Security considerations:
+ * - `id` is NOT in the schema — it must always be server-generated
+ * - `.strict()` rejects unknown fields, preventing id injection
+ * - `role` only allows safe public roles (client, freelancer), not admin
+ */
+export const createUserSchema = z.object({
+  email: z.string().email("Valid email is required"),
+  name: z.string().min(1, "Name is required").max(100),
+  role: z.enum(["client", "freelancer"]).default("client"),
+  bio: z.string().max(500).optional()
+}).strict();


### PR DESCRIPTION
## Fix for #1766: user creation accepts empty payloads and client-controlled ids

### Vulnerability

The `POST /api/users` endpoint accepted arbitrary request bodies and forwarded them directly to `createUser`. The service spread the entire payload into the user object, allowing:

1. **Client-controlled IDs**: An attacker could submit an `id` field and override the server-generated ID
2. **Empty payloads**: Objects without name/email/role could become persisted-looking user records
3. **Unsafe roles**: Admin role could be assigned via the payload

### Fix Summary

1. **validators/user.js** (NEW) - createUserSchema using Zod with .strict():
   - Requires email (validated) and name (min 1, max 100)
   - Only allows safe roles: client (default) or freelancer
   - .strict() rejects unknown fields including id
   - Optional bio field (max 500 chars)

2. **controllers/userController.js** - Parses req.body with schema, returns 400 for validation errors

3. **services/userService.js** - Destructures only validated fields, never trusts payload.id

### Test Results

- POST /api/users with empty body returns 400
- POST /api/users with missing name returns 400
- POST /api/users with client-controlled id field returns 400
- POST /api/users with admin role returns 400
- POST /api/users with valid payload returns 201 with server-generated id
- POST /api/users with invalid email returns 400

Fixes #1766
