### PR TITLE
Add summary cards to client dashboard

### DIFF
--- a/apps/web/app/dashboard/client/page.tsx
+++ b/apps/web/app/dashboard/client/page.tsx
@@ -1,8 +1,30 @@
 export default function ClientDashboardPage() {
+  const summaries = [
+    { label: "Active jobs", value: "3", detail: "2 proposals need review" },
+    { label: "Shortlisted freelancers", value: "5", detail: "3 available this week" },
+    { label: "Payment milestones", value: "$4.2k", detail: "1 milestone awaiting approval" }
+  ];
+
   return (
-    <section className="card">
+    <section>
       <h2>Dashboard (Client)</h2>
-      <p>Track jobs, shortlisted freelancers, and payment milestones.</p>
+      <div className="grid">
+        {summaries.map((summary) => (
+          <article className="card" key={summary.label}>
+            <h3>{summary.label}</h3>
+            <p>{summary.value}</p>
+            <p>{summary.detail}</p>
+          </article>
+        ))}
+      </div>
+      <section className="card">
+        <h3>Next actions</h3>
+        <ul>
+          <li>Review proposals for the AI customer support widget.</li>
+          <li>Confirm the onboarding flow design milestone.</li>
+          <li>Invite shortlisted freelancers to the API migration job.</li>
+        </ul>
+      </section>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replaces the client dashboard placeholder copy with marketplace summary cards
- adds sections for active jobs, shortlisted freelancers, and payment milestones
- includes next actions so the page better matches its stated client workflow

Fixes #2466
/claim #743

## Testing
- npm run build -w apps/web
- git diff --check