### PR TITLE
Validate proposal job ids

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing job ids", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ coverLetter: "I can help." }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid proposal payload" });
+  });
+});
+
+test("POST /api/proposals accepts non-empty job ids", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ jobId: "job_123", coverLetter: "I can help." }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, "job_123");
+    assert.equal(payload.data.coverLetter, "I can help.");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().trim().min(1),
+}).passthrough();


### PR DESCRIPTION
/claim #743

Closes #2928.

Summary:
- Require a non-empty jobId before creating proposals.
- Preserve additional proposal fields through a passthrough schema.
- Add route tests for rejected missing job ids and accepted valid proposals.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check