### PR TITLE
Validate review creation ratings

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("review creation rejects ratings outside the public 1-5 range", async () => {
+  await withServer(async (baseUrl) => {
+    for (const rating of [0, 6]) {
+      const { response, payload } = await postReview(baseUrl, {
+        targetId: "usr_target",
+        rating,
+        comment: "invalid rating"
+      });
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, { success: false, message: "Invalid review payload" });
+    }
+  });
+});
+
+test("review creation accepts valid ratings", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postReview(baseUrl, {
+      targetId: "usr_target",
+      rating: 5,
+      comment: "great work"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_\d+$/);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.targetId, "usr_target");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(1000).optional()
+});


### PR DESCRIPTION
Fixes #3064
/claim #743

## Summary
- Add a focused review creation validator for `targetId`, integer `rating`, and optional `comment`.
- Reject review ratings outside the public 1-5 range with a `400` response.
- Add API regression coverage for invalid `0` / `6` ratings and a valid `5` rating.

## Validation
- `node --test "apps/api/src/tests/**/*.test.js"`
- `git diff --check`

Note: I used the direct Node test command because upstream `apps/api/package.json` currently points `npm test` at the `src/tests` directory rather than the test file glob.