### PR TITLE
fix: keep user ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps the server-generated id when payload includes id", async () => {
+  const user = await createUser({
+    id: "usr_attacker",
+    email: "creator@example.com",
+    role: "client"
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.email, "creator@example.com");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
## Summary
- keep the server-generated `usr_...` id authoritative when creating users
- preserve normal user payload fields while ignoring caller-supplied `id` values
- add focused `createUser` regression coverage
- make the API test script target `src/tests/*.test.js` so the checked-in test suite runs under `node --test`

Closes #2587
References #743
/claim #743

## Validation
- `npm test -w apps/api` — 2 tests passed
- `git diff --check`

## Demo evidence
The included service test calls `createUser` with `id: "usr_attacker"` and verifies the returned user still has a server-generated `usr_<timestamp>` id while preserving the submitted email and role.