### PR TITLE
Require authentication for payment creation route

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("payment creation route requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 100 })
+    });
+    const payload = await createResponse.json();
+
+    assert.equal(createResponse.status, 401);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `authMiddleware` to `POST /api/payments` (`apps/api/src/routes/paymentRoutes.js`).
- Add focused test for unauthenticated payment creation in `apps/api/src/tests/paymentAuth.test.js` expecting 401.

## Why

Issue `SecureBananaLabs/bug-bounty#2190` reports that `paymentRoutes.post("/", createPayment)` accepts unauthenticated payment creation.

## Bounty/claim

Closes #2190
/claim #743

No upstream checks were run before publishing for this issue. The test is narrowly scoped and mirrors existing auth-middleware patterns.