### PR TITLE
Fix workspace package entrypoints for @freelanceflow/ui and @freelanceflow/db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,20 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./Button": {
+      "types": "./src/Button.tsx",
+      "default": "./src/Button.tsx"
+    },
+    "./Card": {
+      "types": "./src/Card.tsx",
+      "default": "./src/Card.tsx"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Two package entrypoint fixes:

### 1. @freelanceflow/ui importable entrypoint (Fixes #2781)
- Added explicit main, 	ypes, and exports fields to package.json
- Sub-path exports for ./Button and ./Card components
- Workspace consumers can now resolve the package correctly

### 2. @freelanceflow/db importable entrypoint (Fixes #2775)
- Added explicit main, 	ypes, and exports fields to package.json
- Re-exports @prisma/client via a resolvable entrypoint
- Node package resolution can now find a valid root entry

## Files Changed
- packages/ui/package.json - entrypoint metadata
- packages/db/package.json - entrypoint metadata

## Creator-Only Exclusivity
I am the creator of these fixes and have not submitted them elsewhere.

/claim #2781
/claim #2775