### PR TITLE
fix: restrict registration role enum — remove admin from public schema

### DIFF
--- a/apps/api/src/tests/register-admin.test.js
+++ b/apps/api/src/tests/register-admin.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema should reject admin role", () => {
+  const payload = { email: "hacker@evil.com", password: "password123", role: "admin" };
+  assert.throws(
+    () => registerSchema.parse(payload),
+    /Invalid enum value/,
+    "Expected ZodError when role=admin is provided"
+  );
+});
+
+test("registerSchema should accept client role", () => {
+  const payload = { email: "client@test.com", password: "password123", role: "client" };
+  const result = registerSchema.parse(payload);
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema should accept freelancer role", () => {
+  const payload = { email: "freelancer@test.com", password: "password123", role: "freelancer" };
+  const result = registerSchema.parse(payload);
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerSchema should default to client when role omitted", () => {
+  const payload = { email: "default@test.com", password: "password123" };
+  const result = registerSchema.parse(payload);
+  assert.equal(result.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Description

The `registerSchema` validator allows `"admin"` as a valid role during public registration, enabling any unauthenticated caller to self-assign administrator privileges. This fix removes `"admin"` from the allowed role enum so only `"client"` and `"freelancer"` roles are accepted at registration.

## OpenSpec — Spec Verification

### Before fix (vulnerable)
- GIVEN POST /api/auth/register with role: "admin"
- WHEN registerSchema.parse() validates the payload
- THEN admin role passes validation — user registered with admin privileges

### After fix (patched)
- GIVEN same request
- WHEN registerSchema.parse() validates
- THEN ZodError thrown — only "client" and "freelancer" permitted

## Changes

- **apps/api/src/validators/auth.js**: Removed `"admin"` from `role` enum in `registerSchema`
- **apps/api/src/tests/register-admin.test.js**: Added 4 tests covering admin rejection, client/freelancer acceptance, and default role behaviour

## Test Evidence

### TDD — RED phase
- Before fix: registerSchema.parse({..., role: "admin"}) **PASSES** (vulnerability confirmed)

### TDD — GREEN phase
- After fix: `node --test apps/api/src/tests/register-admin.test.js` → **4/4 PASS**
  - registerSchema should reject admin role ✓
  - registerSchema should accept client role ✓
  - registerSchema should accept freelancer role ✓
  - registerSchema should default to client when role omitted ✓
- `node --test apps/api/src/tests/health.test.js` → **1/1 PASS** (no regression)

## How to verify
```bash
node -e "const {registerSchema}=require(\"./apps/api/src/validators/auth.js\"); try { registerSchema.parse({email:\"a@b.com\",password:\"pass1234\",role:\"admin\"}); console.log(\"UNSAFE: admin accepted\"); } catch(e){ console.log(\"SAFE: admin rejected —\", e.issues[0].message); }"
```

/claim #2433

Closes #2433