### PR TITLE
Keep notification creation fields server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,11 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = {
+    ...payload,
+    id: `ntf_${Date.now()}`,
+    read: false
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps id server-owned and starts unread", async () => {
+  const notification = await createNotification({
+    id: "client-notification-id",
+    read: true,
+    userId: "user_1",
+    type: "message",
+    message: "You have a new message"
+  });
+
+  assert.notEqual(notification.id, "client-notification-id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "user_1");
+  assert.equal(notification.message, "You have a new message");
+});


### PR DESCRIPTION
Closes #3460\n/claim #3460\n\nParent bounty: #743\nOriginal reference: #3444\n\nSummary:\n- keep notification ids server-owned\n- force new notifications to start unread\n- add service-level regression tests\n\nTest:\n- cd apps/api && node --test src/tests/notificationService.test.js