### PR TITLE
Keep review ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps review ids server-owned", async () => {
+  const review = await createReview({
+    id: "rev_attacker",
+    jobId: "job_1",
+    reviewerId: "usr_1",
+    rating: 5
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "rev_attacker");
+  assert.equal(review.jobId, "job_1");
+  assert.equal(review.reviewerId, "usr_1");
+  assert.equal(review.rating, 5);
+});


### PR DESCRIPTION
## Summary
- prevents caller-supplied review ids from overriding generated service ids
- preserves normal review payload fields while keeping the `rev_` id server-owned
- adds a focused service regression test for id override attempts
- updates the API test script so node:test runs test files on current Node

Fixes #2517
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check