### PR TITLE
fix(api): ignore caller-supplied message id on creation

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignoredId, ...messagePayload } = payload ?? {};
+  const message = {
+    ...messagePayload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
+
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-id.test.js
+++ b/apps/api/src/tests/message-id.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/messages ignores caller-supplied id", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      id: "client-controlled-id",
+      content: "hello"
+    })
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.content, "hello");
+  assert.notEqual(payload.data.id, "client-controlled-id");
+  assert.match(payload.data.id, /^msg_\d+$/);
+  assert.ok(payload.data.sentAt);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary\n- Ignore any caller-supplied id in message creation payload\n- Keep server-generated msg_<timestamp> as the only persisted id\n- Add regression test for POST /api/messages with client-provided id\n\n## Testing\n- 
ode --test src/tests/message-id.test.js (pass)\n\nCloses #2526\n/claim #2526