### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a product launch.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "web",
+  skills: ["nextjs"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const parsed = createJobSchema.parse(validJob);
+
+  assert.equal(parsed.budgetMin, 500);
+  assert.equal(parsed.budgetMax, 1200);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 1200, budgetMax: 500 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 900, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema accepts partial budget updates", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 900 }), { budgetMin: 900 });
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 900 }), { budgetMax: 900 });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const orderedBudgetRange = (job) => job.budgetMax >= job.budgetMin;
+
+export const createJobSchema = jobSchemaBase.refine(orderedBudgetRange, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchemaBase.partial().refine((job) => {
+  if (job.budgetMin === undefined || job.budgetMax === undefined) {
+    return true;
+  }
+
+  return orderedBudgetRange(job);
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary

- Add budget range validation to `createJobSchema`.
- Add matching validation to `updateJobSchema` only when both budget fields are present.
- Add API validator tests for ordered, inverted, and partial budget update cases.

## Validation

- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/jobValidator.test.js`
- `node --test apps/api/src/tests/jobValidator.test.js` -> 4 passed
- `node --test apps/api/src/tests/*.test.js` -> 5 passed
- `git diff --check`

/claim #3400
