### PR TITLE
fix: reject invalid login credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,10 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid email or password", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,53 @@
+import { scryptSync, timingSafeEqual } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
+
+const usersByEmail = new Map();
+const passwordSalt = "freelanceflow-auth-placeholder";
+
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}
+
+function hashPassword(password) {
+  return scryptSync(password, passwordSalt, 32);
+}
+
+function passwordsMatch(storedHash, password) {
+  const candidateHash = hashPassword(password);
+  return storedHash.length === candidateHash.length && timingSafeEqual(storedHash, candidateHash);
+}
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
+  const email = normalizeEmail(payload.email);
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
+    email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  };
+
+  usersByEmail.set(email, user);
+
+  return {
+    id,
+    email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const user = usersByEmail.get(normalizeEmail(payload.email));
+  if (!user || !passwordsMatch(user.passwordHash, payload.password)) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authRoutes.test.js
+++ b/apps/api/src/tests/authRoutes.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("login rejects unknown users", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const baseUrl = `http://127.0.0.1:${server.address().port}`;
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email: `missing-${Date.now()}@example.com`,
+      password: "correct-password"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid email or password" });
+  } finally {
+    await close(server);
+  }
+});
+
+test("login verifies registered credentials before minting a token", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const baseUrl = `http://127.0.0.1:${server.address().port}`;
+    const email = `registered-${Date.now()}@example.com`;
+    const password = "correct-password";
+
+    const registerResponse = await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password,
+      role: "client"
+    });
+    assert.equal(registerResponse.status, 201);
+
+    const wrongPasswordResponse = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "wrong-password"
+    });
+    const wrongPasswordPayload = await wrongPasswordResponse.json();
+
+    assert.equal(wrongPasswordResponse.status, 401);
+    assert.deepEqual(wrongPasswordPayload, { success: false, message: "Invalid email or password" });
+
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", { email, password });
+    const loginPayload = await loginResponse.json();
+
+    assert.equal(loginResponse.status, 200);
+    assert.equal(loginPayload.success, true);
+    assert.equal(loginPayload.data.email, email);
+    assert.match(loginPayload.data.token, /^[\w-]+\.[\w-]+\.[\w-]+$/);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Keep registered users in the existing in-memory auth placeholder so login can verify credentials before minting tokens.
- Return HTTP 401 for unknown emails and wrong passwords.
- Preserve the successful login response shape for valid registered credentials.

Closes #3466
/claim #743

## Validation
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/authRoutes.test.js`
- `node --test apps/api/src/tests/authRoutes.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authRoutes.test.js`
- `git diff --check`

## Demo Video
- https://github.com/vicentsmith470-web/bug-bounty/releases/download/demo-login-3466/login-3466-demo.mp4

The regression test exercises the login route through a real ephemeral HTTP server: unknown-user login and wrong-password login both return HTTP 401, while a registered email/password pair succeeds with a JWT response.