### PR TITLE
fix: require fullName in registration payload

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema requires a non-empty fullName", () => {
+  assert.throws(
+    () =>
+      registerSchema.parse({
+        fullName: "   ",
+        email: "user@example.com",
+        password: "password123",
+        role: "client"
+      }),
+    /String must contain at least 1 character/
+  );
+});
+
+test("registerUser returns fullName from validated payload", async () => {
+  const payload = registerSchema.parse({
+    fullName: "Anicca Test",
+    email: "user@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  const result = await registerUser(payload);
+
+  assert.equal(result.fullName, "Anicca Test");
+  assert.equal(result.email, "user@example.com");
+  assert.equal(result.role, "freelancer");
+  assert.ok(result.token);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary
- require non-empty `fullName` in the registration schema
- carry `fullName` through `registerUser()` so the returned payload matches the Prisma `User` model
- add auth tests covering schema validation and register payload behavior

## Verification
- `node --test apps/api/src/tests/*.test.js`