### PR TITLE
Add actionable settings controls

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,62 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.settings-page { display: grid; gap: 1rem; }
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #2a3765;
+}
+.settings-header h2 { margin: 0.25rem 0; font-size: 2rem; }
+.settings-header p { margin: 0; color: #b8c2e6; line-height: 1.55; }
+.eyebrow { color: #7dd3fc; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; text-transform: uppercase; }
+.settings-summary {
+  min-width: 210px;
+  background: #10182e;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  padding: 0.85rem;
+}
+.settings-summary span { display: block; color: #94a3b8; font-size: 0.85rem; }
+.settings-summary strong { display: block; margin-top: 0.35rem; color: #facc15; }
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
+.settings-panel {
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 8px;
+  padding: 1rem;
+  min-width: 0;
+}
+.settings-panel-header { display: flex; justify-content: space-between; gap: 0.75rem; align-items: center; }
+.settings-panel h3 { margin: 0; font-size: 1.05rem; }
+.settings-panel p { color: #cbd5e1; line-height: 1.5; }
+.chip {
+  flex: 0 0 auto;
+  border: 1px solid #22c55e;
+  color: #bbf7d0;
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.75rem;
+}
+.chip.warning { border-color: #facc15; color: #fde68a; }
+.settings-list { margin: 0 0 1rem; padding-left: 1rem; color: #dbeafe; line-height: 1.7; }
+.settings-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.settings-actions button {
+  border: 1px solid #38bdf8;
+  background: #0f172a;
+  color: #e0f2fe;
+  border-radius: 6px;
+  padding: 0.55rem 0.7rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+@media (max-width: 700px) {
+  .settings-header { display: grid; }
+  .settings-summary { min-width: 0; }
+  .settings-grid { grid-template-columns: 1fr; }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,76 @@
 export default function SettingsPage() {
+  const settingsSections = [
+    {
+      title: "Account profile",
+      status: "Visible",
+      description: "Client profile is published with verified email and company details.",
+      actions: ["Edit profile", "Preview public profile"],
+      details: ["Display name: Priya Sharma", "Company: Northstar Retail", "Role: Client"]
+    },
+    {
+      title: "Notifications",
+      status: "Digest on",
+      description: "Proposal, message, and invoice alerts are grouped into a daily digest.",
+      actions: ["Change cadence", "Test email alert"],
+      details: ["Proposal updates: instant", "Messages: instant", "Billing: daily digest"]
+    },
+    {
+      title: "Security",
+      status: "Review needed",
+      description: "Password was updated recently, but two-factor authentication is not enabled.",
+      actions: ["Enable 2FA", "Review sessions"],
+      details: ["Password: updated 12 days ago", "2FA: not enabled", "Active sessions: 2"]
+    },
+    {
+      title: "Billing and payouts",
+      status: "Ready",
+      description: "Default payment method and invoice contact are configured for new projects.",
+      actions: ["Update billing", "Download tax info"],
+      details: ["Default currency: USD", "Invoice email: finance@example.com", "Payout method: bank transfer"]
+    }
+  ];
+
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
-    </section>
+    <div className="settings-page">
+      <section className="settings-header">
+        <div>
+          <p className="eyebrow">Account settings</p>
+          <h2>Manage marketplace account controls</h2>
+          <p>
+            Review the account state users need before hiring, bidding, receiving alerts, and handling payments.
+          </p>
+        </div>
+        <div className="settings-summary" aria-label="Settings completion summary">
+          <span>3 of 4 ready</span>
+          <strong>Security review pending</strong>
+        </div>
+      </section>
+
+      <section className="settings-grid" aria-label="Settings sections">
+        {settingsSections.map((section) => (
+          <article className="settings-panel" key={section.title}>
+            <div className="settings-panel-header">
+              <h3>{section.title}</h3>
+              <span className={section.status === "Review needed" ? "chip warning" : "chip"}>
+                {section.status}
+              </span>
+            </div>
+            <p>{section.description}</p>
+            <ul className="settings-list">
+              {section.details.map((detail) => (
+                <li key={detail}>{detail}</li>
+              ))}
+            </ul>
+            <div className="settings-actions">
+              {section.actions.map((action) => (
+                <button type="button" key={action}>
+                  {action}
+                </button>
+              ))}
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
/claim #743

Fixes #2317.

## Summary
- Replaced the `/settings` placeholder with a static account controls overview.
- Added profile, notification, security, and billing/payout sections with status chips, key settings, and next-action controls.
- Kept the implementation mock-data-only and scoped to the settings page plus shared styles.

## Validation
- `npm run build -w apps/web`
- `git diff --check`
- Local preview: `http://127.0.0.1:3000/settings` returned the rendered settings page HTML.

## Notes
- No API behavior, persistence, credentials, cookies, payout details, or private auth material are included.