### PR TITLE
fix(users): validate user creation input, reject client-controlled fields

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,10 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const message = parsed.error.issues.map((i) => i.message).join("; ");
+    return fail(res, message, 400);
+  }
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /users requires name and email", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => server.once("listening", r).once("error", e));
+  const { port } = server.address();
+
+  // Empty body → 400
+  let res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  assert.equal(res.status, 400);
+
+  // Body with client-controlled id → 400 (strict schema rejects unknown fields)
+  res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: "usr_evil", name: "Hacker", email: "a@b.com" }),
+  });
+  assert.equal(res.status, 400);
+
+  // Valid body → 201
+  res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Ed", email: "ed@example.com" }),
+  });
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.ok(body.success);
+  assert.equal(body.data.name, "Ed");
+  assert.equal(body.data.email, "ed@example.com");
+  assert.equal(body.data.role, "client");
+  // Server-generated id must not be attacker-controlled
+  assert.ok(body.data.id.startsWith("usr_"));
+
+  // Admin role is rejected
+  res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Bot", email: "bot@x.com", role: "admin" }),
+  });
+  assert.equal(res.status, 400);
+
+  await new Promise((r, e) => server.close((err) => (err ? e(err) : r())));
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z
+  .object({
+    name: z.string().min(1, "name is required"),
+    email: z.string().email("email must be a valid email address"),
+    role: z.enum(["client", "freelancer"]).default("client"),
+  })
+  .strict();


### PR DESCRIPTION
## Fix for #1766

The `/api/users` creation path accepts arbitrary request bodies, allowing client-controlled `id` fields, empty payloads, and injection of unwanted properties.

### Changes

**`apps/api/src/validators/user.js`** — new Zod schema (`createUserSchema`):
- Requires `name` (non-empty string) and `email` (valid email)
- Allows only `client` and `freelancer` roles (defaults to `client`)
- Uses `.strict()` to reject any unknown fields (e.g. `id`, `isAdmin`, etc.)

**`apps/api/src/controllers/userController.js`**:
- Uses `safeParse` to validate `req.body` before forwarding to service
- Returns 400 with descriptive error messages on validation failure
- Follows the same pattern as `authController.js` (Zod in controller, not service)

**`apps/api/src/tests/user.test.js`** — new test covering:
- Empty body → 400
- Body with client-controlled `id` → 400 (strict schema rejects it)
- Valid body with name + email → 201, role defaults to `client`, server-generated `id`
- `role: "admin"` → 400 (admin not in allowed enum)

### Why this approach

- Uses **Zod** (already a project dependency) instead of hand-rolled validation — consistent with the rest of the codebase
- Validates in the **controller layer** — consistent with `authController.js`
- **`.strict()`** on the schema means any unknown field causes rejection — no need to enumerate blocked fields
- Minimal diff: 3 files, +68/-2 lines

Fixes #1766