### PR TITLE
fix: reject inverted job budgets

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API integration",
+  description: "Create a production-ready API integration.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "engineering",
+  skills: ["node"],
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1500,
+    budgetMax: 500,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 900,
+    budgetMax: 100,
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job budget schemas accept ordered ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 500 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,19 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function hasOrderedBudgetRange(payload) {
+  return (
+    payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMax >= payload.budgetMin
+  );
+}
+
+const budgetRangeOptions = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = jobFields.refine(hasOrderedBudgetRange, budgetRangeOptions);
+
+export const updateJobSchema = jobFields.partial().refine(hasOrderedBudgetRange, budgetRangeOptions);


### PR DESCRIPTION
/claim #743

Closes #2853.

Summary:
- Adds shared budget range validation for job create and update schemas.
- Rejects payloads where `budgetMax` is lower than `budgetMin`.
- Keeps valid equal or ascending ranges accepted.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check