### PR TITLE
fix: add user creation timestamps

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: `usr_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser adds a server-owned createdAt timestamp", async () => {
+  const beforeCreate = Date.now();
+  const user = await createUser({
+    email: "created-at-user@example.com",
+    fullName: "Created At User",
+    role: "client",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+  const afterCreate = Date.now();
+
+  assert.equal(typeof user.createdAt, "string");
+
+  const createdAtTime = Date.parse(user.createdAt);
+  assert.ok(Number.isFinite(createdAtTime));
+  assert.ok(createdAtTime >= beforeCreate);
+  assert.ok(createdAtTime <= afterCreate);
+  assert.notEqual(user.createdAt, "2000-01-01T00:00:00.000Z");
+
+  const users = await listUsers();
+  assert.equal(users.at(-1).createdAt, user.createdAt);
+});


### PR DESCRIPTION
/claim #743

Closes #3311

## Summary
- Add a server-owned ISO `createdAt` timestamp in `createUser` after caller payload fields are applied.
- Store and return the same timestamp for the in-memory user record.
- Add a focused regression test proving caller-supplied `createdAt` cannot override the server timestamp.

## Demo
Short demo GIF: https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3311/evidentled-user-createdat-demo.gif

![User createdAt demo](https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3311/evidentled-user-createdat-demo.gif)

Backup animated SVG artifact: https://gist.github.com/EvidentLed/0eca084d8b92b82ae149540e6f016e7f

## Verification
- Red check before the fix: `node --test apps/api/src/tests/userService.test.js` failed because the service accepted caller-supplied `createdAt`.
- `node --test apps/api/src/tests/userService.test.js` -> 1 pass, 0 fail.
- `node --test apps/api/src/tests/*.test.js` -> 2 pass, 0 fail.
- `git diff --check origin/main..HEAD` -> passed.
