### PR TITLE
fix: keep registration token subject stable

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "correct horse battery staple",
+    role: "client",
+  });
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+  assert.equal(result.email, "new-client@example.com");
+});


### PR DESCRIPTION
/claim #743

Closes #2768.

Summary:
- Generates the registration user id once.
- Returns that same id in the response and signs the JWT with the same value as `sub`.
- Adds focused service coverage proving `decoded.sub === result.id`.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check