### PR TITLE
Keep created notifications unread

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { read, ...notificationPayload } = payload ?? {};
+  const notification = { id: `ntf_${Date.now()}`, ...notificationPayload, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notifications.test.js
+++ b/apps/api/src/tests/notifications.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications ignores caller-supplied read state", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "user_1",
+        message: "New proposal received",
+        read: true
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.userId, "user_1");
+    assert.equal(payload.data.message, "New proposal received");
+    assert.equal(payload.data.read, false);
+  });
+});


### PR DESCRIPTION
/claim #3347

## Summary
- Ensure newly-created notifications always start with `read: false`.
- Ignore caller-supplied `read` values during notification creation.
- Add a focused API regression test for `POST /api/notifications` with `read: true`.

## Verification
- `npm ci`
- `npm test -w apps/api`
- `git diff --check`

## Payment
Method: USDC
Address: 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6
Network: Base

Fixes #3347
