### PR TITLE
fix(api): require auth on POST /api/users

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);


### PR DESCRIPTION
## Summary
- add auth middleware import in user routes
- protect user creation endpoint

## Change
- from: `userRoutes.post("/", postUser);`
- to: `userRoutes.post("/", authMiddleware, postUser);`

## Why
Prevents unauthenticated users from creating users.

Closes #2779