### PR TITLE
Keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs an access token for the returned user id", async () => {
+  const originalNow = Date.now;
+  const timestamps = [1000, 1001];
+  Date.now = () => timestamps.shift() ?? 1001;
+
+  try {
+    const user = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(user.token);
+
+    assert.equal(user.id, "usr_1000");
+    assert.equal(decoded.sub, user.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Fixes #2244.

## Summary
- Generate the registration user id once inside `registerUser()`.
- Reuse that id for both the returned `id` and the access-token `sub` claim.
- Added a regression test that stubs sequential `Date.now()` values and verifies the decoded token subject matches the returned user id.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- Scope is limited to registration token subject consistency.
- This does not change login, refresh tokens, password storage, role rules, persistence, or broader auth behavior.
