### PR TITLE
fix: require auth for user listing endpoint

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/user-list-auth.test.js
+++ b/apps/api/src/tests/user-list-auth.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/users returns 401 without authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("GET /api/users returns 200 with a valid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "list-auth@example.com",
+        password: "password123"
+      })
+    });
+
+    assert.equal(loginResponse.status, 200);
+
+    const loginPayload = await loginResponse.json();
+    const response = await fetch(`${baseUrl}/api/users`, {
+      headers: { Authorization: `Bearer ${loginPayload.data.token}` }
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication for GET /api/users
- add focused regression tests for unauthenticated 401 and authenticated success path

## Testing
- node --test src/tests/user-list-auth.test.js

Closes #2507
/claim #2507