### PR TITLE
Fix upload memory exhaustion via multer file size limit

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      code: "LIMIT_FILE_SIZE",
+      message: "File size exceeds 5 MB limit"
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload-size-limit.test.js
+++ b/apps/api/src/tests/upload-size-limit.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects files over 5 MB with predictable error code", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob([Buffer.alloc(5 * 1024 * 1024 + 1)]), "too-large.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      code: "LIMIT_FILE_SIZE",
+      message: "File size exceeds 5 MB limit"
+    });
+  });
+});
+
+test("POST /api/uploads accepts files at or below 5 MB", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob([Buffer.alloc(1024)]), "small.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "small.txt",
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a 5 MB multer fileSize limit to POST /api/uploads
- map oversized upload failures to a predictable API response (413 + code: LIMIT_FILE_SIZE)
- add focused tests for oversized upload rejection and normal upload success

## Verification
- node --test src/tests/*.test.js (from apps/api)

Closes #2484
/claim #2484