### PR TITLE
fix: add input validation to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -4,7 +4,7 @@ import { globalSearch } from "../services/searchService.js";
 export async function search(req, res) {
   const raw = req.query.q ?? "";
   if (typeof raw !== "string" || raw.trim().length > 200) {
-    return fail(res, "Query must be a string with at most 200 characters");
+    return fail(res, "Query must be a string with at most 200 characters", 400);
   }
   return ok(res, await globalSearch(raw.trim()));
 }

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q ?? "";
+  if (typeof raw !== "string" || raw.trim().length > 200) {
+    return fail(res, "Query must be a string with at most 200 characters");
+  }
+  return ok(res, await globalSearch(raw.trim()));
 }


### PR DESCRIPTION
Fixes #2996

- Validates query is a string
- Trims and limits to 200 characters
- Returns 400 for invalid input

/claim #2996