### PR TITLE
fix(auth): validate oauth callback provider and code

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const SUPPORTED_OAUTH_PROVIDERS = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,19 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = typeof req.params.provider === "string" ? req.params.provider.trim().toLowerCase() : "";
+  const code = typeof req.query.code === "string" ? req.query.code.trim() : "";
+
+  if (!SUPPORTED_OAUTH_PROVIDERS.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
+  if (!code) {
+    return fail(res, "Missing OAuth authorization code", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauth-callback.test.js
+++ b/apps/api/src/tests/oauth-callback.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported provider", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/slack/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Unsupported OAuth provider" });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback requires non-empty code", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Missing OAuth authorization code" });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback accepts supported provider with code", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/GitHub/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate /api/auth/oauth/:provider/callback against a supported provider allowlist
- normalize provider names to lowercase before success response
- require a non-empty code query parameter for callback success
- add regression tests for unsupported provider, missing code, and normalized supported provider

## Testing
- 
ode --test src/tests/oauth-callback.test.js

Closes #2480
/claim #2480