### PR TITLE
Show role context on /jobs listing cards

### DIFF
--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -10,6 +10,9 @@ export default function JobsPage() {
           <article className="card" key={job.id}>
             <h3>{job.title}</h3>
             <p>{job.budget}</p>
+            <p>Skills: {job.skills.join(", ")}</p>
+            <p>Work mode: {job.workMode}</p>
+            <p>Timeline: {job.timeline}</p>
             <Link href={`/jobs/${job.id}`}>View details</Link>
           </article>
         ))}

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,28 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    skills: ["React", "LLM APIs"],
+    workMode: "Remote",
+    timeline: "4 weeks"
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    skills: ["Node.js", "API Design"],
+    workMode: "Hybrid",
+    timeline: "6 weeks"
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    skills: ["Figma", "UX Research"],
+    workMode: "Remote",
+    timeline: "2 weeks"
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
## Summary\n- extend mock job listings with concise role context (skills, workMode, 	imeline)\n- render the three role-context fields on /jobs cards\n- keep implementation frontend-only with existing mock data\n\n## Verification\n- 
pm run build -w apps/web\n\nCloses #2463\n/claim #2463