### PR TITLE
Fix: Enforce authentication on upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,8 +2,11 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
+import { authMiddleware } from "../middleware/auth.js";
+
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const app = createApp();
+
+test("Upload endpoint authentication", async (t) => {
+  await t.test("Deny access without token", async () => {
+    const res = await request(app)
+      .post("/api/uploads")
+      .attach("file", Buffer.from("test content"), "test.txt");
+    assert.strictEqual(res.status, 401);
+  });
+
+  await t.test("Allow access with valid token", async () => {
+    const accessToken = signAccessToken({ id: "user_123", role: "client" });
+    
+    const res = await request(app)
+      .post("/api/uploads")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .attach("file", Buffer.from("test content"), "test.txt");
+    
+    // We expect it to pass authMiddleware. The controller might return 200 or something else if file upload logic fails (e.g., missing bucket), but it shouldn't be 401.
+    assert.notStrictEqual(res.status, 401);
+  });
+});

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -22,7 +22,9 @@ test("Upload endpoint authentication", async (t) => {
       .set("Authorization", `Bearer ${accessToken}`)
       .attach("file", Buffer.from("test content"), "test.txt");
     
-    // We expect it to pass authMiddleware. The controller might return 200 or something else if file upload logic fails (e.g., missing bucket), but it shouldn't be 401.
-    assert.notStrictEqual(res.status, 401);
+    // Assert strict success status and structure
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.success, true);
+    assert.strictEqual(res.body.data.filename, "test.txt");
   });
 });


### PR DESCRIPTION
Fixes #3192

This PR enforces authentication on the file upload endpoint.

**Changes:**
- Applied \uthMiddleware\ to the \/api/uploads\ route so that unauthenticated users can no longer upload files or abuse storage.
- Added integration tests to verify the authentication behavior for the upload endpoint.

💳 Payment Details:
- Method: USDC
- Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
- Network: Base