### PR TITLE
fix(lhf-001): remove hardcoded JWT secret fallback

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.JWT_SECRET,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+// Enforce required secrets in production
+const REQUIRED_IN_PRODUCTION = ["JWT_SECRET", "DATABASE_URL"];
+if (env.nodeEnv === "production") {
+  const missing = REQUIRED_IN_PRODUCTION.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables in production: ${missing.join(", ")}. ` +
+      "Set these values before starting the server."
+    );
+  }
+}


### PR DESCRIPTION
## Fixes

🔴 **LHF-001: Hardcoded JWT secret fallback enables token forgery**

## What changed

- Removed `"development-secret"` default value for `JWT_SECRET`
- Added startup validation that crashes in production if secrets are missing

## Before/After

Before: `jwtSecret: process.env.JWT_SECRET ?? "development-secret"`
After: `jwtSecret: process.env.JWT_SECRET` + production guard

## Bounty Claim

/bounty $100
Wallet: TRON `TKaPPxtvKDfMJkset12MzEhrF9hwrtmMPi`

Closes #3356