### PR TITLE
fix(api): require auth on review/message/proposal creation routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/creation-auth.test.js
+++ b/apps/api/src/tests/creation-auth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const routes = [
+  { path: "/api/reviews", body: { jobId: "job_1", rating: 5, comment: "Great work" } },
+  { path: "/api/messages", body: { to: "usr_2", body: "Hello" } },
+  { path: "/api/proposals", body: { jobId: "job_1", amount: 250, coverLetter: "I can help" } }
+];
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+for (const route of routes) {
+  test(`POST ${route.path} requires authentication`, async () => {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}${route.path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(route.body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 401);
+      assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+    });
+  });
+
+  test(`POST ${route.path} accepts authenticated creation`, async () => {
+    await withServer(async (baseUrl) => {
+      const token = signAccessToken({ sub: "usr_test", role: "client" });
+      const response = await fetch(`${baseUrl}${route.path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(route.body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 201);
+      assert.equal(payload.success, true);
+      assert.match(payload.data.id, /^(rev|msg|prp)_/);
+    });
+  });
+}


### PR DESCRIPTION
## Summary\n- add \\^GuthMiddleware\\ to POST \\/api/reviews\\, \\/api/messages\\, and \\/api/proposals\\\n- add focused auth tests covering unauthenticated 401 and authenticated 201 for the three creation routes\n\n## Testing\n- node --test src/tests/creation-auth.test.js\n\nCloses #2473
/claim #2473