### PR TITLE
fix: keep proposal ids server-owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -2,10 +2,31 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createProposal } from "../services/proposalService.js";
 
-test("createProposal keeps ids server-owned", async () => {
-  const proposal = await createProposal({ id: "prp_client", jobId: "job_1", coverLetter: "Hello" });
+test("createProposal keeps generated ids server-owned and preserves proposal payload", async () => {
+  const proposal = await createProposal({
+    id: "prp_client_supplied",
+    jobId: "job_1",
+    freelancerId: "usr_freelancer",
+    coverLetter: "Hello",
+    bidAmount: 250
+  });
 
-  assert.match(proposal.id, /^prp_/);
-  assert.notEqual(proposal.id, "prp_client");
+  assert.notEqual(proposal.id, "prp_client_supplied");
+  assert.match(proposal.id, /^prp_\d+$/);
   assert.equal(proposal.jobId, "job_1");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.coverLetter, "Hello");
+  assert.equal(proposal.bidAmount, 250);
+});
+
+test("createProposal stores the generated id, not a spoofed caller id", async () => {
+  const proposal = await createProposal({
+    id: "prp_spoofed_storage_key",
+    jobId: "job_2",
+    freelancerId: "usr_other",
+    coverLetter: "Second proposal"
+  });
+
+  assert.notEqual(proposal.id, "prp_spoofed_storage_key");
+  assert.match(proposal.id, /^prp_\d+$/);
 });

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps ids server-owned", async () => {
+  const proposal = await createProposal({ id: "prp_client", jobId: "job_1", coverLetter: "Hello" });
+
+  assert.match(proposal.id, /^prp_/);
+  assert.notEqual(proposal.id, "prp_client");
+  assert.equal(proposal.jobId, "job_1");
+});


### PR DESCRIPTION
## Summary
- prevent proposal creation payloads from overriding generated ids
- preserve submitted proposal fields
- add stronger regression coverage for returned/generated proposal id ownership

## Test Plan
- `node --test apps/api/src/tests/proposalService.test.js --test-name-pattern 'server-owned|spoofed caller id' --test-reporter=spec`
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`
- `git diff --check`

Closes #3442

/claim #743
