### PR TITLE
Add proposal creation timestamps

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createProposal } from "../services/proposalService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
 
 test("createProposal adds a server-side createdAt timestamp", async () => {
   const proposal = await createProposal({
@@ -9,7 +9,11 @@ test("createProposal adds a server-side createdAt timestamp", async () => {
     estDuration: "1 week",
     createdAt: "2000-01-01T00:00:00.000Z"
   });
+  const proposals = await listProposals();
+  const storedProposal = proposals.find((candidate) => candidate.id === proposal.id);
 
   assert.match(proposal.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.doesNotThrow(() => new Date(proposal.createdAt).toISOString());
   assert.notEqual(proposal.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(storedProposal.createdAt, proposal.createdAt);
 });

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal adds a server-side createdAt timestamp", async () => {
+  const proposal = await createProposal({
+    coverLetter: "I can deliver this project.",
+    bidAmount: 300,
+    estDuration: "1 week",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+
+  assert.match(proposal.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.notEqual(proposal.createdAt, "2000-01-01T00:00:00.000Z");
+});


### PR DESCRIPTION
Closes #3303

## Summary
- Adds a server-generated ISO createdAt timestamp to proposal records.
- Adds focused regression coverage for the behavior.

## Validation
- `node --test 'apps/api/src/tests/**/*.test.js' --test-reporter=spec -> 2 passed`
