### PR TITLE
fix: generate user id once to prevent token sub drift on registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.register.test.js
+++ b/apps/api/src/tests/auth.register.test.js
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser returns token whose sub matches the returned id", async () => {
+  const result = await registerUser({ email: "x@x.com", password: "password123", role: "client" });
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, result.id);
+});


### PR DESCRIPTION
Fixes #1743

## Problem
`registerUser()` in `authService.js` called `Date.now()` twice — once to build the response `id` and once to build the JWT `sub`. If the two calls landed on different milliseconds, the returned user id and the token subject would not match, causing auth and ownership checks to point at a user id that was never returned to the client.

## Changes
- **`services/authService.js`**: Extracted `const id = \`usr_${Date.now()}\`` once and reused it for both the `id` field and the token `sub`. No other functions were changed.
- **`tests/auth.register.test.js`**: Regression test that calls `registerUser`, decodes the token with `verifyAccessToken`, and asserts `decoded.sub === result.id`.

## Test
```bash
cd apps/api && node --test src/tests/auth.register.test.js
```
