### PR TITLE
Fix API test harness target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -4,7 +4,7 @@ import { createApp } from "../app.js";
 
 test("GET /health returns ok payload", async () => {
   const app = createApp();
-  const server = app.listen(0);
+  const server = app.listen(0, "127.0.0.1");
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);


### PR DESCRIPTION
/claim #743

Closes #3221

## Summary

Fixes the API test harness so `npm test` can actually discover and run the existing health test:

- changes the API workspace test script from the `src/tests` directory target to the concrete `src/tests/**/*.test.js` file pattern
- binds the health test's temporary Express server to `127.0.0.1` instead of every interface

## Demo Evidence

Before this change, `npm test` failed before discovering test files because Node tried to load `src/tests` as a module.

After this change:

```text
> test
> npm run test -w apps/api

> test
> node --test "src/tests/**/*.test.js"

✔ GET /health returns ok payload (54.690208ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

## Validation

- `node --check apps/api/src/tests/health.test.js`
- `git diff --check`
- `npm test`
