### PR TITLE
Preserve server-generated IDs on record creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serverGeneratedIds.test.js
+++ b/apps/api/src/tests/serverGeneratedIds.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("record creation endpoints keep server-owned ids", async () => {
+  await withServer(async (baseUrl) => {
+    const cases = [
+      ["/api/users", "usr_", { id: "usr_attacker", email: "owner@example.com" }],
+      ["/api/proposals", "prp_", { id: "prp_attacker", jobId: "job_1", amount: 500 }],
+      ["/api/reviews", "rev_", { id: "rev_attacker", rating: 5, targetId: "usr_1" }],
+      ["/api/messages", "msg_", { id: "msg_attacker", body: "hello", recipientId: "usr_2" }]
+    ];
+
+    for (const [path, prefix, body] of cases) {
+      const { response, payload } = await postJson(baseUrl, path, body);
+
+      assert.equal(response.status, 201);
+      assert.equal(payload.success, true);
+      assert.match(payload.data.id, new RegExp(`^${prefix}\\d+$`));
+      assert.notEqual(payload.data.id, body.id);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #3058
/claim #743

## Summary
- Preserve server-owned IDs for user, proposal, review, and message creation even when the request body includes an `id` field.
- Add API regression coverage that posts attacker-controlled IDs and verifies the response keeps the generated `usr_`, `prp_`, `rev_`, and `msg_` IDs.
- Fix the API package test script so Node runs the test files instead of attempting to execute the test directory.

## Validation
- `npm test -w apps/api`
- `git diff --check`