### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects ratings outside 1 to 5", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Authorization": `${"Bearer "}${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        jobId: "job_123",
+        revieweeId: "usr_freelancer",
+        rating: 6,
+        comment: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid review payload" });
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  jobId: z.string().trim().min(1),
+  revieweeId: z.string().trim().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().max(2000).optional()
+});


### PR DESCRIPTION
Closes #3391
/claim #3391

Summary:
- validate review creation payloads before persistence
- reject out-of-range ratings with a 400 response
- add a regression test for invalid rating values

Validation:
- node --test apps/api/src/tests/reviewValidation.test.js apps/api/src/tests/health.test.js
