### PR TITLE
Return validation errors as bad requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedAsyncHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", asyncHandler(metrics));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", asyncHandler(getMessages));
+messageRoutes.post("/", asyncHandler(postMessage));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", asyncHandler(getNotifications));
+notificationRoutes.post("/", asyncHandler(postNotification));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", asyncHandler(createPayment));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", asyncHandler(getProposals));
+proposalRoutes.post("/", asyncHandler(postProposal));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", asyncHandler(getReviews));
+reviewRoutes.post("/", asyncHandler(postReview));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", asyncHandler(search));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), asyncHandler(uploadFile));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", asyncHandler(getUsers));
+userRoutes.post("/", asyncHandler(postUser));

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -1,24 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { request } from "./helpers/request.js";
 
 test("GET /health returns ok payload", async () => {
   const app = createApp();
-  const server = app.listen(0);
-
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  const response = await request(app, { path: "/health" });
+  const payload = response.json();
 
   assert.equal(response.status, 200);
   assert.deepEqual(payload, { ok: true, service: "api" });
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
 });

--- a/apps/api/src/tests/helpers/request.js
+++ b/apps/api/src/tests/helpers/request.js
@@ -1,0 +1,75 @@
+import { Readable, Writable } from "node:stream";
+
+export function request(app, { body, headers = {}, method = "GET", path }) {
+  const payload = body === undefined ? "" : JSON.stringify(body);
+  const req = Readable.from(payload ? [payload] : []);
+  const socket = { encrypted: false, remoteAddress: "127.0.0.1" };
+
+  req.method = method;
+  req.url = path;
+  req.headers = {
+    ...headers,
+    ...(payload
+      ? {
+          "content-length": Buffer.byteLength(payload),
+          "content-type": "application/json"
+        }
+      : {})
+  };
+  req.socket = socket;
+  req.connection = socket;
+
+  const chunks = [];
+  const responseHeaders = {};
+  const res = new Writable({
+    write(chunk, encoding, callback) {
+      chunks.push(Buffer.from(chunk, encoding));
+      callback();
+    }
+  });
+
+  res.statusCode = 200;
+  res.locals = {};
+  res.setHeader = (name, value) => {
+    responseHeaders[name.toLowerCase()] = value;
+  };
+  res.getHeader = (name) => responseHeaders[name.toLowerCase()];
+  res.getHeaders = () => ({ ...responseHeaders });
+  res.removeHeader = (name) => {
+    delete responseHeaders[name.toLowerCase()];
+  };
+  res.writeHead = (statusCode, statusMessage, headersToWrite) => {
+    res.statusCode = statusCode;
+    const headers = typeof statusMessage === "object" ? statusMessage : headersToWrite;
+    if (headers) {
+      Object.entries(headers).forEach(([name, value]) => res.setHeader(name, value));
+    }
+    return res;
+  };
+
+  const originalEnd = res.end.bind(res);
+  res.end = (chunk, encoding, callback) => {
+    if (chunk) {
+      chunks.push(Buffer.from(chunk, typeof encoding === "string" ? encoding : undefined));
+    }
+    return originalEnd(typeof encoding === "function" ? encoding : callback);
+  };
+
+  return new Promise((resolve, reject) => {
+    res.on("finish", () => {
+      const text = Buffer.concat(chunks).toString("utf8");
+      resolve({
+        headers: responseHeaders,
+        json: () => JSON.parse(text),
+        status: res.statusCode,
+        text
+      });
+    });
+
+    app.handle(req, res, (error) => {
+      if (error) {
+        reject(error);
+      }
+    });
+  });
+}

--- a/apps/api/src/tests/validation.test.js
+++ b/apps/api/src/tests/validation.test.js
@@ -1,39 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
-
-async function withServer(run) {
-  const app = createApp();
-  const server = app.listen(0);
-
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  try {
-    const { port } = server.address();
-    await run(`http://127.0.0.1:${port}`);
-  } finally {
-    await new Promise((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
-}
+import { request } from "./helpers/request.js";
 
 test("Zod request validation failures return 400 with field details", async () => {
-  await withServer(async (baseUrl) => {
-    const response = await fetch(`${baseUrl}/api/jobs`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({})
-    });
-    const payload = await response.json();
-
-    assert.equal(response.status, 400);
-    assert.equal(payload.success, false);
-    assert.equal(payload.message, "Validation failed");
-    assert.ok(payload.issues.some((issue) => issue.path === "title"));
-    assert.ok(payload.issues.some((issue) => issue.path === "budgetMin"));
+  const app = createApp();
+  const response = await request(app, {
+    body: {},
+    method: "POST",
+    path: "/api/jobs"
   });
+  const payload = response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+  assert.ok(payload.issues.some((issue) => issue.path === "title"));
+  assert.ok(payload.issues.some((issue) => issue.path === "budgetMin"));
 });

--- a/apps/api/src/tests/validation.test.js
+++ b/apps/api/src/tests/validation.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Zod request validation failures return 400 with field details", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.issues.some((issue) => issue.path === "title"));
+    assert.ok(payload.issues.some((issue) => issue.path === "budgetMin"));
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Adds an async route wrapper so Express 4 forwards rejected async controllers to the error middleware.
- Converts Zod validation failures into 400 responses with field-level `issues` instead of generic 500s/hanging requests.
- Updates the API test script glob so the workspace test command discovers test files on current Node.

Refs #2440

## Validation
- npm test -w apps/api -- --test-reporter=spec
- git diff --check