### PR TITLE
fix: reject non-positive payment amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -2,10 +2,14 @@ import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 import { createPaymentSchema } from "../validators/payment.js";
 
+function paymentValidationMessage(error) {
+  return error.issues[0]?.message ?? "Invalid payment payload";
+}
+
 export async function createPayment(req, res) {
   const payload = createPaymentSchema.safeParse(req.body);
   if (!payload.success) {
-    return fail(res, "Payment amount must be greater than 0", 400);
+    return fail(res, paymentValidationMessage(payload.error), 400);
   }
 
   return ok(res, await createPaymentIntent(payload.data), 201);

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Payment amount must be greater than 0", 400);
+  }
+
+  return ok(res, await createPaymentIntent(payload.data), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -56,3 +56,39 @@ test("POST /api/payments accepts positive amounts", async () => {
     assert.equal(payload.data.provider, "stripe");
   });
 });
+
+test("POST /api/payments defaults omitted currency to usd", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25 })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});
+
+test("POST /api/payments rejects blank currency", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25, currency: " " })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Payment currency is required"
+    });
+  });
+});

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 0, currency: "usd" })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Payment amount must be greater than 0"
+    });
+  });
+});
+
+test("POST /api/payments accepts positive amounts", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25, currency: "eur" })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "eur");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("usd")
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,6 +1,15 @@
 import { z } from "zod";
 
 export const createPaymentSchema = z.object({
-  amount: z.number().positive(),
-  currency: z.string().min(1).default("usd")
+  amount: z
+    .number({
+      required_error: "Payment amount is required",
+      invalid_type_error: "Payment amount must be a number"
+    })
+    .positive({ message: "Payment amount must be greater than 0" }),
+  currency: z
+    .string({ invalid_type_error: "Payment currency must be a string" })
+    .trim()
+    .min(1, { message: "Payment currency is required" })
+    .default("usd")
 });


### PR DESCRIPTION
Parent bounty: #743

/claim #743
Fixes #3385

## Summary

- validate `POST /api/payments` payloads before payment intent creation
- reject non-positive payment amounts with HTTP 400
- preserve the positive amount path and default omitted currency to `usd`
- reject blank currency values

## Validation

- `node --test apps/api/src/tests/paymentRoutes.test.js`
- `npm test -w apps/api`
- `git diff --check`

## Demo

https://github.com/NikYak228/bug-bounty/releases/download/demo-3385/securebanana-3521-demo.mp4