### PR TITLE
Return defensive proposal list copies

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposalListService.test.js
+++ b/apps/api/src/tests/proposalListService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("listProposals returns a defensive array copy", async () => {
+  const proposal = await createProposal({ jobId: "job_123" });
+  const listedProposals = await listProposals();
+
+  listedProposals.length = 0;
+
+  const nextListedProposals = await listProposals();
+
+  assert.equal(nextListedProposals.length, 1);
+  assert.equal(nextListedProposals[0], proposal);
+});


### PR DESCRIPTION
/claim #743

Closes #2879.

Summary:
- Return a copied proposals array from listProposals so callers cannot mutate the backing store.
- Add a regression test that mutates the returned list and verifies stored proposals remain intact.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check