### PR TITLE
Require auth for notification routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", authMiddleware, getNotifications);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notification-routes-auth.test.js
+++ b/apps/api/src/tests/notification-routes-auth.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications requires authentication", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`);
+    assert.equal(response.status, 401);
+  });
+});
+
+test("POST /api/notifications requires authentication", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+
+    assert.equal(response.status, 401);
+  });
+});


### PR DESCRIPTION
## Summary
- add uthMiddleware to GET /api/notifications
- add uthMiddleware to POST /api/notifications
- add targeted tests for unauthenticated access to notification routes

## Verification
- 
ode --test src/tests/notification-routes-auth.test.js

Closes #2531
/claim #2531