### PR TITLE
Return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -39,6 +40,7 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use((req, res) => fail(res, "Not found", 404));
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+async function withServer(fn) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -11,14 +11,33 @@ test("GET /health returns ok payload", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+test("GET /health returns ok payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+test("unknown API routes return JSON 404 payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/not-a-real-route`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type"), /^application\/json\b/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
   });
 });


### PR DESCRIPTION
/claim #743

Closes #3179.
References #743.

## Summary
- Add a final Express fallback handler that returns the shared JSON API error shape for unknown routes.
- Keep existing valid routes such as `GET /health` working unchanged.
- Add route-level regression coverage for unmatched `/api/*` paths returning HTTP 404 JSON instead of Express HTML.

## Validation
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check`

## Manual demo
Before this fix, an unknown route such as `GET /api/not-a-real-route` fell through to Express's HTML 404 handler. After this fix, the regression test verifies the response is:

```json
{
  "success": false,
  "message": "Not found"
}
```

with HTTP `404` and `application/json` content type.

No secrets, production data, payout details, or private credentials are included.