### PR TITLE
fix(api): require auth on POST /api/reviews

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
## Summary
- add auth middleware import in review routes
- protect review creation endpoint

## Change
- from: `reviewRoutes.post("/", postReview);`
- to: `reviewRoutes.post("/", authMiddleware, postReview);`

## Why
Prevents unauthenticated users from creating reviews.

Closes #2776