### PR TITLE
Require auth for notification routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("notification routes reject unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const listResponse = await fetch(`${baseUrl}/api/notifications`);
+    const createResponse = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Invoice paid" })
+    });
+
+    assert.equal(listResponse.status, 401);
+    assert.equal(createResponse.status, 401);
+  });
+});
+
+test("notification routes accept valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_notifications", role: "client" });
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    };
+
+    const createResponse = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ title: "Proposal update" })
+    });
+    const created = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(created.success, true);
+    assert.equal(created.data.title, "Proposal update");
+
+    const listResponse = await fetch(`${baseUrl}/api/notifications`, { headers });
+    const listed = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listed.success, true);
+    assert.equal(
+      listed.data.some((notification) => notification.id === created.data.id),
+      true
+    );
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #2748

## Summary
- Apply the existing `authMiddleware` to `/api/notifications` so list/create requests require a valid bearer token.
- Add API coverage proving unauthenticated notification GET/POST requests return `401`.
- Add API coverage proving valid bearer tokens can still create and list notifications.
- Fix the API package `test` script so it runs the intended Node test glob instead of treating `src/tests` as a file.

## Validation
- `npm test -w apps/api`
- `git diff --check`

## Demo evidence
The focused API tests exercise the before/after behavior directly: anonymous requests are rejected, while a signed access token can create and list notifications.

Parent bounty: #743