### PR TITLE
Fix #2494: return defensive copies from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((notification) => ({ ...notification }));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-services-defensive-copies.test.js
+++ b/apps/api/src/tests/list-services-defensive-copies.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+async function assertDefensiveListCopy(name, createRecord, listRecords) {
+  const created = await createRecord({ marker: `${name}-${Date.now()}`, note: "original" });
+
+  const firstRead = await listRecords();
+  const firstRecord = firstRead.find((record) => record.id === created.id);
+  assert.ok(firstRecord, `${name}: created record should be listed`);
+
+  firstRecord.note = "tampered";
+  firstRead.push({ id: `fake-${name}` });
+
+  const secondRead = await listRecords();
+  const secondRecord = secondRead.find((record) => record.id === created.id);
+
+  assert.ok(secondRecord, `${name}: created record should still be listed`);
+  assert.equal(secondRecord.note, "original", `${name}: item mutation must not affect storage`);
+  assert.equal(
+    secondRead.some((record) => record.id === `fake-${name}`),
+    false,
+    `${name}: array mutation must not affect storage`
+  );
+}
+
+test("list services return defensive copies", async () => {
+  await assertDefensiveListCopy("users", createUser, listUsers);
+  await assertDefensiveListCopy("jobs", createJob, listJobs);
+  await assertDefensiveListCopy("proposals", createProposal, listProposals);
+  await assertDefensiveListCopy("messages", sendMessage, listMessages);
+  await assertDefensiveListCopy("notifications", createNotification, listNotifications);
+  await assertDefensiveListCopy("reviews", createReview, listReviews);
+});


### PR DESCRIPTION
## Summary\n- return defensive array/item copies in in-memory list services\n- add focused regression test to prove caller mutation does not mutate stored records\n\n## Testing\n- node --test apps/api/src/tests/list-services-defensive-copies.test.js\n- node --test apps/api/src/tests/*.test.js\n- npm test --workspace @freelanceflow/api (fails on Node 24 because script uses 
ode --test src/tests)\n\nCloses #2494\nMirror #2417
/claim #2494