### PR TITLE
Validate refresh token requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,17 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshTokenSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
+
+function validationFailed(res, error) {
+  return res.status(400).json({
+    success: false,
+    message: "Validation failed",
+    issues: error.issues.map((issue) => ({
+      path: issue.path,
+      message: issue.message
+    }))
+  });
+}
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +33,19 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const parsed = refreshTokenSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return validationFailed(res, parsed.error);
+  }
+
+  try {
+    const result = await refreshToken(parsed.data.refreshToken);
+    return ok(res, result);
+  } catch {
+    return res.status(401).json({
+      success: false,
+      message: "Invalid refresh token"
+    });
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,13 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+
+  return {
+    token: signAccessToken({
+      sub: payload.sub,
+      role: payload.role ?? "client"
+    })
+  };
 }

--- a/apps/api/src/tests/refreshToken.test.js
+++ b/apps/api/src/tests/refreshToken.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing refresh token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/refresh`, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.issues[0].path[0], "refreshToken");
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refresh token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/refresh`, {
+      refreshToken: "not-a-valid-token"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Invalid refresh token");
+  });
+});
+
+test("POST /api/auth/refresh mints a token after verification succeeds", async () => {
+  await withTestServer(async (baseUrl) => {
+    const loginResponse = await postJson(`${baseUrl}/api/auth/login`, {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const loginPayload = await loginResponse.json();
+
+    const response = await postJson(`${baseUrl}/api/auth/refresh`, {
+      refreshToken: loginPayload.data.token
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(typeof payload.data.token, "string");
+    assert.ok(payload.data.token.length > 0);
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- require a `refreshToken` body field before issuing a new token
- verify the provided token and reuse its subject/role claims for the new access token
- return 400 for malformed refresh requests and 401 for invalid token values
- make the API test script target test files explicitly so the suite runs cross-platform

## Tests
- npm test

Closes #3206
Related to #743

/claim #3206