### PR TITLE
Enforces JWT authentication on job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobAuth.test.js
+++ b/apps/api/src/tests/jobAuth.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/jobs auth enforcement regression test suite", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/jobs`;
+
+  await t.test("Fail: returns 401 when request lacks authorization header", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Senior Backend Developer",
+        description: "Must have 5 years Node.js experience.",
+        budgetMin: 50,
+        budgetMax: 100,
+        categoryId: "cat_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unauthorized/i);
+  });
+
+  await t.test("Success: allows job creation when presenting a valid token", async () => {
+    const validToken = signAccessToken({ sub: "usr_test_employer", role: "client" });
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${validToken}`
+      },
+      body: JSON.stringify({
+        title: "Senior Backend Developer",
+        description: "Must have 5 years Node.js experience.",
+        budgetMin: 50,
+        budgetMax: 100,
+        categoryId: "cat_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, "Senior Backend Developer");
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
 This PR resolves a security vulnerability where unauthenticated callers could create new job listings via the POST /api/jobs endpoint, posing a spam risk to the platform.

Changes:
     - Imported and applied the authMiddleware before the postJob handler in apps/api/src/routes/jobRoutes.js.
     - Restricts job creation only to authenticated callers presenting a valid token.
     - Adds comprehensive regression tests in apps/api/src/tests/jobAuth.test.js validating authentication block
     and success paths.

All tests ran and passed successfully in the local node test environment.