### PR TITLE
Keep job creation fields server-owned

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,11 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = {
+    ...payload,
+    id: `job_${Date.now()}`,
+    status: "open"
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps id and initial status server-owned", async () => {
+  const job = await createJob({
+    id: "client-job-id",
+    status: "closed",
+    title: "Build a dashboard",
+    description: "Create a useful dashboard for the client",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "analytics",
+    skills: ["node"]
+  });
+
+  assert.notEqual(job.id, "client-job-id");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build a dashboard");
+  assert.equal(job.budgetMax, 200);
+});


### PR DESCRIPTION
Closes #3458\n/claim #3458\n\nParent bounty: #743\nOriginal reference: #3446\n\nSummary:\n- keep generated job ids server-owned\n- keep initial status server-owned\n- add regression tests for caller-supplied id/status\n\nTest:\n- cd apps/api && node --test src/tests/jobService.test.js