### PR TITLE
fix: restrict public registration roles

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const validRegistration = {
+  email: "new-user@example.com",
+  password: "correct horse battery staple",
+};
+
+test("registerSchema defaults public registrations to client role", () => {
+  const result = registerSchema.parse(validRegistration);
+
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema allows freelancer self-registration", () => {
+  const result = registerSchema.parse({
+    ...validRegistration,
+    role: "freelancer",
+  });
+
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const result = registerSchema.safeParse({
+    ...validRegistration,
+    role: "admin",
+  });
+
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

Closes #2856.

Summary:
- Restricts public registration to `client` and `freelancer` roles.
- Keeps omitted role defaulting to `client`.
- Adds schema coverage proving `admin` self-assignment is rejected.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check