### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q ?? "";
+
+  if (typeof query !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  if (query.length > 100) {
+    return fail(res, "Search query must be 100 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/searchRoutes.test.js
+++ b/apps/api/src/tests/searchRoutes.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects overly long query strings", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(101);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be 100 characters or fewer");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be a string");
+  });
+});


### PR DESCRIPTION
## Summary
- validate that q is a single string before passing it to the search service
- reject search queries longer than 100 characters
- add regression tests for long and repeated query parameters

## Tests
- node --test src/tests/*.test.js

/claim #3079