### PR TITLE
Fix job creation to use server-owned OPEN status

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, ...payload, status: "OPEN" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-create-status.test.js
+++ b/apps/api/src/tests/job-create-status.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs uses server-owned OPEN status and ignores client status", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: "Build secure API",
+      description: "Need security hardening for auth and payment flow",
+      budgetMin: 100,
+      budgetMax: 300,
+      categoryId: "security",
+      skills: ["nodejs"],
+      status: "CLOSED"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.status, "OPEN");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- enforce `status: "OPEN"` in `createJob` at service layer
- make server-owned status a final override so client payload cannot set job state
- add targeted API test proving client `status` is ignored on create

## Verification
- `node --test src/tests/job-create-status.test.js`

Closes #2487
/claim #2487