### PR TITLE
Add review creation timestamps

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: `rev_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createReview } from "../services/reviewService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
 
 test("createReview adds a server-side createdAt timestamp", async () => {
   const review = await createReview({
@@ -8,7 +8,11 @@ test("createReview adds a server-side createdAt timestamp", async () => {
     comment: "Great delivery.",
     createdAt: "2000-01-01T00:00:00.000Z"
   });
+  const reviews = await listReviews();
+  const storedReview = reviews.find((candidate) => candidate.id === review.id);
 
   assert.match(review.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.doesNotThrow(() => new Date(review.createdAt).toISOString());
   assert.notEqual(review.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(storedReview.createdAt, review.createdAt);
 });

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview adds a server-side createdAt timestamp", async () => {
+  const review = await createReview({
+    rating: 5,
+    comment: "Great delivery.",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+
+  assert.match(review.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.notEqual(review.createdAt, "2000-01-01T00:00:00.000Z");
+});


### PR DESCRIPTION
Closes #3304

## Summary
- Adds a server-generated ISO createdAt timestamp to review records.
- Adds focused regression coverage for the behavior.

## Validation
- `node --test 'apps/api/src/tests/**/*.test.js' --test-reporter=spec -> 2 passed`
