### PR TITLE
Preserve job id on payment intents

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -2,6 +2,7 @@ export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
+    jobId: payload.jobId,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent preserves the submitted job id", async () => {
+  const intent = await createPaymentIntent({
+    jobId: "job_123",
+    amount: 2500,
+    currency: "usd"
+  });
+
+  assert.equal(intent.jobId, "job_123");
+  assert.equal(intent.amount, 2500);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+});


### PR DESCRIPTION
Closes #3462\n/claim #3462\n\nParent bounty: #743\nOriginal reference: #3402\n\nSummary:\n- include the submitted jobId in createPaymentIntent() responses\n- add a regression test proving the response keeps the job association\n\nTest:\n- cd apps/api && node --test src/tests/paymentService.test.js