### PR TITLE
fix(auth): validate login against registered credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,9 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid email or password", 401);
+  }
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,33 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = new Map();
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+  registeredUsers.set(payload.email, {
+    id,
+    email: payload.email,
+    password: payload.password,
+    role: payload.role
+  });
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const registeredUser = registeredUsers.get(payload.email);
+  if (!registeredUser || registeredUser.password !== payload.password) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: registeredUser.email,
+    token: signAccessToken({ sub: registeredUser.id, role: registeredUser.role })
   };
 }
 

--- a/apps/api/src/tests/auth-login-credentials.test.js
+++ b/apps/api/src/tests/auth-login-credentials.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/auth/login accepts matching registered credentials", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const email = `login-ok-${Date.now()}@example.com`;
+  const password = "password123";
+
+  const registerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password, role: "client" })
+  });
+  assert.equal(registerResponse.status, 201);
+
+  const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  const loginPayload = await loginResponse.json();
+
+  assert.equal(loginResponse.status, 200);
+  assert.equal(loginPayload.success, true);
+  assert.equal(loginPayload.data.email, email);
+  assert.equal(typeof loginPayload.data.token, "string");
+  assert.ok(loginPayload.data.token.length > 0);
+
+  await stopServer(server);
+});
+
+test("POST /api/auth/login rejects invalid credentials with expected error", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const email = `login-fail-${Date.now()}@example.com`;
+
+  const registerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: "password123", role: "client" })
+  });
+  assert.equal(registerResponse.status, 201);
+
+  const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: "wrongpass123" })
+  });
+  const loginPayload = await loginResponse.json();
+
+  assert.equal(loginResponse.status, 401);
+  assert.deepEqual(loginPayload, {
+    success: false,
+    message: "Invalid email or password"
+  });
+
+  await stopServer(server);
+});


### PR DESCRIPTION
## Summary
- store newly registered credentials in the auth service stub and validate login against that store
- reject wrong email/password combinations with a stable 401 response: Invalid email or password
- add focused API tests for successful login with registered creds and failed login with wrong creds

## Testing
- node --test apps/api/src/tests/auth-login-credentials.test.js
- node --test apps/api/src/tests/*.test.js

Closes #2505
Mirror #2316
/claim #2505