### PR TITLE
Validate refresh token requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const parsed = refreshSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(parsed.data.token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function postRefresh(baseUrl, body) {
+  return fetch(`${baseUrl}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects blank token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, { token: "   " });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, { token: "not-a-jwt" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh mints replacement token for verified token", async () => {
+  await withServer(async (baseUrl) => {
+    const refreshToken = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+    const response = await postRefresh(baseUrl, { token: refreshToken });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.token, "string");
+
+    const verified = verifyAccessToken(payload.data.token);
+    assert.equal(verified.sub, "usr_refresh");
+    assert.equal(verified.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/refresh rejects expired verified-shape token", async () => {
+  await withServer(async (baseUrl) => {
+    const expiredToken = jwt.sign(
+      { sub: "usr_expired", role: "client", exp: Math.floor(Date.now() / 1000) - 60 },
+      env.jwtSecret
+    );
+    const response = await postRefresh(baseUrl, { token: expiredToken });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary
- require `POST /api/auth/refresh` callers to submit a non-empty token
- verify the submitted token before minting a replacement access token
- return 400 for missing/blank refresh payloads and 401 for invalid or expired tokens
- make the API test script target test files so `npm test -w apps/api` runs the suite

/claim #3229

## Validation
- `npm test -w apps/api`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

No secrets or payout details are included.