### PR TITLE
fix: require authentication on upload endpoint (fixes #3169)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads rejects unauthenticated requests", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const addr = server.address();
+  const port = addr.port;
+  const host = addr.family === "IPv6" ? `[::1]` : "127.0.0.1";
+  const base = `http://${host}:${port}`;
+
+  // Request without auth header
+  const r = await fetch(`${base}/api/uploads`, { method: "POST" });
+  assert.equal(r.status, 401, "Expected 401 for unauthenticated upload request");
+
+  const body = await r.json();
+  assert.equal(body.message, "Unauthorized");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## What

The `POST /api/uploads` endpoint does not require authentication. Anyone can upload files without being logged in.

## Change

- Import `authMiddleware` in `uploadRoutes.js`
- Add `authMiddleware` as a route guard before `upload.single("file")`
- Add regression test confirming unauthenticated uploads receive 401

## Testing

- `node --test apps/api/src/tests/upload.test.js` — passes, confirms 401 for unauthenticated requests

Closes #3169