### PR TITLE
Add dedicated admin middleware for admin routes

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,13 @@
+import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user) {
+    return fail(res, "Unauthorized", 401);
+  }
+
+  if (req.user.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
+import { adminMiddleware } from "../middleware/admin.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-metrics-auth.test.js
+++ b/apps/api/src/tests/admin-metrics-auth.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("admin metrics rejects authenticated non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+
+    assert.equal(response.status, 403);
+  });
+});
+
+test("admin metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+
+    assert.equal(response.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `adminMiddleware` that authorizes requests using `req.user` populated by `authMiddleware`.
- Apply the middleware to `/api/admin` routes after authentication.
- Cover non-admin rejection and admin access for admin metrics.

Closes #2453

## Tests
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/admin-metrics-auth.test.js`

## Notes
- `npm test -w apps/api` currently fails under Node 24 because the existing script runs `node --test src/tests`, which Node treats as a module path rather than discovering files in the directory.
/claim #2453