### PR TITLE
Reject admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin self-assignment", () => {
+  const result = registerSchema.safeParse({
+    email: "new-user@example.com",
+    password: "password123",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerSchema still accepts public registration roles", () => {
+  const clientResult = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const freelancerResult = registerSchema.safeParse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(clientResult.success, true);
+  assert.equal(freelancerResult.success, true);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- prevent public registration from self-assigning the admin role
- keep client and freelancer as allowed public registration roles
- add validator regression tests for rejected and accepted roles

## Tests
- node --test src/tests/*.test.js

/claim #3071