### PR TITLE
Require auth for uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createUploadForm() {
+  const form = new FormData();
+  form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+  return form;
+}
+
+test("POST /api/uploads rejects unauthenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: createUploadForm()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/uploads allows authenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      body: createUploadForm()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #2290.

## Summary
- Added `authMiddleware` before `multer` on `POST /api/uploads` so anonymous callers cannot upload files.
- Kept the upload controller behavior unchanged for authenticated callers.
- Added route coverage proving unauthenticated uploads return `401` and authenticated uploads still succeed.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- Scope is limited to the upload route and its regression tests.
- No secrets, credentials, cookies, payout details, or private auth material are included.
