### PR TITLE
Resolve freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,26 @@
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((profile) => profile.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer profile matches <strong>{params.username}</strong>.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p>Portfolio, reviews, and active proposals for this freelancer appear here.</p>
+      <Link href="/freelancers/search">Back to freelancer search</Link>
     </section>
   );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,10 @@
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  turbopack: {
+    root: path.join(__dirname, "../..")
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
/claim #2849

## Summary
- Resolves `/freelancers/[username]` against `apps/web/lib/mock.ts`.
- Shows the matching freelancer's rate and skills for known usernames.
- Adds a clear not-found fallback for unknown usernames.
- Sets `turbopack.root` so `next build` does not infer a parent user directory in Windows workspaces.

## Validation
- `npm run build -w apps/web`
- `git diff --check`

## Scope
Kept the profile fix limited to the web freelancer profile route plus the minimal Next config needed for reproducible local build validation.
