### PR TITLE
Reject duplicate registrations

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
   const result = await registerUser(payload);
+  if (!result) {
+    return fail(res, "Email already registered", 409);
+  }
+
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,7 +1,15 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredEmails = new Set();
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const emailKey = payload.email.toLowerCase();
+  if (registeredEmails.has(emailKey)) {
+    return null;
+  }
+  registeredEmails.add(emailKey);
+
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function register(baseUrl, email) {
+  const response = await fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      email,
+      password: "password123",
+      role: "client"
+    })
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("POST /api/auth/register rejects duplicate emails", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `duplicate-${Date.now()}@example.com`;
+    const first = await register(baseUrl, email);
+    const second = await register(baseUrl, email);
+
+    assert.equal(first.response.status, 201);
+    assert.equal(second.response.status, 409);
+    assert.deepEqual(second.payload, {
+      success: false,
+      message: "Email already registered"
+    });
+  });
+});
+
+test("POST /api/auth/register rejects case-variant duplicate emails", async () => {
+  await withServer(async (baseUrl) => {
+    const suffix = Date.now();
+    const first = await register(baseUrl, `Case-${suffix}@example.com`);
+    const second = await register(baseUrl, `case-${suffix}@example.com`);
+
+    assert.equal(first.response.status, 201);
+    assert.equal(second.response.status, 409);
+  });
+});


### PR DESCRIPTION
## Summary
- Track registered email identities in the existing in-memory auth service.
- Reject exact and case-variant duplicate registrations with `409 Email already registered`.
- Add regression tests for duplicate registration behavior.

## Validation
- `node --test apps\api\src\tests\*.test.js`
- `git diff --check`

Fixes #2346
Refs #743
/claim #743
