### PR TITLE
fix(db): expose workspace package entrypoint

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/db/src/index.test.mjs
+++ b/packages/db/src/index.test.mjs
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("@freelanceflow/db exposes the workspace package entrypoint", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.equal(typeof db.PrismaClient, "function");
+});


### PR DESCRIPTION
## Summary
- Add explicit `type`, `main`, `types`, and `exports` metadata for `@freelanceflow/db`.
- Keep the entrypoint scoped to the existing `packages/db/src/index.ts` Prisma client export.
- Add a lightweight import regression test proving workspace package-name resolution works.

Closes #3040
References #743

/claim #743

## Verification
- node -e 'import("@freelanceflow/db").then((db) => console.log(typeof db.PrismaClient)).catch((error) => { console.error(error.message); process.exit(1); })'
- node --test packages/db/src/index.test.mjs
- node --check packages/db/src/index.test.mjs
- npm install --package-lock-only --ignore-scripts
- git diff --check

No runtime service behavior, auth, API routes, Prisma schema, migrations, or generated Prisma client output changed.