### PR TITLE
fix: use Prisma enum role casing for refresh token

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -19,5 +19,5 @@ export async function loginUser(payload) {
 }
 
 export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+  return { token: signAccessToken({ sub: "usr_existing", role: "CLIENT" }) };
 }

--- a/apps/api/src/tests/authRefreshService.test.js
+++ b/apps/api/src/tests/authRefreshService.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refreshToken } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("refreshToken signs tokens with canonical client role casing", async () => {
+  const result = await refreshToken();
+
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(claims.sub, "usr_existing");
+  assert.equal(claims.role, "CLIENT");
+});


### PR DESCRIPTION
/claim #743

Closes #3327

## Summary
- Update `refreshToken` so the stubbed existing-client token uses the Prisma enum role spelling (`CLIENT`) instead of the lowercase API request-role string.
- Keep the change limited to the refresh-token role claim in the auth service stub.
- Scope note: current API request validation uses lowercase role strings, and PR #3516 preserves the authenticated caller role; this PR evidence only covers the stubbed service-token casing described in scoped issue #3327.

## Demo
Short demo GIF: https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3327/evidentled-refresh-role-demo.gif

![Refresh role demo](https://raw.githubusercontent.com/EvidentLed/bug-bounty/codex/demo-assets-3327/evidentled-refresh-role-demo.gif)

## Verification
- Red check before the fix: `node --test apps/api/src/tests/authRefreshService.test.js` failed because the decoded role was `client`.
- `node --test apps/api/src/tests/authRefreshService.test.js` -> 1 pass, 0 fail.
- `node --test apps/api/src/tests/*.test.js` -> 2 pass, 0 fail.
- `git diff --check origin/main..HEAD` -> passed.
