### PR TITLE
Normalize payment intent currency codes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = (payload.currency ?? "USD").toUpperCase();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults currency to USD", async () => {
+  const intent = await createPaymentIntent({ amount: 1200 });
+
+  assert.equal(intent.currency, "USD");
+});
+
+test("createPaymentIntent normalizes lowercase currency input", async () => {
+  const intent = await createPaymentIntent({ amount: 1200, currency: "eur" });
+
+  assert.equal(intent.currency, "EUR");
+});


### PR DESCRIPTION
Fixes #2670

/claim #2670

## Summary
- Normalize payment intent currency values to uppercase.
- Default missing currency to `USD` so service behavior matches the Prisma schema default.
- Add focused Node test coverage for missing and lowercase currency inputs.
- Update the API test script so the existing `src/tests/*.test.js` files are actually discovered by `node --test`.

## Verification
- `npm install`
- `npm test`

Payment route: PayPal.Me https://paypal.me/sureshc26
