### PR TITLE
fix(api): return list service snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-services.test.js
+++ b/apps/api/src/tests/list-services.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const listServices = [
+  {
+    name: "jobs",
+    create: () => createJob({ title: "Snapshot job" }),
+    list: listJobs,
+    injected: { id: "job_injected", title: "Injected job" },
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ body: "Snapshot message" }),
+    list: listMessages,
+    injected: { id: "msg_injected", body: "Injected message" },
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ message: "Snapshot notification" }),
+    list: listNotifications,
+    injected: { id: "ntf_injected", message: "Injected notification" },
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ summary: "Snapshot proposal" }),
+    list: listProposals,
+    injected: { id: "prp_injected", summary: "Injected proposal" },
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ rating: 5 }),
+    list: listReviews,
+    injected: { id: "rev_injected", rating: 1 },
+  },
+  {
+    name: "users",
+    create: () => createUser({ name: "Snapshot user" }),
+    list: listUsers,
+    injected: { id: "usr_injected", name: "Injected user" },
+  },
+];
+
+for (const service of listServices) {
+  test(`${service.name} list returns a snapshot of stored records`, async () => {
+    const created = await service.create();
+    const listed = await service.list();
+
+    listed.push(service.injected);
+    listed.length = 0;
+
+    const listedAgain = await service.list();
+
+    assert.ok(listedAgain.some((record) => record.id === created.id));
+    assert.equal(
+      listedAgain.some((record) => record.id === service.injected.id),
+      false,
+    );
+  });
+}


### PR DESCRIPTION
/claim #743

Closes #2648.

## Summary
- Return shallow snapshot arrays from API list services instead of exposing module-level stores directly.
- Cover jobs, users, messages, notifications, proposals, and reviews with service-level regression tests.

## Validation
- RED: `node --test apps/api/src/tests/list-services.test.js` failed before the fix because mutating a returned list removed the stored record.
- GREEN: `node --test apps/api/src/tests/list-services.test.js` passed with 6/6 tests.
- `node --test apps/api/src/tests/*.test.js` passed with 7/7 tests when rerun outside the sandbox after the health test hit sandbox `listen EPERM`.
- `git diff --check` passed.

AI-assisted with OpenAI Codex; I reviewed the diff and validation output before submitting.
