### PR TITLE
Validate refresh token requests

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const payload = refreshSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Refresh token required", 400);
+  }
+
+  try {
+    const result = await refreshToken(payload.data.token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,11 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  if (typeof decoded !== "object" || !decoded.sub || !decoded.role) {
+    throw new Error("Invalid refresh token payload");
+  }
+
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function postRefresh(port, body) {
+  return fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing tokens", async () => {
+  await withServer(async (port) => {
+    const response = await postRefresh(port, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Refresh token required");
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid tokens", async () => {
+  await withServer(async (port) => {
+    const response = await postRefresh(port, { token: "not-a-token" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token");
+  });
+});
+
+test("POST /api/auth/refresh preserves token subject and role", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_refreshable", role: "freelancer" });
+    const response = await postRefresh(port, { token });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_refreshable");
+    assert.equal(decoded.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- Require `POST /api/auth/refresh` callers to provide a non-empty request-body `token`.
- Verify the supplied token before minting a replacement access token.
- Preserve the verified `sub` and `role` claims instead of returning a hard-coded `usr_existing` client token.
- Add regression coverage for missing, invalid, and valid refresh token requests.

## Validation
```text
$ node --test apps/api/src/tests/*.test.js
? POST /api/auth/refresh rejects missing tokens
? POST /api/auth/refresh rejects invalid tokens
? POST /api/auth/refresh preserves token subject and role
? GET /health returns ok payload
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Fixes #2478.
Refs #743 and #1750.
/claim #743