### PR TITLE
Normalize payment intent currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
+function normalizeCurrency(currency) {
+  return currency == null ? "USD" : currency.trim().toUpperCase();
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults missing currency to USD", async () => {
+  const intent = await createPaymentIntent({ amount: 1250 });
+
+  assert.equal(intent.amount, 1250);
+  assert.equal(intent.currency, "USD");
+  assert.equal(intent.provider, "stripe");
+  assert.match(intent.paymentId, /^pay_\d+$/);
+});
+
+test("createPaymentIntent normalizes lowercase currency codes", async () => {
+  const intent = await createPaymentIntent({ amount: 4500, currency: "eur" });
+
+  assert.equal(intent.amount, 4500);
+  assert.equal(intent.currency, "EUR");
+  assert.equal(intent.provider, "stripe");
+  assert.match(intent.paymentId, /^pay_\d+$/);
+});


### PR DESCRIPTION
/claim #743

Closes #2636.

## Summary
- default payment intents without an explicit currency to `USD`
- normalize caller-provided currency codes to uppercase before returning the intent
- add focused service tests for missing and lowercase currency inputs

## Validation
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm test --prefix apps/api` currently fails because Node treats the package script argument `src/tests` as a module path on this environment; the explicit `node --test apps/api/src/tests/*.test.js` run passes.
