### PR TITLE
Add post job entry point to jobs list

### DIFF
--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -4,7 +4,12 @@ import { jobs } from "../../lib/mock";
 export default function JobsPage() {
   return (
     <section>
-      <h2>Job Listings</h2>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+        <h2>Job Listings</h2>
+        <Link href="/jobs/post" className="card" style={{ padding: "0.55rem 0.85rem", marginBottom: 0 }}>
+          Post a Job
+        </Link>
+      </div>
       <div className="grid">
         {jobs.map((job) => (
           <article className="card" key={job.id}>


### PR DESCRIPTION
## Summary
- adds a visible Post a Job action to the /jobs listing page
- links the existing jobs list flow to /jobs/post
- keeps the change frontend-only and scoped to the jobs listing page

Fixes #2454
/claim #743

## Testing
- npm run build -w apps/web
- git diff --check