### PR TITLE
fix: add workspace package versions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/api",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/web",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
     },
     "apps/api": {
       "name": "@freelanceflow/api",
+      "version": "0.0.0",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.19.2",
@@ -24,6 +25,7 @@
     },
     "apps/web": {
       "name": "@freelanceflow/web",
+      "version": "0.0.0",
       "dependencies": {
         "next": "16.2.6",
         "react": "19.2.0",
@@ -2175,6 +2177,7 @@
     },
     "packages/db": {
       "name": "@freelanceflow/db",
+      "version": "0.0.0",
       "dependencies": {
         "@prisma/client": "^5.17.0"
       },
@@ -2183,7 +2186,8 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "version": "0.0.0"
     }
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/db",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "generate": "prisma generate",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@freelanceflow/ui",
+  "version": "0.0.0",
   "private": true,
   "main": "src/index.ts"
 }


### PR DESCRIPTION
## Summary

- Add stable `0.0.0` versions to each private workspace package manifest.
- Update `package-lock.json` so npm sees those workspace versions consistently.

## Root Cause

`npm pack --dry-run -w <workspace>` validates package metadata even for private workspaces. The API, web, db, and ui workspace manifests had `name` fields but no `version`, so npm rejected each package with `Invalid package, must have name and version` before it could produce a tarball preview.

## Proof

Before this change, each workspace pack dry-run failed with the same metadata error:

```text
npm error Invalid package, must have name and version
ui_exit=1
db_exit=1
api_exit=1
web_exit=1
```

After this change:

```text
npm pack --dry-run -w packages/ui
npm pack --dry-run -w packages/db
npm pack --dry-run -w apps/api
npm pack --dry-run -w apps/web
pack dry-run passed for packages/ui, packages/db, apps/api, apps/web
```

Also ran:

```text
git diff --check
```

Closes #2997
References #743

/claim #743
