### PR TITLE
fix(lhf-004): add input validation to payment endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues.map(i => i.message).join("; "), 400);
+  }
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive("Amount must be positive").max(999999, "Amount too large"),
+  currency: z.enum(["usd", "eur", "gbp", "cny"]).default("usd"),
+  description: z.string().max(500).optional(),
+  metadata: z.record(z.string()).optional(),
+});


### PR DESCRIPTION
## Fixes

🟠 **LHF-004: Payment endpoint lacks input validation**

## What changed

- Added `validators/payment.js` with Zod schema
- Updated `paymentController.js` to validate before processing

## Validation

| Field | Rule |
|-------|------|
| amount | Required, positive, max 999999 |
| currency | usd/eur/gbp/cny, default usd |

## Bounty Claim

/bounty $100
Wallet: TRON `TKaPPxtvKDfMJkset12MzEhrF9hwrtmMPi`

Closes #3358