### PR TITLE
Use server-owned OPEN status for new jobs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "OPEN" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+const baseJob = {
+  title: "Build a reporting dashboard",
+  description: "Create a weekly reporting dashboard for client metrics.",
+  budgetMin: 1000,
+  budgetMax: 2500,
+  categoryId: "engineering",
+  skills: ["Node.js", "PostgreSQL"]
+};
+
+test("createJob uses the server-owned OPEN status", async () => {
+  const job = await createJob(baseJob);
+
+  assert.equal(job.status, "OPEN");
+});
+
+test("createJob ignores caller-supplied status values", async () => {
+  const job = await createJob({
+    ...baseJob,
+    status: "COMPLETED"
+  });
+
+  assert.equal(job.status, "OPEN");
+});


### PR DESCRIPTION
## Summary
- creates new in-memory jobs with the Prisma-compatible OPEN status
- prevents direct service callers from overriding the initial job status
- adds service regression tests for default status and status override attempts
- updates the API test script so node:test runs the test files on current Node

Fixes #2487
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check