### PR TITLE
fix: scope proposal lists to authenticated participants

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
-  return ok(res, await listProposals());
+  return ok(res, await listProposals(req.user?.sub));
 }
 
 export async function postProposal(req, res) {

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,8 +1,17 @@
-import { ok } from "../utils/response.js";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { fail, ok } from "../utils/response.js";
+import { createProposal, listProposalsForUser } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
-  return ok(res, await listProposals(req.user?.sub));
+  if (!req.user) {
+    return fail(res, "Unauthorized", 401);
+  }
+
+  const userId = req.user.sub;
+  if (!userId) {
+    return fail(res, "Unauthorized", 401);
+  }
+
+  return ok(res, await listProposalsForUser(userId));
 }
 
 export async function postProposal(req, res) {

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
+proposalRoutes.get("/", authMiddleware, getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,13 @@
 const proposals = [];
 
-export async function listProposals() {
-  return proposals;
+export async function listProposals(userId) {
+  if (!userId) {
+    return [];
+  }
+
+  return proposals.filter(
+    (proposal) => proposal.freelancerId === userId || proposal.clientId === userId
+  );
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,8 +1,8 @@
 const proposals = [];
 
-export async function listProposals(userId) {
+export async function listProposalsForUser(userId) {
   if (!userId) {
-    return [];
+    throw new Error("userId is required to list proposals");
   }
 
   return proposals.filter(
@@ -14,4 +14,8 @@ export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
   return proposal;
+}
+
+export function resetProposalsForTests() {
+  proposals.length = 0;
 }

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,8 +1,12 @@
-import test from "node:test";
+import { beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
-import { createProposal } from "../services/proposalService.js";
+import { createProposal, resetProposalsForTests } from "../services/proposalService.js";
 import { signAccessToken } from "../utils/jwt.js";
+
+beforeEach(() => {
+  resetProposalsForTests();
+});
 
 async function withServer(fn) {
   const app = createApp();

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,10 +1,14 @@
-import { beforeEach, test } from "node:test";
+import { afterEach, beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 import { createProposal, resetProposalsForTests } from "../services/proposalService.js";
 import { signAccessToken } from "../utils/jwt.js";
 
 beforeEach(() => {
+  resetProposalsForTests();
+});
+
+afterEach(() => {
   resetProposalsForTests();
 });
 

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createProposal } from "../services/proposalService.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/proposals rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/proposals returns only proposals for the authenticated user", async () => {
+  const userId = `usr_${Date.now()}`;
+  const otherUserId = `usr_other_${Date.now()}`;
+
+  await createProposal({
+    title: "Freelancer proposal",
+    freelancerId: userId,
+    clientId: otherUserId
+  });
+  await createProposal({
+    title: "Client proposal",
+    freelancerId: otherUserId,
+    clientId: userId
+  });
+  await createProposal({
+    title: "Unrelated proposal",
+    freelancerId: otherUserId,
+    clientId: `usr_third_${Date.now()}`
+  });
+
+  const token = signAccessToken({ sub: userId, role: "freelancer" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.length, 2);
+    assert.deepEqual(
+      payload.data.map((proposal) => proposal.title).sort(),
+      ["Client proposal", "Freelancer proposal"]
+    );
+  });
+});


### PR DESCRIPTION
/claim #743
Closes #3496
References #743

## Summary

- require bearer-token authentication before listing proposals
- scope proposal list results to the authenticated user as either `freelancerId` or `clientId`
- add route-level regression coverage for anonymous rejection and participant-only results

## Validation

- `node --test apps/api/src/tests/proposalRoutes.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalRoutes.test.js`
- `npm test -w apps/api`
- `git diff --check`

## Demo

https://github.com/NikYak228/bug-bounty/releases/download/demo-3496/securebanana-3497-demo.mp4

## Scope

This PR only changes proposal list reads. It does not change proposal creation, proposal payload validation, or other resource list endpoints.