### PR TITLE
fix: validate positive payment amounts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,17 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  createPaymentIntent,
+  PaymentValidationError
+} from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,25 @@
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+  }
+}
+
+function validatePositiveAmount(amount) {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    throw new PaymentValidationError("Payment amount must be a positive number");
+  }
+
+  return amount;
+}
+
 export async function createPaymentIntent(payload) {
+  const amount = validatePositiveAmount(payload?.amount);
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  createPaymentIntent,
+  PaymentValidationError
+} from "../services/paymentService.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createPaymentIntent accepts positive finite amounts", async () => {
+  const payment = await createPaymentIntent({ amount: 25, currency: "eur" });
+
+  assert.equal(payment.amount, 25);
+  assert.equal(payment.currency, "eur");
+  assert.equal(payment.provider, "stripe");
+  assert.match(payment.paymentId, /^pay_/);
+});
+
+test("createPaymentIntent rejects invalid amounts", async () => {
+  const invalidAmounts = [
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    "10",
+    null
+  ];
+
+  for (const amount of invalidAmounts) {
+    await assert.rejects(
+      () => createPaymentIntent({ amount }),
+      PaymentValidationError
+    );
+  }
+});
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -5 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Payment amount must be a positive number"
+    });
+  });
+});
+
+test("POST /api/payments accepts valid positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 49.99, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 49.99);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
## Summary
- validate that payment intent amounts are finite positive numbers before creating the stub Stripe intent
- return a 400 API response for invalid payment amounts instead of accepting or echoing the value
- add focused service and `/api/payments` route coverage for valid, zero, negative, non-numeric, and non-finite amounts
- make the API test script target `src/tests/*.test.js` so the checked-in test suite runs under `node --test`

Closes #2527
References #743
/claim #743

## Validation
- `npm test -w apps/api` — 5 tests passed
- `git diff --check`

## Demo evidence
The included route tests exercise the payment endpoint directly: invalid negative amounts now return `400` with `Payment amount must be a positive number`, while valid positive amounts still return `201` payment intent data.