### PR TITLE
Restrict CORS origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
+import { env } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -19,7 +20,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: env.corsOrigins }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,21 @@
+const defaultCorsOrigins = ["http://localhost:3000", "http://127.0.0.1:3000"];
+
+function parseCorsOrigins(value) {
+  if (!value) {
+    return defaultCorsOrigins;
+  }
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: parseCorsOrigins(process.env.CORS_ORIGINS)
 };

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS allows configured local frontend origins", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "http://localhost:3000" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "http://localhost:3000");
+  });
+});
+
+test("CORS does not allow unconfigured origins", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "https://evil.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #2299.

## Summary
- Replaced unrestricted `cors()` with an explicit origin allowlist.
- Added `CORS_ORIGINS` parsing with local frontend defaults for development.
- Added CORS regression coverage proving configured local origins receive `access-control-allow-origin` while unconfigured origins do not.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- Scope is limited to API CORS configuration and regression tests.
- No secrets, credentials, cookies, payout details, or private auth material are included.
