### PR TITLE
fix: add auth middleware to message routes (#2422)

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);


### PR DESCRIPTION
## Fix

Added `authMiddleware` to message routes so that only authenticated users can read or send messages.

### Changes
- `apps/api/src/routes/messageRoutes.js`: Added `authMiddleware` via `router.use()`

### Related
- Closes #2422
- Parent bounty: #743

/claim #743