### PR TITLE
fix: add input validation and length limit to search endpoint (fixes #2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let query = (req.query.q ?? "").trim().slice(0, MAX_QUERY_LENGTH);
+  if (!query) {
+    return ok(res, { query: "", users: [], jobs: [], freelancers: [] });
+  }
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/services/searchService.js
+++ b/apps/api/src/services/searchService.js
@@ -1,5 +1,6 @@
 export async function globalSearch(query) {
   // TODO: use PostgreSQL full-text search + ranking.
+  // Query is pre-validated by the controller (trimmed, length-limited).
   return {
     query,
     users: [],


### PR DESCRIPTION
Fixes #2833
Also fixes: #1777, #1781

**Problem:** The `GET /api/search` endpoint passes `req.query.q` directly to the search service without any validation or length limits. An attacker could send extremely long query strings to consume server resources (DoS).

**Fix:**
1. `searchController.js`: Trim whitespace, enforce 200-char max length, return empty results for blank queries.
2. `searchService.js`: Added documentation noting the controller handles pre-validation.

/claim #2833
/claim #1777
/claim #1781