### PR TITLE
fix: keep new notifications unread on creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { read, ...notificationPayload } = payload;
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    ...notificationPayload,
+    read: false
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("createNotification keeps new notifications unread even if payload includes read", async () => {
+  const notification = await createNotification({
+    userId: "usr_notification_read_default",
+    type: "message",
+    message: "New proposal message",
+    read: true
+  });
+
+  assert.equal(notification.read, false);
+
+  const storedNotification = (await listNotifications()).find(
+    (item) => item.id === notification.id
+  );
+
+  assert.equal(storedNotification?.read, false);
+});


### PR DESCRIPTION
/claim #743

Closes #3334
References #743

## Summary
- prevent caller payloads from overriding the unread default during notification creation
- add a focused regression test proving `read: true` in the payload still returns and stores `read: false`

## Demo / verification
- Failing before the fix: `node --test src/tests/notification.test.js` produced `true !== false`
- `node --test src/tests/notification.test.js`
- `node --test src/tests/*.js`
- `git diff --check`

Note: `npm test -w apps/api` still fails in this Node 24 environment because the existing package script invokes `node --test src/tests` as a directory path; explicit test globs above pass with dependencies installed.

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.