### PR TITLE
Preserve server-owned review ids

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps server-owned ids authoritative", async () => {
+  const review = await createReview({
+    id: "client-controlled-id",
+    rating: 5,
+    comment: "Great work.",
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "client-controlled-id");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great work.");
+});


### PR DESCRIPTION
/claim #743

Closes #2867.

Summary:
- Keep generated review ids authoritative even when payloads include an id field.
- Add a regression test while preserving normal review payload fields.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check