### PR TITLE
Fix: Enforce authentication on payment endpoint

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const app = createApp();
+
+test("Payment endpoint authentication", async (t) => {
+  await t.test("Deny access without token", async () => {
+    const res = await request(app)
+      .post("/api/payments")
+      .send({ amount: 100 });
+    assert.strictEqual(res.status, 401);
+  });
+
+  await t.test("Allow access with valid token", async () => {
+    const accessToken = signAccessToken({ id: "user_123", role: "client" });
+    
+    const res = await request(app)
+      .post("/api/payments")
+      .set("Authorization", `Bearer ${accessToken}`)
+      .send({ amount: 100 });
+    
+    // We expect it to pass authMiddleware. The controller might return something else if payment logic fails, but it shouldn't be 401.
+    assert.notStrictEqual(res.status, 401);
+  });
+});

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -22,7 +22,9 @@ test("Payment endpoint authentication", async (t) => {
       .set("Authorization", `Bearer ${accessToken}`)
       .send({ amount: 100 });
     
-    // We expect it to pass authMiddleware. The controller might return something else if payment logic fails, but it shouldn't be 401.
-    assert.notStrictEqual(res.status, 401);
+    // Assert strict success status and structure
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.success, true);
+    assert.strictEqual(res.body.data.amount, 100);
   });
 });


### PR DESCRIPTION
Fixes #3194

This PR enforces authentication on the payment endpoint.

**Changes:**
- Applied \uthMiddleware\ to the \/api/payments\ route so that unauthenticated users can no longer access financial functions.
- Added integration tests to verify the authentication behavior for the payment endpoint.

💳 Payment Details:
- Method: USDC
- Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
- Network: Base