### PR TITLE
fix(api): keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the returned user id as the access-token subject", async (t) => {
+  let timestamp = 1700000000000;
+  t.mock.method(Date, "now", () => timestamp++);
+
+  const user = await registerUser({
+    email: "new-client@example.com",
+    role: "client",
+    password: "correct-horse-battery-staple"
+  });
+  const tokenPayload = verifyAccessToken(user.token);
+
+  assert.equal(tokenPayload.sub, user.id);
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once in `registerUser()`
- use that same id for the returned user object and JWT `sub` claim
- add a regression test that forces timestamp drift between id generation points

## Validation
- `node --test src/tests/auth.test.js`
- `node --test src/tests/*.test.js`

/claim #743
Closes #2845
References #743