### PR TITLE
Use shared success envelope for health route

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { ok } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -24,7 +25,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+    return ok(res, { service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+test("GET /health returns shared success payload", async () => {
   const app = createApp();
   const server = app.listen(0);
 
@@ -16,7 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  assert.deepEqual(payload, { success: true, data: { service: "api" } });
 
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
/claim #743

## Summary
- route `GET /health` through the shared `ok()` response helper
- align the health regression test with the API success envelope

Fixes #3254
References #743

## Validation
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`