### PR TITLE
Return defensive service copies

### DIFF
--- a/apps/api/src/services/copyRecord.js
+++ b/apps/api/src/services/copyRecord.js
@@ -1,0 +1,12 @@
+export function copyRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}
+
+export function copyRecords(records) {
+  return records.map(copyRecord);
+}

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return copyRecords(jobs);
 }
 
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);
-  return job;
+  return copyRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return copyRecords(messages);
 }
 
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return copyRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return copyRecords(notifications);
 }
 
 export async function createNotification(payload) {
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
-  return notification;
+  return copyRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return copyRecords(proposals);
 }
 
 export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
-  return proposal;
+  return copyRecord(proposal);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return copyRecords(reviews);
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return copyRecord(review);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,13 @@
+import { copyRecord, copyRecords } from "./copyRecord.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return copyRecords(users);
 }
 
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  return copyRecord(user);
 }

--- a/apps/api/src/tests/service-copies.test.js
+++ b/apps/api/src/tests/service-copies.test.js
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertDefensiveCopies({ create, list, payload, mutate }) {
+  const created = await create(payload);
+  const expected = {
+    ...created,
+    ...Object.fromEntries(
+      Object.entries(created)
+        .filter(([, value]) => Array.isArray(value))
+        .map(([key, value]) => [key, [...value]])
+    )
+  };
+  mutate(created);
+
+  const firstList = await list();
+  const firstListed = firstList.find((record) => record.id === created.id);
+  assert.ok(firstListed);
+
+  firstList.push({ id: "injected" });
+  mutate(firstListed);
+
+  const secondList = await list();
+  const stored = secondList.find((record) => record.id === created.id);
+  assert.ok(stored);
+  assert.equal(secondList.some((record) => record.id === "injected"), false);
+  assert.deepEqual(stored, expected);
+}
+
+test("user service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "copy-user@example.com", role: "client", skills: ["planning"] },
+    mutate(record) {
+      record.email = "mutated@example.com";
+      record.skills.push("mutated");
+    }
+  });
+});
+
+test("job service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Copy-safe job", budget: 100, skills: ["react"] },
+    mutate(record) {
+      record.title = "Mutated job";
+      record.skills.push("mutated");
+    }
+  });
+});
+
+test("message service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: sendMessage,
+    list: listMessages,
+    payload: { from: "usr_a", to: "usr_b", body: "hello" },
+    mutate(record) {
+      record.body = "mutated";
+    }
+  });
+});
+
+test("notification service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_a", message: "hello" },
+    mutate(record) {
+      record.message = "mutated";
+      record.read = true;
+    }
+  });
+});
+
+test("proposal service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_a", freelancerId: "usr_a", skills: ["node"] },
+    mutate(record) {
+      record.freelancerId = "usr_mutated";
+      record.skills.push("mutated");
+    }
+  });
+});
+
+test("review service returns defensive copies", async () => {
+  await assertDefensiveCopies({
+    create: createReview,
+    list: listReviews,
+    payload: { jobId: "job_a", reviewerId: "usr_a", rating: 5 },
+    mutate(record) {
+      record.rating = 1;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared copy helpers for in-memory service records.
- Return copied arrays and copied records from user, job, message, notification, proposal, and review services.
- Copy nested array fields such as `skills` so callers cannot mutate service-owned arrays through returned records.
- Add regression coverage that mutating create/list results does not alter stored records.

## Validation
```text
$ node --test apps/api/src/tests/*.test.js
? GET /health returns ok payload
? user service returns defensive copies
? job service returns defensive copies
? message service returns defensive copies
? notification service returns defensive copies
? proposal service returns defensive copies
? review service returns defensive copies
```

```text
$ git diff --check
(no whitespace errors; only Windows LF/CRLF working-copy warnings)
```

Fixes #2617.
Refs #743 and #2417.
/claim #743