### PR TITLE
Keep notification fields server owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps id and read state server-owned", async () => {
+  const notification = await createNotification({
+    id: "caller-controlled",
+    read: true,
+    userId: "usr_123",
+    message: "New proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "caller-controlled");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "New proposal received");
+});


### PR DESCRIPTION
/claim #743

Closes #2742

Summary:
- keeps notification id and initial read state server-owned during creation
- prevents request payloads from overriding generated notification ids or pre-marking new notifications as read
- adds a focused notification service regression test

Validation:
- node --test src/tests/health.test.js src/tests/notificationService.test.js
- git diff --check

Note:
- npm test -w apps/api is still blocked by the existing Node 22 test-directory invocation issue: node --test src/tests resolves the directory as a module path on this runtime.