### PR TITLE
Return defensive notification list copies

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/notificationListService.test.js
+++ b/apps/api/src/tests/notificationListService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("listNotifications returns a defensive array copy", async () => {
+  const notification = await createNotification({ message: "New proposal" });
+  const listedNotifications = await listNotifications();
+
+  listedNotifications.length = 0;
+
+  const nextListedNotifications = await listNotifications();
+
+  assert.equal(nextListedNotifications.length, 1);
+  assert.equal(nextListedNotifications[0], notification);
+});


### PR DESCRIPTION
/claim #743

Closes #2886.

Summary:
- Return a copied notifications array from listNotifications so callers cannot mutate the backing store.
- Add a regression test that mutates the returned list and verifies stored notifications remain intact.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check