### PR TITLE
fix: render job details from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,34 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export function generateStaticParams() {
+  return jobs.map((job) => ({ id: job.id }));
+}
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+  const job = jobs.find((item) => item.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No mock job exists for <strong>{id}</strong>.</p>
+        <Link href="/jobs">Back to jobs</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Review the project scope, milestones, and proposal activity for this mock job.</p>
+      <Link href="/jobs">Back to jobs</Link>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

Closes #2760.

Summary:
- Resolves `/jobs/[id]` against `apps/web/lib/mock.ts` instead of rendering placeholder route-id copy.
- Renders the selected mock job title and budget for known ids.
- Adds a clear fallback for unknown job ids with a link back to the job list.

Validation:
- npm run build -w apps/web
- curl http://localhost:3100/jobs/job-101 confirmed the matching job title and budget render
- curl http://localhost:3100/jobs/not-real confirmed the not-found fallback renders
- git diff --check