### PR TITLE
Bound upload route inputs

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,48 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+const ALLOWED_UPLOAD_TYPES = new Set([
+  "application/pdf",
+  "image/gif",
+  "image/jpeg",
+  "image/png"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_UPLOAD_BYTES },
+  fileFilter(req, file, callback) {
+    if (ALLOWED_UPLOAD_TYPES.has(file.mimetype)) {
+      return callback(null, true);
+    }
+
+    const error = new Error("Unsupported file type");
+    error.code = "UNSUPPORTED_FILE_TYPE";
+    return callback(error);
+  }
+});
+
+function uploadSingleFile(req, res, next) {
+  return upload.single("file")(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File exceeds 5 MB upload limit", 413);
+    }
+
+    if (error.code === "UNSUPPORTED_FILE_TYPE") {
+      return fail(res, "Unsupported file type", 400);
+    }
+
+    return next(error);
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", uploadSingleFile, uploadFile);

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function fileForm(name, type, content) {
+  const form = new FormData();
+  form.set("file", new Blob([content], { type }), name);
+  return form;
+}
+
+test("POST /api/uploads accepts allowlisted file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: fileForm("demo.png", "image/png", new Uint8Array([137, 80, 78, 71]))
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "demo.png",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: fileForm("script.sh", "text/x-shellscript", "echo unsafe")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects files over the memory limit", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedFile = new Uint8Array(5 * 1024 * 1024 + 1);
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: fileForm("large.png", "image/png", oversizedFile)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File exceeds 5 MB upload limit"
+    });
+  });
+});

--- a/demos/upload-limits-demo.svg
+++ b/demos/upload-limits-demo.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Upload route input limits demo</title>
+  <desc id="desc">Animated API demo showing allowed uploads, unsupported file type rejection, and oversized file rejection.</desc>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, Segoe UI, Arial, sans-serif;
+    }
+    .bg { fill: #f7f9fc; }
+    .panel { fill: #fff; stroke: #d7dee8; stroke-width: 2; rx: 8; }
+    .heading { fill: #162233; font-size: 30px; font-weight: 700; }
+    .subtle { fill: #607086; font-size: 17px; }
+    .label { fill: #26354a; font-size: 20px; font-weight: 700; }
+    .code { font-family: Consolas, "Courier New", monospace; fill: #142033; font-size: 18px; }
+    .ok { fill: #0f7b43; }
+    .bad { fill: #b2242f; }
+    .card { fill: #f3f6fb; stroke: #d7dee8; rx: 8; }
+    .bar { fill: #d9e2ef; }
+    .bar.ok { fill: #bfe9d1; }
+    .bar.bad { fill: #ffd3d7; }
+    .step { opacity: 0; animation: showStep 9s infinite; }
+    .step2 { animation-delay: 3s; }
+    .step3 { animation-delay: 6s; }
+    @keyframes showStep {
+      0%, 4% { opacity: 0; }
+      8%, 31% { opacity: 1; }
+      35%, 100% { opacity: 0; }
+    }
+  </style>
+  <rect class="bg" width="960" height="540"/>
+  <rect class="panel" x="48" y="40" width="864" height="460"/>
+  <text class="heading" x="86" y="92">POST /api/uploads input guard</text>
+  <text class="subtle" x="86" y="124">The upload route now accepts only JPEG, PNG, GIF, and PDF files up to 5 MB.</text>
+
+  <rect class="card" x="86" y="158" width="788" height="270"/>
+  <text class="label" x="122" y="206">Request</text>
+  <text class="label" x="560" y="206">Response</text>
+  <line x1="520" y1="182" x2="520" y2="404" stroke="#d7dee8" stroke-width="2"/>
+
+  <g class="step step1">
+    <rect class="bar ok" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">file: demo.png, image/png</text>
+    <rect class="bar ok" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code ok" x="584" y="270">201 uploaded</text>
+    <text class="subtle" x="122" y="345">Allowlisted image files pass through to the controller.</text>
+  </g>
+
+  <g class="step step2">
+    <rect class="bar bad" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">file: script.sh, text/x-shellscript</text>
+    <rect class="bar bad" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code bad" x="584" y="270">400 unsupported type</text>
+    <text class="subtle" x="122" y="345">The multer file filter rejects non-allowlisted MIME types.</text>
+  </g>
+
+  <g class="step step3">
+    <rect class="bar bad" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">file: large.png, 5 MB + 1 byte</text>
+    <rect class="bar bad" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code bad" x="584" y="270">413 too large</text>
+    <text class="subtle" x="122" y="345">The memory upload middleware enforces the 5 MB limit before storage.</text>
+  </g>
+
+  <rect x="86" y="448" width="788" height="1" fill="#d7dee8"/>
+  <text class="subtle" x="86" y="476">Validated by node --test apps/api/src/tests/uploadRoutes.test.js</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add a 5 MB file-size limit to the memory-backed upload middleware.
- Allow only JPEG, PNG, GIF, and PDF uploads.
- Return stable JSON API errors for unsupported file types and oversized files.
- Add focused upload route coverage for success, unsupported type rejection, and file-size rejection.

Fixes #3423
/claim #743

## Demo

Animated demo: https://raw.githubusercontent.com/cedar323/bug-bounty/e50c7c07166ea58af526999b6e637c5d0896e7d0/demos/upload-limits-demo.svg

## Validation

- `node --check apps/api/src/routes/uploadRoutes.js`
- `node --check apps/api/src/tests/uploadRoutes.test.js`
- `node --test apps/api/src/tests/uploadRoutes.test.js` (3 tests passed)
- `node --test apps/api/src/tests/*.test.js` (4 tests passed)
- `git diff --check`

## Notes

- `npm test -w apps/api` still fails on the existing script shape because it runs `node --test src/tests` as a directory entry on this Node version. The explicit test-file glob above passes.