### PR TITLE
fix(api): protect POST /payments with auth middleware

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
/claim #2730

## Summary
Require authentication on `POST /api/payments` so only logged-in users can create payment records.

## Changes
- Import `authMiddleware` in `apps/api/src/routes/paymentRoutes.js`
- Update route to `paymentRoutes.post("/", authMiddleware, createPayment)`

## Why
Prevents unauthenticated payment-creation abuse while preserving existing controller flow.

## Issue
- https://github.com/SecureBananaLabs/bug-bounty/issues/2730