### PR TITLE
Reject non-finite job budgets

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createJobSchema } from "../validators/job.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
 
 const validJob = {
   title: "Build search filters",
@@ -12,6 +12,23 @@ const validJob = {
 };
 
 test("createJobSchema rejects non-finite budget values", () => {
-  assert.equal(createJobSchema.safeParse({ ...validJob, budgetMin: Infinity }).success, false);
-  assert.equal(createJobSchema.safeParse({ ...validJob, budgetMax: Infinity }).success, false);
+  for (const value of [Infinity, -Infinity, NaN]) {
+    assert.equal(createJobSchema.safeParse({ ...validJob, budgetMin: value }).success, false);
+    assert.equal(createJobSchema.safeParse({ ...validJob, budgetMax: value }).success, false);
+  }
+});
+
+test("updateJobSchema rejects non-finite budget values", () => {
+  for (const value of [Infinity, -Infinity, NaN]) {
+    assert.equal(updateJobSchema.safeParse({ budgetMin: value }).success, false);
+    assert.equal(updateJobSchema.safeParse({ budgetMax: value }).success, false);
+  }
+});
+
+test("createJobSchema accepts finite nonnegative budget values", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.budgetMin, 100);
+  assert.equal(result.data.budgetMax, 500);
 });

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build search filters",
+  description: "Add search filters for client project discovery.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_web",
+  skills: ["node"]
+};
+
+test("createJobSchema rejects non-finite budget values", () => {
+  assert.equal(createJobSchema.safeParse({ ...validJob, budgetMin: Infinity }).success, false);
+  assert.equal(createJobSchema.safeParse({ ...validJob, budgetMax: Infinity }).success, false);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
Closes #3302

## Summary
- Requires job budget bounds to be finite as well as nonnegative.
- Adds focused regression coverage for the behavior.

## Validation
- `node --test 'apps/api/src/tests/**/*.test.js' --test-reporter=spec -> 2 passed`
