### PR TITLE
fix: validate review rating range

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,15 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const rating = Number(payload.rating);
+
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    const error = new Error("Review rating must be an integer from 1 to 5");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const review = { id: `rev_${Date.now()}`, ...payload, rating };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview rejects ratings outside the 1-5 range", async () => {
+  await assert.rejects(
+    () => createReview({ rating: 0, comment: "too low" }),
+    /integer from 1 to 5/
+  );
+
+  await assert.rejects(
+    () => createReview({ rating: 6, comment: "too high" }),
+    /integer from 1 to 5/
+  );
+});
+
+test("createReview accepts an in-range integer rating", async () => {
+  const review = await createReview({ rating: 5, comment: "solid work" });
+
+  assert.equal(review.rating, 5);
+  assert.match(review.id, /^rev_/);
+});


### PR DESCRIPTION
## Summary
- reject review ratings below 1 or above 5
- normalize accepted numeric ratings before storing them
- add regression coverage for invalid and valid ratings

## Test Plan
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`

Closes #3439

/claim #743
