### PR TITLE
fix: validate refresh token before issuing new access token (Closes #1750)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,14 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  try {
+    const { token } = refreshSchema.parse(req.body);
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch (err) {
+    if (err.name === "ZodError") {
+      return fail(res, "Refresh token is required", 400);
+    }
+    return fail(res, "Invalid or expired refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { refreshSchema } from "../validators/auth.js";
+
+describe("refreshSchema", () => {
+  it("accepts valid token", () => {
+    const result = refreshSchema.safeParse({ token: "valid.jwt.token" });
+    assert.equal(result.success, true);
+  });
+
+  it("rejects empty body", () => {
+    const result = refreshSchema.safeParse({});
+    assert.equal(result.success, false);
+  });
+
+  it("rejects empty token string", () => {
+    const result = refreshSchema.safeParse({ token: "" });
+    assert.equal(result.success, false);
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1, "Refresh token is required")
+});


### PR DESCRIPTION
## Fix: Refresh endpoint now validates token before issuing new access token

### Problem
`POST /api/auth/refresh` previously ignored the request body and called `refreshToken()` without validating any supplied refresh token. Any unauthenticated caller could mint a fresh client token without presenting any credential.

### Changes
1. **validators/auth.js** — Added `refreshSchema` requiring a `token` field
2. **services/authService.js** — Modified `refreshToken()` to accept and verify the token, preserving the decoded `sub` and `role` from the original token
3. **controllers/authController.js** — Updated `refresh` controller to validate request body and return appropriate error codes (400 for missing token, 401 for invalid/expired token)
4. **tests/auth.test.js** — Added regression tests for refresh token schema validation

Closes #1750