### PR TITLE
Return defensive copies from message service

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,15 @@
 const messages = [];
 
+function serializeMessage(message) {
+  return { ...message };
+}
+
 export async function listMessages() {
-  return messages;
+  return messages.map(serializeMessage);
 }
 
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return serializeMessage(message);
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("message service returns defensive copies of stored messages", async () => {
+  const created = await sendMessage({
+    senderId: "client_1",
+    recipientId: "freelancer_1",
+    body: "Please review the brief.",
+  });
+
+  created.body = "mutated returned message";
+
+  const firstList = await listMessages();
+  const storedMessage = firstList.find((message) => message.id === created.id);
+
+  assert.equal(storedMessage.body, "Please review the brief.");
+
+  firstList.push({ id: "msg_fake", body: "injected" });
+  storedMessage.body = "mutated list message";
+
+  const secondList = await listMessages();
+  const preservedMessage = secondList.find((message) => message.id === created.id);
+
+  assert.equal(secondList.some((message) => message.id === "msg_fake"), false);
+  assert.equal(preservedMessage.body, "Please review the brief.");
+});


### PR DESCRIPTION
Fixes #3138

/claim #743

Summary:
- Return defensive copies from `listMessages()` so callers cannot mutate the service-owned message array or stored message objects.
- Return a defensive copy from `sendMessage()` so mutating the created-message response does not alter internal state.
- Add a focused regression test for both mutation paths.

Validation:
- `node --test apps\api\src\tests\*.test.js`
- `git diff --cached --check`

Note:
- `npm test -w apps/api` still fails on the existing `node --test src/tests` script in this runtime before discovering test files; I left that unrelated script issue out of scope for this focused #3138 fix.
