### PR TITLE
Expose UI workspace package entrypoint

### DIFF
--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,14 @@
+import type { ReactElement, ReactNode } from "react";
+
+export interface ButtonProps {
+  children: ReactNode;
+}
+
+export declare function Button(props: ButtonProps): ReactElement;
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export declare function Card(props: CardProps): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const buttonStyle = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children }) {
+  return React.createElement("button", { style: buttonStyle }, children);
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
 }

--- a/packages/ui/test/import.test.mjs
+++ b/packages/ui/test/import.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Button, Card } from "@freelanceflow/ui";
+
+test("@freelanceflow/ui exposes runtime component exports", () => {
+  assert.equal(typeof Button, "function");
+  assert.equal(typeof Card, "function");
+
+  const button = Button({ children: "Post job" });
+  assert.equal(button.type, "button");
+  assert.equal(button.props.children, "Post job");
+
+  const card = Card({ title: "Profile", children: "Ready" });
+  assert.equal(card.type, "section");
+  assert.equal(card.props.children[0].type, "h3");
+  assert.equal(card.props.children[0].props.children, "Profile");
+});


### PR DESCRIPTION
Fixes #2781.

## Summary
- expose `@freelanceflow/ui` through a runtime `index.js` entrypoint
- add TypeScript declarations for the public Button and Card exports
- add a package-level import test so the workspace package cannot regress to an unimportable entrypoint

## Validation
- `npm test -w packages/ui`
- `node --check packages/ui/index.js`
- `node --check packages/ui/test/import.test.mjs`
- `npm run build -w apps/web`
- `git diff --check`