### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(rawQuery) {
+  const value = Array.isArray(rawQuery) ? rawQuery[0] : rawQuery;
+  return String(value ?? "")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .trim()
+    .slice(0, MAX_SEARCH_QUERY_LENGTH);
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = normalizeSearchQuery(req.query.q);
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims control characters and limits query length", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = `\u0000  ${"a".repeat(250)}\n`;
+    const response = await fetch(`${baseUrl}/api/search?q=${encodeURIComponent(longQuery)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "a".repeat(200));
+  });
+});


### PR DESCRIPTION
Fixes #2456.

Changes:
- normalize `q` to a single string value
- strip control characters, trim whitespace, cap query length at 200 chars
- add regression test for oversized/control-character search input

Tested:
- `node --test apps/api/src/tests/*.test.js`