### PR TITLE
Return defensive copies from API list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((notification) => ({ ...notification }));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { listMessages, sendMessage } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  {
+    name: "jobs",
+    create: () => createJob({ title: "Defensive copy job" }),
+    list: listJobs
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ body: "Defensive copy message" }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ body: "Defensive copy notification" }),
+    list: listNotifications
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ coverLetter: "Defensive copy proposal" }),
+    list: listProposals
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ rating: 5, body: "Defensive copy review" }),
+    list: listReviews
+  },
+  {
+    name: "users",
+    create: () => createUser({ name: "Defensive Copy User" }),
+    list: listUsers
+  }
+];
+
+for (const serviceCase of cases) {
+  test(`${serviceCase.name} list returns defensive record copies`, async () => {
+    const before = await serviceCase.list();
+    const created = await serviceCase.create();
+    const snapshot = await serviceCase.list();
+
+    assert.equal(snapshot.length, before.length + 1);
+
+    snapshot.push({ id: "external_record" });
+    snapshot[snapshot.length - 2].id = "external_mutation";
+
+    const after = await serviceCase.list();
+    assert.equal(after.length, before.length + 1);
+    assert.equal(after.at(-1).id, created.id);
+  });
+}


### PR DESCRIPTION
## Summary
- closes #2605
- returns copied arrays of copied records from API list services
- adds regression coverage proving list consumers cannot mutate internal stores through returned arrays or records

/claim #743

## Validation
- `npm test -w apps/api`
- `git diff --check`