### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects blank content", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Authorization": `${"Bearer "}${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ recipientId: "usr_receiver", content: "   " })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid message payload" });
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().trim().min(1),
+  content: z.string().trim().min(1).max(2000)
+});


### PR DESCRIPTION
Closes #3389
/claim #3389

Summary:
- validate message creation payloads before sending
- reject blank message content with a 400 response
- add a route-level regression test for malformed message content

Validation:
- node --test apps/api/src/tests/messageValidation.test.js apps/api/src/tests/health.test.js
