### PR TITLE
fix: keep review creation timestamp server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    id: `rev_${Date.now()}`,
+    ...payload,
+    createdAt: new Date().toISOString()
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createReview } from "../services/reviewService.js";
 
-test("createReview assigns a server-owned createdAt timestamp", async () => {
+test("createReview assigns a server-owned createdAt timestamp and preserves review payload", async () => {
   const callerTimestamp = "1999-01-01T00:00:00.000Z";
   const before = Date.now();
 
@@ -19,6 +19,32 @@ test("createReview assigns a server-owned createdAt timestamp", async () => {
   const createdAt = Date.parse(review.createdAt);
 
   assert.notEqual(review.createdAt, callerTimestamp);
+  assert.ok(Number.isFinite(createdAt));
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= after);
+  assert.equal(review.jobId, "job_123");
+  assert.equal(review.reviewerId, "usr_client");
+  assert.equal(review.revieweeId, "usr_freelancer");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great work");
+});
+
+test("createReview ignores future caller-supplied createdAt values", async () => {
+  const futureTimestamp = "2999-01-01T00:00:00.000Z";
+  const before = Date.now();
+
+  const review = await createReview({
+    jobId: "job_future",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 4,
+    createdAt: futureTimestamp
+  });
+
+  const after = Date.now();
+  const createdAt = Date.parse(review.createdAt);
+
+  assert.notEqual(review.createdAt, futureTimestamp);
   assert.ok(Number.isFinite(createdAt));
   assert.ok(createdAt >= before);
   assert.ok(createdAt <= after);

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview assigns a server-owned createdAt timestamp", async () => {
+  const callerTimestamp = "1999-01-01T00:00:00.000Z";
+  const before = Date.now();
+
+  const review = await createReview({
+    jobId: "job_123",
+    reviewerId: "usr_client",
+    revieweeId: "usr_freelancer",
+    rating: 5,
+    comment: "Great work",
+    createdAt: callerTimestamp
+  });
+
+  const after = Date.now();
+  const createdAt = Date.parse(review.createdAt);
+
+  assert.notEqual(review.createdAt, callerTimestamp);
+  assert.ok(Number.isFinite(createdAt));
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= after);
+});


### PR DESCRIPTION
## Summary
- keep review `createdAt` assigned by the service instead of trusting request payloads
- preserve submitted review fields
- add stronger regression coverage for both backdated and future caller-supplied timestamps

## Test Plan
- `node --test apps/api/src/tests/reviewService.test.js --test-name-pattern 'createdAt timestamp|future caller' --test-reporter=spec`
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`
- `git diff --check`

Closes #3450

/claim #743
