### PR TITLE
fix: add file size limit to multer upload to prevent memory exhaustion DoS

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 } // 5 MB
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Description

The file upload endpoint (`POST /api/uploads`) uses multer with `memoryStorage()` but no `fileSize` limit. This allows clients to upload arbitrarily large files into memory, creating a Denial of Service vector via memory exhaustion.

## Changes

- Added `limits: { fileSize: 5 * 1024 * 1024 }` to multer config in `uploadRoutes.js`
- Files exceeding 5 MB are rejected with a `MulterError` (code `LIMIT_FILE_SIZE`) before being read into memory

## Testing

- Health tests pass (1/1)
- Standard multer error handling applies for oversized uploads

/claim #2397

Closes #2397