### PR TITLE
Validate notification creation messages

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects blank messages", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "   " }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid notification payload" });
+  });
+});
+
+test("POST /api/notifications accepts non-empty messages", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ message: "New proposal", type: "proposal" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "New proposal");
+    assert.equal(payload.data.type, "proposal");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  message: z.string().trim().min(1),
+}).passthrough();


### PR DESCRIPTION
/claim #743

Closes #2924.

Summary:
- Require non-empty notification messages before creating notifications.
- Preserve additional notification fields through a passthrough schema.
- Add route tests for rejected blank messages and accepted valid notifications.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check