### PR TITLE
Add Settlement Window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Settlement Window
+
+The brief arrives with edges clean,
+a budget, risk, and name.
+Two dashboards hold the same quiet light,
+then turn scope into claim.
+
+A proposal leaves the workbench,
+small proof packed close inside.
+It crosses chat and milestone rows
+where careful notes abide.
+
+The reviewer checks the handoff,
+not for noise, but trace.
+Each change must carry where it came from,
+each promise has a place.
+
+When merge lights open in the queue,
+the ledger learns the cost.
+Trust is not a banner raised,
+but evidence not lost.
+
+So payout follows proof at last,
+plain numbers, signed and clear.
+FreelanceFlow keeps the window lit
+for the next good brief to appear.


### PR DESCRIPTION
## Summary
- add root-level `POEM.md` with an original five-stanza poem written for FreelanceFlow

## Creative note
I used a settlement-window theme so scope, proof, review, merge, and payout read like one quiet operational sequence.

## Validation
- `sed -n '1,160p' POEM.md`\n- `awk 'BEGIN{stanzas=0; inblock=0} NF{if(!inblock){stanzas++; inblock=1}} !NF{inblock=0} END{print stanzas " stanza blocks"}' POEM.md`\n- `wc -l POEM.md`\n- `git diff --check`\n\n/claim #76