### PR TITLE
fix: prevent admin role self-assignment

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,16 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid registration payload";
+    return fail(res, message, 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withApiServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "admin-attempt@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.ok(!payload.data?.token);
+  });
+});
+
+test("POST /api/auth/register still allows public user roles", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "freelancer@example.com",
+        password: "password123",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+    const tokenPayload = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(tokenPayload.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/register defaults omitted role to client", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123"
+      })
+    });
+    const payload = await response.json();
+    const tokenPayload = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+    assert.equal(tokenPayload.role, "client");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
+export const publicUserRoleSchema = z.enum(["client", "freelancer"]);
+
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: publicUserRoleSchema.default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

- removes `admin` from the public registration role schema
- returns a `400` response when registration payload validation fails
- keeps `client` as the default role when omitted
- adds API tests for rejected `admin`, accepted `freelancer`, and default `client` registration

## Validation

```bash
node --test src/tests/*.test.js
```

Result: 4 tests passed from `apps/api`.

## Linked issue

Closes #2832
