### PR TITLE
Expose all frontend pages in navigation

### DIFF
--- a/apps/web/components/Navigation.test.mjs
+++ b/apps/web/components/Navigation.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const componentPath = join(dirname(fileURLToPath(import.meta.url)), "Navigation.tsx");
+
+const expectedRoutes = [
+  "/",
+  "/jobs",
+  "/jobs/post",
+  "/freelancers/search",
+  "/dashboard/client",
+  "/dashboard/freelancer",
+  "/messaging",
+  "/notifications",
+  "/billing",
+  "/settings",
+  "/admin"
+];
+
+test("Navigation links to every top-level web app page", async () => {
+  const source = await readFile(componentPath, "utf8");
+
+  for (const href of expectedRoutes) {
+    assert.match(source, new RegExp(`\\["${href}",\\s*"[^"]+"\\]`));
+  }
+});

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -7,6 +7,8 @@ const links = [
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,12 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post a Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
   ["/billing", "Billing"],
   ["/settings", "Settings"],
   ["/admin", "Admin"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "node --test components/Navigation.test.mjs"
   },
   "devDependencies": {
     "@types/node": "22.15.19",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api && npm run test -w apps/web"
   }
 }


### PR DESCRIPTION
## Summary
- adds the existing `/jobs/post`, `/notifications`, `/billing`, and `/settings` pages to the shared navigation
- adds a focused `node:test` coverage check so those top-level routes stay linked
- wires the web navigation test into the root `npm run test` command

## Verification
- `node --test apps/web/components/Navigation.test.mjs`
- parsed root `package.json` and `apps/web/package.json` with Node
- full `npm run test` was not run locally because this Windows environment has `node.exe` but no `npm` executable available

Fixes #3528
Refs #743
/claim #743