### PR TITLE
fix: add Zod validation for payment endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive("Amount must be a positive number"),
+  currency: z.string().length(3).default("usd")
+});


### PR DESCRIPTION
## Summary
- Add Zod schema validation for payment request body before passing to payment service
- Prevents invalid or missing fields (e.g. negative amount, invalid currency) from reaching the service layer

## Changes
- New file `apps/api/src/validators/payment.js` with `createPaymentSchema` (amount: positive number, currency: 3-char string, defaults to "usd")
- Updated `apps/api/src/controllers/paymentController.js` to parse request body with the schema

## Testing
- Validates `amount` is a positive number
- Validates `currency` is a 3-character string (ISO 4217), defaults to "usd"
- Returns 400 with Zod error details on invalid input

Fixes #3358