### PR TITLE
Set baseline web security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,48 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "font-src 'self' data:",
+      "connect-src 'self'",
+      "upgrade-insecure-requests"
+    ].join("; ")
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY"
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff"
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin"
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()"
+  }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Add global Next.js security headers for every web route through `next.config.js`.
- Configure CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.
- Keep the change scoped to web app configuration.

## Validation
```text
$ npm run build -w apps/web
? Compiled successfully
? Generating static pages using 16 workers (13/13)
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

```text
$ Invoke-WebRequest -Method Head http://127.0.0.1:3000/settings
Content-Security-Policy: default-src 'self'; ...; frame-ancestors 'none'; ...
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
```

Fixes #2523.
Refs #743 and #2414.
/claim #743