### PR TITLE
Require fullName during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+
+test("register schema requires fullName", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+});
+
+test("register user preserves validated fullName", async () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    fullName: "Client Example",
+    password: "password123",
+    role: "client"
+  });
+
+  const user = await registerUser(payload);
+
+  assert.equal(user.email, "client@example.com");
+  assert.equal(user.fullName, "Client Example");
+  assert.equal(user.role, "client");
+  assert.equal(typeof user.token, "string");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
+  fullName: z.string().trim().min(1),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });


### PR DESCRIPTION
## Issue
Closes #2770

## Summary
Require `fullName` in registration payload validation so accepted auth registration requests match the required Prisma `User.fullName` field. The registration service now carries the validated name into its returned user payload.

## Acceptance criteria
- [x] Registration payload validation requires a non-empty `fullName`
- [x] `registerUser()` preserves the validated `fullName`
- [x] Tests cover missing and valid `fullName` cases

## Validation
- `node --test src/tests/health.test.js src/tests/authRegistration.test.js` from `apps/api`
- `node --check apps/api/src/validators/auth.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authRegistration.test.js`
- `git diff --check`