### PR TITLE
fix: reject inverted job budget ranges in job validation

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -2,11 +2,19 @@ import { ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
-export async function getJobs(req, res) {
-  return ok(res, await listJobs());
+export async function getJobs(req, res, next) {
+  try {
+    return ok(res, await listJobs());
+  } catch (error) {
+    next(error);
+  }
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (error) {
+    next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  console.error("Unhandled API error:", err instanceof Error ? err.stack || err.message : String(err));
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+import { createApp } from "../app.js";
+
+test("Validator: createJobSchema accepts valid budget ranges", () => {
+  const validData = {
+    title: "Senior Fullstack Developer",
+    description: "Looking for an expert React and Node.js developer.",
+    budgetMin: 50,
+    budgetMax: 100,
+    categoryId: "cat_123",
+    skills: ["React", "Node"]
+  };
+
+  const result = createJobSchema.safeParse(validData);
+  assert.equal(result.success, true);
+});
+
+test("Validator: createJobSchema rejects inverted budget ranges", () => {
+  const invalidData = {
+    title: "Senior Fullstack Developer",
+    description: "Looking for an expert React and Node.js developer.",
+    budgetMin: 150,
+    budgetMax: 100,
+    categoryId: "cat_123",
+    skills: ["React", "Node"]
+  };
+
+  const result = createJobSchema.safeParse(invalidData);
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].message, "budgetMin must be less than or equal to budgetMax");
+});
+
+test("Validator: updateJobSchema accepts partial updates", () => {
+  const partialUpdate = {
+    title: "Lead Frontend Engineer"
+  };
+
+  const result = updateJobSchema.safeParse(partialUpdate);
+  assert.equal(result.success, true);
+});
+
+test("Validator: updateJobSchema rejects inverted budget ranges on partial updates", () => {
+  const invalidPartial = {
+    budgetMin: 500,
+    budgetMax: 200
+  };
+
+  const result = updateJobSchema.safeParse(invalidPartial);
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].message, "budgetMin must be less than or equal to budgetMax");
+});
+
+test("Integration: POST /api/jobs rejects inverted budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        title: "Senior Dev",
+        description: "Looking for a seasoned architect.",
+        budgetMin: 200,
+        budgetMax: 100,
+        categoryId: "cat_999",
+        skills: ["Arch"]
+      })
+    });
+
+    console.log("[TEST] Received response status:", response.status);
+    assert.equal(response.status, 400);
+
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.errors[0].message, "budgetMin must be less than or equal to budgetMax");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("Integration: POST /api/jobs accepts valid budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Connection": "close"
+      },
+      body: JSON.stringify({
+        title: "Senior Dev",
+        description: "Looking for a seasoned architect.",
+        budgetMin: 100,
+        budgetMax: 200,
+        categoryId: "cat_999",
+        skills: ["Arch"]
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 100);
+    assert.equal(payload.data.budgetMax, 200);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,21 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = jobBaseSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin === undefined || data.budgetMax === undefined) return true;
+    return data.budgetMin <= data.budgetMax;
+  },
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
/claim #2853

## Problem
The createJobSchema and updateJobSchema in pps/api/src/validators/job.js did not validate that udgetMin was less than or equal to udgetMax. This allowed clients to submit jobs with an inverted budget range (e.g., udgetMin: 500, budgetMax: 100) which is semantically invalid.

Additionally, the Express error handler did not forward thrown errors to the 
ext() middleware, causing Zod validation errors to crash the server process rather than returning a structured HTTP response.

## Changes

### \pps/api/src/validators/job.js\
- Extracted a \jobBaseSchema\ from the inline \z.object()\
- Added a \.refine()\ check on \createJobSchema\ that rejects any payload where \udgetMin > budgetMax\
- Added a safe \.refine()\ check on \updateJobSchema\ (partial) that only validates the constraint when both fields are present

### \pps/api/src/controllers/jobController.js\
- Wrapped \getJobs\ and \postJob\ in \	ry/catch\ blocks
- Errors are now forwarded to Express's \
ext(error)\ so the global error handler can process them

### \pps/api/src/middleware/errorHandler.js\
- Imported \ZodError\ from \zod\
- Added a specific \instanceof ZodError\ branch that returns a \400 Bad Request\ with detailed validation error messages instead of a generic \500\

### \pps/api/src/tests/job.test.js\ *(new file)*
- 4 unit tests for the Zod validator (valid budget, inverted budget, partial update valid, partial update inverted)
- 2 integration tests using the full Express app (reject inverted → 400, accept valid → 201)

## Validation
All 7 tests pass (including pre-existing health test):
\\\
✔ GET /health returns ok payload
✔ Validator: createJobSchema accepts valid budget ranges
✔ Validator: createJobSchema rejects inverted budget ranges
✔ Validator: updateJobSchema accepts partial updates
✔ Validator: updateJobSchema rejects inverted budget ranges on partial updates
✔ Integration: POST /api/jobs rejects inverted budget ranges
✔ Integration: POST /api/jobs accepts valid budget ranges
\\\

Closes #2853