### PR TITLE
Preserve server-owned message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps server-owned fields authoritative", async () => {
+  const message = await sendMessage({
+    id: "client-controlled-id",
+    sentAt: "2000-01-01T00:00:00.000Z",
+    body: "Hello",
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "client-controlled-id");
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(message.body, "Hello");
+});


### PR DESCRIPTION
/claim #743

Closes #2860.

Summary:
- Keep generated message ids authoritative even when payloads include an id field.
- Add a regression test for server-owned message id and timestamp fields.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check