### PR TITLE
Normalize payment intent currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,29 @@
+const CURRENCY_CODE_PATTERN = /^[A-Za-z]{3}$/;
+
+function normalizeCurrencyCode(currency) {
+  if (currency == null) {
+    return "USD";
+  }
+
+  if (typeof currency !== "string") {
+    throw new TypeError("currency must be a 3-letter code");
+  }
+
+  const normalizedCurrency = currency.trim().toUpperCase();
+
+  if (!CURRENCY_CODE_PATTERN.test(normalizedCurrency)) {
+    throw new TypeError("currency must be a 3-letter code");
+  }
+
+  return normalizedCurrency;
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrencyCode(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults missing currency to USD", async () => {
+  const paymentIntent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(paymentIntent.amount, 2500);
+  assert.equal(paymentIntent.currency, "USD");
+  assert.equal(paymentIntent.provider, "stripe");
+});
+
+test("createPaymentIntent normalizes lowercase currency code", async () => {
+  const paymentIntent = await createPaymentIntent({ amount: 1200, currency: "eur" });
+
+  assert.equal(paymentIntent.currency, "EUR");
+  assert.equal(paymentIntent.amount, 1200);
+  assert.equal(paymentIntent.provider, "stripe");
+});
+
+test("createPaymentIntent rejects invalid currency code", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 1200, currency: "euro" }),
+    /currency must be a 3-letter code/
+  );
+});


### PR DESCRIPTION
Closes #2495
/claim #2495

## Summary
- default payment intent currency to `USD` when missing
- normalize lowercase 3-letter input (e.g. `eur`) to uppercase
- reject invalid currency codes that are not 3-letter alphabetic strings
- preserve existing `amount` and `provider` behavior

## Testing
- `node --test src/tests/paymentService.test.js`