### PR TITLE
Return defensive message list copies

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/tests/messageListService.test.js
+++ b/apps/api/src/tests/messageListService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("listMessages returns a defensive array copy", async () => {
+  const message = await sendMessage({ body: "Hello" });
+  const listedMessages = await listMessages();
+
+  listedMessages.length = 0;
+
+  const nextListedMessages = await listMessages();
+
+  assert.equal(nextListedMessages.length, 1);
+  assert.equal(nextListedMessages[0], message);
+});


### PR DESCRIPTION
/claim #743

Closes #2876.

Summary:
- Return a copied messages array from listMessages so callers cannot mutate the backing store.
- Add a regression test that mutates the returned list and verifies stored messages remain intact.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check