### PR TITLE
Add profile context to freelancer search cards

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,9 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
+            <p>{freelancer.summary}</p>
             <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.location} · {freelancer.availability}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,20 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    location: "Austin, TX",
+    availability: "Available this week",
+    summary: "Full-stack product engineer for dashboard and AI workflow builds."
+  },
+  {
+    username: "jordan-ux",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    location: "Toronto, CA",
+    availability: "Booking for next sprint",
+    summary: "UX researcher and product designer for SaaS onboarding flows."
+  }
 ];


### PR DESCRIPTION
## Summary
- extends mock freelancer data with location, availability, and profile summary fields
- shows those fit signals on the freelancer search cards
- keeps the change frontend-only with no API behavior changes

Fixes #2458
/claim #743

## Testing
- npm run build -w apps/web
- git diff --check