### PR TITLE
Require auth for notification routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/notifications accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});


### PR DESCRIPTION
## Summary
- protect notification routes with the existing auth middleware
- reject unauthenticated access to notification list/create endpoints
- add route coverage for unauthenticated 401 and authenticated success

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? GET /api/notifications rejects unauthenticated requests
? GET /api/notifications accepts authenticated requests
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2231.
/claim #743