### PR TITLE
Validate proposal creation input

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_freelancer",
+  coverLetter: "I can complete this project with a clean implementation plan.",
+  bidAmount: 1200,
+  estimatedDuration: "2 weeks"
+};
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects proposals missing estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const { estimatedDuration, ...missingDuration } = validProposal;
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(missingDuration)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals rejects client-controlled IDs", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...validProposal, id: "prp_attacker" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals creates valid proposals with a server-generated ID", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validProposal)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, validProposal.jobId);
+    assert.equal(payload.data.freelancerId, validProposal.freelancerId);
+    assert.equal(payload.data.estimatedDuration, validProposal.estimatedDuration);
+    assert.match(payload.data.id, /^prp_/);
+    assert.notEqual(payload.data.id, "prp_attacker");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().trim().min(10),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.string().trim().min(1)
+}).strict();


### PR DESCRIPTION
/claim #743

Fixes #2313.

## Summary
- Added strict proposal creation validation for `jobId`, `freelancerId`, `coverLetter`, `bidAmount`, and `estimatedDuration`.
- Rejects malformed proposals and client-supplied proposal IDs.
- Keeps generated proposal IDs authoritative in the service.
- Added route coverage for missing estimated duration, client-controlled IDs, and valid proposal creation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Notes
- Scope is limited to proposal creation validation and ID precedence.
- No secrets, credentials, cookies, payout details, or private auth material are included.
