### PR TITLE
fix: validate refresh token in /api/auth/refresh endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.parse(req.body);
+  const result = refreshToken(payload.refreshToken);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,15 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export function refreshToken(oldToken) {
+  if (!oldToken) {
+    throw new Error("Refresh token is required");
+  }
+
+  // Verify the old token and extract user info
+  const decoded = verifyAccessToken(oldToken);
+
+  // Issue a new access token with the same user info
+  const newToken = signAccessToken({ sub: decoded.sub, role: decoded.role });
+  return { token: newToken };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { refreshToken } from "../services/authService.js";
+
+const JWT_SECRET = "development-secret";
+
+test("refreshToken accepts a valid token and returns a new one", () => {
+  const oldToken = jwt.sign({ sub: "usr_123", role: "freelancer" }, JWT_SECRET, {
+    expiresIn: "15m"
+  });
+
+  const result = refreshToken(oldToken);
+
+  assert.ok(result.token, "should return a new token");
+
+  const decoded = jwt.verify(result.token, JWT_SECRET);
+  assert.equal(decoded.sub, "usr_123");
+  assert.equal(decoded.role, "freelancer");
+});
+
+test("refreshToken throws on missing token", () => {
+  assert.throws(() => refreshToken(undefined), /Refresh token is required/);
+  assert.throws(() => refreshToken(""), /Refresh token is required/);
+  assert.throws(() => refreshToken(null), /Refresh token is required/);
+});
+
+test("refreshToken throws on malformed token", () => {
+  assert.throws(() => refreshToken("not-a-jwt"), /jwt malformed/);
+});
+
+test("refreshToken throws on expired token", () => {
+  const expiredToken = jwt.sign(
+    { sub: "usr_456", role: "client" },
+    JWT_SECRET,
+    { expiresIn: "-1h" }
+  );
+
+  assert.throws(() => refreshToken(expiredToken), /jwt expired/);
+});
+
+test("refreshToken preserves user role in new token", () => {
+  const adminToken = jwt.sign({ sub: "usr_admin", role: "admin" }, JWT_SECRET, {
+    expiresIn: "15m"
+  });
+
+  const result = refreshToken(adminToken);
+  const decoded = jwt.verify(result.token, JWT_SECRET);
+
+  assert.equal(decoded.sub, "usr_admin");
+  assert.equal(decoded.role, "admin");
+});
+
+test("new token has later expiry than old token", () => {
+  const oldToken = jwt.sign({ sub: "usr_789", role: "client" }, JWT_SECRET, {
+    expiresIn: "1m"
+  });
+
+  const result = refreshToken(oldToken);
+
+  const oldDecoded = jwt.decode(oldToken);
+  const newDecoded = jwt.decode(result.token);
+
+  assert.ok(newDecoded.exp > oldDecoded.exp, "new token should expire later");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1, "refreshToken is required")
+});


### PR DESCRIPTION
## Fix

Closes #1775

`POST /api/auth/refresh` previously ignored the request body entirely. The `refreshToken()` service function took no arguments and always returned a new token with hardcoded user info.

### Changes

**`src/services/authService.js`**
- `refreshToken(oldToken)` now requires a token argument
- Validates the token using `verifyAccessToken()`
- Rejects empty, malformed, or expired tokens
- Extracts `sub` and `role` from the old token to issue a new one with the same identity

**`src/controllers/authController.js`**
- `refresh()` now parses `req.body` using `refreshSchema`
- Passes `payload.refreshToken` to the service layer

**`src/validators/auth.js`**
- Added `refreshSchema` requiring a non-empty `refreshToken` string

**`src/tests/refresh.test.js`** (new)
- 6 unit tests covering: valid token refresh, missing token, empty token, malformed token, expired token, and role preservation
- All tests pass ✅

### Testing

```bash
node --test src/tests/refresh.test.js
```

All 6 tests pass.