### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build a profile page",
+  description: "Create the authenticated profile page experience.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJobPayload, budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJobPayload).budgetMax, 500);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both values are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema accepts partial budget updates", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 500 }), { budgetMin: 500 });
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 500 }), { budgetMax: 500 });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const orderedBudgetRange = (payload) =>
+  payload.budgetMin === undefined ||
+  payload.budgetMax === undefined ||
+  payload.budgetMax >= payload.budgetMin;
+
+const budgetRangeError = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(orderedBudgetRange, budgetRangeError);
+
+export const updateJobSchema = jobSchema.partial().refine(orderedBudgetRange, budgetRangeError);


### PR DESCRIPTION
﻿## Summary
- reject create-job payloads where budgetMax is lower than budgetMin
- reject partial job updates when both budget fields are present in inverted order
- add validator tests for ordered, inverted, and partial budget updates
- make the API test script target test files so the existing test suite runs under node --test

Closes #2853

/claim #743

## Testing
- npm.cmd test
