### PR TITLE
Return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,8 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use((req, res) => fail(res, "Not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/notFound.test.js
+++ b/apps/api/src/tests/notFound.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown routes return JSON 404 payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/missing-route`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #3030.

## Summary
- Adds a final Express fallback handler that returns the API JSON error shape for unknown routes.
- Uses the existing `fail()` response helper for the `404` payload.
- Adds route-level regression coverage for unknown routes.

## Root Cause
Requests that did not match a route fell through to Express's built-in 404 handler. That handler returns an HTML error page, which is inconsistent with the API's JSON response helpers and forces API clients to special-case unknown routes.

## Validation
- Reproduced before the fix: `GET /api/missing-route` returned `404` with `text/html; charset=utf-8` and an HTML body.
- `node --test apps/api/src/tests/*.test.js`
- Manual check after the fix:

```json
{
  "status": 404,
  "contentType": "application/json; charset=utf-8",
  "payload": {
    "success": false,
    "message": "Not found"
  }
}
```

- `git diff --check`
