### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -7,6 +7,17 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/job-budget-range.test.js
+++ b/apps/api/src/tests/job-budget-range.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a marketing landing page.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "web",
+  skills: ["nextjs"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createJobSchema accepts ordered and equal budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJob).budgetMax, 1200);
+  assert.equal(
+    createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 500 }).budgetMax,
+    500
+  );
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 1200, budgetMax: 500 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema rejects inverted ranges only when both budget fields are present", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 1200 }), { budgetMin: 1200 });
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 500 }), { budgetMax: 500 });
+
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 1200, budgetMax: 500 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("POST /api/jobs returns 400 for inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...validJob, budgetMin: 1200, budgetMax: 500 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.deepEqual(payload.errors, [
+      {
+        path: "budgetMax",
+        message: "budgetMax must be greater than or equal to budgetMin"
+      }
+    ]);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,30 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+const jobFields = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: budgetRangeMessage
+    });
+  }
+}
+
+export const createJobSchema = z.object(jobFields).superRefine(validateBudgetRange);
+
+export const updateJobSchema = z.object(jobFields).partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary
- Reject `budgetMax < budgetMin` in `createJobSchema` and in `updateJobSchema` when both budget fields are present
- Return a stable 400 validation response from `POST /api/jobs` for inverted budget ranges
- Add focused schema and route regression tests, and point the API test script at the test files so the suite runs through `npm test -w apps/api`

/claim #2853

## Validation
- `npm test -w apps/api`
- `git diff --check`

No secrets or payout details are included.