### PR TITLE
fix: validate and limit search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { normalizeSearchQuery } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = normalizeSearchQuery(req.query.q);
+  if (parsed.error) {
+    return fail(res, parsed.error, 400);
+  }
+
+  return ok(res, await globalSearch(parsed.value));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_SEARCH_QUERY_LENGTH } from "../validators/search.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search normalizes query input", async () => {
+  await withServer(async (port) => {
+    const query = encodeURIComponent(" \u0000  hello world \u001F ");
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "hello world");
+  });
+});
+
+test("GET /api/search rejects overlong query input", async () => {
+  await withServer(async (port) => {
+    const tooLong = "a".repeat(MAX_SEARCH_QUERY_LENGTH + 1);
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${tooLong}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /at most/i);
+  });
+});
+
+test("GET /api/search rejects object-like query input", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q[key]=value`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /must be a string/i);
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,27 @@
+const CONTROL_CHAR_REGEX = /[\u0000-\u001F\u007F]/g;
+export const MAX_SEARCH_QUERY_LENGTH = 200;
+
+export function normalizeSearchQuery(rawQuery) {
+  let candidate = rawQuery;
+
+  if (Array.isArray(candidate)) {
+    candidate = candidate[0] ?? "";
+  }
+
+  if (candidate == null) {
+    candidate = "";
+  }
+
+  if (typeof candidate !== "string") {
+    return { error: "Search query must be a string." };
+  }
+
+  const normalized = candidate.replace(CONTROL_CHAR_REGEX, "").trim();
+  if (normalized.length > MAX_SEARCH_QUERY_LENGTH) {
+    return {
+      error: `Search query must be at most ${MAX_SEARCH_QUERY_LENGTH} characters.`
+    };
+  }
+
+  return { value: normalized };
+}


### PR DESCRIPTION
## Summary
- validate and normalize q in GET /api/search before calling the service
- trim input, strip control characters, and enforce a max length of 200 chars
- return 400 for invalid query types and overlong input
- add focused API tests for normalization, length limit, and invalid object-like input

## Testing
- 
ode --test src/tests/search.test.js

Closes #2456
/claim #2456