### PR TITLE
Validate and limit search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,37 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+const SEARCH_QUERY_PATTERN = /^[a-zA-Z0-9\s._-]*$/;
+
+function normalizeSearchQuery(value) {
+  if (value === undefined) {
+    return { query: "" };
+  }
+
+  if (typeof value !== "string") {
+    return { error: "Search query must be a single string" };
+  }
+
+  const query = value.trim();
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return { error: `Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer` };
+  }
+
+  if (!SEARCH_QUERY_PATTERN.test(query)) {
+    return { error: "Search query contains unsupported characters" };
+  }
+
+  return { query };
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const normalized = normalizeSearchQuery(req.query.q);
+
+  if (normalized.error) {
+    return fail(res, normalized.error, 400);
+  }
+
+  return ok(res, await globalSearch(normalized.query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid query text", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20React-UI%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "React-UI");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=react&q=node`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.message, "Search query must be a single string");
+  });
+});
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.message, "Search query must be 200 characters or fewer");
+  });
+});
+
+test("GET /api/search rejects unsupported characters", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%3Cscript%3E`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.message, "Search query contains unsupported characters");
+  });
+});


### PR DESCRIPTION
## Summary
- validate `/api/search?q=` before passing it to the search service
- trim valid query strings and reject repeated/non-string values
- reject queries longer than 200 characters or containing unsupported characters
- make the API test script target test files explicitly so the suite runs cross-platform

## Tests
- npm test

Closes #3200
Related to #743

/claim #3200