### PR TITLE
fix: reject inverted budget ranges in job creation and updates (#2853)

### DIFF
--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+// --- createJobSchema tests ---
+
+test("createJobSchema accepts valid budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    skills: ["javascript"],
+  });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts equal budgetMin and budgetMax", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 200,
+    budgetMax: 200,
+    categoryId: "cat_1",
+    skills: [],
+  });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget range (budgetMax < budgetMin)", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "cat_1",
+    skills: [],
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.path.includes("budgetMax")));
+  assert.ok(
+    result.error.issues.some((i) =>
+      i.message.includes("budgetMax must be greater than or equal to budgetMin")
+    )
+  );
+});
+
+test("createJobSchema rejects zero budgetMin with lower budgetMax", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 100,
+    budgetMax: 0,
+    categoryId: "cat_1",
+    skills: [],
+  });
+  assert.equal(result.success, false);
+});
+
+// --- updateJobSchema tests ---
+
+test("updateJobSchema accepts partial update without budget fields", () => {
+  const result = updateJobSchema.safeParse({
+    title: "Updated Title",
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 200,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMax: 500,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with valid budget range", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 100,
+    budgetMax: 500,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects partial update with inverted budget range", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100,
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.path.includes("budgetMax")));
+});
+
+test("updateJobSchema accepts equal budgetMin and budgetMax in partial update", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 300,
+    budgetMax: 300,
+  });
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,23 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
+
+export const updateJobSchema = baseJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #2853 - `createJobSchema` and `updateJobSchema` now reject payloads where `budgetMax < budgetMin`.

## Problem

`createJobSchema` currently accepts payloads where `budgetMax` is lower than `budgetMin`, creating invalid job records (e.g., USD 500-100 budget range) that can break filtering, sorting, and display assumptions.

## Changes

### `apps/api/src/validators/job.js`
- Added `.refine()` to `createJobSchema` that rejects when `budgetMax < budgetMin`
- Refactored to use a shared `baseJobSchema` to avoid code duplication
- Updated `updateJobSchema = baseJobSchema.partial().refine()` that checks the range only when both `budgetMin` and `budgetMax` are present in the partial update
- Clear error message: `"budgetMax must be greater than or equal to budgetMin"` on the `budgetMax` field path

### `apps/api/src/tests/jobValidation.test.js` (new)
10 unit tests covering:
- Valid budget ranges (budgetMin < budgetMax)
- Equal budgetMin and budgetMax (valid)
- Inverted budget ranges (rejected)
- Partial updates with only budgetMin or only budgetMax (valid - no check needed)
- Partial updates with inverted range (rejected)
- Partial updates with equal values (valid)

## Test Results

All 10 tests pass:
```
# tests 10
# pass 10
# fail 0
```

## Validation

- [x] References exactly one issue (#2853)
- [x] Includes tests
- [x] Minimal, focused changes
- [x] No unrelated changes