### PR TITLE
Validate login credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,10 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid credentials", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,46 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
+
+const usersByEmail = new Map();
+
+function hashPassword(password) {
+  return createHash("sha256").update(password).digest("hex");
+}
+
+function passwordsMatch(password, expectedHash) {
+  const actualHash = hashPassword(password);
+  return timingSafeEqual(Buffer.from(actualHash), Buffer.from(expectedHash));
+}
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password),
+    role: payload.role
+  };
+  usersByEmail.set(payload.email.toLowerCase(), user);
+
+  return {
+    id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const user = usersByEmail.get(payload.email.toLowerCase());
+  if (!user || !passwordsMatch(payload.password, user.passwordHash)) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authLogin.test.js
+++ b/apps/api/src/tests/authLogin.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("POST /api/auth/login rejects unknown credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "missing@example.com",
+      password: "password123"
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("POST /api/auth/login requires the registered password", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `login-${Date.now()}@example.com`;
+    const password = "password123";
+    const registerResult = await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password,
+      role: "client"
+    });
+
+    assert.equal(registerResult.response.status, 201);
+
+    const wrongPassword = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "password456"
+    });
+    assert.equal(wrongPassword.response.status, 401);
+
+    const validLogin = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password
+    });
+
+    assert.equal(validLogin.response.status, 200);
+    assert.equal(validLogin.payload.success, true);
+    assert.equal(validLogin.payload.data.email, email);
+    assert.equal(typeof validLogin.payload.data.token, "string");
+  });
+});


### PR DESCRIPTION
## Summary
- Store registered users in the existing in-memory auth service for the process lifetime.
- Reject login attempts for unknown users or wrong passwords with `401 Invalid credentials`.
- Issue login tokens only for matching registered users, using the stored user id and role.
- Add regression coverage for unknown credentials, wrong passwords, and successful login.

## Validation
- `node --test apps\api\src\tests\*.test.js`
- `git diff --check`

Fixes #2316
Refs #743
/claim #743
