### PR TITLE
fix: generate registerUser ID once to ensure consistent token subject (#1758)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Summary

- Captures the timestamp-based user ID in a single `const id = `usr_${Date.now()}`` assignment in `apps/api/src/services/authService.js`.
- Reuses that value for both the response `id` field and the JWT `sub` claim, eliminating the race condition where two separate `Date.now()` calls could land on different milliseconds.

Fixes #1758

## Test plan
- [ ] `POST /auth/register` returns a response where `id` matches the `sub` claim in the returned token
- [ ] Existing health check test passes