### PR TITLE
fix: render freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,35 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export function generateStaticParams() {
+  return freelancers.map((freelancer) => ({ username: freelancer.username }));
+}
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+  const freelancer = freelancers.find((item) => item.username === username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No mock freelancer exists for <strong>{username}</strong>.</p>
+        <Link href="/freelancers/search">Back to search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(" · ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
+      <Link href="/freelancers/search">Back to search</Link>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

Closes #2849.

Summary:
- Resolves `/freelancers/[username]` against `apps/web/lib/mock.ts` instead of rendering placeholder username copy.
- Renders matching skills and hourly rate for known mock freelancers.
- Adds a clear fallback for unknown usernames with a link back to freelancer search.

Validation:
- npm run build -w apps/web
- curl http://localhost:3100/freelancers/maya-dev confirmed the matching username, skills, and rate render
- curl http://localhost:3100/freelancers/nope confirmed the not-found fallback renders
- git diff --check