### PR TITLE
fix: require authentication on file upload endpoint (fixes #1771)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
## Summary

Applies `authMiddleware` to the `POST /api/uploads` route so only authenticated users can upload files.

## Changes
- `apps/api/src/routes/uploadRoutes.js`: add `authMiddleware` import and apply to POST route

## Security
Prevents anonymous file uploads which could lead to storage abuse.

Fixes #1771

/claim #1771