### PR TITLE
fix(api): keep message ids server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps message ids server-owned", async (t) => {
+  t.mock.method(Date, "now", () => 1700000000000);
+
+  const message = await sendMessage({
+    id: "msg_client_supplied",
+    body: "hello"
+  });
+
+  assert.equal(message.id, "msg_1700000000000");
+});


### PR DESCRIPTION
## Summary
- keep `sendMessage()` ids server-owned even when payloads include `id`
- apply the trusted `msg_...` id after copying caller payload fields
- add service-level regression coverage for client-supplied id override attempts

## Validation
- `node --test src/tests/message-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2877
References #743