### PR TITLE
Add async ledger technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,23 @@
+# Async Ledger
+
+A route wakes early, headers bright,
+then hands its promise to the queue;
+the worker lifts it out of sight,
+where retries make old errors new.
+
+The lock is small, the state is plain,
+a row that says what happened when;
+each commit dries the race like rain,
+then lets the pending work begin.
+
+The cache forgets what changed below,
+the logs keep names for every turn;
+a trace line shows the hidden flow,
+so late-night failures have a return.
+
+And when the pull request reaches shore,
+the checks report their quiet green;
+one merged fix opens one more door,
+one ledger marks the work as seen.
+
+Author note: I chose an async job pipeline because bounty work often moves through queued review, retries, commits, and observable state before a real payout can settle.


### PR DESCRIPTION
Adds POEM.md with an original four-stanza technical poem about async job pipelines, queued review, retries, commits, and observable state.

Creative decision: I used an async ledger metaphor because bounty work moves through queueing, review, retries, and settlement before value becomes real.

Verification:
- POEM.md is in the project root
- 4 stanzas, 4 lines each
- includes an author note
- git diff --check

/claim #76