### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { searchQuerySchema } from "../validators/search.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid search query";
+    return fail(res, message, 400);
+  }
+
+  return ok(res, await globalSearch(parsed.data.q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withApiServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims and sanitizes the search query", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20hello%00%20%20world%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "hello world");
+  });
+});
+
+test("GET /api/search rejects overly long search queries", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /200 characters or fewer/);
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withApiServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=alpha&q=beta`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be a string");
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const MAX_SEARCH_QUERY_LENGTH = 200;
+
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/g;
+const WHITESPACE_PATTERN = /\s+/g;
+
+export function normalizeSearchQuery(query) {
+  return query
+    .replace(CONTROL_CHARACTER_PATTERN, " ")
+    .trim()
+    .replace(WHITESPACE_PATTERN, " ");
+}
+
+export const searchQuerySchema = z.object({
+  q: z.preprocess(
+    (value) => value ?? "",
+    z
+      .string({ invalid_type_error: "Search query must be a string" })
+      .transform(normalizeSearchQuery)
+      .refine((query) => query.length <= MAX_SEARCH_QUERY_LENGTH, {
+        message: `Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer`
+      })
+  )
+});


### PR DESCRIPTION
## Summary

- validates `GET /api/search` query input with a dedicated Zod schema
- trims and normalizes accepted search queries before calling `globalSearch`
- rejects queries over 200 characters and repeated `q` parameters with `400`
- adds API tests for sanitized input, overly long input, and repeated query parameters
- updates the API test script so the Node test runner executes test files directly

## Validation

```bash
npm test
```

Result: 4 tests passed.

## Linked issue

Closes #2833
