### PR TITLE
Require full name during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -4,6 +4,7 @@ export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+test("registration requires a full name", () => {
+  assert.throws(() =>
+    registerSchema.parse({
+      email: "maya@example.com",
+      password: "strong-password"
+    })
+  );
+});
+
+test("registration preserves a valid full name", async () => {
+  const payload = registerSchema.parse({
+    fullName: "Maya Patel",
+    email: "maya@example.com",
+    password: "strong-password",
+    role: "freelancer"
+  });
+
+  const result = await registerUser(payload);
+
+  assert.equal(result.fullName, "Maya Patel");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Summary
- Require a non-empty fullName in registration payload validation
- Preserve the validated fullName in the registration result
- Add focused tests for missing and valid fullName cases
- Make the API test script run test files directly

Closes #2770

## Verification
- npm.cmd test -w apps/api
- npm.cmd run build -w apps/web
- git diff --check