### PR TITLE
Require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobAuth.test.js
+++ b/apps/api/src/tests/jobAuth.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a polished marketing page for a product launch.",
+  budgetMin: 250,
+  budgetMax: 500,
+  categoryId: "cat_design",
+  skills: ["design"]
+};
+
+test("POST /api/jobs rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/jobs accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJobPayload.title);
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication before creating jobs
- keep public job listing unchanged
- add route coverage for unauthenticated rejection and authenticated job creation success

## Validation
```text
$ node --test apps\api\src\tests\*.test.js
? GET /health returns ok payload
? POST /api/jobs rejects unauthenticated requests
? POST /api/jobs accepts authenticated requests
? tests 3
? pass 3
? fail 0
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Note: `npm run test -w apps/api` still hits the existing `node --test src/tests` directory-entry issue already covered separately by #1892, so this branch uses the explicit test glob above for validation.

Fixes #2297.
/claim #743