### PR TITLE
fix: restrict admin metrics to admin users

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,17 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
+function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}
+
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", requireAdmin, metrics);

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, { success: false, message: "Forbidden" });
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+    assert.equal(payload.data.flaggedAccounts, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Add an admin role guard to `/api/admin/metrics` after the existing bearer-token authentication middleware
- Return `403 Forbidden` for authenticated non-admin users
- Keep admin metrics behavior unchanged for valid admin tokens
- Add focused API coverage for client-role rejection and admin-role success
- Update the API test script so the `src/tests` suite runs reliably via globbed test files

## Validation
- `npm test -w apps/api` -> 3 tests passed
- `npm test` -> 3 tests passed
- `git diff --check`

/claim #1764