### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build profile search",
+  description: "Create searchable freelancer profile listings.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "engineering",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts an ordered budget range", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects an inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema rejects inverted ranges only when both bounds are present", () => {
+  const inverted = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+  const partialMin = updateJobSchema.safeParse({ budgetMin: 500 });
+  const partialMax = updateJobSchema.safeParse({ budgetMax: 100 });
+
+  assert.equal(inverted.success, false);
+  assert.equal(inverted.error.issues[0].path.join("."), "budgetMax");
+  assert.equal(partialMin.success, true);
+  assert.equal(partialMax.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function validateBudgetRange(data, ctx) {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,8 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchemaBase.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchemaBase
+  .partial()
+  .superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary

- rejects `createJobSchema` payloads where `budgetMax < budgetMin`
- applies the same validation to partial updates when both bounds are present
- adds validator coverage for valid create payloads, invalid create payloads, and partial update behavior
- updates the API test script so `npm test` discovers the test files

Closes #2853.

## Validation

- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/job-validator.test.js`
- `python -m json.tool apps/api/package.json`
- `npm test`