### PR TITLE
fix: validate proposal creation input (Closes #1739)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues.map(i => i.message).join("; "), 400);
+  }
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  freelancerId: z.string().min(1, "freelancerId is required"),
+  coverLetter: z.string().min(10, "coverLetter must be at least 10 characters"),
+  bidAmount: z.number().positive("bidAmount must be positive"),
+  estDuration: z.string().min(1, "estDuration is required")
+});


### PR DESCRIPTION
## Fix: Validate proposal creation input

### Problem
`POST /api/proposals` forwarded `req.body` directly into `createProposal()` without validation, allowing proposals to be created without required fields like `estDuration`.

### Changes
- **New:** `apps/api/src/validators/proposal.js` — Zod schema requiring `jobId`, `freelancerId`, `coverLetter`, positive `bidAmount`, and `estDuration`
- **Modified:** `apps/api/src/controllers/proposalController.js` — applies `createProposalSchema.safeParse()` before calling the service, returns 400 with validation errors on failure

### Validation Rules
- `jobId` — required, non-empty string
- `freelancerId` — required, non-empty string  
- `coverLetter` — required, minimum 10 characters
- `bidAmount` — required, positive number
- `estDuration` — required, non-empty string

Closes #1739
