### PR TITLE
fix: patch PostCSS audit advisory via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1672,8 +1672,8 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
Add root npm override for postcss@8.5.10 to resolve GHSA-qx2v-qp2m-jg93.

postcss <8.5.10 has a moderate XSS advisory. The web workspace resolves postcss@8.4.31 through next@16.2.6.

Changes:
- Add `"overrides": { "postcss": "8.5.10" }` to root package.json
- Update package-lock.json to reflect postcss@8.5.10

Fixes #1779