### PR TITLE
fix: reject inverted budget ranges in createJobSchema and updateJobSchema

### DIFF
--- a/apps/api/src/tests/jobSchema.test.js
+++ b/apps/api/src/tests/jobSchema.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const inverted = {
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  assert.throws(
+    () => createJobSchema.parse(inverted),
+    { message: /budgetMax must be greater than or equal to budgetMin/ }
+  );
+});
+
+test("createJobSchema accepts valid budget ranges", () => {
+  const valid = {
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  const result = createJobSchema.parse(valid);
+  assert.equal(result.budgetMin, 100);
+  assert.equal(result.budgetMax, 500);
+});
+
+test("createJobSchema accepts equal budget values", () => {
+  const equal = {
+    title: "Test Job",
+    description: "A test job description",
+    budgetMin: 300,
+    budgetMax: 300,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  const result = createJobSchema.parse(equal);
+  assert.equal(result.budgetMin, 300);
+  assert.equal(result.budgetMax, 300);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both present", () => {
+  const inverted = {
+    budgetMin: 500,
+    budgetMax: 100
+  };
+
+  assert.throws(
+    () => updateJobSchema.parse(inverted),
+    { message: /budgetMax must be greater than or equal to budgetMin/ }
+  );
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const partial = { budgetMin: 200 };
+  const result = updateJobSchema.parse(partial);
+  assert.equal(result.budgetMin, 200);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const partial = { budgetMax: 800 };
+  const result = updateJobSchema.parse(partial);
+  assert.equal(result.budgetMax, 800);
+});
+
+test("updateJobSchema accepts valid budget ranges when both present", () => {
+  const valid = { budgetMin: 100, budgetMax: 500 };
+  const result = updateJobSchema.parse(valid);
+  assert.equal(result.budgetMin, 100);
+  assert.equal(result.budgetMax, 500);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobObjectSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,26 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobObjectSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = jobObjectSchema
+  .partial()
+  .refine(
+    (data) => {
+      // Only validate when both fields are present
+      if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+        return data.budgetMax >= data.budgetMin;
+      }
+      return true;
+    },
+    {
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    }
+  );


### PR DESCRIPTION
## Fix for #2853 — Reject inverted budget ranges

### Problem
`createJobSchema` accepted payloads where `budgetMax < budgetMin`, creating invalid job records (e.g. USD 500-100 budget range) that break filtering, sorting, and display assumptions.

### Solution
- Added `.refine()` to `createJobSchema` ensuring `budgetMax >= budgetMin` at validation time
- Added `.refine()` to `updateJobSchema` that validates the constraint only when **both** budget fields are present in the partial update
- Partial updates with only `budgetMin` or `budgetMax` continue to pass (cannot cross-validate a single field)
- Equal values (`budgetMin === budgetMax`) are accepted (fixed-price jobs)

### Changes
- `apps/api/src/validators/job.js` — Added budget range refinements to both schemas
- `apps/api/src/tests/jobSchema.test.js` — 7 new unit tests covering all validation paths

### Test Results
```
✔ createJobSchema rejects inverted budget ranges
✔ createJobSchema accepts valid budget ranges
✔ createJobSchema accepts equal budget values
✔ updateJobSchema rejects inverted budget ranges when both present
✔ updateJobSchema accepts partial update with only budgetMin
✔ updateJobSchema accepts partial update with only budgetMax
✔ updateJobSchema accepts valid budget ranges when both present
7 tests, 7 pass, 0 fail
```

Closes #2853
Related #2835