### PR TITLE
fix(api): run test files from npm script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- point the API npm test script at `src/tests/*.test.js` files
- avoid invoking Node's test runner on the `src/tests` directory path as a module
- restore `npm test -w apps/api` so it runs the existing API tests

## Validation
- RED: `npm test -w apps/api` failed with `Cannot find module .../apps/api/src/tests` before the fix
- GREEN: `npm test -w apps/api`
- `git diff --check`

/claim #743
Closes #2961
References #743