### PR TITLE
fix: add admin role authorization check to admin routes (fixes #1770)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Fixes #1770
Also fixes: #1764

**Problem:** Admin routes only used `authMiddleware` which verifies JWT validity but does not check if the user has the `admin` role. Any authenticated user (client, freelancer) could access admin-only endpoints like `/api/admin/metrics`.

**Fix:**
1. Added `adminMiddleware` to `middleware/auth.js` that checks `req.user.role === "admin"` and returns 403 if not.
2. Applied `adminMiddleware` to all admin routes after `authMiddleware`.

/claim #1770
/claim #1764