### PR TITLE
Add API benchmark suite

### DIFF
--- a/.env.benchmark.example
+++ b/.env.benchmark.example
@@ -1,0 +1,14 @@
+# Optional. If omitted, the runner starts the local Express API on an ephemeral port.
+BENCHMARK_TARGET_URL=http://127.0.0.1:4000
+
+# Optional. Used when benchmarking a remote/staging target with protected endpoints.
+BENCHMARK_AUTH_TOKEN=
+
+# Optional. Used for locally generated benchmark JWTs.
+JWT_SECRET=development-secret
+
+# Optional run shape overrides.
+BENCHMARK_REQUESTS_PER_ENDPOINT=8
+BENCHMARK_CONCURRENCY=2
+BENCHMARK_TIMEOUT_MS=10000
+BENCHMARK_RESULTS_DIR=benchmarks/results

--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -1,0 +1,22 @@
+name: Benchmark smoke
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "benchmarks/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/benchmark-smoke.yml"
+
+jobs:
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run benchmark:smoke

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -1,0 +1,553 @@
+{
+  "runId": "bench_1780239027334",
+  "mode": "default",
+  "startedAt": "2026-05-31T14:50:27.418Z",
+  "completedAt": "2026-05-31T14:50:27.500Z",
+  "baseUrl": "http://127.0.0.1:60202",
+  "config": {
+    "requestsPerEndpoint": 8,
+    "concurrency": 2,
+    "timeoutMs": 10000,
+    "endpointCount": 21
+  },
+  "environment": {
+    "platform": "Darwin 25.3.0 arm64",
+    "cpu": "Apple M1",
+    "logicalCores": 8,
+    "totalMemoryBytes": 8589934592,
+    "freeMemoryBytes": 397885440,
+    "node": "v22.22.0",
+    "target": "local-loopback"
+  },
+  "results": [
+    {
+      "name": "health",
+      "method": "GET",
+      "path": "/health",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 17.16,
+      "sustainedRps": 466.32,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 1.58,
+        "p95": 11.03,
+        "p99": 11.03
+      },
+      "ttfbMs": {
+        "p50": 1.5,
+        "p95": 10.98,
+        "p99": 10.98
+      },
+      "responseBytes": 216
+    },
+    {
+      "name": "auth register",
+      "method": "POST",
+      "path": "/api/auth/register",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 10.88,
+      "sustainedRps": 735.6,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 1.08,
+        "p95": 6.46,
+        "p99": 6.46
+      },
+      "ttfbMs": {
+        "p50": 1.06,
+        "p95": 6.31,
+        "p99": 6.31
+      },
+      "responseBytes": 2560
+    },
+    {
+      "name": "auth login",
+      "method": "POST",
+      "path": "/api/auth/login",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 3.59,
+      "sustainedRps": 2230.98,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.67,
+        "p95": 1.31,
+        "p99": 1.31
+      },
+      "ttfbMs": {
+        "p50": 0.65,
+        "p95": 1.28,
+        "p99": 1.28
+      },
+      "responseBytes": 2152
+    },
+    {
+      "name": "oauth callback",
+      "method": "GET",
+      "path": "/api/auth/oauth/google/callback",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.1,
+      "sustainedRps": 3803.04,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.46,
+        "p95": 0.62,
+        "p99": 0.62
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.6,
+        "p99": 0.6
+      },
+      "responseBytes": 592
+    },
+    {
+      "name": "auth refresh",
+      "method": "POST",
+      "path": "/api/auth/refresh",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.52,
+      "sustainedRps": 3176.13,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.58,
+        "p95": 0.69,
+        "p99": 0.69
+      },
+      "ttfbMs": {
+        "p50": 0.55,
+        "p95": 0.67,
+        "p99": 0.67
+      },
+      "responseBytes": 1704
+    },
+    {
+      "name": "users list",
+      "method": "GET",
+      "path": "/api/users",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 1.96,
+      "sustainedRps": 4083.63,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.45,
+        "p95": 0.53,
+        "p99": 0.53
+      },
+      "ttfbMs": {
+        "p50": 0.43,
+        "p95": 0.51,
+        "p99": 0.51
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "users create",
+      "method": "POST",
+      "path": "/api/users",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.17,
+      "sustainedRps": 3691.03,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.49,
+        "p95": 0.56,
+        "p99": 0.56
+      },
+      "ttfbMs": {
+        "p50": 0.47,
+        "p95": 0.54,
+        "p99": 0.54
+      },
+      "responseBytes": 1672
+    },
+    {
+      "name": "jobs list",
+      "method": "GET",
+      "path": "/api/jobs",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.79,
+      "sustainedRps": 2871.97,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.55,
+        "p95": 1.14,
+        "p99": 1.14
+      },
+      "ttfbMs": {
+        "p50": 0.53,
+        "p95": 1.12,
+        "p99": 1.12
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "jobs create",
+      "method": "POST",
+      "path": "/api/jobs",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.85,
+      "sustainedRps": 2811.91,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.57,
+        "p95": 0.94,
+        "p99": 0.94
+      },
+      "ttfbMs": {
+        "p50": 0.55,
+        "p95": 0.91,
+        "p99": 0.91
+      },
+      "responseBytes": 2928
+    },
+    {
+      "name": "proposals list",
+      "method": "GET",
+      "path": "/api/proposals",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.18,
+      "sustainedRps": 3674.43,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.43,
+        "p95": 0.84,
+        "p99": 0.84
+      },
+      "ttfbMs": {
+        "p50": 0.41,
+        "p95": 0.82,
+        "p99": 0.82
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "proposals create",
+      "method": "POST",
+      "path": "/api/proposals",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.14,
+      "sustainedRps": 3746.41,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.49,
+        "p95": 0.53,
+        "p99": 0.53
+      },
+      "ttfbMs": {
+        "p50": 0.47,
+        "p95": 0.51,
+        "p99": 0.51
+      },
+      "responseBytes": 2336
+    },
+    {
+      "name": "payments create",
+      "method": "POST",
+      "path": "/api/payments",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.27,
+      "sustainedRps": 3526.3,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.49,
+        "p95": 0.66,
+        "p99": 0.66
+      },
+      "ttfbMs": {
+        "p50": 0.47,
+        "p95": 0.64,
+        "p99": 0.64
+      },
+      "responseBytes": 864
+    },
+    {
+      "name": "reviews list",
+      "method": "GET",
+      "path": "/api/reviews",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.29,
+      "sustainedRps": 3498.22,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.5,
+        "p95": 0.69,
+        "p99": 0.69
+      },
+      "ttfbMs": {
+        "p50": 0.48,
+        "p95": 0.66,
+        "p99": 0.66
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "reviews create",
+      "method": "POST",
+      "path": "/api/reviews",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.8,
+      "sustainedRps": 2857.02,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.61,
+        "p95": 0.78,
+        "p99": 0.78
+      },
+      "ttfbMs": {
+        "p50": 0.59,
+        "p95": 0.75,
+        "p99": 0.75
+      },
+      "responseBytes": 2264
+    },
+    {
+      "name": "messages list",
+      "method": "GET",
+      "path": "/api/messages",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.38,
+      "sustainedRps": 3367.42,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.51,
+        "p95": 0.8,
+        "p99": 0.8
+      },
+      "ttfbMs": {
+        "p50": 0.49,
+        "p95": 0.78,
+        "p99": 0.78
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "messages create",
+      "method": "POST",
+      "path": "/api/messages",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 2.3,
+      "sustainedRps": 3479.71,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.53,
+        "p95": 0.59,
+        "p99": 0.59
+      },
+      "ttfbMs": {
+        "p50": 0.51,
+        "p95": 0.57,
+        "p99": 0.57
+      },
+      "responseBytes": 2320
+    },
+    {
+      "name": "notifications list",
+      "method": "GET",
+      "path": "/api/notifications",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.02,
+      "sustainedRps": 3965.39,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.48,
+        "p95": 0.54,
+        "p99": 0.54
+      },
+      "ttfbMs": {
+        "p50": 0.45,
+        "p95": 0.52,
+        "p99": 0.52
+      },
+      "responseBytes": 208
+    },
+    {
+      "name": "notifications create",
+      "method": "POST",
+      "path": "/api/notifications",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 3.29,
+      "sustainedRps": 2432.97,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 0.67,
+        "p95": 1.14,
+        "p99": 1.14
+      },
+      "ttfbMs": {
+        "p50": 0.64,
+        "p95": 1.11,
+        "p99": 1.11
+      },
+      "responseBytes": 1448
+    },
+    {
+      "name": "uploads create",
+      "method": "POST",
+      "path": "/api/uploads",
+      "expectedStatus": 201,
+      "requests": 8,
+      "durationMs": 7.93,
+      "sustainedRps": 1008.98,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "201": 8
+      },
+      "latencyMs": {
+        "p50": 1.06,
+        "p95": 3.5,
+        "p99": 3.5
+      },
+      "ttfbMs": {
+        "p50": 1.04,
+        "p95": 3.48,
+        "p99": 3.48
+      },
+      "responseBytes": 640
+    },
+    {
+      "name": "search",
+      "method": "GET",
+      "path": "/api/search?q=marketplace%20payments%20review",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 3.17,
+      "sustainedRps": 2522,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.65,
+        "p95": 1.27,
+        "p99": 1.27
+      },
+      "ttfbMs": {
+        "p50": 0.63,
+        "p95": 1.25,
+        "p99": 1.25
+      },
+      "responseBytes": 808
+    },
+    {
+      "name": "admin metrics",
+      "method": "GET",
+      "path": "/api/admin/metrics",
+      "expectedStatus": 200,
+      "requests": 8,
+      "durationMs": 2.87,
+      "sustainedRps": 2786,
+      "peakRps": 8,
+      "errorRatePercent": 0,
+      "statusCounts": {
+        "200": 8
+      },
+      "latencyMs": {
+        "p50": 0.54,
+        "p95": 1.14,
+        "p99": 1.14
+      },
+      "ttfbMs": {
+        "p50": 0.52,
+        "p95": 1.12,
+        "p99": 1.12
+      },
+      "responseBytes": 848
+    }
+  ],
+  "thresholdSummary": {
+    "passed": true,
+    "failures": []
+  }
+}

--- a/benchmarks/results/latest.md
+++ b/benchmarks/results/latest.md
@@ -1,0 +1,45 @@
+# API Benchmark Summary
+
+- Run ID: bench_1780239027334
+- Mode: default
+- Target: http://127.0.0.1:60202
+- Started: 2026-05-31T14:50:27.418Z
+- Completed: 2026-05-31T14:50:27.500Z
+- Requests per endpoint: 8
+- Concurrency: 2
+- Threshold status: passed
+
+## Environment
+
+- Platform: Darwin 25.3.0 arm64
+- CPU: Apple M1
+- Logical cores: 8
+- Memory: 8192 MiB total, 379 MiB free at run start
+- Node: v22.22.0
+
+## Endpoint Results
+
+| Endpoint | Requests | Error % | p50 ms | p95 ms | p99 ms | TTFB p95 ms | Sustained RPS | Peak RPS | Statuses |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| GET /health | 8 | 0 | 1.58 | 11.03 | 11.03 | 10.98 | 466.32 | 8 | {"200":8} |
+| POST /api/auth/register | 8 | 0 | 1.08 | 6.46 | 6.46 | 6.31 | 735.6 | 8 | {"201":8} |
+| POST /api/auth/login | 8 | 0 | 0.67 | 1.31 | 1.31 | 1.28 | 2230.98 | 8 | {"200":8} |
+| GET /api/auth/oauth/google/callback | 8 | 0 | 0.46 | 0.62 | 0.62 | 0.6 | 3803.04 | 8 | {"200":8} |
+| POST /api/auth/refresh | 8 | 0 | 0.58 | 0.69 | 0.69 | 0.67 | 3176.13 | 8 | {"200":8} |
+| GET /api/users | 8 | 0 | 0.45 | 0.53 | 0.53 | 0.51 | 4083.63 | 8 | {"200":8} |
+| POST /api/users | 8 | 0 | 0.49 | 0.56 | 0.56 | 0.54 | 3691.03 | 8 | {"201":8} |
+| GET /api/jobs | 8 | 0 | 0.55 | 1.14 | 1.14 | 1.12 | 2871.97 | 8 | {"200":8} |
+| POST /api/jobs | 8 | 0 | 0.57 | 0.94 | 0.94 | 0.91 | 2811.91 | 8 | {"201":8} |
+| GET /api/proposals | 8 | 0 | 0.43 | 0.84 | 0.84 | 0.82 | 3674.43 | 8 | {"200":8} |
+| POST /api/proposals | 8 | 0 | 0.49 | 0.53 | 0.53 | 0.51 | 3746.41 | 8 | {"201":8} |
+| POST /api/payments | 8 | 0 | 0.49 | 0.66 | 0.66 | 0.64 | 3526.3 | 8 | {"201":8} |
+| GET /api/reviews | 8 | 0 | 0.5 | 0.69 | 0.69 | 0.66 | 3498.22 | 8 | {"200":8} |
+| POST /api/reviews | 8 | 0 | 0.61 | 0.78 | 0.78 | 0.75 | 2857.02 | 8 | {"201":8} |
+| GET /api/messages | 8 | 0 | 0.51 | 0.8 | 0.8 | 0.78 | 3367.42 | 8 | {"200":8} |
+| POST /api/messages | 8 | 0 | 0.53 | 0.59 | 0.59 | 0.57 | 3479.71 | 8 | {"201":8} |
+| GET /api/notifications | 8 | 0 | 0.48 | 0.54 | 0.54 | 0.52 | 3965.39 | 8 | {"200":8} |
+| POST /api/notifications | 8 | 0 | 0.67 | 1.14 | 1.14 | 1.11 | 2432.97 | 8 | {"201":8} |
+| POST /api/uploads | 8 | 0 | 1.06 | 3.5 | 3.5 | 3.48 | 1008.98 | 8 | {"201":8} |
+| GET /api/search?q=marketplace%20payments%20review | 8 | 0 | 0.65 | 1.27 | 1.27 | 1.25 | 2522 | 8 | {"200":8} |
+| GET /api/admin/metrics | 8 | 0 | 0.54 | 1.14 | 1.14 | 1.12 | 2786 | 8 | {"200":8} |
+

--- a/benchmarks/run-benchmark.mjs
+++ b/benchmarks/run-benchmark.mjs
@@ -1,0 +1,529 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = new Set(process.argv.slice(2));
+const smoke = args.has("--smoke");
+const enforceThresholds = args.has("--enforce-thresholds");
+const runId = `bench_${Date.now()}`;
+const resultsDir = path.resolve(repoRoot, process.env.BENCHMARK_RESULTS_DIR ?? "benchmarks/results");
+const requestsPerEndpoint = Number(process.env.BENCHMARK_REQUESTS_PER_ENDPOINT ?? (smoke ? 2 : 8));
+const concurrency = Number(process.env.BENCHMARK_CONCURRENCY ?? (smoke ? 1 : 2));
+const timeoutMs = Number(process.env.BENCHMARK_TIMEOUT_MS ?? 10000);
+
+const endpoints = [
+  {
+    name: "health",
+    method: "GET",
+    path: "/health",
+    expectedStatus: 200
+  },
+  {
+    name: "auth register",
+    method: "POST",
+    path: "/api/auth/register",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      email: `bench-register-${runId}-${iteration}@example.com`,
+      password: "benchmark-password-123",
+      role: "client"
+    })
+  },
+  {
+    name: "auth login",
+    method: "POST",
+    path: "/api/auth/login",
+    expectedStatus: 200,
+    json: ({ iteration }) => ({
+      email: `bench-login-${runId}-${iteration}@example.com`,
+      password: "benchmark-password-123"
+    })
+  },
+  {
+    name: "oauth callback",
+    method: "GET",
+    path: "/api/auth/oauth/google/callback",
+    expectedStatus: 200
+  },
+  {
+    name: "auth refresh",
+    method: "POST",
+    path: "/api/auth/refresh",
+    expectedStatus: 200,
+    json: () => ({ refreshToken: `refresh-${runId}` })
+  },
+  {
+    name: "users list",
+    method: "GET",
+    path: "/api/users",
+    expectedStatus: 200
+  },
+  {
+    name: "users create",
+    method: "POST",
+    path: "/api/users",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      email: `bench-user-${runId}-${iteration}@example.com`,
+      fullName: "Benchmark Client",
+      role: "client",
+      profile: { company: "Benchmark Studio", timezone: "UTC" }
+    })
+  },
+  {
+    name: "jobs list",
+    method: "GET",
+    path: "/api/jobs",
+    expectedStatus: 200
+  },
+  {
+    name: "jobs create",
+    method: "POST",
+    path: "/api/jobs",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      title: `Benchmark marketplace build ${iteration}`,
+      description: "Design and ship a scoped marketplace workflow with milestone review, payment state, and notification handling for performance testing.",
+      budgetMin: 1200,
+      budgetMax: 4800,
+      categoryId: "engineering",
+      skills: ["node", "nextjs", "payments", "testing"]
+    })
+  },
+  {
+    name: "proposals list",
+    method: "GET",
+    path: "/api/proposals",
+    expectedStatus: 200
+  },
+  {
+    name: "proposals create",
+    method: "POST",
+    path: "/api/proposals",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      jobId: `job_${runId}_${iteration}`,
+      freelancerId: "usr_benchmark_freelancer",
+      bidAmount: 2400,
+      coverLetter: "Benchmark proposal with relevant experience, milestones, acceptance criteria, and delivery checkpoints.",
+      estimatedDurationDays: 14
+    })
+  },
+  {
+    name: "payments create",
+    method: "POST",
+    path: "/api/payments",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      amount: 2400 + iteration,
+      currency: "usd",
+      milestoneId: `milestone_${runId}_${iteration}`,
+      payerId: "usr_benchmark_client",
+      payeeId: "usr_benchmark_freelancer"
+    })
+  },
+  {
+    name: "reviews list",
+    method: "GET",
+    path: "/api/reviews",
+    expectedStatus: 200
+  },
+  {
+    name: "reviews create",
+    method: "POST",
+    path: "/api/reviews",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      jobId: `job_${runId}_${iteration}`,
+      reviewerId: "usr_benchmark_client",
+      revieweeId: "usr_benchmark_freelancer",
+      rating: 5,
+      comment: "Clear delivery, fast feedback loops, and reliable milestone proof for benchmark payload coverage."
+    })
+  },
+  {
+    name: "messages list",
+    method: "GET",
+    path: "/api/messages",
+    expectedStatus: 200
+  },
+  {
+    name: "messages create",
+    method: "POST",
+    path: "/api/messages",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      threadId: `thread_${runId}`,
+      senderId: "usr_benchmark_client",
+      recipientId: "usr_benchmark_freelancer",
+      body: `Benchmark message ${iteration}: confirm scope, proof artifact, and next review checkpoint.`
+    })
+  },
+  {
+    name: "notifications list",
+    method: "GET",
+    path: "/api/notifications",
+    expectedStatus: 200
+  },
+  {
+    name: "notifications create",
+    method: "POST",
+    path: "/api/notifications",
+    expectedStatus: 201,
+    json: ({ iteration }) => ({
+      userId: "usr_benchmark_client",
+      type: "milestone",
+      message: `Milestone ${iteration} is ready for review in the benchmark flow.`
+    })
+  },
+  {
+    name: "uploads create",
+    method: "POST",
+    path: "/api/uploads",
+    expectedStatus: 201,
+    multipart: ({ iteration }) => ({
+      fieldName: "file",
+      filename: `benchmark-proof-${iteration}.txt`,
+      contentType: "text/plain",
+      content: `Benchmark proof artifact ${iteration}\nScope: marketplace flow\nResult: accepted\n`
+    })
+  },
+  {
+    name: "search",
+    method: "GET",
+    path: "/api/search?q=marketplace%20payments%20review",
+    expectedStatus: 200
+  },
+  {
+    name: "admin metrics",
+    method: "GET",
+    path: "/api/admin/metrics",
+    expectedStatus: 200,
+    auth: true
+  }
+];
+
+const thresholds = JSON.parse(await fs.readFile(path.join(repoRoot, "benchmarks/thresholds.json"), "utf8"));
+const localServer = await maybeStartLocalServer();
+const baseUrl = process.env.BENCHMARK_TARGET_URL || localServer.baseUrl;
+const authToken = await getBenchmarkToken();
+
+try {
+  const environment = getEnvironment();
+  const startedAt = new Date().toISOString();
+  const results = [];
+
+  for (const endpoint of endpoints) {
+    results.push(await runEndpoint(endpoint));
+  }
+
+  const report = {
+    runId,
+    mode: smoke ? "smoke" : "default",
+    startedAt,
+    completedAt: new Date().toISOString(),
+    baseUrl,
+    config: {
+      requestsPerEndpoint,
+      concurrency,
+      timeoutMs,
+      endpointCount: endpoints.length
+    },
+    environment,
+    results,
+    thresholdSummary: evaluateThresholds(results)
+  };
+
+  await fs.mkdir(resultsDir, { recursive: true });
+  await fs.writeFile(path.join(resultsDir, "latest.json"), `${JSON.stringify(report, null, 2)}\n`);
+  await fs.writeFile(path.join(resultsDir, "latest.md"), renderMarkdown(report));
+
+  console.log(renderConsoleSummary(report));
+
+  if (enforceThresholds && report.thresholdSummary.failures.length > 0) {
+    console.error("Benchmark thresholds failed:");
+    for (const failure of report.thresholdSummary.failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+  }
+} finally {
+  if (localServer.server) {
+    await new Promise((resolve, reject) => {
+      localServer.server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function maybeStartLocalServer() {
+  if (process.env.BENCHMARK_TARGET_URL) {
+    return { baseUrl: process.env.BENCHMARK_TARGET_URL.replace(/\/$/, ""), server: null };
+  }
+
+  const { createApp } = await import("../apps/api/src/app.js");
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+  return { baseUrl: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function getBenchmarkToken() {
+  if (process.env.BENCHMARK_AUTH_TOKEN) {
+    return process.env.BENCHMARK_AUTH_TOKEN;
+  }
+
+  const { signAccessToken } = await import("../apps/api/src/utils/jwt.js");
+  return signAccessToken({ sub: "usr_benchmark_admin", role: "admin" });
+}
+
+async function runEndpoint(endpoint) {
+  const startedAt = performance.now();
+  const samples = [];
+  let nextIteration = 0;
+
+  async function worker() {
+    while (nextIteration < requestsPerEndpoint) {
+      const iteration = nextIteration;
+      nextIteration += 1;
+      samples.push(await requestOnce(endpoint, iteration));
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, requestsPerEndpoint) }, worker));
+  const durationMs = Math.max(performance.now() - startedAt, 1);
+  const latencies = samples.map((sample) => sample.latencyMs).sort((a, b) => a - b);
+  const ttfb = samples.map((sample) => sample.ttfbMs).sort((a, b) => a - b);
+  const errors = samples.filter((sample) => sample.error || sample.status !== endpoint.expectedStatus);
+  const statusCounts = {};
+
+  for (const sample of samples) {
+    const key = sample.status ? String(sample.status) : "error";
+    statusCounts[key] = (statusCounts[key] ?? 0) + 1;
+  }
+
+  return {
+    name: endpoint.name,
+    method: endpoint.method,
+    path: endpoint.path,
+    expectedStatus: endpoint.expectedStatus,
+    requests: samples.length,
+    durationMs: round(durationMs),
+    sustainedRps: round(samples.length / (durationMs / 1000)),
+    peakRps: calculatePeakRps(samples),
+    errorRatePercent: round((errors.length / samples.length) * 100),
+    statusCounts,
+    latencyMs: {
+      p50: percentile(latencies, 50),
+      p95: percentile(latencies, 95),
+      p99: percentile(latencies, 99)
+    },
+    ttfbMs: {
+      p50: percentile(ttfb, 50),
+      p95: percentile(ttfb, 95),
+      p99: percentile(ttfb, 99)
+    },
+    responseBytes: samples.reduce((total, sample) => total + sample.bytes, 0)
+  };
+}
+
+async function requestOnce(endpoint, iteration) {
+  const url = new URL(endpoint.path, baseUrl);
+  const headers = {};
+  let body;
+
+  if (endpoint.auth) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
+  if (endpoint.json) {
+    body = Buffer.from(JSON.stringify(endpoint.json({ runId, iteration })));
+    headers["content-type"] = "application/json";
+    headers["content-length"] = String(body.length);
+  }
+
+  if (endpoint.multipart) {
+    const part = endpoint.multipart({ runId, iteration });
+    const boundary = `----benchmark-${runId}-${iteration}`;
+    body = Buffer.concat([
+      Buffer.from(`--${boundary}\r\n`),
+      Buffer.from(`Content-Disposition: form-data; name="${part.fieldName}"; filename="${part.filename}"\r\n`),
+      Buffer.from(`Content-Type: ${part.contentType}\r\n\r\n`),
+      Buffer.from(part.content),
+      Buffer.from(`\r\n--${boundary}--\r\n`)
+    ]);
+    headers["content-type"] = `multipart/form-data; boundary=${boundary}`;
+    headers["content-length"] = String(body.length);
+  }
+
+  return new Promise((resolve) => {
+    const startedAt = performance.now();
+    const transport = url.protocol === "https:" ? https : http;
+    const request = transport.request(
+      url,
+      {
+        method: endpoint.method,
+        headers,
+        timeout: timeoutMs
+      },
+      (response) => {
+        const ttfbMs = performance.now() - startedAt;
+        let bytes = 0;
+
+        response.on("data", (chunk) => {
+          bytes += chunk.length;
+        });
+
+        response.on("end", () => {
+          resolve({
+            status: response.statusCode,
+            bytes,
+            latencyMs: round(performance.now() - startedAt),
+            ttfbMs: round(ttfbMs),
+            startedAt
+          });
+        });
+      }
+    );
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Timed out after ${timeoutMs}ms`));
+    });
+
+    request.on("error", (error) => {
+      resolve({
+        status: 0,
+        bytes: 0,
+        latencyMs: round(performance.now() - startedAt),
+        ttfbMs: round(performance.now() - startedAt),
+        startedAt,
+        error: error.message
+      });
+    });
+
+    if (body) {
+      request.write(body);
+    }
+    request.end();
+  });
+}
+
+function evaluateThresholds(results) {
+  const failures = [];
+  const thresholdSet = smoke ? thresholds.smoke : thresholds.default;
+
+  for (const result of results) {
+    const endpointThreshold = thresholds.endpoints[`${result.method} ${result.path}`] ?? thresholdSet;
+    if (result.latencyMs.p99 > endpointThreshold.maxP99Ms) {
+      failures.push(`${result.method} ${result.path} p99 ${result.latencyMs.p99}ms > ${endpointThreshold.maxP99Ms}ms`);
+    }
+    if (result.errorRatePercent > endpointThreshold.maxErrorRatePercent) {
+      failures.push(`${result.method} ${result.path} error rate ${result.errorRatePercent}% > ${endpointThreshold.maxErrorRatePercent}%`);
+    }
+  }
+
+  return {
+    passed: failures.length === 0,
+    failures
+  };
+}
+
+function calculatePeakRps(samples) {
+  const buckets = new Map();
+  for (const sample of samples) {
+    const bucket = Math.floor(sample.startedAt / 1000);
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+  }
+  return Math.max(...buckets.values(), samples.length);
+}
+
+function percentile(values, p) {
+  if (values.length === 0) return 0;
+  const index = Math.min(values.length - 1, Math.ceil((p / 100) * values.length) - 1);
+  return round(values[index]);
+}
+
+function round(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function getEnvironment() {
+  return {
+    platform: `${os.type()} ${os.release()} ${os.arch()}`,
+    cpu: os.cpus()[0]?.model ?? "unknown",
+    logicalCores: os.cpus().length,
+    totalMemoryBytes: os.totalmem(),
+    freeMemoryBytes: os.freemem(),
+    node: process.version,
+    target: process.env.BENCHMARK_TARGET_URL ? "external" : "local-loopback"
+  };
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    "# API Benchmark Summary",
+    "",
+    `- Run ID: ${report.runId}`,
+    `- Mode: ${report.mode}`,
+    `- Target: ${report.baseUrl}`,
+    `- Started: ${report.startedAt}`,
+    `- Completed: ${report.completedAt}`,
+    `- Requests per endpoint: ${report.config.requestsPerEndpoint}`,
+    `- Concurrency: ${report.config.concurrency}`,
+    `- Threshold status: ${report.thresholdSummary.passed ? "passed" : "failed"}`,
+    "",
+    "## Environment",
+    "",
+    `- Platform: ${report.environment.platform}`,
+    `- CPU: ${report.environment.cpu}`,
+    `- Logical cores: ${report.environment.logicalCores}`,
+    `- Memory: ${Math.round(report.environment.totalMemoryBytes / 1024 / 1024)} MiB total, ${Math.round(report.environment.freeMemoryBytes / 1024 / 1024)} MiB free at run start`,
+    `- Node: ${report.environment.node}`,
+    "",
+    "## Endpoint Results",
+    "",
+    "| Endpoint | Requests | Error % | p50 ms | p95 ms | p99 ms | TTFB p95 ms | Sustained RPS | Peak RPS | Statuses |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |"
+  ];
+
+  for (const result of report.results) {
+    lines.push(`| ${result.method} ${result.path} | ${result.requests} | ${result.errorRatePercent} | ${result.latencyMs.p50} | ${result.latencyMs.p95} | ${result.latencyMs.p99} | ${result.ttfbMs.p95} | ${result.sustainedRps} | ${result.peakRps} | ${JSON.stringify(result.statusCounts)} |`);
+  }
+
+  if (report.thresholdSummary.failures.length > 0) {
+    lines.push("", "## Threshold Failures", "");
+    for (const failure of report.thresholdSummary.failures) {
+      lines.push(`- ${failure}`);
+    }
+  }
+
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function renderConsoleSummary(report) {
+  const lines = [
+    `Benchmark ${report.runId} (${report.mode}) against ${report.baseUrl}`,
+    `Thresholds: ${report.thresholdSummary.passed ? "passed" : "failed"}`,
+    "Endpoint summary:"
+  ];
+
+  for (const result of report.results) {
+    lines.push(
+      `- ${result.method} ${result.path}: p99 ${result.latencyMs.p99}ms, ` +
+      `${result.sustainedRps} rps, errors ${result.errorRatePercent}%`
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -1,0 +1,16 @@
+{
+  "default": {
+    "maxP99Ms": 1500,
+    "maxErrorRatePercent": 0
+  },
+  "smoke": {
+    "maxP99Ms": 2000,
+    "maxErrorRatePercent": 0
+  },
+  "endpoints": {
+    "POST /api/uploads": {
+      "maxP99Ms": 2500,
+      "maxErrorRatePercent": 0
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "benchmark": "node benchmarks/run-benchmark.mjs",
+    "benchmark:smoke": "node benchmarks/run-benchmark.mjs --smoke --enforce-thresholds",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
## Summary
- add a dependency-light Node benchmark runner under `benchmarks/` for `/health` plus every mounted `/api/*` route
- cover realistic JSON and multipart payloads, including a benchmark-only admin JWT for `/api/admin/metrics`
- capture p50/p95/p99 latency, p95 TTFB, sustained/peak RPS, status distribution, and error rate
- write generated JSON and Markdown reports to `benchmarks/results/latest.{json,md}`
- add reviewable thresholds, root `npm run benchmark` / `npm run benchmark:smoke` scripts, `.env.benchmark.example`, and a PR smoke workflow

## Benchmark summary
Full committed report: `benchmarks/results/latest.md`

- Mode: default local loopback
- Endpoints covered: 21
- Requests per endpoint: 8
- Concurrency: 2
- Threshold status: passed
- Error rate: 0% for every endpoint

Slowest p99 endpoints from the committed run:

| Endpoint | p99 ms | Sustained RPS | Error % |
| --- | ---: | ---: | ---: |
| `GET /health` | 11.03 | 466.32 | 0 |
| `POST /api/auth/register` | 6.46 | 735.6 | 0 |
| `POST /api/uploads` | 3.5 | 1008.98 | 0 |
| `POST /api/auth/login` | 1.31 | 2230.98 | 0 |
| `GET /api/search?q=marketplace%20payments%20review` | 1.27 | 2522 | 0 |

## Benchmark Environment

**Hardware**
- CPU model & core count: Apple M1, 8 physical / 8 logical cores reported by macOS
- RAM: 8 GiB total; generated report captures available memory at run start
- Storage type: local Apple SSD/NVMe-class storage
- Network interface: loopback for local benchmark target
- Machine type: local Mac mini workstation
- OS & version: macOS 26.3, Darwin 25.3.0, arm64

**Runtime**
- Node.js version: v22.22.0
- npm version: 10.9.4
- Resource limits: none intentionally applied
- Other significant processes: normal Codex desktop and shell activity

**If submitted by or with an AI agent**
- Agent/tool: OpenAI Codex desktop
- Underlying model: GPT-5-based Codex coding agent
- Inference provider: OpenAI
- Orchestration framework: none beyond Codex shell/GitHub tooling
- Execution mode: user-initiated, agent-executed autonomous implementation
- Shell/tool access: yes
- Internet access: yes, for GitHub issue/PR checks
- Benchmark commands: run directly by the agent locally
- Known constraints: no production secrets or staging target; validation used local loopback and synthetic benchmark data

## Validation
- `npm install`
- `npm run benchmark`
- `BENCHMARK_RESULTS_DIR="$(mktemp -d)" npm run benchmark:smoke`
- `node --check benchmarks/run-benchmark.mjs`
- `git diff --check`

/claim #30
