### PR TITLE
Fix review creation to ignore caller-supplied id

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...rest } = payload ?? {};
+  const review = { ...rest, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-create.test.js
+++ b/apps/api/src/tests/review-create.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/reviews ignores caller-supplied id", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "attacker-controlled-id",
+        rating: 5,
+        comment: "great work",
+      }),
+    });
+    const payload = await response.json();
+    const review = payload.data;
+
+    assert.equal(response.status, 201);
+    assert.equal(review.id === "attacker-controlled-id", false);
+    assert.match(review.id, /^rev_\d+$/);
+    assert.equal(review.rating, 5);
+    assert.equal(review.comment, "great work");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- ignore caller-supplied \id\ in review creation and always generate server-side review IDs
- add regression test for \POST /api/reviews\ proving client \id\ is ignored

## Testing
- node --test apps/api/src/tests/review-create.test.js

Closes #2517
/claim #2517