### PR TITLE
fix(auth): reject duplicate registration email identities

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -4,8 +4,19 @@ import { ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error?.code === "AUTH_EMAIL_EXISTS") {
+      return res.status(409).json({
+        success: false,
+        code: "AUTH_EMAIL_EXISTS",
+        message: "Email already registered"
+      });
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,7 +1,18 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredEmails = new Set();
+
 export async function registerUser(payload) {
+  const emailKey = payload.email.trim().toLowerCase();
+  if (registeredEmails.has(emailKey)) {
+    const error = new Error("Email already registered");
+    error.status = 409;
+    error.code = "AUTH_EMAIL_EXISTS";
+    throw error;
+  }
+
   // TODO: persist new user via Prisma
+  registeredEmails.add(emailKey);
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,

--- a/apps/api/src/tests/auth-register-duplicate-email.test.js
+++ b/apps/api/src/tests/auth-register-duplicate-email.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/register rejects duplicate email with predictable code", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const email = `dup-${Date.now()}@example.com`;
+
+    const firstResponse = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email,
+        password: "StrongPass123!",
+        role: "client"
+      })
+    });
+    const firstPayload = await firstResponse.json();
+
+    const secondResponse = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: email.toUpperCase(),
+        password: "StrongPass123!",
+        role: "client"
+      })
+    });
+    const secondPayload = await secondResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(firstPayload.success, true);
+
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondPayload, {
+      success: false,
+      code: "AUTH_EMAIL_EXISTS",
+      message: "Email already registered"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- reject duplicate emails in `POST /api/auth/register`
- return stable error payload with code `AUTH_EMAIL_EXISTS` and status `409`
- add focused API test covering duplicate registration (including case-insensitive duplicate)

## Verification
- `node --test apps/api/src/tests/auth-register-duplicate-email.test.js`
- `node --test apps/api/src/tests/*.test.js`

Closes #2502
/claim #2502