### PR TITLE
Return defensive copies from proposal service

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,15 @@
 const proposals = [];
 
+function serializeProposal(proposal) {
+  return { ...proposal };
+}
+
 export async function listProposals() {
-  return proposals;
+  return proposals.map(serializeProposal);
 }
 
 export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
-  return proposal;
+  return serializeProposal(proposal);
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("proposal service returns defensive copies of stored proposals", async () => {
+  const created = await createProposal({
+    jobId: "job_1",
+    freelancerId: "freelancer_1",
+    coverLetter: "I can deliver the milestone.",
+    bidAmount: 1200,
+  });
+
+  created.coverLetter = "mutated returned proposal";
+
+  const firstList = await listProposals();
+  const storedProposal = firstList.find((proposal) => proposal.id === created.id);
+
+  assert.equal(storedProposal.coverLetter, "I can deliver the milestone.");
+
+  firstList.push({ id: "prp_fake", coverLetter: "injected" });
+  storedProposal.coverLetter = "mutated list proposal";
+
+  const secondList = await listProposals();
+  const preservedProposal = secondList.find((proposal) => proposal.id === created.id);
+
+  assert.equal(secondList.some((proposal) => proposal.id === "prp_fake"), false);
+  assert.equal(preservedProposal.coverLetter, "I can deliver the milestone.");
+});


### PR DESCRIPTION
Fixes #3140

/claim #743

Summary:
- Return defensive copies from `listProposals()` so callers cannot mutate the service-owned proposal array or stored proposal objects.
- Return a defensive copy from `createProposal()` so mutating the created-proposal response does not alter internal state.
- Add a focused regression test for both mutation paths.

Validation:
- `node --test apps\api\src\tests\*.test.js`
- `git diff --cached --check`

Note:
- `npm test -w apps/api` still fails on the existing `node --test src/tests` script in this runtime before discovering test files; I left that unrelated script issue out of scope for this focused #3140 fix.
