### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for launch",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues.map((issue) => issue.path), [["budgetMax"]]);
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 250,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues.map((issue) => issue.path), [["budgetMax"]]);
+});
+
+test("updateJobSchema allows partial budget updates with one side omitted", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 250 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 250 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,12 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const hasOrderedBudgetRange = ({ budgetMin, budgetMax }) => (
+  budgetMin === undefined || budgetMax === undefined || budgetMax >= budgetMin
+);
+
+const orderedBudgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +15,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(hasOrderedBudgetRange, {
+  message: orderedBudgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(hasOrderedBudgetRange, {
+  message: orderedBudgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- Add ordered budget-range validation for job create and partial update schemas.
- Keep one-sided partial budget updates valid while rejecting inverted ranges when both fields are present.
- Add focused node:test coverage for valid create, invalid create/update, and partial update behavior.

Closes #3468
Refs #743

## Test plan
- `npm test`

## Automation disclosure
Implemented and tested by Hermes Agent on behalf of @hermesbountyhunter.