### PR TITLE
fix: preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-controlled id and read fields", async () => {
+  const notification = await createNotification({
+    id: "client-controlled-id",
+    read: true,
+    title: "Proposal update",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "client-controlled-id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.title, "Proposal update");
+});


### PR DESCRIPTION
/claim #743

Closes #2762.

Summary:
- Ensures notification creation applies server-owned `id` and `read` fields after request payload data.
- Prevents callers from overriding the generated notification id or creating already-read notifications.
- Adds a focused regression test for caller-controlled `id` and `read` values.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check

Note: `npm test -w apps/api` currently fails before running tests because the package script invokes `node --test src/tests`, which Node resolves as a missing module path on this machine. The explicit test-file command above passes.