### PR TITLE
fix(api): reject upload requests without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects missing files", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("description", "metadata without a file");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads accepts a multipart file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "hello.txt",
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #3519.

## Summary
- Returns HTTP 400 when `POST /api/uploads` is called without the expected multipart `file` field.
- Keeps valid upload behavior unchanged: successful file uploads still return HTTP 201 with filename and `uploaded` status.
- Adds focused upload route coverage for both missing-file rejection and successful multipart upload.

## Demo / validation
```text
$ node --test apps/api/src/tests/health.test.js apps/api/src/tests/uploadRoutes.test.js
✔ GET /health returns ok payload
✔ POST /api/uploads rejects missing files
✔ POST /api/uploads accepts a multipart file
ℹ pass 3
```

```text
$ node --check apps/api/src/controllers/uploadController.js
$ node --check apps/api/src/tests/uploadRoutes.test.js
# both files passed syntax validation
```