### PR TITLE
fix: require authentication on payment routes

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/payments", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("rejects missing authentication", async () => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    assert.equal(response.status, 401);
+  });
+
+  await t.test("rejects invalid authentication", async () => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer badtoken"
+      },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    assert.equal(response.status, 401);
+  });
+
+  await t.test("creates payment intent with valid authentication", async () => {
+    const token = signAccessToken({ sub: "usr_123", role: "client" });
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ amount: 5000, currency: "eur" })
+    });
+    assert.equal(response.status, 201);
+    
+    const payload = await response.json();
+    assert.ok(payload.success);
+    assert.equal(payload.data.amount, 5000);
+    assert.equal(payload.data.currency, "eur");
+    assert.ok(payload.data.paymentId.startsWith("pay_"));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -15,6 +15,10 @@ test("POST /api/payments", async (t) => {
   const { port } = server.address();
   const baseUrl = `http://127.0.0.1:${port}`;
 
+  t.after(() => new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  }));
+
   await t.test("rejects missing authentication", async () => {
     const response = await fetch(`${baseUrl}/api/payments`, {
       method: "POST",
@@ -53,9 +57,5 @@ test("POST /api/payments", async (t) => {
     assert.equal(payload.data.amount, 5000);
     assert.equal(payload.data.currency, "eur");
     assert.ok(payload.data.paymentId.startsWith("pay_"));
-  });
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
   });
 });


### PR DESCRIPTION
## Summary
- Updates `paymentRoutes.js` to protect the `/api/payments` route with the existing `authMiddleware`.
- Adds comprehensive integration tests verifying that anonymous requests are rejected and valid tokens properly create payment intents.

## Tests
- `npm test -w apps/api` G�� G�� All tests passing.

Closes #2983


?? Payment Details:
Method: USDC
Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
Network: Base

