### PR TITLE
Include status on payment intents

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "pending"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent includes an initial pending status", async () => {
+  const result = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(result.amount, 2500);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+  assert.equal(result.status, "pending");
+  assert.match(result.paymentId, /^pay_/);
+});
+
+test("createPaymentIntent preserves an explicit currency with pending status", async () => {
+  const result = await createPaymentIntent({ amount: 1000, currency: "eur" });
+
+  assert.equal(result.currency, "eur");
+  assert.equal(result.status, "pending");
+});


### PR DESCRIPTION
/claim #743

## Summary
- include `status: "pending"` in newly-created payment intent responses
- add focused service tests for the payment intent response shape

Fixes #3297
References #743

## Validation
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`