### PR TITLE
fix: validate refresh token before issuing new access token (fixes #3170)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,11 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  try {
+    const { token } = refreshSchema.parse(req.body);
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Refresh token is required", 400);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth/refresh rejects requests without a token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const addr = server.address();
+  const port = addr.port;
+  const host = addr.family === "IPv6" ? `[::1]` : "127.0.0.1";
+  const base = `http://${host}:${port}`;
+
+  const r1 = await fetch(`${base}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({})
+  });
+  assert.equal(r1.status, 400, "Expected 400 for missing token");
+
+  const body1 = await r1.json();
+  assert.equal(body1.success, false);
+
+  // With a valid token, it should succeed and preserve sub/role
+  const validToken = signAccessToken({ sub: "usr_test123", role: "freelancer" });
+  const r2 = await fetch(`${base}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token: validToken })
+  });
+  assert.equal(r2.status, 200, "Expected 200 for valid token");
+
+  const body2 = await r2.json();
+  assert.ok(body2.success);
+  assert.ok(body2.data?.token, "Should return a new token");
+
+  // Verify the new token has the same sub and role
+  const { verifyAccessToken } = await import("../utils/jwt.js");
+  const decoded = verifyAccessToken(body2.data.token);
+  assert.equal(decoded.sub, "usr_test123");
+  assert.equal(decoded.role, "freelancer");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1, "Refresh token is required")
+});


### PR DESCRIPTION
## What

`POST /api/auth/refresh` ignored the request body and minted a new access token for a hardcoded `usr_existing` user without validating any supplied token.

## Change

- Add `refreshSchema` (zod) requiring a `token` field in the request body
- Update `refresh()` controller to parse and validate the token with `refreshSchema`
- Update `refreshToken()` service to: verify the provided token via `verifyAccessToken()`, decode `sub` and `role`, issue a new access token preserving those claims
- Add regression test covering: missing token → 400, valid token → 200 with preserved sub/role

## Testing

- `node --test apps/api/src/tests/refresh.test.js` — passes
- Missing token: returns 400 with error message
- Valid token: returns 200 with new token, decoded sub/role match original

Closes #3170