### PR TITLE
fix(api): reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  const payload = parsed.data;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/job-budget-range.test.js
+++ b/apps/api/src/tests/job-budget-range.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validPayload = {
+  title: "Build API integrations",
+  description: "Need a freelancer to build integrations quickly.",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "backend",
+  skills: ["node.js"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs accepts budget range when max >= min", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validPayload)
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 500);
+    assert.equal(payload.data.budgetMax, 1000);
+  });
+});
+
+test("POST /api/jobs rejects inverted budget range when max < min", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...validPayload, budgetMin: 1000, budgetMax: 500 })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid job payload");
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,18 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine((data) => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine((data) => {
+  if (data.budgetMin === undefined || data.budgetMax === undefined) {
+    return true;
+  }
+
+  return data.budgetMax >= data.budgetMin;
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- reject job payloads where budgetMax < budgetMin
- return HTTP 400 for invalid job payloads in job creation
- add focused tests for valid and inverted budget range cases

Closes #2491
Mirror #2409
/claim #2491