### PR TITLE
fix(ui): @freelanceflow/ui package entrypoint should be directly importable (Fixes #2787)

### DIFF
--- a/apps/api/src/tests/ui.test.js
+++ b/apps/api/src/tests/ui.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert";
+
+test("ui package entrypoint validation", async (t) => {
+  await t.test("should successfully import Button and Card from @freelanceflow/ui", async () => {
+    const { Button, Card } = await import("@freelanceflow/ui");
+    assert.ok(Button);
+    assert.ok(Card);
+    assert.equal(typeof Button, "function");
+    assert.equal(typeof Card, "function");
+  });
+});

--- a/packages/ui/dist/Button.d.ts
+++ b/packages/ui/dist/Button.d.ts
@@ -1,0 +1,4 @@
+import React from "react";
+export declare function Button({ children }: {
+    children: React.ReactNode;
+}): import("react/jsx-runtime").JSX.Element;

--- a/packages/ui/dist/Button.js
+++ b/packages/ui/dist/Button.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Button = Button;
+const jsx_runtime_1 = require("react/jsx-runtime");
+function Button({ children }) {
+    return ((0, jsx_runtime_1.jsx)("button", { style: {
+            background: "#5468ff",
+            color: "white",
+            border: "none",
+            borderRadius: 8,
+            padding: "0.6rem 0.9rem",
+            cursor: "pointer"
+        }, children: children }));
+}

--- a/packages/ui/dist/Card.d.ts
+++ b/packages/ui/dist/Card.d.ts
@@ -1,0 +1,5 @@
+import React from "react";
+export declare function Card({ title, children }: {
+    title: string;
+    children: React.ReactNode;
+}): import("react/jsx-runtime").JSX.Element;

--- a/packages/ui/dist/Card.js
+++ b/packages/ui/dist/Card.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Card = Card;
+const jsx_runtime_1 = require("react/jsx-runtime");
+function Card({ title, children }) {
+    return ((0, jsx_runtime_1.jsxs)("section", { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }, children: [(0, jsx_runtime_1.jsx)("h3", { children: title }), (0, jsx_runtime_1.jsx)("div", { children: children })] }));
+}

--- a/packages/ui/dist/index.d.ts
+++ b/packages/ui/dist/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./Button";
+export * from "./Card";

--- a/packages/ui/dist/index.js
+++ b/packages/ui/dist/index.js
@@ -1,0 +1,18 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./Button"), exports);
+__exportStar(require("./Card"), exports);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "npx tsc"
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This PR fixes issue #2787 by compiling the TypeScript component modules in `packages/ui` into a standard `dist` JavaScript entrypoint and updating `package.json` with proper `main`, `types`, and `exports` declarations. It also adds a lightweight test in `apps/api/src/tests/ui.test.js` to guarantee that the UI components are successfully importable via the workspace package name.