### PR TITLE
Preserve server-owned message fields

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("sendMessage preserves server-owned id and sentAt fields", async () => {
+  const message = await sendMessage({
+    id: "msg_client_supplied",
+    threadId: "thread-123",
+    body: "Hello",
+    sentAt: "1999-01-01T00:00:00.000Z"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_client_supplied");
+  assert.notEqual(message.sentAt, "1999-01-01T00:00:00.000Z");
+  assert.equal(message.threadId, "thread-123");
+  assert.equal(message.body, "Hello");
+  assert.equal(Date.parse(message.sentAt) > 0, true);
+
+  const storedMessages = await listMessages();
+  assert.equal(storedMessages.at(-1), message);
+});


### PR DESCRIPTION
Closes #3188
/claim #743

## Summary
- ensure message creation always overwrites caller-supplied `id` with a server-generated `msg_*` id
- keep `sentAt` server-owned by writing it after the request payload
- add a focused service regression test for caller-supplied `id` and `sentAt`

## Validation
- `node --test apps/api/src/tests/messageService.test.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/tests/messageService.test.js`
- `git diff --check`

AI-assisted with Codex, manually reviewed. No secrets, credentials, private prompts, or wallet data are included.