### PR TITLE
fix(auth): add proper error handling and try-catch to oauthCallback

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -14,11 +14,18 @@ export async function login(req, res) {
   return ok(res, result);
 }
 
-export async function oauthCallback(req, res) {
-  return ok(res, {
-    provider: req.params.provider,
-    status: "callback-received"
-  });
+export async function oauthCallback(req, res, next) {
+  try {
+    if (!req.params.provider) {
+      throw new Error("Provider parameter is missing");
+    }
+    return ok(res, {
+      provider: req.params.provider,
+      status: "callback-received"
+    });
+  } catch (error) {
+    next(error);
+  }
 }
 
 export async function refresh(req, res) {


### PR DESCRIPTION
## Description

This PR fixes the unhandled promise rejection issue in the `oauthCallback` controller as reported in #2432.

### Changes Made
- Wrapped the controller logic in a `try/catch` block.
- Added a specific check to throw an error if `req.params.provider` is missing.
- Forwarded any caught errors to the `next()` middleware to ensure a standard 500 error response instead of crashing the server process.

## Related Issues
Closes #2432

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`