### PR TITLE
Keep job service records and lifecycle fields server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,11 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
-  return job;
+  return { ...job };
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("job service keeps records and lifecycle fields server-owned", async () => {
+  const initialJobs = await listJobs();
+  const initialCount = initialJobs.length;
+
+  const created = await createJob({
+    id: "job_client_controlled",
+    status: "closed",
+    title: "Server-owned lifecycle fields",
+    budgetMin: 30,
+    budgetMax: 60
+  });
+
+  assert.match(created.id, /^job_\d+$/);
+  assert.notEqual(created.id, "job_client_controlled");
+  assert.equal(created.status, "open");
+
+  created.title = "mutated through returned create payload";
+
+  const listedJobs = await listJobs();
+  assert.equal(listedJobs.length, initialCount + 1);
+  assert.equal(listedJobs.at(-1).title, "Server-owned lifecycle fields");
+
+  listedJobs.push({
+    id: "job_client_injected",
+    status: "open",
+    title: "injected through list result"
+  });
+  listedJobs.at(-2).title = "mutated through list result";
+
+  const reloadedJobs = await listJobs();
+  assert.equal(reloadedJobs.length, initialCount + 1);
+  assert.equal(reloadedJobs.at(-1).id, created.id);
+  assert.equal(reloadedJobs.at(-1).title, "Server-owned lifecycle fields");
+  assert.equal(
+    reloadedJobs.some((job) => job.id === "job_client_injected"),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- return defensive copies from `listJobs()` so callers cannot mutate the service-owned job array or stored records
- return a copy from `createJob()` instead of exposing the internally stored object reference
- keep job ids and initial lifecycle status server-owned by applying trusted fields after copying the payload
- update the API test script to target concrete test files and add regression coverage for returned-object/list mutation plus client-supplied `id` and `status` fields

Fixes #3158

## Verification
- npm test -w apps/api
- git diff --check
