### PR TITLE
Prevent admin role self-assignment in registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,9 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const payload = parsed.data;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }

--- a/apps/api/src/tests/auth-register-role.test.js
+++ b/apps/api/src/tests/auth-register-role.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function register(baseUrl, role) {
+  return fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: `${role}-${Date.now()}@example.com`,
+      password: "password123",
+      role
+    })
+  });
+}
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await register(baseUrl, "admin");
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/register accepts public client and freelancer roles", async () => {
+  await withServer(async (baseUrl) => {
+    for (const role of ["client", "freelancer"]) {
+      const response = await register(baseUrl, role);
+      const payload = await response.json();
+
+      assert.equal(response.status, 201);
+      assert.equal(payload.success, true);
+      assert.equal(payload.data.role, role);
+    }
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- disallow \^Gdmin\ in the registration schema
- return 400 on invalid registration payload for schema violations
- add focused registration role tests

## Testing
- node --test src/tests/auth-register-role.test.js

Closes #2452
/claim #2452