### PR TITLE
Fix settings page account controls

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,45 @@
+const settingsSections = [
+  {
+    title: "Account",
+    status: "Public profile active",
+    description: "Maya Chen is visible to clients searching for Next.js and TypeScript projects.",
+    action: "Review profile",
+  },
+  {
+    title: "Notifications",
+    status: "Digest enabled",
+    description: "Proposal updates, unread messages, and billing alerts are grouped into a daily summary.",
+    action: "Tune alerts",
+  },
+  {
+    title: "Security",
+    status: "Two-factor pending",
+    description: "Password login is active. Add an authenticator app before accepting large contracts.",
+    action: "Secure account",
+  },
+  {
+    title: "Payouts",
+    status: "Bank transfer ready",
+    description: "Default payout method is connected and invoice reminders are enabled.",
+    action: "Manage payouts",
+  },
+];
+
 export default function SettingsPage() {
   return (
     <section className="card">
       <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+      <p>Account preferences, profile visibility, security, and payout defaults.</p>
+      <div className="grid">
+        {settingsSections.map((section) => (
+          <article className="card" key={section.title}>
+            <h3>{section.title}</h3>
+            <strong>{section.status}</strong>
+            <p>{section.description}</p>
+            <button type="button">{section.action}</button>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

Closes #3208
Parent bounty: #743

Closes #3208

## Summary
- replace the placeholder settings page with a static account controls overview
- add account, notification, security, and payout sections with statuses and next actions
- keep the change scoped to `apps/web/app/settings/page.tsx`

## Tests
- Not run locally; static Next.js page change only