### PR TITLE
Preserve payment job ids

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
+    jobId: payload.jobId,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent preserves the target job id", async () => {
+  const payment = await createPaymentIntent({
+    amount: 250,
+    currency: "USD",
+    jobId: "job_123"
+  });
+
+  assert.equal(payment.jobId, "job_123");
+});


### PR DESCRIPTION
Closes #3301

## Summary
- Adds jobId to the payment intent response so clients can keep the stubbed Stripe intent associated with its job.
- Adds focused regression coverage for the behavior.

## Validation
- `node --test 'apps/api/src/tests/**/*.test.js' --test-reporter=spec -> 2 passed`
