### PR TITLE
Keep health checks outside API rate limit

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/healthRateLimit.test.js
+++ b/apps/api/src/tests/healthRateLimit.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /health remains available after API routes hit the rate limit", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    let apiResponse;
+    for (let i = 0; i < 201; i += 1) {
+      apiResponse = await fetch(`${baseUrl}/api/users`);
+    }
+
+    assert.equal(apiResponse.status, 429);
+
+    const healthResponse = await fetch(`${baseUrl}/health`);
+    const healthPayload = await healthResponse.json();
+
+    assert.equal(healthResponse.status, 200);
+    assert.deepEqual(healthPayload, { ok: true, service: "api" });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
Closes #983.

## Summary
- Register `/health` before the shared API rate limiter so infrastructure health checks remain available after API traffic exhausts the quota.
- Keep the existing limiter on the `/api/*` route groups.
- Add a regression test that exhausts `/api/users` and verifies `/health` still returns the stable OK payload.

## Validation
- `node --test src/tests/health.test.js src/tests/healthRateLimit.test.js` from `apps/api`
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/healthRateLimit.test.js`
- `git diff --check`