### PR TITLE
fix: add authentication to POST /api/jobs endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
Add authMiddleware to the job creation route to prevent unauthenticated users from posting job listings.

- Adds 
- Wraps the POST route with authMiddleware
- GET route remains public

Fixes #1776