### PR TITLE
fix: reject inverted job budget ranges in job validation (#2853)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+export const createJobBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,22 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = createJobBase.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
+
+export const updateJobSchema = createJobBase.partial().refine(
+  (data) => {
+    // Only validate budget range when both fields are present
+    if (data.budgetMin === undefined || data.budgetMax === undefined) return true;
+    return data.budgetMax >= data.budgetMin;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin when both are provided",
+    path: ["budgetMax"],
+  }
+);


### PR DESCRIPTION
## Summary
Adds Zod refinement to prevent job creation/update with inverted budget ranges (`budgetMax < budgetMin`).

## Changes
- **apps/api/src/validators/job.js**: Added `.refine()` to `createJobSchema` rejecting `budgetMax < budgetMin`
- Added separate refinement for `updateJobSchema` that only validates when both budget fields are present
- Single-field partial updates (e.g., only `budgetMin`) unaffected

## Validation verified
| Test | Result |
|------|--------|
| Valid create (100-500) | ✅ Pass |
| Inverted create (500-100) | ✅ Rejected |
| Single-field update | ✅ Pass |
| Inverted update (500-100) | ✅ Rejected |
| Equal budgets (100-100) | ✅ Pass |
| No budget fields in update | ✅ Pass |

/claim #2853

Fixes #2853