### PR TITLE
Require auth on content creation routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/creationAuth.test.js
+++ b/apps/api/src/tests/creationAuth.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("creation routes require authentication while list routes stay public", async () => {
+  await withServer(async (baseUrl) => {
+    for (const route of ["/api/reviews", "/api/messages", "/api/proposals"]) {
+      const listResponse = await fetch(`${baseUrl}${route}`);
+      assert.equal(listResponse.status, 200);
+
+      const createResponse = await fetch(`${baseUrl}${route}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "unauthenticated content" })
+      });
+      const payload = await createResponse.json();
+
+      assert.equal(createResponse.status, 401);
+      assert.equal(payload.message, "Unauthorized");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- require `authMiddleware` before creating reviews, messages, and proposals
- keep the existing public list/read routes unchanged
- add focused API route coverage for unauthenticated POST rejection

Closes #2444
/claim #743

## Validation

- `node --test apps/api/src/tests/creationAuth.test.js`
- `node --test apps/api/src/tests/*.test.js`

Note: `npm run test -w apps/api` currently fails because the existing package script runs `node --test src/tests`, which Node treats as a missing file entrypoint. The glob command above exercises the existing health test plus the new route auth test successfully.