### PR TITLE
Add relay of trust poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Relay of Trust
+
+The brief arrives with edges clean,
+A promise measured line by line;
+The work begins where scope is seen,
+And proof is made before a sign.
+
+A message crosses review light,
+With context kept and changes small;
+Each careful check turns doubt to sight,
+Each passing test steadies the call.
+
+The merge is not a sudden gate,
+But hands that pass what they can prove;
+A client, builder, branch, and date
+All leave a trail the team can move.
+
+Then payout follows work made clear,
+Not noise, not luck, not hurried claim;
+Trust is the system we engineer,
+And every handoff signs its name.


### PR DESCRIPTION
/claim #76

## Summary
- Added an original root-level `POEM.md` for FreelanceFlow.
- Theme: a compact handoff poem about scope, evidence, review, merge, payout, and trust.

## Creative decision
I used a relay-of-trust structure because FreelanceFlow is a marketplace where each handoff should be clear, reviewable, and accountable.

## Validation
- `git diff --check`
- Markdown-only change; no runtime behavior changed.
