### PR TITLE
Fix API npm test script target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- point the API workspace test script at `src/tests/*.test.js` instead of the test directory path
- restores `npm test -w apps/api` so it discovers and runs the existing Node test file

## Verification
- Reproduced failure before the fix: `npm test -w apps/api` exited with `Cannot find module .../apps/api/src/tests`.
- `npm install`
- `npm test -w apps/api`
- `git diff --check`

Fixes #3032
/claim #743