### PR TITLE
fix: render mock job detail for known IDs and fallback for unknown (issu

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,22 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { jobs } from '../../../lib/mock';
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((j: { id: string }) => j.id === id);
+
+  if (!job) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold">Job Not Found</h1>
+        <p>The job with ID &quot;{id}&quot; does not exist.</p>
+      </div>
+    );
+  }
+
   return (
-    <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
-    </section>
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold">{job.title}</h1>
+      <p className="text-lg text-gray-600">Budget: ${job.budget}</p>
+    </div>
   );
 }


### PR DESCRIPTION
创建 /jobs/[id] 页面，从 mock.ts 查找工作数据并渲染标题和预算，未知 ID 显示 fallback