### PR TITLE
Add API process fatal error handlers

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,8 +1,11 @@
 import { connectDb } from "./config/db.js";
 import { env } from "./config/env.js";
 import { createApp } from "./app.js";
+import { installProcessErrorHandlers } from "./utils/processErrorHandlers.js";
 
 async function bootstrap() {
+  installProcessErrorHandlers();
+
   await connectDb();
   const app = createApp();
   app.listen(env.port, () => {

--- a/apps/api/src/tests/processErrorHandlers.test.js
+++ b/apps/api/src/tests/processErrorHandlers.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { installProcessErrorHandlers } from "../utils/processErrorHandlers.js";
+
+function createProcessHarness() {
+  const processHarness = new EventEmitter();
+  const logEntries = [];
+  const exitCodes = [];
+
+  return {
+    processHarness,
+    logEntries,
+    exitCodes,
+    options: {
+      logger: (...args) => logEntries.push(args),
+      exit: (code) => exitCodes.push(code)
+    }
+  };
+}
+
+test("installs process-level fatal error handlers once", () => {
+  const { processHarness, options } = createProcessHarness();
+
+  assert.equal(installProcessErrorHandlers(processHarness, options), true);
+  assert.equal(installProcessErrorHandlers(processHarness, options), false);
+  assert.equal(processHarness.listenerCount("unhandledRejection"), 1);
+  assert.equal(processHarness.listenerCount("uncaughtException"), 1);
+});
+
+test("unhandled promise rejections are logged and terminate the process", () => {
+  const { processHarness, logEntries, exitCodes, options } = createProcessHarness();
+  const rejection = new Error("background failure");
+
+  installProcessErrorHandlers(processHarness, options);
+  processHarness.emit("unhandledRejection", rejection);
+
+  assert.equal(exitCodes[0], 1);
+  assert.deepEqual(logEntries[0], ["Unhandled promise rejection:", rejection]);
+});
+
+test("uncaught exceptions are logged and terminate the process", () => {
+  const { processHarness, logEntries, exitCodes, options } = createProcessHarness();
+  const error = new Error("fatal failure");
+
+  installProcessErrorHandlers(processHarness, options);
+  processHarness.emit("uncaughtException", error);
+
+  assert.equal(exitCodes[0], 1);
+  assert.deepEqual(logEntries[0], ["Uncaught exception:", error]);
+});

--- a/apps/api/src/utils/processErrorHandlers.js
+++ b/apps/api/src/utils/processErrorHandlers.js
@@ -1,0 +1,29 @@
+const INSTALL_MARKER = Symbol.for("freelanceflow.processErrorHandlersInstalled");
+
+export function installProcessErrorHandlers(targetProcess = process, options = {}) {
+  if (targetProcess[INSTALL_MARKER]) {
+    return false;
+  }
+
+  const logger = options.logger ?? console.error;
+  const exit = options.exit ?? ((code) => targetProcess.exit(code));
+
+  targetProcess.on("unhandledRejection", (reason) => {
+    logger("Unhandled promise rejection:", reason);
+    exit(1);
+  });
+
+  targetProcess.on("uncaughtException", (error) => {
+    logger("Uncaught exception:", error);
+    exit(1);
+  });
+
+  Object.defineProperty(targetProcess, INSTALL_MARKER, {
+    value: true,
+    configurable: false,
+    enumerable: false,
+    writable: false
+  });
+
+  return true;
+}


### PR DESCRIPTION
/claim #743

Closes #2583

Summary:
- installs process-level unhandledRejection and uncaughtException handlers during API bootstrap
- logs the original fatal reason/error and exits with code 1 for supervisor restart
- guards installation so duplicate calls do not register duplicate listeners
- adds focused regression tests using an EventEmitter harness

Demo:
https://github.com/orenodinner/bug-bounty/releases/download/process-handlers-demo-8353cf3/process-handlers-demo.mp4

Validation:
- node --test src/tests/health.test.js src/tests/processErrorHandlers.test.js
- git diff --check

Note:
- npm test -w apps/api is still blocked on the existing Node 22 test-directory script issue and is intentionally out of scope for this single-issue PR.