### PR TITLE
fix: bound auth password length

### DIFF
--- a/apps/api/src/tests/authValidation.test.js
+++ b/apps/api/src/tests/authValidation.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, MAX_PASSWORD_LENGTH, registerSchema } from "../validators/auth.js";
+
+const validPassword = "a".repeat(MAX_PASSWORD_LENGTH);
+const oversizedPassword = "a".repeat(MAX_PASSWORD_LENGTH + 1);
+
+test("auth password validators accept passwords at the configured maximum", () => {
+  assert.doesNotThrow(() => {
+    registerSchema.parse({
+      email: "client@example.com",
+      password: validPassword,
+      role: "client"
+    });
+  });
+
+  assert.doesNotThrow(() => {
+    loginSchema.parse({
+      email: "client@example.com",
+      password: validPassword
+    });
+  });
+});
+
+test("auth password validators reject oversized passwords", () => {
+  assert.throws(
+    () =>
+      registerSchema.parse({
+        email: "client@example.com",
+        password: oversizedPassword,
+        role: "client"
+      }),
+    /at most 128 character/
+  );
+
+  assert.throws(
+    () =>
+      loginSchema.parse({
+        email: "client@example.com",
+        password: oversizedPassword
+      }),
+    /at most 128 character/
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
+export const MAX_PASSWORD_LENGTH = 128;
+
+const passwordSchema = z.string().min(8).max(MAX_PASSWORD_LENGTH);
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
/claim #743

## Summary
- closes #2389
- adds a shared `MAX_PASSWORD_LENGTH` / `passwordSchema` for auth credentials
- applies the same 8-128 character password contract to register and login validators
- adds focused node:test coverage for 128-character acceptance and 129-character rejection on both schemas

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/securebanana/securebanana-2389-auth-password-max-demo.mp4

## Validation
- `C:\Users\Juanr\Documents\Codex\2026-05-27\goal-generame-al-menos-200-usd\tools\node\node.exe --test apps/api/src/tests/authValidation.test.js` -> 2 passed
- `C:\Users\Juanr\Documents\Codex\2026-05-27\goal-generame-al-menos-200-usd\tools\node\node.exe --test apps/api/src/tests/health.test.js apps/api/src/tests/authValidation.test.js` -> 3 passed
- `C:\Users\Juanr\Documents\Codex\2026-05-27\goal-generame-al-menos-200-usd\tools\node\node.exe --check apps/api/src/validators/auth.js` -> passed
- `C:\Users\Juanr\Documents\Codex\2026-05-27\goal-generame-al-menos-200-usd\tools\node\node.exe --check apps/api/src/tests/authValidation.test.js` -> passed
- `git diff --check` -> passed with Windows line-ending warnings only

Note: `npm test -w apps/api` still fails on the existing upstream script `node --test src/tests`, which Node 22 treats as a missing directory entrypoint. This PR keeps that unrelated script issue out of scope and validates the touched API tests directly.