### PR TITLE
Use canonical role casing for login tokens

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -14,7 +14,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "CLIENT" })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("loginUser signs tokens with canonical UserRole casing", async () => {
+  const result = await loginUser({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, "usr_existing");
+  assert.equal(decoded.role, "CLIENT");
+});


### PR DESCRIPTION
/claim #743

Closes #3338

## Summary

- Sign stubbed login access tokens with the canonical `CLIENT` role claim used by the Prisma `UserRole` enum.
- Add a focused service regression test that decodes the JWT and verifies the login token subject and role claim.

## Validation

- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authService.test.js`
- `node --test apps/api/src/tests/authService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Demo evidence: the focused Node test exercises the login flow, decodes the issued JWT, and verifies the canonical role claim.

AI assistance disclosure: this PR was prepared with Codex assistance and manually scoped to the login-token role casing issue.
