### PR TITLE
Resolve job detail pages from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,25 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((entry) => entry.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job matches <strong>{params.id}</strong>.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Job ID:</strong> {job.id}</p>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Open this listing to review scope, milestones, and incoming proposals.</p>
     </section>
   );
 }


### PR DESCRIPTION
Fixes #2760

Summary:
- resolve `/jobs/[id]` against the shared mock jobs dataset
- show the matching title and budget for known job ids
- return a clear fallback when the requested job id does not exist

Tests:
- `npm run build` (in `apps/web`)