### PR TITLE
Require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobRoutes.test.js
+++ b/apps/api/src/tests/jobRoutes.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const validJobPayload = {
+  title: "Build a landing page",
+  description: "Create a responsive landing page for a product launch.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "cat_web",
+  skills: ["nextjs", "css"]
+};
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs rejects unauthenticated job creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/jobs allows authenticated job creation", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJobPayload.title);
+    assert.equal(payload.data.status, "open");
+    assert.match(payload.data.id, /^job_/);
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #2258.

## Summary
- Added `authMiddleware` to `POST /api/jobs` so anonymous callers cannot create job listings.
- Left `GET /api/jobs` public for listing jobs.
- Added route coverage proving unauthenticated job creation returns `401` and authenticated job creation still succeeds.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- Scope is limited to the job creation route and its regression tests.
- No secrets, credentials, cookies, payout details, or private auth material are included.
