### PR TITLE
fix: validate refresh token before issuing new access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = refreshSchema.parse(req.body);
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,8 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  const { sub, role } = decoded;
+  return { token: signAccessToken({ sub, role }) };
 }

--- a/apps/api/src/tests/auth.refresh.test.js
+++ b/apps/api/src/tests/auth.refresh.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refreshToken } from "../services/authService.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+import { refreshSchema } from "../validators/auth.js";
+
+// --- refreshSchema validation tests ---
+
+test("refreshSchema: missing token field throws ZodError", () => {
+  assert.throws(
+    () => refreshSchema.parse({}),
+    (err) => {
+      assert.equal(err.constructor.name, "ZodError");
+      return true;
+    }
+  );
+});
+
+test("refreshSchema: non-string token throws ZodError", () => {
+  assert.throws(
+    () => refreshSchema.parse({ token: 123 }),
+    (err) => {
+      assert.equal(err.constructor.name, "ZodError");
+      return true;
+    }
+  );
+});
+
+test("refreshSchema: valid token string passes", () => {
+  const result = refreshSchema.parse({ token: "some.token.value" });
+  assert.equal(result.token, "some.token.value");
+});
+
+// --- refreshToken service tests ---
+
+test("refreshToken: missing/undefined token throws", async () => {
+  await assert.rejects(
+    async () => refreshToken(undefined),
+    (err) => {
+      // jsonwebtoken throws JsonWebTokenError or similar
+      assert.ok(err instanceof Error);
+      return true;
+    }
+  );
+});
+
+test("refreshToken: invalid token string throws", async () => {
+  await assert.rejects(
+    async () => refreshToken("this.is.not.valid"),
+    (err) => {
+      assert.ok(err instanceof Error);
+      return true;
+    }
+  );
+});
+
+test("refreshToken: valid token returns new token with matching sub and role", async () => {
+  const originalToken = signAccessToken({ sub: "usr_abc123", role: "freelancer" });
+  const result = await refreshToken(originalToken);
+
+  assert.ok(result.token, "result should have a token property");
+  assert.equal(typeof result.token, "string", "token should be a string");
+
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, "usr_abc123");
+  assert.equal(decoded.role, "freelancer");
+});
+
+test("refreshToken: preserves role=admin from original token", async () => {
+  const originalToken = signAccessToken({ sub: "usr_admin1", role: "admin" });
+  const result = await refreshToken(originalToken);
+
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, "usr_admin1");
+  assert.equal(decoded.role, "admin");
+});
+
+test("refreshToken: preserves role=client from original token", async () => {
+  const originalToken = signAccessToken({ sub: "usr_client99", role: "client" });
+  const result = await refreshToken(originalToken);
+
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, "usr_client99");
+  assert.equal(decoded.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string()
+});


### PR DESCRIPTION
Fixes #1750

## Problem
`POST /api/auth/refresh` accepted any request and minted a new access token for the hard-coded `usr_existing` user without validating any credential. An unauthenticated caller could call the endpoint with an empty body and receive a valid token.

## Changes
- **`validators/auth.js`**: Added `refreshSchema` requiring a `token` string field.
- **`services/authService.js`**: `refreshToken(token)` now calls `verifyAccessToken(token)`, extracts `sub` and `role` from the decoded payload, and signs a fresh token with those values. Invalid or missing tokens cause `jwt.verify` to throw (returning 500/401 via the error handler).
- **`controllers/authController.js`**: The `refresh` handler now parses the request body with `refreshSchema` and passes the validated token to the service.
- **`tests/auth.refresh.test.js`**: Eight regression tests covering missing token (ZodError), non-string token (ZodError), invalid JWT string, and valid token preserving `sub`/`role` for multiple roles.

## Test
```bash
cd apps/api && node --test src/tests/auth.refresh.test.js
```
