### PR TITLE
fix: restrict CORS to explicit ALLOWED_ORIGINS allowlist

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,8 +18,26 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim()).filter(Boolean)
+    : [];
+
+  app.use(
+    cors({
+      credentials: true,
+      origin(origin, callback) {
+        // Allow requests with no origin (server-to-server, curl, etc.)
+        if (!origin) {
+          return callback(null, true);
+        }
+        if (allowedOrigins.includes(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error(`CORS: origin '${origin}' not allowed`));
+      },
+    })
+  );
   app.use(helmet());
-  app.use(cors());
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+// Helper to start/stop server with a specific ALLOWED_ORIGINS env value
+async function withServer(env, fn) {
+  const prev = process.env.ALLOWED_ORIGINS;
+  process.env.ALLOWED_ORIGINS = env;
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((res, rej) => {
+    server.once("listening", res);
+    server.once("error", rej);
+  });
+  try {
+    await fn(server.address().port);
+  } finally {
+    process.env.ALLOWED_ORIGINS = prev;
+    await new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  }
+}
+
+test("allowed origin receives Access-Control-Allow-Origin header", async () => {
+  await withServer("http://allowed.example.com", async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "http://allowed.example.com" },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("access-control-allow-origin"),
+      "http://allowed.example.com"
+    );
+  });
+});
+
+test("unlisted origin does not receive Access-Control-Allow-Origin header", async () => {
+  await withServer("http://allowed.example.com", async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "http://evil.example.com" },
+    });
+    // Either a CORS error response or no ACAO header for the bad origin
+    const acaoHeader = response.headers.get("access-control-allow-origin");
+    assert.notEqual(acaoHeader, "http://evil.example.com");
+  });
+});
+
+test("health endpoint works with no Origin header", async () => {
+  await withServer("http://allowed.example.com", async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
Fixes #1774

## Problem
The Express app used `cors()` with no configuration, allowing requests from any origin (`Access-Control-Allow-Origin: *`). In a production environment this enables cross-origin attacks from arbitrary domains.

## Changes
- **`app.js`**: Replaced `cors()` with a configured instance that reads `ALLOWED_ORIGINS` from the environment (comma-separated). Requests with no `Origin` header (server-to-server, curl) are allowed. Origins in the allowlist are allowed. All other origins receive a CORS error. `credentials: true` is set. If `ALLOWED_ORIGINS` is unset, all browser origins are blocked.
- **`tests/cors.test.js`**: Three tests: allowed origin receives the `Access-Control-Allow-Origin` header; unlisted origin does not; health endpoint works without an origin header.

## Test
```bash
cd apps/api && node --test src/tests/cors.test.js
```
