### PR TITLE
Enforces JWT authentication on file upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/uploads auth enforcement regression test suite", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/uploads`;
+
+  await t.test("Fail: returns 401 when request lacks authorization header", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST"
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unauthorized/i);
+  });
+
+  await t.test("Fail: returns 401 when authorization token is invalid", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer invalid-token-value"
+      }
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /invalid token/i);
+  });
+
+  await t.test("Success: allows upload (returns 201) when presenting a valid token", async () => {
+    const validToken = signAccessToken({ sub: "usr_test_uploader", role: "client" });
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${validToken}`
+      }
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.status, "no-file"); // MULTER processes okay, no file sent
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
This PR resolves a security vulnerability where unauthenticated callers could upload files to the POST/api/uploads endpoint, causing storage exhaustion risk.

Changes:
 - Imported and applied the authMiddleware before the multer handler in apps/api/src/routes/uploadRoutes.js.
 - Restricts file uploads only to authenticated callers presenting a valid token.
 - Adds comprehensive regression tests in apps/api/src/tests/uploadAuth.test.js validating authentication block and success paths.

All tests ran and passed successfully in the local node test environment.