### PR TITLE
Keep message records server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,15 @@
 const messages = [];
 
+function snapshotMessage(message) {
+  return { ...message };
+}
+
 export async function listMessages() {
-  return messages;
+  return messages.map(snapshotMessage);
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return snapshotMessage(message);
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps ids server-owned", async () => {
+  const message = await sendMessage({
+    id: "client_supplied_id",
+    body: "hello",
+    receiverId: "usr_id_override_receiver",
+    senderId: "usr_sender"
+  });
+
+  assert.notEqual(message.id, "client_supplied_id");
+  assert.match(message.id, /^msg_\d+$/);
+
+  const stored = (await listMessages()).find((item) => item.receiverId === "usr_id_override_receiver");
+  assert.equal(stored.id, message.id);
+  assert.notEqual(stored.id, "client_supplied_id");
+});
+
+test("sendMessage returns a snapshot instead of the stored record", async () => {
+  const message = await sendMessage({
+    body: "original",
+    receiverId: "usr_return_snapshot_receiver",
+    senderId: "usr_sender"
+  });
+
+  message.body = "mutated";
+
+  const stored = (await listMessages()).find((item) => item.receiverId === "usr_return_snapshot_receiver");
+  assert.equal(stored.body, "original");
+});
+
+test("listMessages returns defensive snapshots", async () => {
+  const message = await sendMessage({
+    body: "snapshot",
+    receiverId: "usr_list_snapshot_receiver",
+    senderId: "usr_sender"
+  });
+
+  const listed = await listMessages();
+  const originalLength = listed.length;
+  const listedMessage = listed.find((item) => item.receiverId === "usr_list_snapshot_receiver");
+
+  listedMessage.body = "mutated through listed object";
+  listed.length = 0;
+
+  const listedAgain = await listMessages();
+  const stored = listedAgain.find((item) => item.receiverId === "usr_list_snapshot_receiver");
+
+  assert.equal(listedAgain.length, originalLength);
+  assert.equal(stored.body, "snapshot");
+});

--- a/demos/message-owned-records-demo.svg
+++ b/demos/message-owned-records-demo.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Server-owned message records demo</title>
+  <desc id="desc">Animated service demo showing that message ids are server-owned and returned records are defensive snapshots.</desc>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, Segoe UI, Arial, sans-serif;
+    }
+    .bg { fill: #f8faf8; }
+    .panel { fill: #fff; stroke: #d9e2d7; stroke-width: 2; rx: 8; }
+    .heading { fill: #17251d; font-size: 30px; font-weight: 700; }
+    .subtle { fill: #607466; font-size: 17px; }
+    .label { fill: #24372b; font-size: 20px; font-weight: 700; }
+    .code { font-family: Consolas, "Courier New", monospace; fill: #15261c; font-size: 18px; }
+    .ok { fill: #157347; }
+    .warn { fill: #9a4f00; }
+    .card { fill: #f2f7f1; stroke: #d9e2d7; rx: 8; }
+    .bar { fill: #dde9db; rx: 7; }
+    .server { fill: #c9efd8; }
+    .client { fill: #ffe0bd; }
+    .step { opacity: 0; animation: showStep 9s infinite; }
+    .step2 { animation-delay: 3s; }
+    .step3 { animation-delay: 6s; }
+    @keyframes showStep {
+      0%, 4% { opacity: 0; }
+      8%, 31% { opacity: 1; }
+      35%, 100% { opacity: 0; }
+    }
+  </style>
+  <rect class="bg" width="960" height="540"/>
+  <rect class="panel" x="48" y="40" width="864" height="460"/>
+  <text class="heading" x="86" y="92">Message records stay server-owned</text>
+  <text class="subtle" x="86" y="124">The service now protects generated ids and returns snapshots instead of live records.</text>
+
+  <rect class="card" x="86" y="158" width="788" height="270"/>
+  <text class="label" x="122" y="206">Caller input</text>
+  <text class="label" x="560" y="206">Stored result</text>
+  <line x1="520" y1="182" x2="520" y2="404" stroke="#d9e2d7" stroke-width="2"/>
+
+  <g class="step step1">
+    <rect class="bar client" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">id: client_supplied_id</text>
+    <rect class="bar server" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code ok" x="584" y="270">id: msg_...</text>
+    <text class="subtle" x="122" y="345">Generated id is applied after payload fields, so callers cannot override it.</text>
+  </g>
+
+  <g class="step step2">
+    <rect class="bar client" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">returned.body = "mutated"</text>
+    <rect class="bar server" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code ok" x="584" y="270">stored: "original"</text>
+    <text class="subtle" x="122" y="345">sendMessage returns a defensive copy, not the in-memory record.</text>
+  </g>
+
+  <g class="step step3">
+    <rect class="bar client" x="122" y="236" width="330" height="54" rx="7"/>
+    <text class="code" x="146" y="270">listed.length = 0</text>
+    <rect class="bar server" x="560" y="236" width="250" height="54" rx="7"/>
+    <text class="code ok" x="584" y="270">list unchanged</text>
+    <text class="subtle" x="122" y="345">listMessages returns snapshots so external mutation cannot corrupt storage.</text>
+  </g>
+
+  <rect x="86" y="448" width="788" height="1" fill="#d9e2d7"/>
+  <text class="subtle" x="86" y="476">Validated by node --test apps/api/src/tests/messageService.test.js</text>
+</svg>


### PR DESCRIPTION
## Summary

- Keep message ids server-owned by applying the generated id after caller payload fields.
- Return defensive snapshots from `sendMessage()` and `listMessages()` so callers cannot mutate the in-memory backing store.
- Add focused service tests for caller-supplied id override, returned-record mutation, and listed-record mutation.

Fixes #3426
/claim #743

## Demo

Animated demo: https://raw.githubusercontent.com/cedar323/bug-bounty/129d496bbd37bf60f3a5cd5d62f769df86b18048/demos/message-owned-records-demo.svg

## Validation

- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/tests/messageService.test.js`
- `node --test apps/api/src/tests/messageService.test.js` (3 tests passed)
- `node --test apps/api/src/tests/*.test.js` (4 tests passed)
- `git diff --check`

## Notes

- `npm test -w apps/api` still fails on the existing script shape because it runs `node --test src/tests` as a directory entry on this Node version. The explicit test-file glob above passes.