### PR TITLE
Render selected job details

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,39 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((entry) => entry.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No active job matches <strong>{id}</strong>.</p>
+        <p>Return to the job listings to choose an available project.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <p style={{ marginTop: 0, color: "#9fb0d8" }}>{job.category}</p>
+      <h2>{job.title}</h2>
+      <p>{job.description}</p>
+      <p><strong>Budget:</strong> {job.budget}</p>
+
+      <h3>Required skills</h3>
+      <ul>
+        {job.skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
+
+      <h3>Milestones</h3>
+      <ol>
+        {job.milestones.map((milestone) => (
+          <li key={milestone}>{milestone}</li>
+        ))}
+      </ol>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,31 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    category: "AI Automation",
+    description: "Create a lightweight support widget that answers product questions and escalates complex tickets.",
+    skills: ["Next.js", "OpenAI API", "Customer Support"],
+    milestones: ["Prototype chat flow", "Connect knowledge base", "QA escalation paths"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    category: "Backend Engineering",
+    description: "Move a small legacy REST API to a maintainable Node.js service with clear route boundaries.",
+    skills: ["Node.js", "Express", "API Migration"],
+    milestones: ["Map legacy endpoints", "Implement service layer", "Run parity tests"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    category: "Product Design",
+    description: "Design onboarding screens that guide new teams from signup to their first published project.",
+    skills: ["Figma", "UX Writing", "SaaS Onboarding"],
+    milestones: ["Audit current flow", "Draft wireframes", "Deliver high-fidelity screens"]
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
## Issue
Closes #2755

## Summary
Render the matching mock job on `/jobs/[id]` instead of placeholder copy, including category, description, budget, required skills, and milestones. Unknown ids now show a clear not-found fallback.

## Acceptance criteria
- [x] Known job ids render the matching mock job title and budget
- [x] The detail page exposes useful project context instead of generic placeholder copy
- [x] Unknown job ids render a clear not-found fallback

## Validation
- `npm run build -w apps/web`
- `git diff --check`