### PR TITLE
Keep registration token subject aligned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  const userId = `usr_${Date.now()}`;
+
   // TODO: persist new user via Prisma
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the access token for the returned user id", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
Fixes #2674

/claim #2674

## Summary
- Generate the registration user id once and reuse it for the returned `id` and JWT `sub` claim.
- Add focused service coverage proving the decoded access token subject matches the returned user id.
- Update the API test script so Node discovers `src/tests/**/*.test.js` test files.

## Verification
- `npm test`

Payment route: PayPal.Me https://paypal.me/sureshc26
