### PR TITLE
Fix inverted budget validation and freelancer profile lookup

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,40 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+const budgetMin = z.number().nonnegative();
+const budgetMax = z.number().nonnegative();
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin,
+    budgetMax,
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMin <= data.budgetMax, {
+    message: "budgetMin must not exceed budgetMax",
+    path: ["budgetMin"]
+  });
+
+export const updateJobSchema = z
+  .object({
+    title: z.string().min(4).optional(),
+    description: z.string().min(10).optional(),
+    budgetMin: z.number().nonnegative().optional(),
+    budgetMax: z.number().nonnegative().optional(),
+    categoryId: z.string().min(1).optional(),
+    skills: z.array(z.string().min(1)).default([]).optional()
+  })
+  .refine(
+    (data) => {
+      if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+        return data.budgetMin <= data.budgetMax;
+      }
+      return true;
+    },
+    {
+      message: "budgetMin must not exceed budgetMax",
+      path: ["budgetMin"]
+    }
+  );

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer matches the username &quot;{params.username}&quot;.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Two targeted bug fixes:

### 1. Reject inverted job budget ranges (Fixes #2853)
- Added .refine() to createJobSchema ensuring udgetMin <= budgetMax
- Added matching validation to updateJobSchema when both fields are present
- Existing valid ordered ranges continue to parse without change

### 2. Freelancer profile resolves mock data by username (Fixes #2849)
- /freelancers/[username] now looks up matching entry from mock.ts
- Known usernames render skills and hourly rate
- Unknown usernames render a clear not-found fallback

## Files Changed
- pps/api/src/validators/job.js - budget range refinement
- pps/web/app/freelancers/[username]/page.tsx - mock profile resolution

## Creator-Only Exclusivity
I am the creator of these fixes and have not submitted them elsewhere.

/claim #2853
/claim #2849