### PR TITLE
fix: resolve freelancer profiles from mock data by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer profile matches <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>Skills: {freelancer.skills.join(" · ")}</p>
+      <p>Rate: {freelancer.rate}</p>
     </section>
   );
 }

--- a/apps/web/lib/mock.test.js
+++ b/apps/web/lib/mock.test.js
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { freelancers } from "../lib/mock.ts";
+
+describe("freelancer mock lookup", () => {
+  it("resolves known freelancer by username", () => {
+    const result = freelancers.find((f) => f.username === "maya-dev");
+    assert.ok(result);
+    assert.strictEqual(result.username, "maya-dev");
+    assert.deepStrictEqual(result.skills, ["Next.js", "TypeScript"]);
+    assert.strictEqual(result.rate, "$65/hr");
+  });
+
+  it("resolves second known freelancer", () => {
+    const result = freelancers.find((f) => f.username === "jordan-ux");
+    assert.ok(result);
+    assert.strictEqual(result.username, "jordan-ux");
+    assert.deepStrictEqual(result.skills, ["Figma", "UX Research"]);
+    assert.strictEqual(result.rate, "$52/hr");
+  });
+
+  it("returns undefined for unknown username", () => {
+    const result = freelancers.find((f) => f.username === "nonexistent");
+    assert.strictEqual(result, undefined);
+  });
+
+  it("returns undefined for empty string username", () => {
+    const result = freelancers.find((f) => f.username === "");
+    assert.strictEqual(result, undefined);
+  });
+});


### PR DESCRIPTION
## Problem

The `/freelancers/[username]` route renders placeholder text with the requested username instead of looking up the selected freelancer from `apps/web/lib/mock.ts`. Search cards link to `/freelancers/maya-dev` and `/freelancers/jordan-ux`, but the profile page does not show matching skills or hourly rate. Unknown usernames also appear successful.

## Solution

- FreelancerProfilePage now looks up freelancers from `mock.ts` by username
- Known usernames render the matching skills and hourly rate
- Unknown usernames render a clear "Freelancer Not Found" fallback
- Added 4 regression tests for mock lookup logic

## Test Results

All 4 tests pass (known usernames resolve correctly, unknown/empty usernames return undefined).

## Files Changed

- `apps/web/app/freelancers/[username]/page.tsx` — Import mock data, look up by username, render profile or not-found
- `apps/web/lib/mock.test.js` — New test file (4 tests)

Closes SecureBananaLabs/bug-bounty#2849