### PR TITLE
Add versions to workspace package manifests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/api",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/web",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "freelance-platform-monorepo",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freelance-platform-monorepo",
+      "version": "0.1.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -12,6 +14,7 @@
     },
     "apps/api": {
       "name": "@freelanceflow/api",
+      "version": "0.1.0",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.19.2",
@@ -24,6 +27,7 @@
     },
     "apps/web": {
       "name": "@freelanceflow/web",
+      "version": "0.1.0",
       "dependencies": {
         "next": "16.2.6",
         "react": "19.2.0",
@@ -2175,6 +2179,7 @@
     },
     "packages/db": {
       "name": "@freelanceflow/db",
+      "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.17.0"
       },
@@ -2183,7 +2188,8 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "version": "0.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "freelance-platform-monorepo",
+  "version": "0.1.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/db",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "generate": "prisma generate",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/ui",
+  "version": "0.1.0",
   "private": true,
   "main": "src/index.ts"
 }


### PR DESCRIPTION
/claim #743

Closes #2985.

## Summary
- Adds valid `0.1.0` semver versions to the root manifest and all workspace package manifests.
- Refreshes `package-lock.json` so npm records the same versions for the root and workspace packages.
- Restores `npm pack --dry-run` as a working release/artifact validation path for `apps/api`, `apps/web`, `packages/db`, and `packages/ui`.

## Root cause
Each package had a `name` but no `version`. npm treats that as invalid package metadata for `npm pack`, so dry-run packaging failed before producing package details.

## Validation
- `npm pack --dry-run`
- `npm pack --dry-run -w apps/api`
- `npm pack --dry-run -w apps/web`
- `npm pack --dry-run -w packages/db`
- `npm pack --dry-run -w packages/ui`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm test` currently fails on `main` because `apps/api/package.json` invokes `node --test src/tests`, which Node resolves as a missing module path. I left that existing issue out of scope and used the direct test-file command above.
