### PR TITLE
fix: use canonical refresh role claim

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -19,5 +19,5 @@ export async function loginUser(payload) {
 }
 
 export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+  return { token: signAccessToken({ sub: "usr_existing", role: "CLIENT" }) };
 }

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refreshToken } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("refreshToken signs access tokens with canonical client role casing", async () => {
+  const result = await refreshToken();
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, "usr_existing");
+  assert.equal(decoded.role, "CLIENT");
+});


### PR DESCRIPTION
## Summary
- update the stubbed refresh service to sign `CLIENT` instead of lowercase `client`
- add a focused service regression that verifies the decoded refreshed JWT role claim
- keep the scope limited to refresh-token role casing

Closes #2354
/claim #743

## Validation
- `node --test src/tests/authService.test.js src/tests/health.test.js` from `apps/api`
- `git diff --check`