### PR TITLE
Enforces input validation and rating boundaries on review creation

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,21 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
+import { z } from "zod";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  try {
+    const payload = createReviewSchema.parse(req.body);
+    const result = await createReview(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail(res, "Invalid review payload: " + error.errors[0].message, 400);
+    }
+    return fail(res, "Invalid review payload", 400);
+  }
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/reviews input validation regression test suite", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/reviews`;
+
+  await t.test("Success: accepts a valid review payload", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Excellent service!",
+        reviewerId: "usr_client_1",
+        revieweeId: "usr_freelancer_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+  });
+
+  await t.test("Fail: rejects rating below 1", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 0,
+        comment: "Bad service",
+        reviewerId: "usr_client_1",
+        revieweeId: "usr_freelancer_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /greater than or equal to 1/i);
+  });
+
+  await t.test("Fail: rejects rating above 5", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 6,
+        comment: "Superb!",
+        reviewerId: "usr_client_1",
+        revieweeId: "usr_freelancer_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /less than or equal to 5/i);
+  });
+
+  await t.test("Fail: rejects empty comment", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 4,
+        comment: "",
+        reviewerId: "usr_client_1",
+        revieweeId: "usr_freelancer_1"
+      })
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1),
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});


### PR DESCRIPTION
This PR resolves a security and data integrity issue where the /api/reviews endpoint accepted invalid ratings (e.g. 0 or 6) and blank comments due to a lack of request schema validation.

Changes:
     - Created createReviewSchema using Zod inside apps/api/src/validators/review.js enforcing rating as an integer between 1 and 5, and requiring comment, reviewerId, and revieweeId as non-empty strings.
     - Updated apps/api/src/controllers/reviewController.js to parse request body against the schema and return 400 Bad Request on validation failures.
     - Added comprehensive regression tests in apps/api/src/tests/reviewValidation.test.js.
 All tests ran and passed successfully in the local node test environment.