### PR TITLE
Add baseline web security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,32 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self'",
+      "frame-ancestors 'none'"
+    ].join("; ")
+  },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
Closes #2414

## Summary
- configures global Next.js response headers for every web route
- adds CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy
- keeps the change scoped to `apps/web/next.config.js`

## Verification
- `node node_modules/next/dist/bin/next build` from `apps/web`