### PR TITLE
Require auth on payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/payment-auth.test.js
+++ b/apps/api/src/tests/payment-auth.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments requires auth and allows authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const unauthenticated = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 2500, currency: "eur" })
+    });
+
+    assert.equal(unauthenticated.status, 401);
+
+    const token = signAccessToken({ sub: "usr_payment", role: "client" });
+    const authenticated = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "eur" })
+    });
+    const payload = await authenticated.json();
+
+    assert.equal(authenticated.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "eur");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});


### PR DESCRIPTION
Closes #2451\n\n## Summary\n- Protect POST /api/payments with authMiddleware before creating payments.\n- Add a focused payment auth regression test for unauthenticated 401 and authenticated business-layer success.\n\n## Tests\n- node --test apps/api/src/tests/payment-auth.test.js\n- node --test apps/api/src/tests/payment-auth.test.js apps/api/src/tests/health.test.js\n\nNote: npm run test -w apps/api currently fails locally because the script runs node --test src/tests, which Node v24 resolves as a missing module directory.
/claim #2451