### PR TITLE
Limit API JSON request body size

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body is too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/jsonBodyLimit.test.js
+++ b/apps/api/src/tests/jsonBodyLimit.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.closeAllConnections();
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/jobs rejects oversized JSON request bodies", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "x".repeat(110 * 1024) })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Request body is too large"
+    });
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/jobs continues to parse normal-sized JSON request bodies", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Small test job",
+        description: "A normal-sized JSON body should still parse.",
+        budgetMin: 100,
+        budgetMax: 200,
+        categoryId: "testing",
+        skills: ["api"]
+      })
+    });
+
+    assert.equal(response.status, 201);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
Contributor: Tristan Tang

## Summary
- Add a 100kb limit to the API JSON parser so oversized request bodies fail before reaching route handlers.
- Return a stable `413` JSON error for `entity.too.large` parser failures.
- Avoid logging expected oversized-body rejections as unhandled API errors.
- Cover both the oversized rejection path and a normal-sized `/api/jobs` request that still parses successfully.

## Verification
- `node --test src/tests/jsonBodyLimit.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`