### PR TITLE
fix: prevent admin role self-assignment and fix refresh token extraction

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Description

This PR fixes two critical security issues described in #2406:

1.  **Admin role self-assignment:** Removed `"admin"` from the allowed roles in `registerSchema` to prevent unauthorized users from granting themselves administrative privileges during registration.
2.  **Refresh token extraction:** Fixed the `refresh` controller to correctly extract the `token` from `req.body` and pass it to the `refreshToken` service.

## Related Issues

Closes #2406

*Note for maintainers: Payout can be processed to Solana wallet: `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp` upon successful merge.*