### PR TITLE
Normalize payment intent currency codes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = String(payload.currency ?? "USD").toUpperCase();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults currency to USD", async () => {
+  const intent = await createPaymentIntent({ amount: 1250 });
+
+  assert.equal(intent.currency, "USD");
+  assert.equal(intent.amount, 1250);
+  assert.equal(intent.provider, "stripe");
+});
+
+test("createPaymentIntent normalizes lowercase currency input", async () => {
+  const intent = await createPaymentIntent({ amount: 950, currency: "eur" });
+
+  assert.equal(intent.currency, "EUR");
+  assert.equal(intent.amount, 950);
+  assert.equal(intent.provider, "stripe");
+});


### PR DESCRIPTION
## Summary
- defaults payment intent currencies to the Prisma-compatible USD value
- normalizes lowercase caller currency input to uppercase codes
- adds service tests for default and lowercase-input currency handling
- updates the API test script so node:test runs test files on current Node

Fixes #2495
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check