### PR TITLE
Validate message bodies before creation

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Message body is required", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messages.test.js
+++ b/apps/api/src/tests/messages.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(testFn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await testFn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, payload) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/messages rejects missing message body", async () => {
+  await withServer(async (baseUrl) => {
+    const before = await (await fetch(`${baseUrl}/api/messages`)).json();
+    const response = await postJson(baseUrl, "/api/messages", {});
+    const payload = await response.json();
+    const after = await (await fetch(`${baseUrl}/api/messages`)).json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Message body is required" });
+    assert.deepEqual(after.data, before.data);
+  });
+});
+
+test("POST /api/messages rejects blank message body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/messages", {
+      threadId: "thread_blank",
+      senderId: "usr_client",
+      recipientId: "usr_freelancer",
+      body: "   "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Message body is required" });
+  });
+});
+
+test("POST /api/messages stores valid message bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/messages", {
+      threadId: "thread_valid",
+      senderId: "usr_client",
+      recipientId: "usr_freelancer",
+      body: "Can you send the milestone update?"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.body, "Can you send the milestone update?");
+    assert.match(payload.data.id, /^msg_/);
+    assert.ok(payload.data.sentAt);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  body: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Fixes #3152

Adds explicit validation for `POST /api/messages` so missing or blank message bodies return a 400 response instead of being stored in the in-memory message list.

What changed:
- adds `createMessageSchema` requiring `body` to be a non-empty string after trim
- uses `safeParse` in the message controller and returns `{ success: false, message: "Message body is required" }` with HTTP 400
- preserves valid message creation and passthrough metadata fields
- adds API coverage for missing body, blank body, and valid body creation

Verification:
- `node --test src/tests/*.test.js` from `apps/api`
- `git diff --check`

/claim #743