### PR TITLE
fix(api): require auth on POST /api/messages

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);


### PR DESCRIPTION
## Summary
- add auth middleware import in message routes
- protect message creation endpoint

## Change
- from: `messageRoutes.post("/", postMessage);`
- to: `messageRoutes.post("/", authMiddleware, postMessage);`

## Why
Prevents unauthenticated users from creating messages.

Closes #2736