### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build marketplace UI",
+  description: "Create the first version of a marketplace interface.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "design",
+  skills: ["figma"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJobPayload);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(result.error.issues[0].message, "budgetMax must be greater than or equal to budgetMin");
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 750,
+    budgetMax: 250
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 750 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 750 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+function hasOrderedBudgetRange(data) {
+  return data.budgetMin === undefined ||
+    data.budgetMax === undefined ||
+    data.budgetMax >= data.budgetMin;
+}
+
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +17,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobFieldsSchema.refine(hasOrderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobFieldsSchema.partial().refine(hasOrderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- add shared budget range validation for job create and partial update payloads
- keep valid ordered ranges and single-field partial updates accepted
- make the API test script target test files explicitly so the suite runs cross-platform

## Tests
- npm test

Closes #3196
Related to #743

/claim #3196