### PR TITLE
fix: prevent admin role self-assignment during registration (fixes #2832)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #2832
Also fixes: #1823

**Problem:** The `registerSchema` in `validators/auth.js` allowed any user to register with `role: "admin"` by including it in the request body. This enables privilege escalation via self-registration.

**Fix:** Removed `"admin"` from the `role` enum in `registerSchema`. Only `"client"` and `"freelancer"` are now valid registration roles.

/claim #2832
/claim #1823