### PR TITLE
fix: count malformed json requests in rate limiter

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("malformed JSON requests are counted by the global API limiter", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const originalConsoleError = console.error;
+
+  try {
+    console.error = () => {};
+
+    const { port } = server.address();
+    let response;
+
+    for (let index = 0; index < 201; index += 1) {
+      response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{"
+      });
+    }
+
+    assert.equal(response.status, 429);
+  } finally {
+    console.error = originalConsoleError;
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Move the global API rate limiter before JSON body parsing so malformed JSON requests are counted before parser errors short-circuit the stack.
- Add a focused regression test proving repeated malformed JSON requests eventually receive HTTP 429.

Closes #3365
/claim #743

## Validation
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/rateLimit.test.js`
- `node --test apps/api/src/tests/rateLimit.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/rateLimit.test.js`
- `git diff --check`

## Demo Video
- https://github.com/vicentsmith470-web/bug-bounty/releases/download/demo-rate-limit-3365/rate-limit-3365-demo.mp4

The regression test exercises the API over a real ephemeral HTTP server: 201 malformed JSON `POST /api/jobs` requests from the same client, with the final response asserted as HTTP 429.