### PR TITLE
Expose account pages in global navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -7,6 +7,9 @@ const links = [
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
## Summary
- adds Billing, Notifications, and Settings to the shared web navigation
- makes the existing account-management pages reachable from the main app shell
- keeps the change scoped to navigation wiring only

Fixes #2441
/claim #743

## Testing
- npm run build -w apps/web
- git diff --check