### PR TITLE
fix: add auth middleware to job creation and input validation to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchSchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchSchema.parse(req.query);
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchSchema = z.object({
+  q: z.string().min(1).max(200)
+});


### PR DESCRIPTION
## Summary

Fixes #1783 and #1781

### #1783 - Add authentication middleware to job creation endpoint

**Problem:** The `POST /jobs` endpoint lacks authentication, allowing unauthenticated users to create jobs.

**Fix:** Added `authMiddleware` to the POST route in `jobRoutes.js`, requiring a valid Bearer token to create a job. This follows the same pattern already used in `adminRoutes.js`.

**Changes:**
- `apps/api/src/routes/jobRoutes.js`: Import `authMiddleware` and add it as middleware to the POST route

### #1781 - Add input validation to search endpoint

**Problem:** The `GET /search` endpoint accepts unvalidated query parameters, allowing empty or excessively long search queries.

**Fix:** Created a `searchSchema` validator using Zod (consistent with existing validators like `createJobSchema` and `loginSchema`) and applied it in the search controller.

**Changes:**
- `apps/api/src/validators/search.js`: New file with `searchSchema` requiring `q` to be a string of 1-200 characters
- `apps/api/src/controllers/searchController.js`: Use `searchSchema.parse(req.query)` instead of raw `req.query.q`

## Testing

- Unauthenticated POST to `/jobs` now returns 401 Unauthorized
- GET `/search` without `q` parameter now returns validation error
- GET `/search` with empty `q` parameter now returns validation error
- GET `/search` with valid `q` parameter works as before
