### PR TITLE
fix(auth): sign refresh token with uppercase CLIENT UserRole casing

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -19,5 +19,5 @@ export async function loginUser(payload) {
 }
 
 export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+  return { token: signAccessToken({ sub: "usr_existing", role: "CLIENT" }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+test("POST /api/auth/refresh returns uppercase CLIENT role in token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(payload.data && payload.data.token, "Response should contain data.token");
+
+  const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+  assert.equal(decoded.role, "CLIENT", "Role claim in token must be uppercase 'CLIENT'");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #3335

This pull request updates the `refreshToken()` function in `authService.js` to sign the refreshed access token with the canonical uppercase `CLIENT` role claim instead of the lowercase `client` string. This aligns the JWT claims with the canonical `UserRole` enum values from the database domain schema.

We also added a native Node.js test in `apps/api/src/tests/auth.test.js` to verify the casing of the role claim in the refreshed token.