### PR TITLE
Require auth on upload writes

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload-auth.test.js
+++ b/apps/api/src/tests/upload-auth.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads requires auth and accepts authenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const unauthenticatedRes = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST"
+    });
+
+    assert.equal(unauthenticatedRes.status, 401);
+
+    const token = signAccessToken({ sub: "usr_upload", role: "client" });
+    const body = new FormData();
+    body.append("file", new Blob(["hello upload"], { type: "text/plain" }), "hello.txt");
+
+    const authenticatedRes = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body
+    });
+    const payload = await authenticatedRes.json();
+
+    assert.equal(authenticatedRes.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "hello.txt",
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require authMiddleware before handling POST /api/uploads multipart uploads
- add focused regression coverage for unauthenticated 401 and authenticated success

## Tests
- node --test src/tests/upload-auth.test.js
- node --test src/tests/*.test.js

Closes #2447
/claim #2447