### PR TITLE
[codex] add server-owned job creation timestamps

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, status: "open", ...payload, createdAt: new Date().toISOString() };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-created-at.test.js
+++ b/apps/api/src/tests/job-created-at.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob adds a server-owned ISO createdAt timestamp", async () => {
+  const callerTimestamp = "2000-01-01T00:00:00.000Z";
+  const beforeCreate = Date.now();
+
+  const job = await createJob({
+    title: "Build a search page",
+    description: "Create a searchable freelancer directory.",
+    budgetMin: 500,
+    budgetMax: 900,
+    categoryId: "cat_web",
+    skills: ["React"],
+    createdAt: callerTimestamp
+  });
+
+  const afterCreate = Date.now();
+  const createdAt = Date.parse(job.createdAt);
+
+  assert.notEqual(job.createdAt, callerTimestamp);
+  assert.equal(new Date(createdAt).toISOString(), job.createdAt);
+  assert.ok(createdAt >= beforeCreate);
+  assert.ok(createdAt <= afterCreate);
+
+  const storedJobs = await listJobs();
+  assert.equal(storedJobs.at(-1).createdAt, job.createdAt);
+});


### PR DESCRIPTION
## Summary
- add a server-owned ISO `createdAt` timestamp when jobs are created
- keep caller-supplied timestamps from overriding the generated value
- add focused service regression coverage for returned and stored timestamps

## Why
The Prisma `Job` model defines `createdAt`, but the in-memory `createJob` service omitted it. This left newly created records without creation metadata and allowed a caller-supplied `createdAt` value to flow through the payload spread.

## Demo
[Watch the short job timestamp demo](https://github.com/TheGreatAion/bug-bounty/releases/download/demo-3313/job-created-at-demo.mp4)

## Verification
- `node --test src/tests/health.test.js src/tests/job-created-at.test.js`
- `git diff --check`
- Demo MP4 decoded successfully with `ffmpeg -i job-created-at-demo.mp4 -f null -`

The repository-wide `npm test` command still fails before discovery because `node --test src/tests` treats the test directory as a module path. That inherited harness issue is already tracked separately in #2014.

Closes #3313

/claim #743
