### PR TITLE
fix: include payment intent lifecycle status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
+    status: "pending",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent returns an explicit initial lifecycle status", async () => {
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: "USD"
+  });
+
+  assert.equal(intent.status, "pending");
+  assert.equal(intent.provider, "stripe");
+  assert.equal(intent.amount, 125);
+  assert.equal(intent.currency, "USD");
+});


### PR DESCRIPTION
## Summary
- add an explicit `pending` lifecycle status to stubbed payment-intent responses
- add a focused service regression covering the initial status field
- keep scope limited to successful payment response shape

Closes #2359
/claim #743

## Validation
- `node --test src/tests/paymentService.test.js src/tests/health.test.js` from `apps/api`
- `git diff --check`