### PR TITLE
fix(api): keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-registration.test.js
+++ b/apps/api/src/tests/auth-registration.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the access token with the returned user id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1700000000000;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1700000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
﻿## What this fixes
- Generates the registration user id once and reuses it for the response and JWT subject.
- Keeps the returned user id and token subject in sync for issue #2768.

## Validation
- `node --test src/tests/*.js` passes locally.

## Why this is the right fix
- Narrow change in the registration/auth flow only.
- Adds focused regression coverage proving the decoded token subject matches the returned id.

## Value
- Avoids response/token drift with a very small, low-risk patch.
