### PR TITLE
Fix auth and access-control gaps

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = refreshSchema.parse(req.body);
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...allowedRoles) {
+  return (req, res, next) => {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err?.name === "ZodError") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload",
+      issues: err.issues
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,12 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return {
+    token: signAccessToken({
+      sub: payload.sub,
+      role: payload.role
+    })
+  };
 }

--- a/apps/api/src/tests/auth-security.test.js
+++ b/apps/api/src/tests/auth-security.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "admin-attempt@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/refresh requires and validates a submitted token", async () => {
+  await withServer(async (baseUrl) => {
+    const missingResponse = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+
+    assert.equal(missingResponse.status, 400);
+
+    const validToken = signAccessToken({ sub: "usr_refresh", role: "client" });
+    const validResponse = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: validToken })
+    });
+    const payload = await validResponse.json();
+
+    assert.equal(validResponse.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});
+
+test("admin metrics requires an admin token", async () => {
+  await withServer(async (baseUrl) => {
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${clientToken}` }
+    });
+
+    assert.equal(clientResponse.status, 403);
+
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const adminResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+
+    assert.equal(adminResponse.status, 200);
+  });
+});
+
+test("sensitive write routes require authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const routes = [
+      ["/api/jobs", { title: "Test job", description: "Test job description", budgetMin: 1, budgetMax: 2, categoryId: "cat_test" }],
+      ["/api/proposals", { jobId: "job_test", freelancerId: "usr_test", coverLetter: "Test", bid: 1 }],
+      ["/api/payments", { amount: 100, currency: "usd" }],
+      ["/api/reviews", { reviewerId: "usr_a", revieweeId: "usr_b", rating: 5 }],
+      ["/api/messages", { senderId: "usr_a", recipientId: "usr_b", message: "hello" }],
+      ["/api/notifications", { userId: "usr_a", type: "test", message: "hello" }]
+    ];
+
+    for (const [path, body] of routes) {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      assert.equal(response.status, 401, `${path} should reject anonymous writes`);
+    }
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,14 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
+});
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
 });


### PR DESCRIPTION
## Summary

Fixes public auth and access-control gaps that allowed admin self-assignment, refresh-token minting without caller validation, admin endpoint access by any authenticated user, and anonymous writes to sensitive routes.

Fixes #2373

## Changes

- Restricts registration roles to `client` and `freelancer`.
- Adds refresh request validation requiring a submitted token.
- Verifies the submitted refresh token before issuing a new token.
- Handles Zod validation errors as `400` responses instead of generic `500`s.
- Adds `requireRole(...)` middleware.
- Restricts `/api/admin/*` to authenticated admin users.
- Requires authentication for sensitive write routes:
  - `POST /api/jobs`
  - `POST /api/proposals`
  - `POST /api/payments`
  - `POST /api/reviews`
  - `POST /api/messages`
  - `POST /api/notifications`
  - `POST /api/uploads`
- Adds regression tests for auth and access-control behavior.

## Verification

```bash
node --check apps/api/src/validators/auth.js
node --check apps/api/src/controllers/authController.js
node --check apps/api/src/services/authService.js
node --check apps/api/src/middleware/errorHandler.js
node --check apps/api/src/middleware/auth.js
node --check apps/api/src/routes/adminRoutes.js
node --check apps/api/src/routes/jobRoutes.js
node --check apps/api/src/routes/messageRoutes.js
node --check apps/api/src/routes/notificationRoutes.js
node --check apps/api/src/routes/paymentRoutes.js
node --check apps/api/src/routes/proposalRoutes.js
node --check apps/api/src/routes/reviewRoutes.js
node --check apps/api/src/routes/uploadRoutes.js
node --check apps/api/src/tests/auth-security.test.js