### PR TITLE
fix: require fullName during registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,10 +2,14 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return next(error);
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -10,7 +10,7 @@ export function errorHandler(err, req, res, next) {
     return res.status(400).json({
       success: false,
       message: "Validation failed",
-      errors: err.errors.map(e => ({ path: e.path.join('.'), message: e.message }))
+      errors: err.issues.map(e => ({ path: e.path.join('.'), message: e.message }))
     });
   }
 

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -10,7 +10,7 @@ export function errorHandler(err, req, res, next) {
     return res.status(400).json({
       success: false,
       message: "Validation failed",
-      errors: err.errors
+      errors: err.errors.map(e => ({ path: e.path.join('.'), message: e.message }))
     });
   }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -4,6 +4,7 @@ export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })

--- a/apps/api/src/tests/auth-register.test.js
+++ b/apps/api/src/tests/auth-register.test.js
@@ -14,6 +14,10 @@ test("POST /api/auth/register fullName validation", async (t) => {
   const { port } = server.address();
   const baseUrl = `http://127.0.0.1:${port}`;
 
+  t.after(() => new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  }));
+
   await t.test("rejects registration without fullName", async () => {
     const response = await fetch(`${baseUrl}/api/auth/register`, {
       method: "POST",
@@ -61,9 +65,5 @@ test("POST /api/auth/register fullName validation", async (t) => {
     assert.equal(payload.data.fullName, "Jane Doe");
     assert.equal(payload.data.email, "jane@example.com");
     assert.ok(payload.data.token);
-  });
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
   });
 });

--- a/apps/api/src/tests/auth-register.test.js
+++ b/apps/api/src/tests/auth-register.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/register fullName validation", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  await t.test("rejects registration without fullName", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "test@example.com",
+        password: "securepassword123",
+        role: "client"
+      })
+    });
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+  });
+
+  await t.test("rejects registration with empty fullName", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fullName: "",
+        email: "test2@example.com",
+        password: "securepassword123",
+        role: "client"
+      })
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("accepts registration with valid fullName and returns it", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fullName: "Jane Doe",
+        email: "jane@example.com",
+        password: "securepassword123",
+        role: "client"
+      })
+    });
+    assert.equal(response.status, 201);
+    
+    const payload = await response.json();
+    assert.ok(payload.success);
+    assert.equal(payload.data.fullName, "Jane Doe");
+    assert.equal(payload.data.email, "jane@example.com");
+    assert.ok(payload.data.token);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Summary
- Updates `registerSchema` in `apps/api/src/validators/auth.js` to require a non-empty `fullName` string.
- Updates `registerUser()` in `authService.js` to persist the validated `fullName` payload into the returned user object.
- Wraps the `register` controller in a `try...catch` block to properly forward synchronous Zod validation errors to the error handler.
- Updates the global `errorHandler` to catch `ZodError` and return a structured `400 Bad Request` payload rather than failing with a generic `500`.
- Adds comprehensive integration tests verifying missing and empty `fullName` rejections alongside valid name preservation.

## Tests
- `npm test -w apps/api` G�� G�� All tests passing.

Closes #2986


?? Payment Details:
Method: USDC
Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
Network: Base

