### PR TITLE
ecures the POST /api/auth/refresh endpoint with token validation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { z } from "zod";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,14 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  try {
+    const payload = refreshSchema.parse(req.body);
+    const result = await refreshToken(payload.token);
+    return ok(res, result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail(res, "Missing or invalid token in request body", 400);
+    }
+    return fail(res, error.message || "Invalid or expired token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,13 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  try {
+    const decoded = verifyAccessToken(token);
+    return {
+      token: signAccessToken({ sub: decoded.sub, role: decoded.role })
+    };
+  } catch (error) {
+    throw new Error("Invalid or expired refresh token");
+  }
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env.js";
+
+test("POST /api/auth/refresh regression test suite", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/auth/refresh`;
+
+  await t.test("Success: returns a fresh token with valid token", async () => {
+    const originalPayload = { sub: "usr_test_123", role: "freelancer" };
+    const validToken = signAccessToken(originalPayload);
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: validToken })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.token);
+
+    // Verify the new token holds the same sub and role
+    const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+    assert.equal(decoded.sub, originalPayload.sub);
+    assert.equal(decoded.role, originalPayload.role);
+  });
+
+  await t.test("Fail: returns 400 when token is missing in request body", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /missing or invalid/i);
+  });
+
+  await t.test("Fail: returns 401 when token is invalid", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "invalid-token-string" })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /invalid or expired/i);
+  });
+
+  await t.test("Fail: returns 401 when token is expired", async () => {
+    const expiredToken = jwt.sign({ sub: "usr_expired", role: "client" }, env.jwtSecret, { expiresIn: "-1s" });
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: expiredToken })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /invalid or expired/i);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1, "token is required")
+});


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the refresh token endpoint allowed unauthenticated
     clients to mint fresh tokens without providing credentials.

     Changes:
     1.  Zod Schema Validation: Added refreshSchema requiring the token field in apps/api/src/validators/auth.js.
     2.  Token Decryption and Claims Preservation:
         *   Updated authController.js to parse body payloads and pass the token to the auth service.
         *   Updated authService.js to run verifyAccessToken on the token, extracting the caller's original sub
     (User ID) and role.
         *   Returns a new token signed with the extracted claims.
     3.  Error Handling: Returns 400 Bad Request for missing tokens, and 401 Unauthorized for invalid/expired
     tokens.
     4.  Regression Tests: Added a comprehensive test suite apps/api/src/tests/authRefresh.test.js validating all 4
     scenarios.

     All tests ran and passed successfully in the local node test environment.