### PR TITLE
fix(lhf-003): prevent self-registration as admin

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Fixes

🟠 **LHF-003: Registration schema allows self-assignment of admin role**

## What changed

Removed `"admin"` from `role` enum in `registerSchema`.

## Before/After

Before: `role: z.enum(["client", "freelancer", "admin"])`
After: `role: z.enum(["client", "freelancer"])`

## Bounty Claim

/bounty $100
Wallet: TRON `TKaPPxtvKDfMJkset12MzEhrF9hwrtmMPi`

Closes #3357