### PR TITLE
Keep review service records and ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,11 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
-  return review;
+  return { ...review };
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("review service keeps records and ids server-owned", async () => {
+  const initialReviews = await listReviews();
+  const initialCount = initialReviews.length;
+
+  const created = await createReview({
+    id: "rev_client_controlled",
+    jobId: "job_review_copy",
+    reviewerId: "usr_reviewer",
+    rating: 5,
+    comment: "The work was delivered cleanly"
+  });
+
+  assert.match(created.id, /^rev_\d+$/);
+  assert.notEqual(created.id, "rev_client_controlled");
+
+  created.comment = "mutated through returned create payload";
+
+  const listedReviews = await listReviews();
+  assert.equal(listedReviews.length, initialCount + 1);
+  assert.equal(listedReviews.at(-1).comment, "The work was delivered cleanly");
+
+  listedReviews.push({
+    id: "rev_client_injected",
+    jobId: "job_review_copy",
+    reviewerId: "usr_attacker",
+    rating: 1,
+    comment: "injected through list result"
+  });
+  listedReviews.at(-2).comment = "mutated through list result";
+
+  const reloadedReviews = await listReviews();
+  assert.equal(reloadedReviews.length, initialCount + 1);
+  assert.equal(reloadedReviews.at(-1).id, created.id);
+  assert.equal(reloadedReviews.at(-1).comment, "The work was delivered cleanly");
+  assert.equal(
+    reloadedReviews.some((review) => review.id === "rev_client_injected"),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- return defensive copies from `listReviews()` so callers cannot mutate the service-owned review array or stored records
- return a copy from `createReview()` instead of exposing the internally stored object reference
- keep review ids server-owned by applying the generated id after copying the payload
- update the API test script to target concrete test files and add regression coverage for returned-object/list mutation plus client-supplied ids

Fixes #3142

## Verification
- npm test -w apps/api
- git diff --check