### PR TITLE
Keep proposal ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps proposal ids server-owned", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker",
+    jobId: "job_1",
+    freelancerId: "usr_1",
+    coverLetter: "I can complete this work with a focused delivery plan."
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "prp_attacker");
+  assert.equal(proposal.jobId, "job_1");
+  assert.equal(proposal.freelancerId, "usr_1");
+});


### PR DESCRIPTION
## Summary
- prevents caller-supplied proposal ids from overriding generated service ids
- preserves normal proposal payload fields while keeping the `prp_` id server-owned
- adds a focused service regression test for id override attempts
- updates the API test script so node:test runs test files on current Node

Fixes #2509
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check