### PR TITLE
Protect server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/notifications ignores caller-supplied id and read state", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "attacker-controlled-id",
+        read: true,
+        title: "Build failed",
+        message: "CI needs attention"
+      })
+    });
+    const payload = await response.json();
+    const notification = payload.data;
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(notification.title, "Build failed");
+    assert.equal(notification.message, "CI needs attention");
+    assert.notEqual(notification.id, "attacker-controlled-id");
+    assert.match(notification.id, /^ntf_/);
+    assert.equal(notification.read, false);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
Fixes #2762

Summary:
- prevent caller-supplied `id` and `read` fields from overriding server-owned notification state during creation
- add a route-level regression test for `POST /api/notifications`

Tests:
- `node --test src/tests/health.test.js src/tests/notification.test.js`

Note:
- the existing `npm test` script currently points to `node --test src/tests`, which fails on this environment before individual tests run.