### PR TITLE
fix: add payment intent creation timestamps

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    createdAt: new Date().toISOString()
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent adds a server-owned createdAt timestamp", async () => {
+  const beforeCreate = Date.now();
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: "usd",
+    jobId: "job_created_at",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+  const afterCreate = Date.now();
+
+  assert.equal(typeof intent.createdAt, "string");
+
+  const createdAtTime = Date.parse(intent.createdAt);
+  assert.ok(Number.isFinite(createdAtTime));
+  assert.ok(createdAtTime >= beforeCreate);
+  assert.ok(createdAtTime <= afterCreate);
+  assert.notEqual(intent.createdAt, "2000-01-01T00:00:00.000Z");
+});


### PR DESCRIPTION
/claim #743

Closes #3316

## Summary
- Add a server-owned ISO `createdAt` timestamp to `createPaymentIntent` responses.
- Keep the timestamp generated by the service, not by caller input.
- Add focused regression coverage for the timestamp response behavior.

## Demo
Short demo GIF: https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3316/evidentled-payment-createdat-demo.gif

![Payment createdAt demo](https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3316/evidentled-payment-createdat-demo.gif)

## Verification
- Red check before the fix: `node --test apps/api/src/tests/paymentService.test.js` failed because `intent.createdAt` was undefined.
- `node --test apps/api/src/tests/paymentService.test.js` -> 1 pass, 0 fail.
- `node --test apps/api/src/tests/*.test.js` -> 2 pass, 0 fail.
- `git diff --check origin/main..HEAD` -> passed.
