### PR TITLE
fix(api): return 400 for invalid jobs

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/job-validation.test.js
+++ b/apps/api/src/tests/job-validation.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs returns 400 for invalid job payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "bad" }),
+      signal: AbortSignal.timeout(1000)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid job payload");
+  });
+});


### PR DESCRIPTION
## Summary
- validate job creation payloads with `safeParse` before creating jobs
- return a stable `400` JSON error for invalid `POST /api/jobs` requests
- add route-level regression coverage for invalid job payloads

## Validation
- `node --test src/tests/job-validation.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2855
References #743