### PR TITLE
fix(api): enforce admin role authorization on admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminOnlyMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { adminOnlyMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminOnlyMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
/claim #2732

## Summary
Restrict admin metrics access to users with role `admin`.

## Changes
- Add `adminOnlyMiddleware` in `apps/api/src/middleware/auth.js`
- Apply it in `apps/api/src/routes/adminRoutes.js` after `authMiddleware`

## Why
`authMiddleware` alone verifies token validity, but not role authorization. This change enforces RBAC on admin endpoints.

## Issue
- https://github.com/SecureBananaLabs/bug-bounty/issues/2732