### PR TITLE
fix: add trust proxy setting to Express app

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,7 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  app.set("trust proxy", 1);
   app.use(helmet());
   app.use(cors());
   app.use(express.json());


### PR DESCRIPTION
## Description

The Express app was missing `app.set("trust proxy", 1)`, which causes the rate limiter and `req.ip` to see the proxy IP instead of the actual client IP when deployed behind a reverse proxy.

## Changes

- Added `app.set("trust proxy", 1)` in `apps/api/src/app.js` after app creation, before middleware registration.

## Testing

- `node --test src/tests/health.test.js` passes (1/1).
- Verified the change is syntactically correct.

/claim #2375

Closes #2375