### PR TITLE
fix: rate limiter should count malformed JSON before body parsing (fixes #1735)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("rate limiter counts malformed JSON before body parsing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const addr = server.address();
+  const port = addr.port;
+  // On WSL the server binds to :: by default
+  const host = addr.family === "IPv6" ? `[::1]` : "127.0.0.1";
+  const base = `http://${host}:${port}`;
+
+  const opts = {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{invalid json!!}"
+  };
+
+  const r1 = await fetch(`${base}/api/auth/register`, opts);
+
+  // The rate limiter runs before express.json(), so malformed JSON
+  // is counted toward the quota. Check the ratelimit header shows
+  // it was counted (remaining < 200).
+  const ratelimit = r1.headers.get("ratelimit") ?? "";
+  const remaining = parseInt(ratelimit.match(/remaining=(\d+)/)?.[1] ?? "200", 10);
+  assert.ok(
+    remaining < 200,
+    `Expected remaining < 200, got ${remaining} — rate limiter not counting malformed JSON (header: "${ratelimit}")`
+  );
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## What

The global API rate limiter was registered **after** `express.json()` in `apps/api/src/app.js`. Malformed JSON requests were parsed (and rejected) by the body parser before the limiter could count them, allowing repeated invalid requests to consume parsing work without being counted toward the quota.

## Change

- Move `apiLimiter` middleware before `express.json()` so the rate limiter processes requests before body parsing
- Add a regression test that sends malformed JSON and asserts the `ratelimit` header shows a decremented quota

## Testing

- `node --test apps/api/src/tests/rateLimit.test.js` — passes, confirms the ratelimit header decrements when malformed JSON is sent
- Verified manually with curl: malformed JSON requests now show `remaining=199` in response headers

Closes #1735