### PR TITLE
fix(api): protect POST /jobs with auth middleware

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
/claim #2725

## Summary
Require authentication on `POST /api/jobs` so only logged-in users can create job listings.

## Changes
- Import `authMiddleware` in `apps/api/src/routes/jobRoutes.js`
- Update route from `jobRoutes.post("/", postJob)` to `jobRoutes.post("/", authMiddleware, postJob)`

## Why
Prevents unauthenticated spam/malicious job postings while keeping public job listing reads unchanged.

## Issue
- https://github.com/SecureBananaLabs/bug-bounty/issues/2725