### PR TITLE
fix: require auth for notification routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationRoutes.test.js
+++ b/apps/api/src/tests/notificationRoutes.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/notifications rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ type: "alert", message: "New activity" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});


### PR DESCRIPTION
Parent bounty: #743

This protects `/api/notifications` with the existing `authMiddleware` so anonymous callers cannot list or create notifications. It adds focused regression coverage for unauthenticated GET and POST requests returning 401.

Fixes #3099
/claim #743

Validation:
- npm test -w apps/api
- git diff --check
