### PR TITLE
Limit upload file size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,26 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
+const uploadSingleFile = upload.single("file");
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", (req, res, next) => {
+  uploadSingleFile(req, res, (error) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File too large", 413);
+    }
+
+    if (error) {
+      return next(error);
+    }
+
+    return uploadFile(req, res);
+  });
+});

--- a/apps/api/src/tests/uploadSizeLimit.test.js
+++ b/apps/api/src/tests/uploadSizeLimit.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function formWithFile(fileSize) {
+  const form = new FormData();
+  form.append("file", new Blob(["x".repeat(fileSize)], { type: "text/plain" }), "upload.txt");
+  return form;
+}
+
+test("POST /api/uploads rejects files over five megabytes", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: formWithFile(5 * 1024 * 1024 + 1),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, { success: false, message: "File too large" });
+  });
+});
+
+test("POST /api/uploads still accepts small files", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: formWithFile(16),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "upload.txt");
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #2951.

Summary:
- Add a 5 MB multer file-size limit for upload parsing.
- Return a controlled 413 response for oversized uploads.
- Add route tests for oversized and small multipart uploads.

Validation:
- node --test apps/api/src/tests/*.test.js
- git diff --check