### PR TITLE
Keep user service records and ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,11 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
-  return user;
+  return { ...user };
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("user service keeps records and ids server-owned", async () => {
+  const initialUsers = await listUsers();
+  const initialCount = initialUsers.length;
+
+  const created = await createUser({
+    id: "usr_client_controlled",
+    email: "server-owned-user@example.com",
+    fullName: "Server Owned User",
+    role: "client"
+  });
+
+  assert.match(created.id, /^usr_\d+$/);
+  assert.notEqual(created.id, "usr_client_controlled");
+
+  created.fullName = "mutated through returned create payload";
+
+  const listedUsers = await listUsers();
+  assert.equal(listedUsers.length, initialCount + 1);
+  assert.equal(listedUsers.at(-1).fullName, "Server Owned User");
+
+  listedUsers.push({
+    id: "usr_client_injected",
+    email: "injected@example.com",
+    fullName: "Injected User",
+    role: "admin"
+  });
+  listedUsers.at(-2).fullName = "mutated through list result";
+
+  const reloadedUsers = await listUsers();
+  assert.equal(reloadedUsers.length, initialCount + 1);
+  assert.equal(reloadedUsers.at(-1).id, created.id);
+  assert.equal(reloadedUsers.at(-1).fullName, "Server Owned User");
+  assert.equal(
+    reloadedUsers.some((user) => user.id === "usr_client_injected"),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- return defensive copies from `listUsers()` so callers cannot mutate the service-owned user array or stored records
- return a copy from `createUser()` instead of exposing the internally stored object reference
- keep user ids server-owned by applying the generated id after copying the payload
- update the API test script to target concrete test files and add regression coverage for returned-object/list mutation plus client-supplied ids

Fixes #3164

## Verification
- npm test -w apps/api
- git diff --check
