### PR TITLE
Keep message service records and ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return { ...message };
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,11 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return { ...message };
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("message service does not expose its internal message store", async () => {
+  const initialMessages = await listMessages();
+  const initialCount = initialMessages.length;
+
+  const created = await sendMessage({
+    conversationId: "conv_defensive_copy",
+    senderId: "usr_sender",
+    body: "Please keep the internal store private"
+  });
+
+  created.body = "mutated through returned create payload";
+
+  const listedMessages = await listMessages();
+  assert.equal(listedMessages.length, initialCount + 1);
+  assert.equal(listedMessages.at(-1).body, "Please keep the internal store private");
+
+  listedMessages.push({
+    id: "msg_client_injected",
+    conversationId: "conv_defensive_copy",
+    senderId: "usr_attacker",
+    body: "injected through list result"
+  });
+  listedMessages.at(-2).body = "mutated through list result";
+
+  const reloadedMessages = await listMessages();
+  assert.equal(reloadedMessages.length, initialCount + 1);
+  assert.equal(reloadedMessages.at(-1).id, created.id);
+  assert.equal(reloadedMessages.at(-1).body, "Please keep the internal store private");
+  assert.equal(
+    reloadedMessages.some((message) => message.id === "msg_client_injected"),
+    false
+  );
+});

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -7,11 +7,14 @@ test("message service does not expose its internal message store", async () => {
   const initialCount = initialMessages.length;
 
   const created = await sendMessage({
+    id: "msg_client_controlled",
     conversationId: "conv_defensive_copy",
     senderId: "usr_sender",
     body: "Please keep the internal store private"
   });
 
+  assert.match(created.id, /^msg_\d+$/);
+  assert.notEqual(created.id, "msg_client_controlled");
   created.body = "mutated through returned create payload";
 
   const listedMessages = await listMessages();


### PR DESCRIPTION
## Summary
- return defensive copies from `listMessages()` so callers cannot mutate the service-owned message array or stored records
- return a copy from `sendMessage()` instead of exposing the internally stored object reference
- keep message ids server-owned by applying the generated id after copying the payload
- update the API test script to target concrete test files and add regression coverage for returned-object/list mutation plus client-supplied ids

Fixes #3135

## Verification
- npm test -w apps/api
- git diff --check