### PR TITLE
fix: restrict CORS to configurable origin (fixes #1774)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,10 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin: process.env.CORS_ORIGIN || "http://localhost:3000",
+    credentials: true,
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
## Summary

Configures CORS with an explicit origin via `CORS_ORIGIN` environment variable, defaulting to `http://localhost:3000`.

## Changes
- `apps/api/src/app.js`: replace `cors()` with `cors({ origin: ..., credentials: true })`

## Security
Prevents cross-origin requests from arbitrary domains in production.

Fixes #1774

/claim #1774