### PR TITLE
fix: generate user id once so registration token sub matches result id

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser returns matching id and token sub claim", async () => {
+  const result = await registerUser({ email: "test@example.com", role: "client" });
+
+  assert.ok(result.id, "result.id should be defined");
+  assert.ok(result.token, "result.token should be defined");
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(
+    decoded.sub,
+    result.id,
+    `token sub ("${decoded.sub}") should match result.id ("${result.id}")`
+  );
+});


### PR DESCRIPTION
Fixes #2768

## Problem

`authService.js` called `Date.now()` twice during `registerUser` — once for the returned `id` field and once for the JWT `sub` claim. If the two calls crossed a millisecond boundary, the token would be signed for a different subject than the user id returned in the response.

## Fix

1. **`apps/api/src/services/authService.js`**: Capture `const id = \`usr_${Date.now()}\`` once before the return statement, then use that same `id` variable for both the `id:` field in the response and the `sub:` claim in `signAccessToken`.

2. **`apps/api/src/tests/authService.test.js`**: Added a focused test using Node built-in test runner that calls `registerUser`, verifies `result.id` is defined, verifies `result.token` is defined, decodes the token via `verifyAccessToken`, and asserts `decoded.sub === result.id`.

## Test results

Both tests pass (`registerUser returns matching id and token sub claim` + existing health check).