### PR TITLE
fix: protect review ids from payload override

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id, ...safePayload } = payload;
+  const review = { ...safePayload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller supplied id", async () => {
+  const review = await createReview({
+    id: "rev_attacker_controlled",
+    jobId: "job_123",
+    reviewerId: "usr_client",
+    rating: 5,
+    comment: "Great work.",
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "rev_attacker_controlled");
+  assert.equal(review.jobId, "job_123");
+  assert.equal(review.reviewerId, "usr_client");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great work.");
+});


### PR DESCRIPTION
/claim #743

## Summary
- ignore caller-supplied `id` when creating reviews
- preserve the rest of the review payload
- add a node:test regression test for immutable server-controlled review ids

Fixes #3084
References #743

## Testing
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/reviewService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/proposalService.test.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/services/reviewService.js`
- `C:\Users\heick\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --check apps/api/src/tests/reviewService.test.js`