### PR TITLE
fix(api): keep review ids server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-service.test.js
+++ b/apps/api/src/tests/review-service.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps review ids server-owned", async (t) => {
+  t.mock.method(Date, "now", () => 1700000000000);
+
+  const review = await createReview({
+    id: "rev_client_supplied",
+    rating: 5,
+    body: "Great collaboration."
+  });
+
+  assert.equal(review.id, "rev_1700000000000");
+});


### PR DESCRIPTION
## Summary
- keep `createReview()` ids server-owned even when payloads include `id`
- apply the trusted `rev_...` id after copying caller payload fields
- add service-level regression coverage for client-supplied id override attempts

## Validation
- `node --test src/tests/review-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2908
References #743