### PR TITLE
Expose db workspace package entrypoint

### DIFF
--- a/apps/api/src/tests/dbPackage.test.js
+++ b/apps/api/src/tests/dbPackage.test.js
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("@freelanceflow/db exposes an importable workspace entrypoint", async () => {
+  const dbPackage = await import("@freelanceflow/db");
+
+  assert.equal(typeof dbPackage.PrismaClient, "function");
+});

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "index.js",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Issue
Closes #2775

## Summary
Add an explicit ESM package entrypoint for `@freelanceflow/db` so workspace consumers can import it by package name. The package metadata now declares `main`, `types`, and `exports`, and the root entrypoint re-exports Prisma Client.

## Acceptance criteria
- [x] `@freelanceflow/db` exposes a valid JavaScript entrypoint
- [x] Package metadata includes explicit `main`, `types`, and `exports`
- [x] A focused test imports the package through the workspace package name

## Validation
- `node --test src/tests/health.test.js src/tests/dbPackage.test.js` from `apps/api`
- `node --check packages/db/index.js`
- `node --check apps/api/src/tests/dbPackage.test.js`
- `git diff --check`