### PR TITLE
fix: cap job title and description lengths

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+function validJob(overrides = {}) {
+  return {
+    title: "Build a landing page",
+    description: "Create a responsive marketing landing page.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "web",
+    skills: ["react"],
+    ...overrides
+  };
+}
+
+test("createJobSchema accepts title and description at the maximum length", () => {
+  const payload = validJob({
+    title: "T".repeat(200),
+    description: "D".repeat(5000)
+  });
+
+  const parsed = createJobSchema.parse(payload);
+
+  assert.equal(parsed.title.length, 200);
+  assert.equal(parsed.description.length, 5000);
+});
+
+test("createJobSchema rejects overlong title and description", () => {
+  assert.throws(
+    () => createJobSchema.parse(validJob({ title: "T".repeat(201) })),
+    /String must contain at most 200/
+  );
+  assert.throws(
+    () => createJobSchema.parse(validJob({ description: "D".repeat(5001) })),
+    /String must contain at most 5000/
+  );
+});
+
+test("updateJobSchema keeps maximum length validation for partial updates", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ title: "T".repeat(201) }),
+    /String must contain at most 200/
+  );
+  assert.throws(
+    () => updateJobSchema.parse({ description: "D".repeat(5001) }),
+    /String must contain at most 5000/
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().min(4).max(200),
+  description: z.string().min(10).max(5000),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),


### PR DESCRIPTION
## Summary
- cap job titles at 200 characters and job descriptions at 5000 characters in `createJobSchema`
- ensure partial job updates keep the same maximum-length validation through `updateJobSchema`
- add focused validator coverage for boundary-valid and over-limit payloads
- make the API test script target `src/tests/*.test.js` so the checked-in test suite runs under `node --test`

Closes #2540
References #743
/claim #743

## Validation
- `npm test -w apps/api` — 4 tests passed
- `git diff --check`

## Demo evidence
The validator tests exercise both accepted boundary lengths and rejected over-limit values: 200/5000 character payloads pass, while 201/5001 character payloads fail for create and partial update schemas.