### PR TITLE
Keep health checks outside API rate limit

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+async function withServer(run) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -11,14 +11,43 @@ test("GET /health returns ok payload", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+test("GET /health returns ok payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+test("GET /health bypasses the global API rate limit", async () => {
+  await withServer(async (baseUrl) => {
+    for (let requestNumber = 1; requestNumber <= 201; requestNumber += 1) {
+      const response = await fetch(`${baseUrl}/health`);
+      assert.equal(response.status, 200, `request ${requestNumber} should remain healthy`);
+    }
+  });
+});
+
+test("API routes still use the global API rate limit", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+
+    for (let requestNumber = 1; requestNumber <= 201; requestNumber += 1) {
+      response = await fetch(`${baseUrl}/api/jobs`);
+    }
+
+    assert.equal(response.status, 429);
   });
 });


### PR DESCRIPTION
/claim #743

Closes #2585

Summary:
- registers /health before the global API rate limiter
- preserves the limiter for /api routes
- adds regression coverage for repeated health probes and API limiter behavior

Demo:
https://github.com/orenodinner/bug-bounty/releases/download/health-rate-limit-demo-7c26545/health-rate-limit-demo-7c26545.mp4

Validation:
- node --test src/tests/health.test.js
- git diff --check

Note:
npm test -w apps/api is still blocked on the existing Node 22 test-directory script issue (`node --test src/tests`) and is intentionally out of scope for this single-issue PR.