### PR TITLE
Keep proposal service records and ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,11 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("proposal service keeps records and ids server-owned", async () => {
+  const initialProposals = await listProposals();
+  const initialCount = initialProposals.length;
+
+  const created = await createProposal({
+    id: "prp_client_controlled",
+    jobId: "job_proposal_copy",
+    freelancerId: "usr_freelancer",
+    coverLetter: "I can deliver this project cleanly",
+    estimatedDuration: "3 days"
+  });
+
+  assert.match(created.id, /^prp_\d+$/);
+  assert.notEqual(created.id, "prp_client_controlled");
+
+  created.coverLetter = "mutated through returned create payload";
+
+  const listedProposals = await listProposals();
+  assert.equal(listedProposals.length, initialCount + 1);
+  assert.equal(listedProposals.at(-1).coverLetter, "I can deliver this project cleanly");
+
+  listedProposals.push({
+    id: "prp_client_injected",
+    jobId: "job_proposal_copy",
+    freelancerId: "usr_attacker",
+    coverLetter: "injected through list result",
+    estimatedDuration: "1 day"
+  });
+  listedProposals.at(-2).coverLetter = "mutated through list result";
+
+  const reloadedProposals = await listProposals();
+  assert.equal(reloadedProposals.length, initialCount + 1);
+  assert.equal(reloadedProposals.at(-1).id, created.id);
+  assert.equal(reloadedProposals.at(-1).coverLetter, "I can deliver this project cleanly");
+  assert.equal(
+    reloadedProposals.some((proposal) => proposal.id === "prp_client_injected"),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- return defensive copies from `listProposals()` so callers cannot mutate the service-owned proposal array or stored records
- return a copy from `createProposal()` instead of exposing the internally stored object reference
- keep proposal ids server-owned by applying the generated id after copying the payload
- update the API test script to target concrete test files and add regression coverage for returned-object/list mutation plus client-supplied ids

Fixes #3154

## Verification
- npm test -w apps/api
- git diff --check
