### PR TITLE
Return 400 for invalid job payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/jobs returns 400 for invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, {
+      title: "Bug",
+      description: "short",
+      budgetMin: -1,
+      budgetMax: "not-a-number",
+      categoryId: ""
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request payload");
+  });
+});


### PR DESCRIPTION
## Summary
- return 400 for invalid job creation payloads before calling the job service
- add API coverage for invalid job payload responses
- fix the API test script glob so Node's test runner executes the test files

## Related issue
Fixes #2977

## Testing
- npm test -w apps/api
