### PR TITLE
Use returned user id in registration token

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token for the returned user id", async () => {
+  const originalDateNow = Date.now;
+  const timestamps = [1_700_000_000_000, 1_700_000_000_001];
+
+  Date.now = () => timestamps.shift() ?? 1_700_000_000_002;
+
+  try {
+    const user = await registerUser({
+      email: "client@example.com",
+      role: "client"
+    });
+    const claims = verifyAccessToken(user.token);
+
+    assert.equal(user.id, "usr_1700000000000");
+    assert.equal(claims.sub, user.id);
+    assert.equal(claims.role, "client");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
/claim #3369

## Summary
- Generate the registration user id once and reuse it for the JWT subject claim.
- Add a focused service regression test that verifies the returned user id matches the token subject when time advances between calls.

## Verification
- API test suite passed.
- Whitespace diff check passed.

## Payment
Method: USDC
Address: 0xe87b4889baeee4ed60a1b2bfc7b3a6a17bce4ad6
Network: Base

Fixes #3369
