### PR TITLE
Prevents admin role self-assignment during public registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
his PR resolves a security vulnerability where unauthenticated callers could self-assign the admin role during public user registration.

Changes:
 - Updated the Zod registerSchema inside apps/api/src/validators/auth.js by removing the admin role from the allowed enum parameters.
- Restricted public registration roles to only client and freelancer (defaulting to client).

This ensures that administrative roles cannot be requested or self-assigned via the public auth API.