### PR TITLE
Add notification creation timestamps

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, createdAt: new Date().toISOString() };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createNotification } from "../services/notificationService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
 
 test("createNotification adds a server-side createdAt timestamp", async () => {
   const notification = await createNotification({
@@ -9,7 +9,11 @@ test("createNotification adds a server-side createdAt timestamp", async () => {
     body: "A freelancer sent a proposal.",
     createdAt: "2000-01-01T00:00:00.000Z"
   });
+  const notifications = await listNotifications();
+  const storedNotification = notifications.find((candidate) => candidate.id === notification.id);
 
   assert.match(notification.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.doesNotThrow(() => new Date(notification.createdAt).toISOString());
   assert.notEqual(notification.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(storedNotification.createdAt, notification.createdAt);
 });

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification adds a server-side createdAt timestamp", async () => {
+  const notification = await createNotification({
+    userId: "usr_123",
+    title: "Proposal update",
+    body: "A freelancer sent a proposal.",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+
+  assert.match(notification.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.notEqual(notification.createdAt, "2000-01-01T00:00:00.000Z");
+});


### PR DESCRIPTION
Closes #3305

## Summary
- Adds a server-generated ISO createdAt timestamp to notification records.
- Adds focused regression coverage for the behavior.

## Validation
- `node --test 'apps/api/src/tests/**/*.test.js' --test-reporter=spec -> 2 passed`
