### PR TITLE
Validate POST /api/users input with Zod

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/user-validation.test.js
+++ b/apps/api/src/tests/user-validation.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects invalid input with 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/users accepts valid input and strips server-managed fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        fullName: "Client User",
+        id: "usr_injected",
+        role: "admin",
+        isVerified: true,
+        createdAt: "2026-05-30T00:00:00.000Z"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.fullName, "Client User");
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_injected");
+    assert.equal(Object.hasOwn(payload.data, "role"), false);
+    assert.equal(Object.hasOwn(payload.data, "isVerified"), false);
+    assert.equal(Object.hasOwn(payload.data, "createdAt"), false);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1).optional(),
+  bio: z.string().max(1000).optional()
+});


### PR DESCRIPTION
## Summary
- add a Zod schema for `POST /api/users`
- reject invalid user creation payloads with HTTP 400
- pass only schema-approved fields into user creation so client-supplied server-managed fields are ignored

## Tests
- `node --test apps/api/src/tests/user-validation.test.js`
- `node --test apps/api/src/tests/*.test.js`

Closes #2448
/claim #2448