### PR TITLE
Fix #2458: show availability and profile context in freelancer search cards

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -11,6 +11,8 @@ export default function FreelancerSearchPage() {
             <h3>{freelancer.username}</h3>
             <p>{freelancer.skills.join(" · ")}</p>
             <p>{freelancer.rate}</p>
+            <p>{freelancer.availability}</p>
+            <p>{freelancer.profileContext}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>
         ))}

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,18 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    availability: "Available now",
+    profileContext: "Frontend engineer focused on SaaS dashboards and performance tuning."
+  },
+  {
+    username: "jordan-ux",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    availability: "Available in 1 week",
+    profileContext: "Product designer with strong discovery, research, and onboarding UX experience."
+  }
 ];


### PR DESCRIPTION
## Summary\n- add availability and profile context fields to freelancer mock data\n- render availability and profile context in freelancer search cards\n- keep scope minimal to the search-card surface required by issue #2458\n\n## Validation\n- npm run build -w apps/web\n- npx tsc -p apps/web/tsconfig.json --noEmit\n\nCloses #2458\n/claim #2458