### PR TITLE
Harden auth on sensitive APIs and fix refresh flow

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { z } from "zod";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,17 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const schema = z.object({ refreshToken: z.string().min(1) });
+
+  try {
+    const payload = schema.parse(req.body);
+    const result = await refreshToken(payload.refreshToken);
+    return ok(res, result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail(res, "Missing refresh token", 401);
+    }
+
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded",
   }, 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", authMiddleware, getMessages);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", authMiddleware, getNotifications);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,12 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const refreshPayload = verifyAccessToken(token);
+  return {
+    token: signAccessToken({
+      sub: refreshPayload.sub,
+      role: refreshPayload.role || "client",
+    }),
+  };
 }

--- a/apps/api/src/tests/securityHardening.test.js
+++ b/apps/api/src/tests/securityHardening.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function loginToken(baseUrl) {
+  const loginResponse = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: "security@example.com",
+      password: "supersecret",
+    }),
+  });
+
+  const payload = await loginResponse.json();
+  return payload.data?.token;
+}
+
+test("protected APIs reject unauthenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = await loginToken(baseUrl);
+
+    const protectedGetEndpoints = [
+      "/api/messages",
+      "/api/notifications",
+    ];
+
+    for (const path of protectedGetEndpoints) {
+      const response = await fetch(`${baseUrl}${path}`);
+      const payload = await response.json();
+      assert.equal(response.status, 401);
+      assert.equal(payload.message, "Unauthorized");
+
+      const postResponse = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "attempt" }),
+      });
+      const postPayload = await postResponse.json();
+      assert.equal(postResponse.status, 401);
+      assert.equal(postPayload.message, "Unauthorized");
+    }
+
+    const uploadResponse = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+    });
+    assert.equal(uploadResponse.status, 401);
+
+    const noFileWithToken = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+    });
+    const noFilePayload = await noFileWithToken.json();
+    assert.equal(noFileWithToken.status, 400);
+    assert.equal(noFilePayload.message, "No file provided");
+  });
+});
+
+test("refresh endpoint validates presence of a refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const noToken = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const noTokenPayload = await noToken.json();
+    assert.equal(noToken.status, 401);
+    assert.equal(noTokenPayload.message, "Missing refresh token");
+
+    const invalidToken = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "invalid" }),
+    });
+    const invalidPayload = await invalidToken.json();
+    assert.equal(invalidToken.status, 401);
+    assert.equal(invalidPayload.message, "Invalid refresh token");
+
+    const token = await loginToken(baseUrl);
+    const validRefresh = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: token }),
+    });
+    const validPayload = await validRefresh.json();
+
+    assert.equal(validRefresh.status, 200);
+    assert.equal(typeof validPayload.data?.token, "string");
+    assert.ok(validPayload.data.token.length > 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Require auth on `POST /api/uploads`, `GET/POST /api/messages`, and `GET/POST /api/notifications`.
- Enforce refresh token validation in `/api/auth/refresh` and reject missing/invalid tokens.
- Upload endpoint now rejects multipart requests without a file (`No file provided`).
- Added regression tests for unauthenticated access and refresh-token validation.

## Changes
- `apps/api/src/routes/uploadRoutes.js`
  - add `authMiddleware` to upload creation route.
- `apps/api/src/controllers/uploadController.js`
  - return `400` when `req.file` is missing with message `No file provided`.
- `apps/api/src/routes/messageRoutes.js`
  - require auth for GET/POST messages.
- `apps/api/src/routes/notificationRoutes.js`
  - require auth for GET/POST notifications.
- `apps/api/src/controllers/authController.js`
  - validate `refreshToken` in request body and return `401 Missing refresh token`/`401 Invalid refresh token` accordingly.
- `apps/api/src/services/authService.js`
  - verify token before minting new access token.
- `apps/api/src/tests/securityHardening.test.js`
  - regression coverage for unauthorized access and refresh flow.

## References
Closes #3130
Closes #3131
Closes #3067
Closes #3095
Closes #3099
/claim #743

## Validation
- `node --test apps/api/src/tests/securityHardening.test.js`
- `node --test apps/api/src/tests/*.test.js`
