### PR TITLE
fix(api): keep user ids server-owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-service.test.js
+++ b/apps/api/src/tests/user-service.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps user ids server-owned", async (t) => {
+  const originalNow = Date.now;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+  Date.now = () => 1700000000000;
+
+  const user = await createUser({
+    id: "usr_client_supplied",
+    email: "client@example.com",
+    name: "Client Supplied"
+  });
+
+  assert.equal(user.id, "usr_1700000000000");
+});


### PR DESCRIPTION
## Summary
- keep `createUser()` ids server-owned even when payloads include `id`
- apply the trusted `usr_...` id after copying caller payload fields
- add service-level regression coverage for client-supplied id override attempts

## Validation
- `node --test src/tests/user-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2940
References #743