### PR TITLE
fix: add input validation and length limit to search query #1777

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
-import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from '../validations/searchValidation.js';
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = searchQuerySchema.safeParse({ q: req.query.q });
+  if (!result.success) {
+    return res.status(400).json({ error: 'Invalid query parameter', details: result.error.issues });
+  }
+  const q = result.data.q ?? '';
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/validations/searchValidation.js
+++ b/apps/api/src/validations/searchValidation.js
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .max(200, 'Search query must be at most 200 characters')
+    .optional()
+    .default(''),
+});


### PR DESCRIPTION
为 GET /api/search 接口的查询参数 q 添加 Zod 验证和最大长度限制（200 字符），防止资源消耗。