### PR TITLE
fix: redact production error logs

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,16 @@
+import { env } from "../config/env.js";
+
+function toProductionLogPayload(err) {
+  return {
+    name: err?.name ?? "Error",
+    status: err?.status ?? err?.statusCode ?? 500
+  };
+}
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  const logPayload = env.nodeEnv === "production" ? toProductionLogPayload(err) : err;
+  console.error("Unhandled API error:", logPayload);
+
   if (res.headersSent) {
     return next(err);
   }

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { env } from "../config/env.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("production error logs omit raw secret-bearing error messages", () => {
+  const originalNodeEnv = env.nodeEnv;
+  const originalConsoleError = console.error;
+  const calls = [];
+
+  env.nodeEnv = "production";
+  console.error = (...args) => calls.push(args);
+
+  try {
+    const res = createResponse();
+    const secret = "sk_live_hidden_token";
+    const err = new Error(`database auth failed for ${secret}`);
+
+    errorHandler(err, {}, res, () => assert.fail("next should not be called"));
+
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.body, {
+      success: false,
+      message: "Unexpected server error"
+    });
+
+    const serializedLogs = JSON.stringify(calls);
+    assert.equal(serializedLogs.includes(secret), false);
+    assert.equal(serializedLogs.includes("database auth failed"), false);
+    assert.match(serializedLogs, /"name":"Error"/);
+    assert.match(serializedLogs, /"status":500/);
+  } finally {
+    env.nodeEnv = originalNodeEnv;
+    console.error = originalConsoleError;
+  }
+});


### PR DESCRIPTION
## Summary
- sanitize production error-handler logs so raw error messages and stacks are not serialized to application logs
- keep verbose local/development logging behavior unchanged
- add a focused regression test proving a secret-looking error message is omitted while the public 500 response remains generic

## Demo
- Short demo video: https://files.catbox.moe/3lxhnf.mp4

## Verification
- `node --test apps/api/src/tests/errorHandler.test.js`
- `node --test apps/api/src/tests/*.test.js` -> 2 passed when run outside the sandbox because the existing health test opens a localhost listener
- `node --check apps/api/src/middleware/errorHandler.js`
- `node --check apps/api/src/tests/errorHandler.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` still fails because the existing package script invokes `node --test src/tests`, which Node treats as a missing module path in this checkout. I used the direct test file glob above to validate this patch.

Closes #3359
/claim #743
