### PR TITLE
fix(api): preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,9 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...clientPayload } =
+    payload && typeof payload === "object" ? payload : {};
+  const notification = { ...clientPayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notifications.test.js
+++ b/apps/api/src/tests/notifications.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications ignores caller-owned id and read fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client-controlled-id",
+        read: true,
+        title: "Proposal updated",
+        message: "The proposal moved to review.",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_\d+$/);
+    assert.notEqual(payload.data.id, "client-controlled-id");
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.title, "Proposal updated");
+    assert.equal(payload.data.message, "The proposal moved to review.");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix notification creation so caller-supplied `id` and `read` cannot override server-owned values.
- Keep new notifications unread by default while preserving allowed client fields.
- Add route-level regression coverage for POST /api/notifications.

Closes #3038
References #743

/claim #743

## Verification
- node --test apps/api/src/tests/notifications.test.js
- cd apps/api && node --test src/tests/*.test.js
- node --check apps/api/src/services/notificationService.js
- node --check apps/api/src/tests/notifications.test.js
- git diff --check

Note: `npm test` currently fails on Node 22 because the existing script invokes `node --test src/tests`, which resolves the directory as a module path. The explicit test glob above passes the existing health test plus the new notification regression test.