### PR TITLE
fix: resolve freelancer profiles from mock data by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,49 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>
+          No freelancer found with the username <strong>{params.username}</strong>.
+        </p>
+        <p style={{ marginTop: "1rem" }}>
+          <a href="/freelancers/search">Browse all freelancers</a>
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <div style={{ marginBottom: "1rem" }}>
+        <strong>Rate:</strong> {freelancer.rate}
+      </div>
+      <div>
+        <strong>Skills:</strong>
+        <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem", flexWrap: "wrap" }}>
+          {freelancer.skills.map((skill) => (
+            <span
+              key={skill}
+              style={{
+                background: "var(--accent)",
+                padding: "0.25rem 0.75rem",
+                borderRadius: "999px",
+                fontSize: "0.875rem",
+              }}
+            >
+              {skill}
+            </span>
+          ))}
+        </div>
+      </div>
+      <p style={{ marginTop: "1rem", color: "var(--muted)" }}>
+        Portfolio, reviews, and active proposals appear here.
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
## What
The `/freelancers/[username]` route now looks up the selected freelancer from `apps/web/lib/mock.ts` instead of rendering a generic placeholder. Known usernames (`maya-dev`, `jordan-ux`) render matching skills and hourly rate. Unknown usernames render a clear not-found fallback with a link to browse all freelancers.

## Why
Search cards link to `/freelancers/maya-dev` and `/freelancers/jordan-ux`, but the profile page showed placeholder text instead of matching mock data. Unknown usernames appeared successful with no indication of an error.

## Testing
- Known username (`maya-dev`): renders skills [Next.js, TypeScript] and rate $65/hr ✓
- Known username (`jordan-ux`): renders skills [Figma, UX Research] and rate $52/hr ✓
- Unknown username: renders "Freelancer Not Found" with link to browse all ✓
- `npm run build -w apps/web` passes successfully ✓
