### PR TITLE
fix: add input validation and prevent client-controlled IDs in user creation (fixes #1773)

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,18 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  let payload;
+  try {
+    payload = createUserSchema.parse(req.body);
+  } catch (err) {
+    return fail(res, err.errors?.[0]?.message || "Invalid input", 400);
+  }
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,9 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Strip any client-supplied id; server owns identity generation
+  const { email, role } = payload;
+  const user = { id: `usr_${Date.now()}`, email, role };
   users.push(user);
   return user;
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email("Valid email is required"),
+  role: z.enum(["client", "freelancer"]).default("client"),
+}).strict();


### PR DESCRIPTION
Fixes #1773
Also fixes: #1766

**Problem:**
1. `POST /api/users` accepted arbitrary request bodies without validation.
2. `createUser()` spread the entire payload including any client-supplied `id`, allowing attackers to inject custom user IDs.
3. Empty or malformed payloads were accepted.

**Fix:**
1. Created `validators/user.js` with a Zod `createUserSchema` requiring `email` and `role` (client/freelancer only, `.strict()`).
2. `userController.postUser()` now validates input via Zod and returns 400 on invalid input.
3. `userService.createUser()` now destructures only `email` and `role`, ignoring any client-supplied `id`.

/claim #1773
/claim #1766