### PR TITLE
fix(api): reject admin role in registration

### DIFF
--- a/apps/api/src/tests/auth-register-schema.test.js
+++ b/apps/api/src/tests/auth-register-schema.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects public admin role signup", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "admin-claim@example.com",
+      password: "correct-horse-battery-staple",
+      role: "admin"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- restrict public registration roles to `client` and `freelancer`
- reject `role: "admin"` self-assignment in `registerSchema`
- add validator regression coverage for public admin-role signup attempts

## Validation
- RED: `node --test src/tests/auth-register-schema.test.js` failed because `role: "admin"` was accepted before the fix
- GREEN: `node --test src/tests/auth-register-schema.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #2964
References #743