### PR TITLE
fix(api): keep notification metadata server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps notification metadata server-owned", async (t) => {
+  const originalNow = Date.now;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+  Date.now = () => 1700000000000;
+
+  const notification = await createNotification({
+    id: "ntf_client_supplied",
+    read: true,
+    message: "New proposal received"
+  });
+
+  assert.equal(notification.id, "ntf_1700000000000");
+  assert.equal(notification.read, false);
+});


### PR DESCRIPTION
## Summary
- keep `createNotification()` ids server-owned even when payloads include `id`
- keep new notifications unread by applying `read: false` after caller payload fields
- add service-level regression coverage for client-supplied metadata override attempts

## Validation
- `node --test src/tests/notification-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2923
References #743