### PR TITLE
fix: protect notification id and read state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload ?? {};
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller supplied id and read state", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker_controlled",
+    read: true,
+    message: "Hello",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_attacker_controlled");
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Hello");
+});


### PR DESCRIPTION
## Summary
- ignore caller-supplied `id` and `read` fields when creating notifications
- preserve the rest of the notification payload
- add a node:test regression test for immutable server-controlled fields

Fixes #3042
References #743

## Testing
- `node --test apps/api/src/tests/notificationService.test.js`

/claim #743
