### PR TITLE
fix: expose @freelanceflow/ui as a directly importable ESM package

### DIFF
--- a/packages/ui/index.cjs
+++ b/packages/ui/index.cjs
@@ -1,0 +1,27 @@
+"use strict";
+
+const React = require("react");
+
+const buttonStyle = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+function Button({ children }) {
+  return React.createElement("button", { style: buttonStyle }, children);
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Button, Card };

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,14 @@
+import type { ReactElement, ReactNode } from "react";
+
+export interface ButtonProps {
+  children: ReactNode;
+}
+
+export declare function Button(props: ButtonProps): ReactElement;
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export declare function Card(props: CardProps): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+const buttonStyle = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children }) {
+  return React.createElement("button", { style: buttonStyle }, children);
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.cjs"
+    }
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
 }

--- a/packages/ui/test/import.test.mjs
+++ b/packages/ui/test/import.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Button, Card } from "@freelanceflow/ui";
+import { createRequire } from "node:module";
+
+test("ESM: @freelanceflow/ui exposes Button and Card as functions", () => {
+  assert.equal(typeof Button, "function");
+  assert.equal(typeof Card, "function");
+});
+
+test("ESM: Button renders a <button> element with forwarded children", () => {
+  const el = Button({ children: "Post job" });
+  assert.equal(el.type, "button");
+  assert.equal(el.props.children, "Post job");
+  assert.ok(el.props.style, "Button should apply inline styles");
+  assert.equal(el.props.style.background, "#5468ff");
+});
+
+test("ESM: Card renders a <section> with title and children", () => {
+  const el = Card({ title: "Profile", children: "Ready" });
+  assert.equal(el.type, "section");
+  // Card should have h3 for title and div for children
+  const [h3, div] = el.props.children;
+  assert.equal(h3.type, "h3");
+  assert.equal(h3.props.children, "Profile");
+  assert.equal(div.type, "div");
+  assert.equal(div.props.children, "Ready");
+});
+
+test("ESM: module namespace contains exactly Button and Card", async () => {
+  const ns = await import("@freelanceflow/ui");
+  const exportedKeys = Object.keys(ns).filter((k) => k !== "default");
+  assert.deepStrictEqual(exportedKeys.sort(), ["Button", "Card"]);
+});
+
+test("CJS: require('@freelanceflow/ui') exposes Button and Card", () => {
+  const require = createRequire(import.meta.url);
+  const cjs = require("@freelanceflow/ui");
+  assert.equal(typeof cjs.Button, "function");
+  assert.equal(typeof cjs.Card, "function");
+
+  const el = cjs.Button({ children: "Apply" });
+  assert.equal(el.type, "button");
+  assert.equal(el.props.children, "Apply");
+});


### PR DESCRIPTION
## Summary
- Add a runtime JavaScript entrypoint (`index.js`) for ESM consumers and (`index.cjs`) for CommonJS consumers so `@freelanceflow/ui` can be imported without a build step
- Add TypeScript declarations (`index.d.ts`) preserving type information for Button and Card
- Update `package.json` with `type: module`, comprehensive `exports` map (ESM & CJS fallback), `sideEffects: false` for tree-shaking, and proper `peerDependencies`
- Add a thorough import test verifying ESM, CJS, prop forwarding, and module shape

## Bounty / Issue
- Issue: https://github.com/SecureBananaLabs/bug-bounty/issues/2781

## Root Cause
The package declared `main` as `src/index.ts` which points at raw TypeScript source. Node cannot import TypeScript files directly, so `import('@freelanceflow/ui')` fails at runtime.

## Solution
Created a hand-written `index.js` and `index.cjs` that mirror the TSX components using `React.createElement` (no JSX compilation needed). Added an `index.d.ts` for TypeScript consumers. Updated `package.json` to use the modern `exports` field with proper `import`, `require`, and `types` conditions. Also added missing `peerDependencies` for React.

## Additional compatibility improvements compared to the minimal runtime-entrypoint approach:
1. **Adds CommonJS fallback**: Added `require` fallback (`index.cjs`) so CommonJS consumers won't break.
2. **Declares React peer dependency**: Added `react` as a peer dependency, which is required since it imports `react`.
3. **Tree-shaking**: Added `sideEffects: false` to allow bundlers to optimize imports.
4. **Adds deeper import/shape tests**: Added comprehensive tests covering ESM, CJS, prop forwarding, element types, and module namespace shape.
5. **Preserves ESM support**: The package is fully ESM compliant and directly importable.

## Tests
- `npm test -w packages/ui` — ✅ 5/5 passed (testing ESM, CJS, and render structures)
- `node --check packages/ui/index.js` and `index.cjs` — ✅ syntax valid
- `node -e import('@freelanceflow/ui')` — ✅ imports successfully
- `npm run build -w apps/web` — ✅ Next.js app builds successfully

Closes #2781