### PR TITLE
Validate auth refresh tokens

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,16 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const parsed = refreshSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "refreshToken is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(parsed.data.refreshToken);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,46 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
+
+function issueTokenPair(user) {
+  const tokenPayload = { sub: user.id, role: user.role };
+
+  return {
+    token: signAccessToken(tokenPayload),
+    refreshToken: signRefreshToken(tokenPayload)
+  };
+}
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: payload.role
+  };
+
+  return {
+    ...user,
+    ...issueTokenPair(user)
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
-  return {
+  const user = {
+    id: "usr_existing",
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    role: "client"
+  };
+
+  return {
+    email: user.email,
+    ...issueTokenPair(user)
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyRefreshToken(token);
+
+  return {
+    token: signAccessToken({ sub: decoded.sub, role: decoded.role })
+  };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { loginUser } from "../services/authService.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects missing refresh tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "refreshToken is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refresh tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "not-a-valid-token" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const accessToken = signAccessToken({ sub: "usr_existing", role: "client" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: accessToken })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh issues an access token for the refresh token subject", async () => {
+  await withServer(async (baseUrl) => {
+    const login = await loginUser({ email: "client@example.com", password: "password123" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: login.refreshToken })
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, "client");
+    assert.equal(decoded.tokenType, "access");
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -2,9 +2,29 @@ import jwt from "jsonwebtoken";
 import { env } from "../config/env.js";
 
 export function signAccessToken(payload) {
-  return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
+  return jwt.sign({ ...payload, tokenType: "access" }, env.jwtSecret, { expiresIn: "15m" });
 }
 
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
+}
+
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, tokenType: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
+}
+
+export function verifyRefreshToken(token) {
+  const decoded = jwt.verify(token, env.jwtSecret);
+
+  if (
+    !decoded ||
+    typeof decoded !== "object" ||
+    decoded.tokenType !== "refresh" ||
+    typeof decoded.sub !== "string" ||
+    typeof decoded.role !== "string"
+  ) {
+    throw new jwt.JsonWebTokenError("Invalid refresh token");
+  }
+
+  return decoded;
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

Fixes #2241.

## Summary
- Added refresh-token signing and verification alongside existing access tokens.
- Login and registration now issue a refresh token tied to the same user subject/role as the access token.
- `POST /api/auth/refresh` now requires `refreshToken`, rejects missing/invalid/access-token input, and mints the new access token from the verified refresh token payload.
- Added endpoint regression tests for missing, invalid, wrong-token-type, and successful refresh flows.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- The change stays inside auth utilities, auth service/controller validation, auth validator schema, and refresh endpoint tests.
- No secrets, credentials, cookies, payout details, or private auth material are included.
