### PR TITLE
fix: return defensive copies from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/serviceListSnapshots.test.js
+++ b/apps/api/src/tests/serviceListSnapshots.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+async function assertSnapshotList({ create, list, payload }) {
+  const record = await create(payload);
+  const first = await list();
+
+  assert.equal(first.length, 1);
+  assert.strictEqual(first[0], record);
+
+  first.push({ id: "corrupt" });
+
+  const second = await list();
+  assert.notStrictEqual(second, first);
+  assert.deepEqual(second, [record]);
+}
+
+test("user list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: createUser,
+    list: listUsers,
+    payload: { name: "Ada Lovelace" },
+  });
+});
+
+test("job list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Review contract" },
+  });
+});
+
+test("proposal list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: createProposal,
+    list: listProposals,
+    payload: { title: "Initial proposal" },
+  });
+});
+
+test("review list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: createReview,
+    list: listReviews,
+    payload: { rating: 5, comment: "Great work" },
+  });
+});
+
+test("message list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: sendMessage,
+    list: listMessages,
+    payload: { to: "client", body: "Hello" },
+  });
+});
+
+test("notification list responses are defensive snapshots", async () => {
+  await assertSnapshotList({
+    create: createNotification,
+    list: listNotifications,
+    payload: { type: "alert", message: "New activity" },
+  });
+});

--- a/apps/api/src/tests/serviceListSnapshots.test.js
+++ b/apps/api/src/tests/serviceListSnapshots.test.js
@@ -7,7 +7,7 @@ import { createReview, listReviews } from "../services/reviewService.js";
 import { sendMessage, listMessages } from "../services/messageService.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
-async function assertSnapshotList({ create, list, payload }) {
+async function assertArraySnapshotList({ create, list, payload }) {
   const record = await create(payload);
   const first = await list();
 
@@ -21,48 +21,48 @@ async function assertSnapshotList({ create, list, payload }) {
   assert.deepEqual(second, [record]);
 }
 
-test("user list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("user list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: createUser,
     list: listUsers,
     payload: { name: "Ada Lovelace" },
   });
 });
 
-test("job list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("job list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: createJob,
     list: listJobs,
     payload: { title: "Review contract" },
   });
 });
 
-test("proposal list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("proposal list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: createProposal,
     list: listProposals,
     payload: { title: "Initial proposal" },
   });
 });
 
-test("review list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("review list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: createReview,
     list: listReviews,
     payload: { rating: 5, comment: "Great work" },
   });
 });
 
-test("message list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("message list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: sendMessage,
     list: listMessages,
     payload: { to: "client", body: "Hello" },
   });
 });
 
-test("notification list responses are defensive snapshots", async () => {
-  await assertSnapshotList({
+test("notification list responses return a new array instance", async () => {
+  await assertArraySnapshotList({
     create: createNotification,
     list: listNotifications,
     payload: { type: "alert", message: "New activity" },


### PR DESCRIPTION
/claim #743

Closes #3498
References #743

## Summary

- return shallow copies from the API list services so callers cannot mutate the backing store through a returned array
- add regression coverage proving a list response can be mutated locally without affecting later reads
- preserve the existing record objects and response shape

## Validation

- `npm test -w apps/api`
- `git diff --check`

## Demo

https://github.com/NikYak228/bug-bounty/releases/download/demo-3498/securebanana-3498-demo.mp4
