### PR TITLE
fix(api): require auth for POST /api/jobs

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobs-auth.test.js
+++ b/apps/api/src/tests/jobs-auth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const jobPayload = {
+  title: "Build secure API",
+  description: "Need a secure endpoint with proper auth checks",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_security",
+  skills: ["nodejs", "security"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs returns 401 when unauthenticated", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(jobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/jobs returns 201 when authenticated", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "user_123", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(jobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, jobPayload.title);
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication middleware on POST /api/jobs
- add focused tests for unauthenticated 401 and authenticated 201
- keep scope minimal to issue #2513 only

## Validation
- 
ode --test src/tests/jobs-auth.test.js
- 
ode --test src/tests/health.test.js src/tests/jobs-auth.test.js

Closes #2513
/claim #2513