### PR TITLE
Set Express trust proxy for API rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,7 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  app.set("trust proxy", 1);
   app.use(helmet());
   app.use(cors());
   app.use(express.json());

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,6 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
+test("createApp trusts the first reverse proxy hop", () => {
+  const app = createApp();
+
+  assert.equal(app.get("trust proxy"), 1);
+});
+
 test("GET /health returns ok payload", async () => {
   const app = createApp();
   const server = app.listen(0);


### PR DESCRIPTION
/claim #743

Closes #2681
Refs #743

Summary:
- sets `trust proxy` to one hop when creating the Express API app
- adds a focused regression test so proxy-aware behavior stays configured

Validation:
- `node --test apps/api/src/tests/health.test.js`
- `git diff --cached --check`