### PR TITLE
Prevent admin self-registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,15 +2,36 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
+function validationFailed(res, error) {
+  return res.status(400).json({
+    success: false,
+    message: "Validation failed",
+    issues: error.issues.map((issue) => ({
+      path: issue.path,
+      message: issue.message
+    }))
+  });
+}
+
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return validationFailed(res, parsed.error);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
+  const parsed = loginSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return validationFailed(res, parsed.error);
+  }
+
+  const result = await loginUser(parsed.data);
   return ok(res, result);
 }
 

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRegister(baseUrl, body) {
+  return fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register defaults public users to client role", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "client");
+  });
+});
+
+test("POST /api/auth/register allows freelancer self-service role", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.issues[0].path[0], "role");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
+const selfServiceRoleSchema = z.enum(["client", "freelancer"]);
+
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: selfServiceRoleSchema.default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- remove `admin` from the public self-service registration role schema
- return explicit 400 validation responses for invalid auth payloads
- keep missing role defaulting to `client` and allow `freelancer`
- make the API test script target test files explicitly so the suite runs cross-platform

## Tests
- npm test

Closes #3204
Related to #743

/claim #3204