### PR TITLE
Reject missing file uploads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects multipart requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const formData = new FormData();
+    formData.append("description", "no attached file");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads keeps success responses for real files", async () => {
+  await withServer(async (baseUrl) => {
+    const formData = new FormData();
+    formData.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- return a clear 400 response when `POST /api/uploads` receives a multipart request without a `file` field
- reserve the existing 201 success shape for requests that actually include `req.file`
- add route-level regression coverage for missing-file and real-file uploads
- update the API test script so `npm test -w apps/api` runs the test files directly

Fixes #3175

## Verification
- `npm test -w apps/api`
- `git diff --check`

Payment route if accepted: PayPal QR/link from contributor profile is available at https://www.paypal.com/qrcodes/p2pqrc/UZDHXLQWMWFPQ