### PR TITLE
fix: protect proposal ids from payload override

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...safePayload } = payload;
+  const proposal = { ...safePayload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal ignores caller supplied id", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker_controlled",
+    jobId: "job_123",
+    freelancerId: "usr_freelancer",
+    coverLetter: "I can help with this.",
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "prp_attacker_controlled");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.coverLetter, "I can help with this.");
+});


### PR DESCRIPTION
/claim #743

## Summary
- ignore caller-supplied `id` when creating proposals
- preserve the rest of the proposal payload
- add a node:test regression test for immutable server-controlled proposal ids

Fixes #3080
References #743

## Testing
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/proposalService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/messageService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/services/proposalService.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/tests/proposalService.test.js`