### PR TITLE
fix(api): keep proposal ids server-owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-service.test.js
+++ b/apps/api/src/tests/proposal-service.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps proposal ids server-owned", async (t) => {
+  t.mock.method(Date, "now", () => 1700000000000);
+
+  const proposal = await createProposal({
+    id: "prp_client_supplied",
+    coverLetter: "I can help with this project."
+  });
+
+  assert.equal(proposal.id, "prp_1700000000000");
+});


### PR DESCRIPTION
## Summary
- keep `createProposal()` ids server-owned even when payloads include `id`
- apply the trusted `prp_...` id after copying caller payload fields
- add service-level regression coverage for client-supplied id override attempts

## Validation
- `node --test src/tests/proposal-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2894
References #743