### PR TITLE
Preserve server-owned user ids

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps server-owned ids authoritative", async () => {
+  const user = await createUser({
+    id: "client-controlled-id",
+    email: "person@example.com",
+    role: "client",
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "client-controlled-id");
+  assert.equal(user.email, "person@example.com");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
/claim #743

Closes #2869.

Summary:
- Keep generated user ids authoritative even when payloads include an id field.
- Add a regression test while preserving normal user payload fields.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check