### PR TITLE
Add actionable billing overview controls

### DIFF
--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -1,8 +1,109 @@
+const payoutMethod = {
+  label: "Stripe Connect",
+  account: "Connected account ending in 4821",
+  status: "Ready",
+  nextAction: "Review payout"
+};
+
+const invoices = [
+  { id: "INV-2048", client: "Northstar Labs", amount: "$2,800", due: "Due Jun 04", status: "Pending" },
+  { id: "INV-2047", client: "Atlas Studio", amount: "$1,500", due: "Paid May 28", status: "Paid" },
+  { id: "INV-2046", client: "Mercury Ops", amount: "$900", due: "Paid May 19", status: "Paid" }
+];
+
+const transactions = [
+  { id: "TRX-9102", label: "Milestone escrow release", amount: "+$1,500", date: "May 28" },
+  { id: "TRX-9101", label: "Platform service fee", amount: "-$75", date: "May 28" },
+  { id: "TRX-9098", label: "Payout transfer", amount: "-$2,225", date: "May 21" }
+];
+
 export default function BillingPage() {
   return (
-    <section className="card">
-      <h2>Billing</h2>
-      <p>Invoices, payout methods, and transaction history are managed here.</p>
+    <section>
+      <div className="page-heading">
+        <div>
+          <h2>Billing</h2>
+          <p>Account balance, invoices, payout method, and recent transactions.</p>
+        </div>
+        <button type="button">Download statement</button>
+      </div>
+
+      <div className="billing-summary">
+        <article className="card metric-card">
+          <span className="eyebrow">Available balance</span>
+          <strong>$3,225</strong>
+          <span className="muted">Ready for next payout</span>
+        </article>
+        <article className="card metric-card">
+          <span className="eyebrow">Pending invoices</span>
+          <strong>$2,800</strong>
+          <span className="muted">1 invoice awaiting client payment</span>
+        </article>
+        <article className="card metric-card">
+          <span className="eyebrow">Next payout</span>
+          <strong>Jun 07</strong>
+          <span className="muted">Weekly payout schedule</span>
+        </article>
+      </div>
+
+      <div className="billing-layout">
+        <section className="card">
+          <div className="section-title">
+            <h3>Invoices</h3>
+            <button type="button">Create invoice</button>
+          </div>
+          <div className="list">
+            {invoices.map((invoice) => (
+              <article className="row-item" key={invoice.id}>
+                <div>
+                  <strong>{invoice.id}</strong>
+                  <span>{invoice.client}</span>
+                </div>
+                <div className="row-meta">
+                  <strong>{invoice.amount}</strong>
+                  <span>{invoice.due}</span>
+                </div>
+                <span className={`status-chip ${invoice.status === "Paid" ? "status-paid" : "status-pending"}`}>
+                  {invoice.status}
+                </span>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <aside className="card">
+          <div className="section-title">
+            <h3>Payout method</h3>
+            <span className="status-chip status-paid">{payoutMethod.status}</span>
+          </div>
+          <div className="payout-panel">
+            <strong>{payoutMethod.label}</strong>
+            <span>{payoutMethod.account}</span>
+            <button type="button">{payoutMethod.nextAction}</button>
+          </div>
+        </aside>
+      </div>
+
+      <section className="card">
+        <div className="section-title">
+          <h3>Transaction history</h3>
+          <button type="button">Export CSV</button>
+        </div>
+        <div className="list">
+          {transactions.map((transaction) => (
+            <article className="row-item" key={transaction.id}>
+              <div>
+                <strong>{transaction.label}</strong>
+                <span>{transaction.id}</span>
+              </div>
+              <div className="row-meta">
+                <strong>{transaction.amount}</strong>
+                <span>{transaction.date}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
     </section>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,30 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+button { border: 1px solid #48619f; border-radius: 8px; background: #22315c; color: #f2f5ff; padding: 0.55rem 0.8rem; font: inherit; cursor: pointer; }
+button:hover { background: #2b3d72; }
+.page-heading, .section-title, .row-item { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.page-heading { margin-bottom: 1rem; }
+.page-heading h2, .section-title h3 { margin: 0; }
+.page-heading p, .muted, .row-item span, .payout-panel span { color: #aab6dc; }
+.billing-summary, .billing-layout { display: grid; gap: 1rem; }
+.billing-summary { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.billing-layout { grid-template-columns: minmax(0, 2fr) minmax(240px, 1fr); }
+.metric-card { display: grid; gap: 0.35rem; }
+.metric-card strong { font-size: 1.6rem; }
+.eyebrow { color: #9db4ff; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.list { display: grid; gap: 0.75rem; margin-top: 1rem; }
+.row-item { border-top: 1px solid #2a3765; padding-top: 0.75rem; }
+.row-item:first-child { border-top: 0; padding-top: 0; }
+.row-item > div, .payout-panel { display: grid; gap: 0.25rem; }
+.row-meta { min-width: 6rem; text-align: right; }
+.status-chip { border: 1px solid #3a4d82; border-radius: 999px; padding: 0.25rem 0.55rem; white-space: nowrap; }
+.status-paid { background: #123a2a; color: #8ff0bd; border-color: #1f7a53; }
+.status-pending { background: #3a3112; color: #f6d878; border-color: #8d7623; }
+.payout-panel { margin-top: 1rem; }
+
+@media (max-width: 720px) {
+  .page-heading, .section-title, .row-item { align-items: flex-start; flex-direction: column; }
+  .billing-layout { grid-template-columns: 1fr; }
+  .row-meta { text-align: left; }
+}


### PR DESCRIPTION
Fixes #3141

Replaces the `/billing` placeholder with a static but actionable billing dashboard using mock data only.

What changed:
- adds available balance, pending invoice, and next payout summary metrics
- renders invoice rows with amount, due/payment state, and status chips
- adds payout method readiness with a next-action control
- adds recent transaction history with export/download actions
- keeps the change scoped to the billing page and shared page styles

Verification:
- `npm run build -w apps/web`
- `git diff --check`
- opened `http://localhost:3000/billing` and verified balance, payout method, and transaction history render

/claim #743