### PR TITLE
fix(api): reject empty upload submissions

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: new FormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "File is required" });
+  });
+});


### PR DESCRIPTION
## Summary
- return `400` when `POST /api/uploads` has no `file` field
- keep successful `201` upload responses for requests with an actual uploaded file
- add route-level regression coverage for empty multipart upload requests

## Validation
- `node --test src/tests/upload.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2850
References #743