### PR TITLE
Ignore TypeScript build info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.*
 coverage
 *.log
+*.tsbuildinfo


### PR DESCRIPTION
/claim #743

Closes #3027.

## Summary
- Adds `*.tsbuildinfo` to the root `.gitignore`.
- Keeps TypeScript incremental build-info files out of normal contributor status output.
- Leaves source and TypeScript configuration behavior unchanged.

## Root Cause
`apps/web/tsconfig.json` enables TypeScript incremental compilation. A direct type-check command writes the default incremental cache file to `apps/web/tsconfig.tsbuildinfo`, but the repository did not ignore `*.tsbuildinfo` artifacts.

## Validation
- Reproduced on upstream `main`: `npx tsc --noEmit -p apps/web/tsconfig.json` exited 0 and left `?? apps/web/tsconfig.tsbuildinfo`.
- Added `*.tsbuildinfo` to `.gitignore`.
- Re-ran `npx tsc --noEmit -p apps/web/tsconfig.json`.
- Verified normal `git status --short` stays clean while `git status --short --ignored apps/web/tsconfig.tsbuildinfo` shows the generated file as ignored.
- `git diff --check HEAD~1..HEAD`
