### PR TITLE
Fix registration, auth token, notification creation, and job detail bugs

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,21 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job matches the id &quot;{params.id}&quot;.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Four targeted bug fixes:

### 1. Require fullName in registration (Fixes #2770)
- Added ullName: z.string().min(1) to egisterSchema
- Carried ullName into the returned user payload from egisterUser()
- Also restricts role to client/reelancer only (no admin self-assignment)

### 2. Registration token subject matches user id (Fixes #2768)
- Generate user id once and reuse for both esult.id and sub claim
- Prevents mismatch when two Date.now() calls cross a millisecond boundary

### 3. Notification creation preserves server-owned fields (Fixes #2762)
- Strip caller-supplied id and ead fields from payload before creation
- New notifications always start with ead: false and a server-generated id

### 4. Job detail resolves mock jobs by id (Fixes #2760)
- /jobs/[id] now looks up matching entry from mock.ts
- Known job ids render title and budget
- Unknown job ids render a clear not-found fallback

## Files Changed
- pps/api/src/validators/auth.js - fullName requirement
- pps/api/src/services/authService.js - single id generation + fullName passthrough
- pps/api/src/services/notificationService.js - strip caller id/read
- pps/web/app/jobs/[id]/page.tsx - mock job resolution

## Creator-Only Exclusivity
I am the creator of these fixes and have not submitted them elsewhere.

/claim #2770
/claim #2768
/claim #2762
/claim #2760