### PR TITLE
docs: include notifications in README database inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 - Messages
 - Categories
 - Skills
+- Notifications
 
 ## Environment Variables
 


### PR DESCRIPTION
/claim #743

Closes #3502
References #743

## Summary

- add the missing `Notifications` bullet to the README database model inventory
- keep the documentation overview aligned with the existing Prisma `Notification` model
- leave schema definitions, API behavior, and unrelated README wording unchanged

## Demo

https://github.com/TheGreatAion/bug-bounty/releases/download/demo-3502/readme-notifications-3502-demo.mp4

## Validation

- `git diff --cached --check`
- verified `packages/db/prisma/schema.prisma` contains `model Notification {`
- verified `README.md` contains the matching `- Notifications` database inventory bullet

## Baseline note

- `npm test -w apps/api` currently fails before this documentation-only change is exercised because the existing script invokes `node --test src/tests`, which Node cannot resolve as a test entry point in this checkout