### PR TITLE
Fix Zod validation responses to return 400

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    return next(err);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    return next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -21,7 +29,11 @@ export async function oauthCallback(req, res) {
   });
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export async function refresh(req, res, next) {
+  try {
+    const result = await refreshToken();
+    return ok(res, result);
+  } catch (err) {
+    return next(err);
+  }
 }

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -6,7 +6,11 @@ export async function getJobs(req, res) {
   return ok(res, await listJobs());
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (err) {
+    return next(err);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,21 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message,
+        code: issue.code
+      }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/zod-validation-errors.test.js
+++ b/apps/api/src/tests/zod-validation-errors.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/login returns 400 for zod validation failures", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email", password: "short" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+  assert.ok(Array.isArray(payload.errors));
+  assert.ok(payload.errors.length >= 1);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- map Zod validation exceptions to HTTP 400 in the API error handler
- pass controller exceptions to Express error middleware via next(err)
- add focused regression test for invalid auth payloads

## Verification
- node --test src/tests/*.test.js (in apps/api)

Closes #2474
/claim #2474