### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -2,11 +2,19 @@ import { ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
-export async function getJobs(req, res) {
-  return ok(res, await listJobs());
+export async function getJobs(req, res, next) {
+  try {
+    return ok(res, await listJobs());
+  } catch (error) {
+    return next(error);
+  }
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/jobBudgetRange.test.js
+++ b/apps/api/src/tests/jobBudgetRange.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Frontend build",
+  description: "Build the frontend implementation",
+  budgetMin: 100,
+  budgetMax: 200,
+  categoryId: "development",
+  skills: ["react"]
+};
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(result.error.issues[0].message, "budgetMax must be greater than or equal to budgetMin");
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJobPayload);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted ranges only when both budget fields are present", () => {
+  const invertedResult = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(invertedResult.success, false);
+
+  const partialResult = updateJobSchema.safeParse({
+    budgetMax: 100
+  });
+
+  assert.equal(partialResult.success, true);
+});
+
+test("POST /api/jobs returns 400 for inverted budget ranges", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...validJobPayload,
+        budgetMin: 500,
+        budgetMax: 100
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.deepEqual(payload.errors[0].path, ["budgetMax"]);
+  } finally {
+    await close(server);
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,30 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobShape = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+function withBudgetRangeValidation(schema) {
+  return schema.superRefine((payload, ctx) => {
+    if (
+      typeof payload.budgetMin === "number" &&
+      typeof payload.budgetMax === "number" &&
+      payload.budgetMax < payload.budgetMin
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["budgetMax"],
+        message: "budgetMax must be greater than or equal to budgetMin"
+      });
+    }
+  });
+}
+
+export const createJobSchema = withBudgetRangeValidation(z.object(jobShape));
+
+export const updateJobSchema = withBudgetRangeValidation(z.object(jobShape).partial());


### PR DESCRIPTION
## Summary
- reject job payloads where `budgetMax` is lower than `budgetMin`
- apply the same range rule to partial job updates when both budget fields are present
- return a stable 400 validation response for Zod validation failures from the job controller
- make the API test script target `*.test.js` files explicitly

## Verification
- `npm test -w apps/api`

Fixes #2853