### PR TITLE
fix: reject budgetMax < budgetMin in job schema validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
+
+export const updateJobSchema = jobBaseSchema.partial().refine(
+  (data) => data.budgetMax === undefined || data.budgetMin === undefined || data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);


### PR DESCRIPTION
Fixes #2853

## Summary

- Added `budgetMax >= budgetMin` cross-field validation to `createJobSchema` and `updateJobSchema` in `apps/api/src/validators/job.js`.
- Extracted a private `jobBaseSchema` ZodObject so `.partial()` can be called before applying `.refine()` (Zod 3 `ZodEffects` has no `.partial()` method).
- Both create and update schemas are covered.

## Bug

The original schemas accepted payloads where `budgetMax < budgetMin`, producing semantically invalid job postings with inverted budget ranges.

## Fix

Refactored into three exports:

1. `jobBaseSchema` — private raw `ZodObject` (unchanged field definitions).
2. `createJobSchema` — `jobBaseSchema.refine(data => data.budgetMax >= data.budgetMin, ...)`.
3. `updateJobSchema` — `jobBaseSchema.partial().refine(data => data.budgetMax === undefined || data.budgetMin === undefined || data.budgetMax >= data.budgetMin, ...)`.

## Before / After

**Before:** no cross-field budget validation; calling `.partial()` on a refined schema would throw at runtime.

**After:** invalid ranges rejected on both create and update; partial updates with only one budget field still accepted.

## Test Results

- Existing health test: PASS
- createJobSchema valid (min=100, max=200): accepted
- createJobSchema invalid (min=200, max=100): rejected with correct message
- updateJobSchema partial (budgetMin only): accepted
- updateJobSchema partial (budgetMax only): accepted
- updateJobSchema both fields with max < min: rejected with correct message