### PR TITLE
Return defensive job list copies

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/tests/jobListService.test.js
+++ b/apps/api/src/tests/jobListService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("listJobs returns a defensive array copy", async () => {
+  const job = await createJob({ title: "Build a dashboard" });
+  const listedJobs = await listJobs();
+
+  listedJobs.length = 0;
+
+  const nextListedJobs = await listJobs();
+
+  assert.equal(nextListedJobs.length, 1);
+  assert.equal(nextListedJobs[0], job);
+});


### PR DESCRIPTION
/claim #743

Closes #2874.

Summary:
- Return a copied jobs array from listJobs so callers cannot mutate the backing store.
- Add a regression test that mutates the returned list and verifies stored jobs remain intact.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check