### PR TITLE
Enforce max length for job title and description

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid job payload");
+  }
+
+  const payload = parsed.data;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/job-field-maxlen.test.js
+++ b/apps/api/src/tests/job-field-maxlen.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createValidJobPayload() {
+  return {
+    title: "Build landing page",
+    description: "Need a production-ready responsive landing page build.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "web",
+    skills: ["react"]
+  };
+}
+
+test("POST /api/jobs rejects oversized title and description with stable 400", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedTitleResponse = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...createValidJobPayload(),
+        title: "t".repeat(201)
+      })
+    });
+    const oversizedTitlePayload = await oversizedTitleResponse.json();
+
+    assert.equal(oversizedTitleResponse.status, 400);
+    assert.deepEqual(oversizedTitlePayload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+
+    const oversizedDescriptionResponse = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...createValidJobPayload(),
+        description: "d".repeat(5001)
+      })
+    });
+    const oversizedDescriptionPayload = await oversizedDescriptionResponse.json();
+
+    assert.equal(oversizedDescriptionResponse.status, 400);
+    assert.deepEqual(oversizedDescriptionPayload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/jobs accepts title/description at max lengths", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...createValidJobPayload(),
+        title: "t".repeat(200),
+        description: "d".repeat(5000)
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title.length, 200);
+    assert.equal(payload.data.description.length, 5000);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+export const JOB_TITLE_MAX_LENGTH = 200;
+export const JOB_DESCRIPTION_MAX_LENGTH = 5000;
+
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().min(4).max(JOB_TITLE_MAX_LENGTH),
+  description: z.string().min(10).max(JOB_DESCRIPTION_MAX_LENGTH),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),


### PR DESCRIPTION
## Summary
- enforce 	itle max length of 200 and description max length of 5000 in createJobSchema
- switch POST /api/jobs validation to safeParse and return a stable 400 response for invalid payloads
- add focused API tests for oversized job title/description rejection and boundary-length acceptance

## Testing
- 
ode --test src/tests/job-field-maxlen.test.js
- 
ode --test src/tests/health.test.js src/tests/job-field-maxlen.test.js

Closes #2516
/claim #2516