### PR TITLE
Add FreelanceFlow proof window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Proof Window
+
+The brief arrives with edges still uncut,
+a client naming risk in careful lines;
+the platform holds the scope, the price, the route,
+and turns loose intent into signs.
+
+A builder answers with a measured plan,
+not louder than the work it means to show;
+the proposal carries what the hands began,
+where estimates and evidence both grow.
+
+In messages, the details learn to stand:
+a question, then a patch, then one more test.
+Each small receipt is placed where both can land
+and judge the moving job against the rest.
+
+The review is not a gate of cold delay;
+it is the light that finds the missing seam.
+What passes there can travel into pay,
+from private effort into shared esteem.
+
+So FreelanceFlow keeps faith in plain exchange:
+scope before speed, proof before applause.
+Between the merge and payout, trust can change
+from promise into process, then to cause.


### PR DESCRIPTION
/claim #76

## Summary
- Added `POEM.md` at the project root.
- Wrote an original five-stanza poem specifically for FreelanceFlow.
- Kept the change limited to the requested Markdown deliverable.

## Creative decision
I used an escrow-and-review flow as the poem's structure so each stanza follows a marketplace job from scope, to proposal, to messaging evidence, to review, to payout.

## Validation
- Confirmed the file is root-level `POEM.md`.
- Confirmed the poem has more than three stanzas.
- Ran `git diff --check`.

## Demo
This is a Markdown-only content change; the full rendered deliverable is visible directly in the PR diff.
