### PR TITLE
fix(api): require auth on POST /api/proposals

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);


### PR DESCRIPTION
## Summary
- add auth middleware import in proposal routes
- protect proposal creation endpoint

## Change
- from: `proposalRoutes.post("/", postProposal);`
- to: `proposalRoutes.post("/", authMiddleware, postProposal);`

## Why
Prevents unauthenticated users from creating proposals.

Closes #2773