### PR TITLE
fix(api): validate payment amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  if (!Number.isFinite(req.body?.amount) || req.body.amount <= 0) {
+    return fail(res, "Invalid payment amount", 400);
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/payment-validation.test.js
+++ b/apps/api/src/tests/payment-validation.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid payment amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -25, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid payment amount" });
+  });
+});


### PR DESCRIPTION
## Summary
- reject missing, non-finite, zero, or negative payment amounts
- return a stable `400` JSON error before creating invalid payment intents
- add route-level regression coverage for invalid payment amounts

## Validation
- `node --test src/tests/payment-validation.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2859
References #743