### PR TITLE
fix(api): return defensive copies from list services

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return cloneRecords(jobs);
 }
 
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);
-  return job;
+  return cloneRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return cloneRecords(messages);
 }
 
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return cloneRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return cloneRecords(notifications);
 }
 
 export async function createNotification(payload) {
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
-  return notification;
+  return cloneRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return cloneRecords(proposals);
 }
 
 export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
-  return proposal;
+  return cloneRecord(proposal);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return cloneRecords(reviews);
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return cloneRecord(review);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,13 @@
+import { cloneRecord, cloneRecords } from "../utils/records.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return cloneRecords(users);
 }
 
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  return cloneRecord(user);
 }

--- a/apps/api/src/tests/serviceIsolation.test.js
+++ b/apps/api/src/tests/serviceIsolation.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertServiceReturnsDefensiveCopies(createRecord, listRecords, payload) {
+  const created = await createRecord(payload);
+  const id = created.id;
+
+  created.mutatedAfterCreate = true;
+
+  const firstList = await listRecords();
+  const listed = firstList.find((record) => record.id === id);
+  assert.ok(listed);
+
+  listed.mutatedAfterList = true;
+  if (Array.isArray(listed.skills)) {
+    listed.skills.push("mutated-skill");
+  }
+  firstList.push({ id: "injected-record" });
+
+  const secondList = await listRecords();
+  const stored = secondList.find((record) => record.id === id);
+
+  assert.ok(stored);
+  assert.equal(stored.mutatedAfterCreate, undefined);
+  assert.equal(stored.mutatedAfterList, undefined);
+  assert.equal(secondList.some((record) => record.id === "injected-record"), false);
+
+  return stored;
+}
+
+test("list service results cannot mutate stored user records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(createUser, listUsers, {
+    email: "defensive-user@example.com",
+    skills: ["Next.js", "TypeScript"]
+  });
+
+  assert.deepEqual(stored.skills, ["Next.js", "TypeScript"]);
+});
+
+test("list service results cannot mutate stored job records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(createJob, listJobs, {
+    title: "Build a focused test fixture",
+    description: "Create a regression fixture for copied service records.",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "testing",
+    skills: ["node:test"]
+  });
+
+  assert.deepEqual(stored.skills, ["node:test"]);
+});
+
+test("list service results cannot mutate stored message records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(sendMessage, listMessages, {
+    body: "Hello",
+    senderId: "usr_sender",
+    receiverId: "usr_receiver"
+  });
+
+  assert.equal(stored.body, "Hello");
+});
+
+test("list service results cannot mutate stored notification records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(createNotification, listNotifications, {
+    userId: "usr_notified",
+    title: "Proposal update",
+    body: "A proposal changed status."
+  });
+
+  assert.equal(stored.read, false);
+});
+
+test("list service results cannot mutate stored proposal records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(createProposal, listProposals, {
+    coverLetter: "I can complete this safely.",
+    bidAmount: 175,
+    estDuration: "2 days",
+    jobId: "job_target",
+    freelancerId: "usr_freelancer"
+  });
+
+  assert.equal(stored.bidAmount, 175);
+});
+
+test("list service results cannot mutate stored review records", async () => {
+  const stored = await assertServiceReturnsDefensiveCopies(createReview, listReviews, {
+    rating: 5,
+    comment: "Great collaboration.",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee"
+  });
+
+  assert.equal(stored.rating, 5);
+});

--- a/apps/api/src/utils/records.js
+++ b/apps/api/src/utils/records.js
@@ -1,0 +1,17 @@
+export function cloneRecord(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneRecord);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneRecord(nested)])
+    );
+  }
+
+  return value;
+}
+
+export function cloneRecords(records) {
+  return records.map(cloneRecord);
+}


### PR DESCRIPTION
## Summary
- add shared clone helpers for service record responses
- return defensive copies from in-memory list/create methods for users, jobs, messages, notifications, proposals, and reviews
- add regression coverage proving returned arrays/records cannot mutate service-owned stores
- make the API test script target actual test files so the regression suite runs

Fixes #2417
/claim #743

## Tests
- npm.cmd run test -w apps/api
- npm.cmd run build -w apps/web
