### PR TITLE
docs: add project-specific poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger of Open Work
+
+Clients arrive with sketches, deadlines, and doubt,
+turning rough intent into a job with edges.
+A title, a budget, a category, a scope,
+and the marketplace begins to hold its shape.
+
+Freelancers answer with profiles full of proof,
+skills arranged like tools within reach.
+Each proposal is a small contract of attention,
+a promise to make the unclear thing shippable.
+
+Messages keep the work from drifting away:
+questions pinned to context, updates close to hand.
+Reviews wait at the far side of delivery,
+where trust becomes something future teams can read.
+
+The API carries the quiet load underneath,
+auth, payments, search, uploads, and admin paths.
+Schemas name the world before it enters storage,
+so every moving part knows what it owes the next.
+
+FreelanceFlow is not just a board of open tasks;
+it is a ledger for momentum, risk, and care.
+When the handoff is clean and the record is fair,
+good work has somewhere reliable to land.


### PR DESCRIPTION
/claim #76

Closes #76.

Creative decision: I used a marketplace-ledger tone so the poem is specific to FreelanceFlow's trust, proposal, API, billing, messaging, review, and delivery loops instead of a generic technology poem.

Summary:
- Adds an original POEM.md with five stanzas in the project root.
- Keeps the PR focused on issue #76 only.

Validation:
- Verified the file is root-level POEM.md.
- Verified the poem has 5 stanza blocks after the title and ASCII-only text.
