### PR TITLE
Closes #3395 - Rejects inverted job budget ranges during job validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin cannot be greater than budgetMax",
+  path: ["budgetMin"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
This PR adds a refine check to the createJobSchema validator in apps/api/src/validators/job.js to ensure that budgetMin is always less than or equal to budgetMax when creating a new job.

Changes:
 - Appended .refine(data => data.budgetMin <= data.budgetMax, ...) validation schema to createJobSchema.
 - Returned a descriptive validation error budgetMin cannot be greater than budgetMax pointing to the budgetMin path.

This resolves the issue where semantically invalid budget ranges (e.g. min > max) could be processed by the API.