### PR TITLE
fix: require authentication on job creation endpoint (fixes #1776)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Summary

Applies `authMiddleware` to the `POST /api/jobs` route so only authenticated users can create job listings. The `GET /api/jobs` list endpoint remains public.

## Changes
- `apps/api/src/routes/jobRoutes.js`: add `authMiddleware` import and apply to POST route only

## Security
Prevents unauthenticated job creation spam.

Fixes #1776

/claim #1776