### PR TITLE
fix(api): authenticate auth refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh signs a new token for the authenticated subject", async () => {
+  const accessToken = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const refreshedPayload = verifyAccessToken(payload.data.token);
+    assert.equal(refreshedPayload.sub, "usr_refresh");
+    assert.equal(refreshedPayload.role, "freelancer");
+  });
+});


### PR DESCRIPTION
## Summary
- require bearer-token authentication for `POST /api/auth/refresh`
- sign refreshed tokens for the verified requester subject and role instead of a hard-coded user
- add route-level regression tests for unauthenticated rejection and authenticated subject preservation

## Validation
- `node --test src/tests/auth-refresh.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2847
References #743