### PR TITLE
fix(api): restrict CORS to configured origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { getCorsAllowedOrigins } from "./config/env.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -17,9 +18,36 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 
 export function createApp() {
   const app = express();
+  const allowedOrigins = getCorsAllowedOrigins();
 
   app.use(helmet());
-  app.use(cors());
+  app.use((req, res, next) => {
+    const requestOrigin = req.headers.origin;
+    if (!requestOrigin) {
+      return next();
+    }
+
+    if (allowedOrigins.includes(requestOrigin)) {
+      return next();
+    }
+
+    return res.status(403).json({
+      success: false,
+      message: "Origin not allowed"
+    });
+  });
+
+  app.use(
+    cors({
+      origin(origin, callback) {
+        if (!origin) {
+          return callback(null, true);
+        }
+
+        return callback(null, allowedOrigins.includes(origin));
+      }
+    })
+  );
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -5,3 +5,15 @@ export const env = {
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+export function getCorsAllowedOrigins() {
+  const rawOrigins =
+    process.env.CORS_ALLOWED_ORIGINS ??
+    process.env.CORS_ORIGIN ??
+    "";
+
+  return rawOrigins
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}

--- a/apps/api/src/tests/cors-origins.test.js
+++ b/apps/api/src/tests/cors-origins.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("CORS allows configured origin", async () => {
+  const originalAllowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+  process.env.CORS_ALLOWED_ORIGINS = "https://allowed.example";
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://allowed.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("access-control-allow-origin"),
+      "https://allowed.example"
+    );
+  } finally {
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+    await stopServer(server);
+  }
+});
+
+test("CORS rejects non-whitelisted origin", async () => {
+  const originalAllowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+  process.env.CORS_ALLOWED_ORIGINS = "https://allowed.example";
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://blocked.example" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Origin not allowed"
+    });
+  } finally {
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary
- replace wildcard CORS with an explicit origin allowlist
- support env-driven config via CORS_ALLOWED_ORIGINS (comma-separated), with CORS_ORIGIN fallback
- reject non-whitelisted origins with 403
- add focused CORS tests for allowed and blocked origins

## Testing
- 
ode --test src/tests/*.test.js (in ^Gpps/api)

Closes #2485
/claim #2485