### PR TITLE
Resolve freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,25 @@
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((entry) => entry.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer matches <strong>{params.username}</strong>.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(" · ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p>Portfolio, reviews, and active proposals would be layered onto this profile view.</p>
     </section>
   );
 }


### PR DESCRIPTION
Fixes #2763

Summary:
- resolve `/freelancers/[username]` against the shared mock freelancers dataset
- show matching skills and hourly rate for known usernames
- return a clear fallback when the requested username does not exist

Tests:
- `npm run build` (in `apps/web`)