### PR TITLE
Add navigation links for top-level pages

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/settings", "Settings"],
+  ["/billing", "Billing"],
   ["/admin", "Admin"]
 ];
 

--- a/apps/web/tests/navigation-links.test.mjs
+++ b/apps/web/tests/navigation-links.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const navigationSource = await readFile(
+  new URL("../components/Navigation.tsx", import.meta.url),
+  "utf8"
+);
+
+const expectedLinks = [
+  ['"/"', '"Home"'],
+  ['"/jobs"', '"Jobs"'],
+  ['"/jobs/post"', '"Post Job"'],
+  ['"/freelancers/search"', '"Find Freelancers"'],
+  ['"/dashboard/client"', '"Client Dashboard"'],
+  ['"/dashboard/freelancer"', '"Freelancer Dashboard"'],
+  ['"/messaging"', '"Messaging"'],
+  ['"/notifications"', '"Notifications"'],
+  ['"/settings"', '"Settings"'],
+  ['"/billing"', '"Billing"'],
+  ['"/admin"', '"Admin"']
+];
+
+test("Navigation exposes every top-level app page", () => {
+  for (const [href, label] of expectedLinks) {
+    assert.ok(
+      navigationSource.includes(`[${href}, ${label}]`),
+      `Expected Navigation links to include ${href}`
+    );
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #3509

## Summary
- Add primary navigation links for the existing Post Job, Notifications, Settings, and Billing pages.
- Add focused Node-based link coverage for the shared Navigation component.

## Demo
Short demo GIF: https://raw.githubusercontent.com/EvidentLed/bug-bounty/d28ac6174116b9c902ba22cf38958e7a31f73196/demo/navigation-links-3509.gif

![Navigation link coverage demo](https://raw.githubusercontent.com/EvidentLed/bug-bounty/d28ac6174116b9c902ba22cf38958e7a31f73196/demo/navigation-links-3509.gif)

## Verification
- Red check before the fix: `node --test apps/web/tests/navigation-links.test.mjs` failed on the missing `/jobs/post` route.
- `node --test apps/web/tests/navigation-links.test.mjs` -> 1 test passed.
- `git diff --check upstream/main..HEAD` -> passed.
