### PR TITLE
Keep registration token subject aligned with returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs an access token for the returned user id", async () => {
+  const user = await registerUser({
+    email: "new-user@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const payload = verifyAccessToken(user.token);
+
+  assert.equal(payload.sub, user.id);
+  assert.equal(payload.role, user.role);
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once
- sign the access token with the same id in the JWT sub claim
- add a regression test to verify the returned id matches the token subject

## Tests
- node --test src/tests/*.test.js

/claim #3083