### PR TITLE
fix(api): validate payment amount strictly for create payment

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
+function parseNonNegativeNumber(value, fallback) {
+  const normalized = value?.trim();
+  if (normalized === undefined || normalized === "") {
+    return fallback;
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  paymentAmountMax: parseNonNegativeNumber(process.env.PAYMENT_AMOUNT_MAX, 1000000)
 };

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid payment payload");
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment-amount-validation.test.js
+++ b/apps/api/src/tests/payment-amount-validation.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects negative amount", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -1 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "amount must be non-negative");
+  });
+});
+
+test("POST /api/payments rejects non-numeric amount", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: "100" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "amount must be a number");
+  });
+});
+
+test("POST /api/payments rejects amount larger than configured max", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: env.paymentAmountMax + 1 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, `amount must be <= ${env.paymentAmountMax}`);
+  });
+});
+
+test("POST /api/payments accepts non-negative amount within max", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: env.paymentAmountMax, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, env.paymentAmountMax);
+    assert.equal(payload.data.currency, "usd");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { env } from "../config/env.js";
+
+export const createPaymentSchema = z.object({
+  amount: z
+    .number({
+      required_error: "amount is required",
+      invalid_type_error: "amount must be a number"
+    })
+    .finite("amount must be a finite number")
+    .nonnegative("amount must be non-negative")
+    .max(env.paymentAmountMax, `amount must be <= ${env.paymentAmountMax}`),
+  currency: z.string().trim().length(3).optional()
+});


### PR DESCRIPTION
## Summary
- add strict validation for payment ^Gmount before creating payment intent
- enforce non-negative + finite numeric amount
- enforce configurable upper bound via PAYMENT_AMOUNT_MAX (fallback 1000000)
- return 400 with validation message on invalid payload
- add focused tests for negative/non-numeric/out-of-bound/valid amount cases

## Validation
- 
ode --test src/tests/payment-amount-validation.test.js (pass)
- 
ode --test src/tests/health.test.js (pass)
- 
pm test --workspace apps/api currently fails due existing script path (
ode --test src/tests) under current Node runtime

Closes #2511
/claim #2511