### PR TITLE
fix: cap auth password length

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+const validEmail = "user@example.com";
+const maxPassword = "a".repeat(128);
+const tooLongPassword = "a".repeat(129);
+
+test("registerSchema accepts a password at the maximum length", () => {
+  const result = registerSchema.safeParse({
+    email: validEmail,
+    password: maxPassword,
+    role: "client"
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("registerSchema rejects a password over the maximum length", () => {
+  const result = registerSchema.safeParse({
+    email: validEmail,
+    password: tooLongPassword,
+    role: "client"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("loginSchema accepts a password at the maximum length", () => {
+  const result = loginSchema.safeParse({
+    email: validEmail,
+    password: maxPassword
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("loginSchema rejects a password over the maximum length", () => {
+  const result = loginSchema.safeParse({
+    email: validEmail,
+    password: tooLongPassword
+  });
+
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,11 +2,11 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: z.string().min(8).max(128),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8).max(128)
 });


### PR DESCRIPTION
## Summary
- cap register and login password validation at 128 characters
- add auth validator boundary tests for 128-character and 129-character passwords
- make the API test script run the test files directly

Closes #2559
References #743
/claim #743

## Validation
- npm test -w apps/api
- git diff --check