### PR TITLE
fix: validate search query to prevent long or unexpected inputs

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchSchema } from "../validators/search.js";
 
-export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+export async function search(req, res, next) {
+  try {
+    const { q } = searchSchema.parse(req.query);
+    return ok(res, await globalSearch(q));
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -10,7 +10,7 @@ export function errorHandler(err, req, res, next) {
     return res.status(400).json({
       success: false,
       message: "Validation failed",
-      errors: err.errors.map(e => ({ path: e.path.join('.'), message: e.message }))
+      errors: err.issues.map(e => ({ path: e.path.join('.'), message: e.message }))
     });
   }
 

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors.map(e => ({ path: e.path.join('.'), message: e.message }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/search input validation", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(() => new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  }));
+
+  await t.test("rejects query string longer than 200 characters", async () => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects array of query parameters", async () => {
+    const response = await fetch(`${baseUrl}/api/search?q=test&q=another`);
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("accepts valid query string", async () => {
+    const response = await fetch(`${baseUrl}/api/search?q=developer`);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.ok(payload.success);
+  });
+
+  await t.test("accepts empty query string and falls back to default", async () => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.ok(payload.success);
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchSchema = z.object({
+  q: z.string().trim().max(200).default("")
+});


### PR DESCRIPTION
## Summary
- Updates `searchController.js` to enforce input validation on the `q` parameter before passing it to the search service.
- Creates `searchSchema` using Zod to trim inputs, limit queries to 200 characters, and automatically reject arrays.
- Wraps the `search` controller in a `try...catch` block to properly route Zod validation errors to the global error handler.
- Brings in the latest `errorHandler` fixes to safely map Zod internals to public `400 Bad Request` shapes.
- Adds comprehensive integration tests verifying query length limits, array rejection, and valid query handling.

## Tests
- `npm test -w apps/api` G�� G�� All tests passing.

Closes #2990


?? Payment Details:
Method: USDC
Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
Network: Base

