### PR TITLE
Fix DB package entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test test/import.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/test/import.test.mjs
+++ b/packages/db/test/import.test.mjs
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("@freelanceflow/db can be imported by package name", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.ok(db.PrismaClient);
+});


### PR DESCRIPTION
## Summary
- Add explicit main/types/exports metadata for @freelanceflow/db
- Add a root JavaScript entrypoint and TypeScript declarations
- Add a focused Node test proving workspace consumers can import the package by name

Closes #2775

## Verification
- node -e "import('@freelanceflow/db').then(m=>console.log(Boolean(m.PrismaClient))).catch(e=>{console.error(e.message); process.exit(1)})"
- npm.cmd test -w packages/db
- npm.cmd run build -w apps/web
- git diff --check