### PR TITLE
fix: preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload ?? {};
+  const notification = {
+    ...safePayload,
+    id: `ntf_${Date.now()}`,
+    read: false
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notifications.test.js
+++ b/apps/api/src/tests/notifications.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/notifications ignores caller-supplied id and read state", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      id: "user-controlled-id",
+      read: true,
+      title: "System alert",
+      message: "Hello"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.title, "System alert");
+  assert.equal(payload.data.message, "Hello");
+  assert.equal(payload.data.read, false);
+  assert.match(payload.data.id, /^ntf_\d+$/);
+  assert.notEqual(payload.data.id, "user-controlled-id");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #2762

## Summary
- ignore caller-supplied `id` and `read` during notification creation
- always return a server-generated notification id
- add an API test covering the override attempt

## Verification
- `node --test apps/api/src/tests/*.test.js`

Note: the repository's existing `npm test` script currently points to `node --test src/tests`, which fails before these changes because Node expects explicit test files.