### PR TITLE
Add actionable post job draft form

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,43 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.page-heading { margin-bottom: 1rem; }
+.page-heading p { color: #aeb9df; margin-top: 0.35rem; }
+.job-form { display: grid; gap: 1.25rem; }
+.form-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.field { display: grid; gap: 0.45rem; color: #d8def4; font-weight: 600; }
+.field-wide { grid-column: 1 / -1; }
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border: 1px solid #34416f;
+  border-radius: 10px;
+  background: #0f1630;
+  color: #f2f5ff;
+  font: inherit;
+  padding: 0.75rem 0.85rem;
+}
+.field textarea { resize: vertical; }
+.job-form-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid #2a3765;
+  padding-top: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.job-form-summary p { color: #aeb9df; margin: 0.35rem 0 0; }
+.actions { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+.actions button {
+  border: 1px solid #405080;
+  border-radius: 10px;
+  background: #1b2444;
+  color: #f2f5ff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+}
+.actions .primary-action { background: #f2f5ff; color: #0b1020; }

--- a/apps/web/app/jobs/post/page.tsx
+++ b/apps/web/app/jobs/post/page.tsx
@@ -1,8 +1,59 @@
 export default function PostJobPage() {
   return (
-    <section className="card">
-      <h2>Post a Job</h2>
-      <p>Draft title, budget, category, and skill requirements for your project.</p>
+    <section>
+      <div className="page-heading">
+        <h2>Post a Job</h2>
+        <p>Draft a clear project brief before inviting freelancers.</p>
+      </div>
+
+      <form className="card job-form">
+        <div className="form-grid">
+          <label className="field field-wide">
+            <span>Project title</span>
+            <input name="title" type="text" defaultValue="Build an AI customer support widget" />
+          </label>
+
+          <label className="field">
+            <span>Category</span>
+            <select name="category" defaultValue="engineering">
+              <option value="engineering">Engineering</option>
+              <option value="design">Design</option>
+              <option value="automation">Automation</option>
+              <option value="data">Data</option>
+            </select>
+          </label>
+
+          <label className="field">
+            <span>Budget range</span>
+            <input name="budget" type="text" defaultValue="$1,500 - $2,000" />
+          </label>
+
+          <label className="field field-wide">
+            <span>Required skills</span>
+            <input name="skills" type="text" defaultValue="Next.js, TypeScript, AI integrations" />
+          </label>
+
+          <label className="field field-wide">
+            <span>Project brief</span>
+            <textarea
+              name="description"
+              rows={6}
+              defaultValue="We need a lightweight support widget that can answer common product questions, collect contact details, and hand off unresolved conversations to the client dashboard."
+            />
+          </label>
+        </div>
+
+        <div className="job-form-summary">
+          <div>
+            <strong>Draft status</strong>
+            <p>Ready for review once timeline and attachments are confirmed.</p>
+          </div>
+          <div className="actions">
+            <button type="button">Save draft</button>
+            <button type="button" className="primary-action">Preview post</button>
+          </div>
+        </div>
+      </form>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replaces the /jobs/post placeholder with a static job draft form
- adds title, category, budget, skills, description, draft status, and action controls
- keeps the change frontend-only with no API behavior changes

Fixes #2445
/claim #743

## Testing
- npm run build -w apps/web
- git diff --check
- curl -I http://localhost:3000/jobs/post