### PR TITLE
Return defensive copies from notification service

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,15 @@
 const notifications = [];
 
+function serializeNotification(notification) {
+  return { ...notification };
+}
+
 export async function listNotifications() {
-  return notifications;
+  return notifications.map(serializeNotification);
 }
 
 export async function createNotification(payload) {
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
-  return notification;
+  return serializeNotification(notification);
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("notification service returns defensive copies of stored notifications", async () => {
+  const created = await createNotification({
+    userId: "user_1",
+    message: "Proposal accepted.",
+  });
+
+  created.message = "mutated returned notification";
+
+  const firstList = await listNotifications();
+  const storedNotification = firstList.find((notification) => notification.id === created.id);
+
+  assert.equal(storedNotification.message, "Proposal accepted.");
+
+  firstList.push({ id: "ntf_fake", message: "injected" });
+  storedNotification.message = "mutated list notification";
+
+  const secondList = await listNotifications();
+  const preservedNotification = secondList.find((notification) => notification.id === created.id);
+
+  assert.equal(secondList.some((notification) => notification.id === "ntf_fake"), false);
+  assert.equal(preservedNotification.message, "Proposal accepted.");
+});


### PR DESCRIPTION
Fixes #3149

/claim #743

Summary:
- Return defensive copies from `listNotifications()` so callers cannot mutate the service-owned notification array or stored notification objects.
- Return a defensive copy from `createNotification()` so mutating the created-notification response does not alter internal state.
- Add a focused regression test for both mutation paths.

Validation:
- `node --test apps\api\src\tests\*.test.js`
- `git diff --cached --check`

Note:
- `npm test -w apps/api` still fails on the existing `node --test src/tests` script in this runtime before discovering test files; I left that unrelated script issue out of scope for this focused #3149 fix.
