### PR TITLE
fix: validate upload file types and return stable 400 error

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,38 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "application/pdf"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  fileFilter(req, file, cb) {
+    if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      return cb(new Error("UNSUPPORTED_FILE_TYPE"));
+    }
+    return cb(null, true);
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+function handleUpload(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error instanceof Error && error.message === "UNSUPPORTED_FILE_TYPE") {
+      return fail(res, "Unsupported file type", 400);
+    }
+
+    return next(error);
+  });
+}
+
+uploadRoutes.post("/", handleUpload, uploadFile);

--- a/apps/api/src/tests/upload-filetype-validation.test.js
+++ b/apps/api/src/tests/upload-filetype-validation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads accepts allowed file type", async () => {
+  await withServer(async (port) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob(["pdf-content"], { type: "application/pdf" }),
+      "sample.pdf"
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "sample.pdf");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});
+
+test("POST /api/uploads rejects non-whitelisted file type with stable error", async () => {
+  await withServer(async (port) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob(["plain-text"], { type: "text/plain" }),
+      "sample.txt"
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported file type"
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- add MIME type whitelist validation to upload route (image/jpeg, image/png, ^Gpplication/pdf)\n- return a stable 400 response with message Unsupported file type for non-whitelisted uploads\n- add focused tests for allowed and rejected file types\n\n## Testing\n- 
ode --test src/tests/upload-filetype-validation.test.js\n- 
ode --test src/tests/*.test.js\n\nCloses #2521\n
/claim #2521