### PR TITLE
fix: protect message ids from payload override

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id, ...safePayload } = payload;
+  const message = { ...safePayload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller supplied id", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker_controlled",
+    senderId: "usr_sender",
+    recipientId: "usr_recipient",
+    body: "Hello",
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_attacker_controlled");
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.recipientId, "usr_recipient");
+  assert.equal(message.body, "Hello");
+  assert.equal(typeof message.sentAt, "string");
+});


### PR DESCRIPTION
/claim #743

## Summary
- ignore caller-supplied `id` when creating messages
- preserve the rest of the message payload and generated `sentAt` timestamp
- add a node:test regression test for immutable server-controlled message ids

Fixes #3075
References #743

## Testing
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/messageService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/notificationService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/services/messageService.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/tests/messageService.test.js`