### PR TITLE
Add server-owned timestamps to created reviews

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: `rev_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview uses a server-owned createdAt timestamp", async () => {
+  const staleTimestamp = "2000-01-01T00:00:00.000Z";
+
+  const result = await createReview({
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5,
+    comment: "Great work",
+    createdAt: staleTimestamp
+  });
+
+  assert.notEqual(result.createdAt, staleTimestamp);
+  assert.equal(new Date(result.createdAt).toISOString(), result.createdAt);
+});


### PR DESCRIPTION
/claim #743

Closes #3345

## Summary

- Populate a server-owned ISO `createdAt` timestamp when creating in-memory reviews.
- Add a focused regression test proving caller-supplied `createdAt` values do not control the created review timestamp.

## Validation

- `node --check apps/api/src/services/reviewService.js`
- `node --check apps/api/src/tests/reviewService.test.js`
- `node --test apps/api/src/tests/reviewService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Demo evidence: the focused Node test creates a review with a stale caller-supplied timestamp and verifies the service returns a fresh ISO timestamp.

AI assistance disclosure: this PR was prepared with Codex assistance and manually scoped to the review creation timestamp issue.
