### PR TITLE
Require auth before uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/uploads accepts authenticated upload requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const formData = new FormData();
+    formData.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "hello.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication before upload requests reach the in-memory multer middleware
- reject unauthenticated upload attempts with the existing 401 response
- add route coverage for unauthenticated rejection and authenticated multipart upload success

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? POST /api/uploads rejects unauthenticated requests
? POST /api/uploads accepts authenticated upload requests
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2275.
/claim #743