### PR TITLE
fix: restrict admin role self-assignment and pass token to refreshToken (#1823)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

- Removes `"admin"` from the `registerSchema` role enum in `apps/api/src/validators/auth.js` so users cannot self-assign admin privileges via the registration endpoint.
- Passes `token` from `req.body` to `refreshToken()` in `apps/api/src/controllers/authController.js` so the service can properly identify the requesting user.

Fixes #1823

## Test plan
- [ ] `POST /auth/register` with `{"role": "admin"}` now returns a validation error
- [ ] `POST /auth/refresh` correctly passes the body token to the service
- [ ] Existing health check test passes