### PR TITLE
Keep message ids and records server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,15 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
-  return message;
+  return { ...message };
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("message service keeps ids and stored records server-owned", async () => {
+  const message = await sendMessage({
+    id: "client-message-id",
+    senderId: "user_1",
+    recipientId: "user_2",
+    content: "Hello"
+  });
+
+  assert.notEqual(message.id, "client-message-id");
+  assert.equal(message.content, "Hello");
+
+  message.content = "mutated response";
+  const firstList = await listMessages();
+  assert.equal(firstList.at(-1).content, "Hello");
+
+  firstList.at(-1).content = "mutated list item";
+  const secondList = await listMessages();
+  assert.equal(secondList.at(-1).content, "Hello");
+});


### PR DESCRIPTION
Closes #3464\n/claim #3464\n\nParent bounty: #743\nOriginal reference: #3429\n\nSummary:\n- prevent caller-supplied message ids from overriding generated ids\n- return defensive snapshots from listMessages() and sendMessage()\n- add regression tests for id ownership and mutation protection\n\nTest:\n- cd apps/api && node --test src/tests/messageService.test.js