### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/tests/proposalValidator.test.js/proposalValidator.test.js
+++ b/apps/api/src/tests/proposalValidator.test.js/proposalValidator.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can complete this job with a clear delivery plan.",
+  bidAmount: 250
+};
+
+test("createProposalSchema rejects empty proposal payloads", () => {
+  const result = createProposalSchema.safeParse({});
+
+  assert.equal(result.success, false);
+  assert.deepEqual(
+    result.error.issues.map((issue) => issue.path.join(".")),
+    ["jobId", "freelancerId", "coverLetter", "bidAmount"]
+  );
+});
+
+test("createProposalSchema rejects non-positive bid amounts", () => {
+  const result = createProposalSchema.safeParse({
+    ...validProposal,
+    bidAmount: 0
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "bidAmount");
+});
+
+test("createProposalSchema accepts valid proposal payloads", () => {
+  const result = createProposalSchema.safeParse(validProposal);
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(20),
+  bidAmount: z.number().positive()
+});


### PR DESCRIPTION
/claim #3104

## Summary
- Add a proposal creation schema for required jobId, freelancerId, coverLetter, and positive bidAmount.
- Parse POST /api/proposals through the schema before creating a proposal.
- Add validator regression tests for empty payloads, non-positive bids, and valid payloads.

## Tests
- node --test src/tests/*.test.js