### PR TITLE
fix: expose @freelanceflow/ui runtime entrypoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2183,7 +2182,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     }
   }
 }

--- a/packages/ui/Button.d.ts
+++ b/packages/ui/Button.d.ts
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+export declare function Button(props: {
+  children: React.ReactNode;
+}): React.JSX.Element;

--- a/packages/ui/Button.js
+++ b/packages/ui/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/Card.d.ts
+++ b/packages/ui/Card.d.ts
@@ -1,0 +1,6 @@
+import * as React from "react";
+
+export declare function Card(props: {
+  title: string;
+  children: React.ReactNode;
+}): React.JSX.Element;

--- a/packages/ui/Card.js
+++ b/packages/ui/Card.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    {
+      style: {
+        border: "1px solid #ddd",
+        borderRadius: 8,
+        padding: "1rem"
+      }
+    },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,2 @@
+export { Button } from "./Button";
+export { Card } from "./Card";

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,2 @@
+export { Button } from "./Button.js";
+export { Card } from "./Card.js";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,27 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./Button": {
+      "types": "./Button.d.ts",
+      "import": "./Button.js",
+      "default": "./Button.js"
+    },
+    "./Card": {
+      "types": "./Card.d.ts",
+      "import": "./Card.js",
+      "default": "./Card.js"
+    }
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  }
 }


### PR DESCRIPTION
## Summary
- replace the TypeScript-only package entrypoint with real ESM JavaScript entrypoints
- add explicit exports for the root package plus Button/Card subpaths
- preserve consumer typings with declaration files and record the peer React dependency

## Verification
- npm install
- node --input-type=module -e "const mod = await import('@freelanceflow/ui'); console.log(Object.keys(mod).sort().join(','))"
- node --input-type=module -e "const { Button } = await import('@freelanceflow/ui/Button'); const { Card } = await import('@freelanceflow/ui/Card'); console.log(typeof Button, typeof Card)"
- npx tsc --noEmit packages/ui/index.d.ts packages/ui/Button.d.ts packages/ui/Card.d.ts

Closes #2781