### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a responsive marketing landing page",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema accepts partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobShape = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const validateBudgetRange = (data, ctx) => {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+};
+
+export const createJobSchema = jobShape.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobShape.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary
- reject job creation payloads where `budgetMax` is lower than `budgetMin`
- reject partial job updates when both budget fields are present and inverted
- add focused validator tests for valid, invalid, and partial budget updates
- update the API test script to target test files so `npm test -w apps/api` runs successfully

Closes #2853

## Bounty
Issue #2853 is labeled bounty `$780`.

## Payout
Base USDC: `0x97620eB52A577cabc95911099E88e83115eB7C20`

## Verification
- `npm test -w apps/api` - 5 passed
- `git diff --check`
- secret scan over diff: no secrets/tokens/keys