### PR TITLE
fix(api): protect POST /uploads with auth middleware

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
/claim #2728

## Summary
Require authentication on `POST /api/uploads` so only logged-in users can upload files.

## Changes
- Import `authMiddleware` in `apps/api/src/routes/uploadRoutes.js`
- Update route to `uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile)`

## Why
Prevents unauthenticated upload abuse while preserving existing upload middleware/controller flow.

## Issue
- https://github.com/SecureBananaLabs/bug-bounty/issues/2728