### PR TITLE
Keep message ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps message id and timestamp server-owned", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker",
+    fromUserId: "usr_1",
+    toUserId: "usr_2",
+    body: "Hello",
+    sentAt: "2000-01-01T00:00:00.000Z"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_attacker");
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.ok(!Number.isNaN(Date.parse(message.sentAt)));
+  assert.equal(message.fromUserId, "usr_1");
+  assert.equal(message.toUserId, "usr_2");
+  assert.equal(message.body, "Hello");
+});


### PR DESCRIPTION
## Summary
- prevents caller-supplied message ids from overriding generated service ids
- keeps `sentAt` server-owned while preserving normal message payload fields
- adds a focused service regression test for id and timestamp override attempts
- updates the API test script so node:test runs test files on current Node

Fixes #2526
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check