### PR TITLE
Keep review creation timestamps server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    ...payload,
+    id: `rev_${Date.now()}`,
+    createdAt: new Date().toISOString()
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview owns the creation timestamp", async () => {
+  const clientTimestamp = "1999-01-01T00:00:00.000Z";
+
+  const review = await createReview({
+    id: "client-review-id",
+    jobId: "job_1",
+    reviewerId: "user_1",
+    rating: 5,
+    comment: "Great work",
+    createdAt: clientTimestamp
+  });
+
+  assert.notEqual(review.id, "client-review-id");
+  assert.notEqual(review.createdAt, clientTimestamp);
+  assert.equal(review.jobId, "job_1");
+  assert.equal(review.rating, 5);
+  assert.doesNotThrow(() => new Date(review.createdAt).toISOString());
+});


### PR DESCRIPTION
Closes #3456\n/claim #3456\n\nParent bounty: #743\nOriginal reference: #3450\n\nSummary:\n- ignore caller-supplied createdAt values when creating reviews\n- set createdAt inside the service\n- add service-level regression coverage\n\nTest:\n- cd apps/api && node --test src/tests/reviewService.test.js