### PR TITLE
fix(auth): add password max length validation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,15 +1,25 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  const payload = parsed.data;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  const payload = parsed.data;
   const result = await loginUser(payload);
   return ok(res, result);
 }

--- a/apps/api/src/tests/auth-password-maxlen.test.js
+++ b/apps/api/src/tests/auth-password-maxlen.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function createLongPassword() {
+  return "a".repeat(73);
+}
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register returns 400 for password longer than 72 chars", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "maxlen-register@example.com",
+        password: createLongPassword(),
+        role: "client"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid request payload" });
+  });
+});
+
+test("POST /api/auth/login returns 400 for password longer than 72 chars", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "maxlen-login@example.com",
+        password: createLongPassword()
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid request payload" });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 72;
+
+const passwordSchema = z.string().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH);
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
## Summary
- enforce auth password max length at 72 chars for register/login payloads
- return stable HTTP 400 on invalid auth payloads via safeParse guard in auth controller
- add regression tests for oversized password on /api/auth/register and /api/auth/login

## Validation
- node --test src/tests/*.test.js (from apps/api)

Closes #2525
/claim #2525