### PR TITLE
fix: override postcss to 8.5.10 to resolve GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Adds root npm override for postcss@8.5.10 as specified in issue #1779, and refreshes package-lock.json.

## Changes
- `package.json`: add `overrides.postcss: "8.5.10"`
- `package-lock.json`: regenerated to resolve postcss@8.5.10

Fixes #1779

/claim #1779