### PR TITLE
Resolve job detail route from mock jobs

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,24 @@
+import { findJobById } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = findJobById(params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job matches <strong>{params.id}</strong>.</p>
+        <p>Return to the job listings to choose an active project.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <p>Responsibilities, milestones, and proposals for <strong>{job.id}</strong> would be shown here.</p>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,8 +1,27 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create a responsive support widget with AI-assisted answers and escalation paths."
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Move a legacy API surface to Node.js while preserving existing client contracts."
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Design onboarding screens and activation checkpoints for a SaaS product."
+  }
 ];
+
+export function findJobById(id: string) {
+  return jobs.find((job) => job.id === id) ?? null;
+}
 
 export const freelancers = [
   { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "node --test tests/*.test.mjs"
   },
   "devDependencies": {
     "@types/node": "22.15.19",

--- a/apps/web/tests/job-detail-route.test.mjs
+++ b/apps/web/tests/job-detail-route.test.mjs
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { createRequire } from "node:module";
+import ts from "typescript";
+import { jsx, jsxs } from "react/jsx-runtime";
+
+const webRoot = path.resolve(import.meta.dirname, "..");
+const require = createRequire(import.meta.url);
+
+function transpileModule(filePath) {
+  const source = fs.readFileSync(filePath, "utf8");
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      jsx: ts.JsxEmit.ReactJSX
+    }
+  }).outputText;
+}
+
+function loadPage() {
+  const mockExports = {};
+  vm.runInNewContext(transpileModule(path.join(webRoot, "lib", "mock.ts")), {
+    exports: mockExports,
+    require,
+    module: { exports: mockExports }
+  });
+
+  const pageExports = {};
+  const pageModule = { exports: pageExports };
+  vm.runInNewContext(transpileModule(path.join(webRoot, "app", "jobs", "[id]", "page.tsx")), {
+    exports: pageExports,
+    module: pageModule,
+    require: (specifier) => {
+      if (specifier === "../../../lib/mock") return mockExports;
+      if (specifier === "react/jsx-runtime") return { jsx, jsxs };
+      return require(specifier);
+    }
+  });
+
+  return pageModule.exports.default;
+}
+
+function flattenText(value) {
+  if (value == null || typeof value === "boolean") return "";
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (Array.isArray(value)) return value.map(flattenText).join(" ");
+  if (typeof value === "object") return flattenText(value.props?.children);
+  return "";
+}
+
+test("job detail route renders matching mock job context", () => {
+  const JobDetailPage = loadPage();
+  const output = JobDetailPage({ params: { id: "job-101" } });
+  const text = flattenText(output);
+
+  assert.match(text, /Build an AI customer support widget/);
+  assert.match(text, /\$1,500/);
+  assert.match(text, /responsive support widget/);
+});
+
+test("job detail route renders a clear fallback for unknown jobs", () => {
+  const JobDetailPage = loadPage();
+  const output = JobDetailPage({ params: { id: "job-missing" } });
+  const text = flattenText(output);
+
+  assert.match(text, /Job not found/);
+  assert.match(text, /job-missing/);
+  assert.doesNotMatch(text, /Budget:/);
+});


### PR DESCRIPTION
## Summary
- resolve `/jobs/[id]` against the existing mock job list instead of rendering the raw route id
- show matching job title, budget, and project context for known ids
- show a clear not-found fallback for unknown job ids
- add a focused route render regression test for known and unknown ids

## Verification
- `npm test -w apps/web`
- `npm run build -w apps/web`
- `git diff --check`

Fixes #2760
/claim #2760