### PR TITLE
fix(api): require auth on POST /api/notifications

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);


### PR DESCRIPTION
## Summary
- add auth middleware import in notification routes
- protect notification creation endpoint

## Change
- from: `notificationRoutes.post("/", postNotification);`
- to: `notificationRoutes.post("/", authMiddleware, postNotification);`

## Why
Prevents unauthenticated users from creating notifications.

Closes #2739