### PR TITLE
Return defensive user list copies

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/userListService.test.js
+++ b/apps/api/src/tests/userListService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers returns a defensive array copy", async () => {
+  const user = await createUser({ email: "person@example.com" });
+  const listedUsers = await listUsers();
+
+  listedUsers.length = 0;
+
+  const nextListedUsers = await listUsers();
+
+  assert.equal(nextListedUsers.length, 1);
+  assert.equal(nextListedUsers[0], user);
+});


### PR DESCRIPTION
/claim #743

Closes #2871.

Summary:
- Return a copied users array from listUsers so callers cannot mutate the backing store.
- Add a regression test that mutates the returned list and verifies stored users remain intact.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check