### PR TITLE
docs: describe implemented API route surface accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The web app includes pages for:
 The API includes:
 
 - Auth routes (register, login, OAuth callback, JWT refresh)
-- CRUD routes for users, jobs, and proposals
+- List and create routes for users, jobs, and proposals
 - Payments routes (Stripe-focused service placeholder)
 - Reviews, messaging, notifications
 - File uploads and search


### PR DESCRIPTION
/claim #743

Closes #3504
References #743

## Summary

- replace the README's inaccurate CRUD wording for users, jobs, and proposals
- describe the currently implemented list-and-create API surface accurately
- leave routes, controllers, runtime behavior, and unrelated documentation unchanged

## Demo

https://github.com/TheGreatAion/bug-bounty/releases/download/demo-3504/readme-route-surface-3504-demo.mp4

## Validation

- `git diff --cached --check`
- verified the README contains `List and create routes for users, jobs, and proposals`
- verified the README no longer claims CRUD for those resources
- verified the current user, job, and proposal routers expose three `GET /` handlers and three `POST /` handlers with no `PATCH`, `PUT`, or `DELETE` handlers

## Baseline note

- `npm test -w apps/api` currently fails before this documentation-only change is exercised because the existing script invokes `node --test src/tests`, which Node cannot resolve as a test entry point in this checkout