### PR TITLE
Render selected freelancer profile

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,37 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "../../../lib/mock";
+
+export default async function FreelancerProfilePage({
+  params
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+  const freelancer = freelancers.find((entry) => entry.username === username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No active freelancer profile matches <strong>{username}</strong>.</p>
+        <p>Return to freelancer search to choose an available profile.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p style={{ marginTop: 0, color: "#9fb0d8" }}>Freelancer profile</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Hourly rate:</strong> {freelancer.rate}</p>
+
+      <h3>Skills</h3>
+      <ul>
+        {freelancer.skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
+
+      <p>Use this profile to compare rate, skill fit, and availability before opening a proposal thread.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Issue
Closes #2763

## Summary
Render the matching mock freelancer on `/freelancers/[username]` instead of placeholder copy. Unknown usernames now show a clear not-found fallback.

## Acceptance criteria
- [x] Known freelancer usernames render the matching mock profile details
- [x] The profile page exposes useful skills/rate context instead of generic placeholder copy
- [x] Unknown usernames render a clear not-found fallback

## Validation
- `npm run build -w apps/web`
- `git diff --check`