### PR TITLE
Validate search query text

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query.q);
+  if (!parsed.success) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  return ok(res, await globalSearch(parsed.data));
 }

--- a/apps/api/src/tests/searchValidation.test.js
+++ b/apps/api/src/tests/searchValidation.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects blank queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});
+
+test("GET /api/search rejects oversized queries", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "x".repeat(101);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});
+
+test("GET /api/search accepts bounded query text", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=react`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "react");
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.string().trim().min(1).max(100);


### PR DESCRIPTION
/claim #743

Closes #2948.

Summary:
- Validate search query text before calling the search service.
- Reject blank or over-100-character queries with a controlled 400 response.
- Add route tests for blank, oversized, and valid searches.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check