### PR TITLE
Fix admin role self-assignment and token refresh validation (Closes #3077)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    next(err);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -21,7 +29,13 @@ export async function oauthCallback(req, res) {
   });
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export async function refresh(req, res, next) {
+  try {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch (err) {
+    next(err);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,10 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  if (!token) {
+    throw new Error("Token is required");
+  }
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/register rejects role: admin", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      email: "attacker@gmail.com",
+      password: "password123",
+      role: "admin"
+    })
+  });
+
+  // Zod parsing should fail on role: "admin"
+  assert.notEqual(response.status, 201);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/auth/refresh passes refresh token and identifies user", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  
+  // Register as freelancer
+  const regRes = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      email: "freelancer@gmail.com",
+      password: "password123",
+      role: "freelancer"
+    })
+  });
+  
+  assert.equal(regRes.status, 201);
+  const regData = await regRes.json();
+  const token = regData.data.token;
+  
+  // Refresh token
+  const refRes = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${token}`
+    }
+  });
+
+  assert.equal(refRes.status, 200);
+  const refData = await refRes.json();
+  
+  // Verify that the new token preserves the role: freelancer
+  const decodedPayload = JSON.parse(Buffer.from(refData.data.token.split('.')[1], 'base64').toString());
+  assert.equal(decodedPayload.role, "freelancer");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Description
This Pull Request resolves a critical security flaw and token validation issue in the authentication endpoints:
1. **Admin Role Self-Assignment Protection**: Updated `apps/api/src/validators/auth.js` register schema to strictly allow only `client` and `freelancer` roles. This prevents malicious registration payloads from assigning administrative privileges arbitrarily.
2. **Token-Aware Refresh Mechanism**: Rewrote the `refresh` endpoint controller and service function to extract, verify, and read from the provided Authorization bearer token rather than reverting to a hardcoded client fallback.

## Testing & Validation
- Created a robust unit test suite at `apps/api/src/tests/auth.test.js` confirming both that `admin` registrations are rejected and that refreshed tokens preserve correct user identity roles (e.g. `freelancer`).
- All 2/2 tests are successfully passing locally.

Closes #3077