### PR TITLE
Preserve server-owned proposal ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps server-owned ids authoritative", async () => {
+  const proposal = await createProposal({
+    id: "client-controlled-id",
+    jobId: "job_123",
+    coverLetter: "I can help.",
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "client-controlled-id");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.coverLetter, "I can help.");
+});


### PR DESCRIPTION
/claim #743

Closes #2865.

Summary:
- Keep generated proposal ids authoritative even when payloads include an id field.
- Add a regression test while preserving normal proposal payload fields.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check