### PR TITLE
Validate refresh token before access reissue

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const refreshTokenValue = req.body?.refreshToken;
+  if (typeof refreshTokenValue !== "string" || refreshTokenValue.length === 0) {
+    return fail(res, "Invalid token", 401);
+  }
+
+  try {
+    const result = await refreshToken(refreshTokenValue);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,29 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+  const claims = { sub: userId, role: payload.role };
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken(claims),
+    refreshToken: signRefreshToken(claims)
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const claims = { sub: "usr_existing", role: "client" };
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken(claims),
+    refreshToken: signRefreshToken(claims)
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  const claims = verifyRefreshToken(refreshTokenValue);
+  return { token: signAccessToken({ sub: claims.sub, role: claims.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, signRefreshToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRefresh(baseUrl, body) {
+  return fetch(`${baseUrl}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("refresh endpoint rejects missing refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, {});
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("refresh endpoint rejects access token", async () => {
+  await withServer(async (baseUrl) => {
+    const accessToken = signAccessToken({ sub: "usr_existing", role: "client" });
+    const response = await postRefresh(baseUrl, { refreshToken: accessToken });
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("refresh endpoint rejects invalid token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, { refreshToken: "not-a-jwt" });
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("refresh endpoint accepts refresh token and reissues access token", async () => {
+  await withServer(async (baseUrl) => {
+    const refreshToken = signRefreshToken({ sub: "usr_existing", role: "client" });
+    const response = await postRefresh(baseUrl, { refreshToken });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, "client");
+    assert.equal(decoded.tokenType, "access");
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -2,9 +2,25 @@ import jwt from "jsonwebtoken";
 import { env } from "../config/env.js";
 
 export function signAccessToken(payload) {
-  return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
+  return jwt.sign({ ...payload, tokenType: "access" }, env.jwtSecret, { expiresIn: "15m" });
+}
+
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, tokenType: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
 }
 
 export function verifyAccessToken(token) {
-  return jwt.verify(token, env.jwtSecret);
+  const decoded = jwt.verify(token, env.jwtSecret);
+  if (decoded.tokenType !== "access") {
+    throw new Error("Invalid access token type");
+  }
+  return decoded;
+}
+
+export function verifyRefreshToken(token) {
+  const decoded = jwt.verify(token, env.jwtSecret);
+  if (decoded.tokenType !== "refresh") {
+    throw new Error("Invalid refresh token type");
+  }
+  return decoded;
 }


### PR DESCRIPTION
## Summary
- require `/api/auth/refresh` callers to submit a refresh token
- reject missing, access-token, and invalid-token refresh attempts with 401
- issue new access tokens only after verifying refresh-token claims

Closes #2449

## Tests
- `node --test src/tests/auth-refresh.test.js`
- `node --test src/tests/*.test.js`

## Note
- `npm test -w apps/api` was also tried, but the existing script runs `node --test src/tests`; with the current Node runtime that treats `src/tests` as a missing module instead of expanding the directory.
/claim #2449