### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build marketplace dashboard",
+  description: "Create a client-facing dashboard for project tracking.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "cat_development",
+  skills: ["React"]
+};
+
+test("create job schema rejects inverted budget ranges", () => {
+  const parsed = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1500,
+    budgetMax: 500
+  });
+
+  assert.equal(parsed.success, false);
+  assert.equal(parsed.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("create job schema accepts ordered budget ranges", () => {
+  const parsed = createJobSchema.safeParse(validJob);
+
+  assert.equal(parsed.success, true);
+});
+
+test("update job schema validates range only when both budget fields are present", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 1000 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 1000, budgetMax: 200 }).success, false);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,28 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(data, ctx) {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+export const createJobSchema = z.object(jobFields).superRefine(validateBudgetRange);
+
+export const updateJobSchema = z.object(jobFields).partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Closes #2409

## Summary
- rejects inverted `budgetMin`/`budgetMax` ranges in job creation
- applies the same guard to partial job updates when both budget fields are present
- adds focused validator tests for invalid, valid, and partial-update cases

## Verification
- `node --test src/tests/health.test.js src/tests/jobValidator.test.js` from `apps/api`