### PR TITLE
Keep user ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps user ids server-owned", async () => {
+  const user = await createUser({
+    id: "usr_attacker",
+    email: "user@example.com",
+    name: "User"
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.email, "user@example.com");
+  assert.equal(user.name, "User");
+});


### PR DESCRIPTION
## Summary
- prevents caller-supplied user ids from overriding generated service ids
- preserves normal user payload fields while keeping the `usr_` id server-owned
- adds a focused service regression test for id override attempts
- updates the API test script so node:test runs test files on current Node

Fixes #2534
/claim #743

## Testing
- npm test -w apps/api
- npm run build -w apps/web
- git diff --check