### PR TITLE
fix(api): reject oversized auth credentials with 400

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,14 +1,21 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const MAX_AUTH_CREDENTIAL_BYTES = 4096;
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
     return fail(res, "Unauthorized", 401);
   }
 
+  const credential = authHeader.slice(7);
+  if (Buffer.byteLength(credential, "utf8") > MAX_AUTH_CREDENTIAL_BYTES) {
+    return fail(res, "Credential too large", 400);
+  }
+
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(credential);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth-oversized-credentials.test.js
+++ b/apps/api/src/tests/auth-oversized-credentials.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/admin/metrics rejects oversized bearer credentials with 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const oversizedToken = "a".repeat(4097);
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${oversizedToken}` }
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, { success: false, message: "Credential too large" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary\n- reject oversized Bearer credentials in auth middleware before JWT verification\n- return HTTP 400 with a clear error message for oversized credentials\n- add a focused test that exercises /api/admin/metrics with oversized credentials\n\n## Validation\n- node --test src/tests/auth-oversized-credentials.test.js\n\nCloses #2490\n/claim #2490