### PR TITLE
fix(api): keep job metadata server-owned

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service.test.js
+++ b/apps/api/src/tests/job-service.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps job metadata server-owned", async (t) => {
+  const originalNow = Date.now;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+  Date.now = () => 1700000000000;
+
+  const job = await createJob({
+    id: "job_client_supplied",
+    status: "closed",
+    title: "Build secure API",
+    description: "Build a secure API for clients",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "cat_api",
+    skills: ["node"]
+  });
+
+  assert.equal(job.id, "job_1700000000000");
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
## Summary
- keep `createJob()` ids server-owned even when payloads include `id`
- keep new jobs open by applying `status: "open"` after caller payload fields
- add service-level regression coverage for client-supplied metadata override attempts

## Validation
- `node --test src/tests/job-service.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2953
References #743