### PR TITLE
fix: expose db workspace entrypoint

### DIFF
--- a/packages/db/import.test.mjs
+++ b/packages/db/import.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("@freelanceflow/db resolves through its workspace package name", async () => {
+  const dbPackage = await import("@freelanceflow/db");
+
+  assert.equal(typeof dbPackage.PrismaClient, "function");
+  assert.ok(dbPackage.Prisma);
+});

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,1 +1,7 @@
-module.exports = require("@prisma/client");
+const prismaClient = require("@prisma/client");
+
+exports.PrismaClient = prismaClient.PrismaClient;
+exports.Prisma = prismaClient.Prisma;
+exports.default = prismaClient;
+
+Object.assign(exports, prismaClient);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./index.js",
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test import.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"


### PR DESCRIPTION
## Summary
- add an explicit JavaScript entrypoint for @freelanceflow/db
- declare main, 	ypes, and conditional exports metadata for workspace consumers
- add a lightweight 
ode:test import regression for the package name

Fixes #3473
References #743 and #2775

## Testing
- 
ode --check packages/db/index.js
- 
ode --check packages/db/import.test.mjs
- Not run locally: 
pm run test -w packages/db because this environment does not have npm/workspace 
ode_modules installed.