### PR TITLE
Fix UI package entrypoint

### DIFF
--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,11 @@
+import type React from "react";
+
+export declare function Button({ children }: { children: React.ReactNode }): React.ReactElement;
+
+export declare function Card({
+  title,
+  children
+}: {
+  title: string;
+  children: React.ReactNode;
+}): React.ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }


### PR DESCRIPTION
## Summary
- Add a real JavaScript entrypoint for @freelanceflow/ui
- Preserve TypeScript declarations for Button and Card exports
- Configure package main/types/exports so Node ESM consumers can import the workspace package directly

Closes #3448

## Verification
- node -e "import('@freelanceflow/ui').then(m=>console.log(Object.keys(m))).catch(e=>{console.error(e.message); process.exit(1)})"
- npm.cmd run build -w apps/web
- git diff --check