### PR TITLE
Align web next-env for production builds

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
/claim #743

Closes #2998.

## Summary
- Aligns the tracked `apps/web/next-env.d.ts` route-types import with the file generated by `next build`.
- Prevents `npm run build -w apps/web` from rewriting that tracked file after a successful production build.
- Keeps the fix scoped to the generated Next environment file.

## Root Cause
The repository tracked the development route-types path:

```ts
import "./.next/dev/types/routes.d.ts";
```

Next rewrites that line during production builds to:

```ts
import "./.next/types/routes.d.ts";
```

That made a normal successful build leave the working tree dirty.

## Validation
- Reproduced on upstream `main`: `npm run build -w apps/web` exited 0 and left `M apps/web/next-env.d.ts`.
- Applied this one-line alignment.
- Re-ran `npm run build -w apps/web`.
- Verified `git diff --exit-code apps/web/next-env.d.ts` exits 0 after the build.
- `git diff --check HEAD~1..HEAD`
