### PR TITLE
fix: keep job creation fields server-owned

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -2,17 +2,35 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createJob } from "../services/jobService.js";
 
-test("createJob keeps id and initial status server-owned", async () => {
+test("createJob keeps id and initial status server-owned while preserving job payload", async () => {
   const job = await createJob({
-    id: "job_client",
+    id: "job_client_supplied",
     status: "closed",
     title: "Build landing page",
+    description: "Marketing site",
     budgetMin: 100,
     budgetMax: 200
   });
 
-  assert.match(job.id, /^job_/);
-  assert.notEqual(job.id, "job_client");
+  assert.notEqual(job.id, "job_client_supplied");
+  assert.match(job.id, /^job_\d+$/);
   assert.equal(job.status, "open");
   assert.equal(job.title, "Build landing page");
+  assert.equal(job.description, "Marketing site");
+  assert.equal(job.budgetMin, 100);
+  assert.equal(job.budgetMax, 200);
+});
+
+test("createJob stores a generated open job even when the payload tries to override controlled fields", async () => {
+  const job = await createJob({
+    id: "job_spoofed_storage_key",
+    status: "archived",
+    title: "API hardening",
+    budgetMin: 300,
+    budgetMax: 500
+  });
+
+  assert.notEqual(job.id, "job_spoofed_storage_key");
+  assert.match(job.id, /^job_\d+$/);
+  assert.equal(job.status, "open");
 });

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps id and initial status server-owned", async () => {
+  const job = await createJob({
+    id: "job_client",
+    status: "closed",
+    title: "Build landing page",
+    budgetMin: 100,
+    budgetMax: 200
+  });
+
+  assert.match(job.id, /^job_/);
+  assert.notEqual(job.id, "job_client");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build landing page");
+});


### PR DESCRIPTION
## Summary
- prevent job creation payloads from overriding generated ids
- force new jobs to start with `open` status
- add stronger regression coverage for both server-owned fields while proving normal job fields are preserved

## Test Plan
- `node --test apps/api/src/tests/jobService.test.js --test-name-pattern 'server-owned|generated open job' --test-reporter=spec`
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`
- `git diff --check`

Closes #3446

/claim #743
