### PR TITLE
Keep proposal ids and timestamps server-owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,15 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = {
+    ...payload,
+    id: `prp_${Date.now()}`,
+    submittedAt: new Date().toISOString()
+  };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("proposal service keeps ids, timestamps, and stored records server-owned", async () => {
+  const proposal = await createProposal({
+    id: "client-proposal-id",
+    submittedAt: "2000-01-01T00:00:00.000Z",
+    jobId: "job_1",
+    freelancerId: "user_1",
+    coverLetter: "I can help with this job."
+  });
+
+  assert.notEqual(proposal.id, "client-proposal-id");
+  assert.notEqual(proposal.submittedAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(proposal.jobId, "job_1");
+
+  proposal.coverLetter = "mutated response";
+  const firstList = await listProposals();
+  assert.equal(firstList.at(-1).coverLetter, "I can help with this job.");
+
+  firstList.at(-1).coverLetter = "mutated list item";
+  const secondList = await listProposals();
+  assert.equal(secondList.at(-1).coverLetter, "I can help with this job.");
+});


### PR DESCRIPTION
Closes #3489
/claim #3489

## Summary
- generate proposal ids after spreading payload data so client-supplied ids cannot override server ids
- add server-owned submittedAt timestamps
- return defensive copies from createProposal and listProposals
- add a focused proposalService regression test

## Tests
- node --test apps/api/src/tests/proposalService.test.js