### PR TITLE
fix: keep new notifications unread

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification always starts unread with a server-owned id", async () => {
+  const notification = await createNotification({ id: "ntf_client", read: true, message: "New proposal" });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.notEqual(notification.id, "ntf_client");
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "New proposal");
+});

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -2,11 +2,29 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createNotification } from "../services/notificationService.js";
 
-test("createNotification always starts unread with a server-owned id", async () => {
-  const notification = await createNotification({ id: "ntf_client", read: true, message: "New proposal" });
+test("createNotification always starts unread with a server-owned id and preserves payload", async () => {
+  const notification = await createNotification({
+    id: "ntf_client_supplied",
+    read: true,
+    userId: "usr_1",
+    message: "New proposal",
+    type: "proposal"
+  });
 
-  assert.match(notification.id, /^ntf_/);
-  assert.notEqual(notification.id, "ntf_client");
+  assert.notEqual(notification.id, "ntf_client_supplied");
+  assert.match(notification.id, /^ntf_\d+$/);
   assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_1");
   assert.equal(notification.message, "New proposal");
+  assert.equal(notification.type, "proposal");
+});
+
+test("createNotification ignores attempts to create already-read notifications", async () => {
+  const notification = await createNotification({
+    read: true,
+    message: "Security alert"
+  });
+
+  assert.equal(notification.read, false);
+  assert.match(notification.id, /^ntf_\d+$/);
 });


### PR DESCRIPTION
## Summary
- prevent clients from creating already-read notifications
- keep notification ids generated by the service
- add stronger regression coverage for server-owned `id`/`read` while preserving normal notification payload fields

## Test Plan
- `node --test apps/api/src/tests/notificationService.test.js --test-name-pattern 'starts unread|already-read' --test-reporter=spec`
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`
- `git diff --check`

Closes #3444

/claim #743
