### PR TITLE
Reject self-review submissions

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +6,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
+  if (req.body?.reviewerId === req.body?.revieweeId) {
+    return fail(res, "Reviewer and reviewee must be different users", 400);
+  }
+
   return ok(res, await createReview(req.body), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects self-reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_same",
+        revieweeId: "usr_same",
+        rating: 5,
+        comment: "self boost"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Reviewer and reviewee must be different users"
+    });
+  });
+});
+
+test("POST /api/reviews accepts different reviewer and reviewee ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 5,
+        comment: "great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.reviewerId, "usr_reviewer");
+    assert.equal(payload.data.revieweeId, "usr_reviewee");
+    assert.equal(payload.data.comment, "great work");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- reject `POST /api/reviews` requests where `reviewerId` and `revieweeId` are the same user
- return the shared JSON error shape for self-review attempts
- add regression coverage for rejected self-reviews and valid different-user reviews

Fixes #3279
References #743

## Validation
- `node --check apps/api/src/controllers/reviewController.js`
- `node --check apps/api/src/tests/review.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`