### PR TITLE
fix(web): add baseline browser security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,33 @@
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value:
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+];
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
 
 module.exports = nextConfig;

--- a/apps/web/tests/security-headers.test.mjs
+++ b/apps/web/tests/security-headers.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const nextConfig = require("../next.config.js");
+
+test("next config sets baseline browser security headers", async () => {
+  assert.equal(typeof nextConfig.headers, "function");
+
+  const routes = await nextConfig.headers();
+  const rootRoute = routes.find((entry) => entry.source === "/:path*");
+
+  assert.ok(rootRoute, "expected a global header rule at '/:path*'");
+
+  const headerMap = Object.fromEntries(
+    rootRoute.headers.map((header) => [header.key, header.value]),
+  );
+
+  assert.equal(
+    headerMap["Content-Security-Policy"],
+    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'",
+  );
+  assert.equal(headerMap["X-Frame-Options"], "DENY");
+  assert.equal(headerMap["X-Content-Type-Options"], "nosniff");
+  assert.equal(
+    headerMap["Referrer-Policy"],
+    "strict-origin-when-cross-origin",
+  );
+});


### PR DESCRIPTION
## Summary
- add minimal global security headers in pps/web/next.config.js
- include CSP, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy
- add a focused Node test to verify header presence and values

## Verification
- 
ode --test apps/web/tests/security-headers.test.mjs

Closes #2523
/claim #2523