### PR TITLE
Render real dynamic detail pages

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,31 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
+export default async function FreelancerProfilePage({
+  params
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  const freelancer = freelancers.find((entry) => entry.username === username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.name}</h2>
+      <p><strong>@{freelancer.username}</strong></p>
+      <p>{freelancer.headline}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <h3>Portfolio</h3>
+      <ul>
+        {freelancer.portfolio.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,26 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((entry) => entry.id === id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Client:</strong> {job.client}</p>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <h3>Milestones</h3>
+      <ul>
+        {job.milestones.map((milestone) => (
+          <li key={milestone}>{milestone}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,10 +1,45 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    client: "Northstar Retail",
+    summary: "Create a lightweight support widget that classifies incoming questions and drafts answers for human review.",
+    milestones: ["Prototype chat widget", "Connect answer suggestions", "Add handoff analytics"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    client: "BrightPath Logistics",
+    summary: "Move a small legacy REST API onto an Express service with validation, tests, and deployment notes.",
+    milestones: ["Map legacy endpoints", "Implement service layer", "Ship migration checklist"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    client: "LedgerKit",
+    summary: "Design onboarding screens that help new teams invite users, connect billing, and finish account setup.",
+    milestones: ["Audit current funnel", "Deliver wireframes", "Prepare handoff notes"]
+  }
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    headline: "Full-stack product engineer for SaaS teams",
+    portfolio: ["Realtime support dashboard", "Usage-based billing portal"]
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Ellis",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    headline: "UX researcher and onboarding flow designer",
+    portfolio: ["Activation research sprint", "Self-serve signup redesign"]
+  }
 ];


### PR DESCRIPTION
## Summary
- Render job detail pages from the shared mock job records instead of generic placeholder text.
- Render freelancer profile pages from the shared mock freelancer records instead of generic placeholder text.
- Return `notFound()` for unknown job ids or freelancer usernames.

## Validation
- `npm run build -w apps/web`
- `git diff --check`

Fixes #2357
Refs #743
/claim #743
