### PR TITLE
Return defensive copies from review service

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,15 @@
 const reviews = [];
 
+function serializeReview(review) {
+  return { ...review };
+}
+
 export async function listReviews() {
-  return reviews;
+  return reviews.map(serializeReview);
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return serializeReview(review);
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("review service returns defensive copies of stored reviews", async () => {
+  const created = await createReview({
+    jobId: "job_1",
+    reviewerId: "client_1",
+    freelancerId: "freelancer_1",
+    rating: 5,
+    comment: "Excellent delivery.",
+  });
+
+  created.comment = "mutated returned review";
+
+  const firstList = await listReviews();
+  const storedReview = firstList.find((review) => review.id === created.id);
+
+  assert.equal(storedReview.comment, "Excellent delivery.");
+
+  firstList.push({ id: "rev_fake", comment: "injected" });
+  storedReview.comment = "mutated list review";
+
+  const secondList = await listReviews();
+  const preservedReview = secondList.find((review) => review.id === created.id);
+
+  assert.equal(secondList.some((review) => review.id === "rev_fake"), false);
+  assert.equal(preservedReview.comment, "Excellent delivery.");
+});


### PR DESCRIPTION
Fixes #3146

/claim #743

Summary:
- Return defensive copies from `listReviews()` so callers cannot mutate the service-owned review array or stored review objects.
- Return a defensive copy from `createReview()` so mutating the created-review response does not alter internal state.
- Add a focused regression test for both mutation paths.

Validation:
- `node --test apps\api\src\tests\*.test.js`
- `git diff --cached --check`

Note:
- `npm test -w apps/api` still fails on the existing `node --test src/tests` script in this runtime before discovering test files; I left that unrelated script issue out of scope for this focused #3146 fix.
