### PR TITLE
Fix freelancer profile route data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,27 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((profile) => profile.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>
+          No freelancer profile exists for <strong>{params.username}</strong>.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>
+        Profile: <strong>{freelancer.username}</strong>
+      </p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Hourly rate: {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #2763.

## Summary
- look up freelancer profiles from `apps/web/lib/mock.ts` using the requested username
- render the matching skills and hourly rate for known freelancer usernames
- show a clear not-found fallback for unknown usernames

## Verification
- npm.cmd install
- npm.cmd run build -w apps/web
- git diff --check