### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Landing page redesign",
+  description: "Refresh the landing page for a better first impression.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "design",
+  skills: ["figma"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted ranges when both budgets are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 400,
+    budgetMax: 250
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMax: 250
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Fixes #2827

## Summary
- reject job payloads where `budgetMax` is lower than `budgetMin`
- apply the same guard to partial job updates when both budget fields are present
- add validator tests for valid, invalid, and partial budget payloads
- update the API test script so `node --test` receives test files instead of the test directory

## Test
- npm test -w apps/api
