### PR TITLE
fix: require fullName during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test --test-force-exit src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,10 +2,14 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    return next(err);
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,14 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("registerSchema requires fullName", () => {
+  assert.throws(() =>
+    registerSchema.parse({
+      email: "new-client@example.com",
+      password: "password123"
+    })
+  );
+
+  assert.throws(() =>
+    registerSchema.parse({
+      fullName: "   ",
+      email: "new-client@example.com",
+      password: "password123"
+    })
+  );
+});
+
+test("registerSchema trims and keeps fullName", () => {
+  const payload = registerSchema.parse({
+    fullName: "  Ada Lovelace  ",
+    email: "ada@example.com",
+    password: "password123"
+  });
+
+  assert.equal(payload.fullName, "Ada Lovelace");
+  assert.equal(payload.role, "client");
+});
+
+test("registerUser returns fullName and a matching user id", async () => {
+  const result = await registerUser({
+    fullName: "Ada Lovelace",
+    email: "ada@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  assert.equal(result.fullName, "Ada Lovelace");
+  assert.equal(result.email, "ada@example.com");
+  assert.equal(result.role, "client");
+  assert.match(result.id, /^usr_/);
+  assert.equal(typeof result.token, "string");
+});
+
+test("POST /api/auth/register rejects requests without fullName", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "new-client@example.com",
+        password: "password123"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.issues[0].path[0], "fullName");
+  });
+});
+
+test("POST /api/auth/register includes fullName in the created user payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        fullName: "Ada Lovelace",
+        email: "ada@example.com",
+        password: "password123"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fullName, "Ada Lovelace");
+    assert.equal(payload.data.email, "ada@example.com");
+    assert.equal(payload.data.role, "client");
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Summary

- Require `fullName` in the registration schema to match the required `User.fullName` model field.
- Include `fullName` in the registration response payload and reuse the generated user id for the JWT subject.
- Return a 400 validation response for Zod validation errors during registration.
- Make the API test script target test files directly and force-exit after tests finish, avoiding lingering handles from app middleware.

## Tests

- `npm test`

Fixes #2770.
