### PR TITLE
Keep user records server-owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,15 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = {
+    ...payload,
+    id: `usr_${Date.now()}`,
+    createdAt: new Date().toISOString()
+  };
   users.push(user);
-  return user;
+  return { ...user };
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("user service keeps ids, timestamps, and stored records server-owned", async () => {
+  const user = await createUser({
+    id: "client-user-id",
+    createdAt: "2000-01-01T00:00:00.000Z",
+    email: "user@example.com",
+    role: "client"
+  });
+
+  assert.notEqual(user.id, "client-user-id");
+  assert.notEqual(user.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(user.email, "user@example.com");
+
+  user.email = "mutated-response@example.com";
+  const firstList = await listUsers();
+  assert.equal(firstList.at(-1).email, "user@example.com");
+
+  firstList.at(-1).email = "mutated-list@example.com";
+  const secondList = await listUsers();
+  assert.equal(secondList.at(-1).email, "user@example.com");
+});


### PR DESCRIPTION
Closes #3491
/claim #3491

## Summary
- generate user ids after spreading payload data so client-supplied ids cannot override server ids
- add server-owned createdAt timestamps
- return defensive copies from createUser and listUsers
- add a focused userService regression test

## Tests
- node --test apps/api/src/tests/userService.test.js
