### PR TITLE
Preserve server-owned job fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps server-owned id and status authoritative", async () => {
+  const job = await createJob({
+    id: "client-controlled-id",
+    status: "closed",
+    title: "Build a dashboard",
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "client-controlled-id");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build a dashboard");
+});


### PR DESCRIPTION
/claim #743

Closes #2863.

Summary:
- Keep generated job ids authoritative even when payloads include an id field.
- Keep new job status server-owned as open even when payloads include another status.
- Add a regression test for both protected fields.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check