### PR TITLE
fix: use Prisma enum role casing for login token

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -14,7 +14,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "CLIENT" })
   };
 }
 

--- a/apps/api/src/tests/authLoginService.test.js
+++ b/apps/api/src/tests/authLoginService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("loginUser signs tokens with canonical client role casing", async () => {
+  const result = await loginUser({
+    email: "existing-client@example.com",
+    password: "correct-password"
+  });
+
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(claims.sub, "usr_existing");
+  assert.equal(claims.role, "CLIENT");
+});


### PR DESCRIPTION
/claim #743

Closes #3319

## Summary
- Update `loginUser` so the stubbed existing-client token uses the Prisma enum role spelling (`CLIENT`) instead of the lowercase API request-role string.
- Keep the change limited to the login-token role claim in the auth service stub.
- Scope note: current API request validation uses lowercase role strings; this PR evidence only covers the stubbed service-token casing described in scoped issue #3319.

## Demo
Short demo GIF: https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3319/evidentled-login-role-demo.gif

![Login role demo](https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3319/evidentled-login-role-demo.gif)

## Verification
- Red check before the fix: `node --test apps/api/src/tests/authLoginService.test.js` failed because the decoded role was `client`.
- `node --test apps/api/src/tests/authLoginService.test.js` -> 1 pass, 0 fail.
- `node --test apps/api/src/tests/*.test.js` -> 2 pass, 0 fail.
- `git diff --check origin/main..HEAD` -> passed.
