### PR TITLE
feat: add /api/pi calculation endpoint (approximate PI value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern TypeScript-first architecture.
 
+## Feature: PI Calculation
+
+A new `/api/pi` endpoint has been added to provide an approximate value of PI. Since PI is an irrational transcendental number, its exact value cannot be computed in finite time or space. The endpoint uses the Leibniz formula to produce a high-precision approximation. You can optionally pass an `iterations` query parameter to control the number of terms summed (default 1,000,000, max 10,000,000).
+
 ## Workspace Structure
 
 - `apps/web` — Next.js 14 App Router frontend
@@ -37,6 +41,7 @@ The API includes:
 - Reviews, messaging, notifications
 - File uploads and search
 - Admin routes
+- **PI calculation route** (`/api/pi`)
 
 Backend architecture follows:
 

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { piRoutes } from "./routes/piRoutes.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +39,7 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+  app.use("/api/pi", piRoutes);
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/routes/piRoutes.js
+++ b/apps/api/src/routes/piRoutes.js
@@ -1,0 +1,39 @@
+import { Router } from "express";
+
+const router = Router();
+
+/**
+ * Calculate PI using Leibniz formula with given number of iterations.
+ * The formula is: pi/4 = 1 - 1/3 + 1/5 - 1/7 + ...
+ * @param {number} iterations - Number of terms to sum
+ * @returns {number} Approximated PI
+ */
+function calculatePiApproximation(iterations = 1000000) {
+  let pi = 0;
+  for (let i = 0; i < iterations; i++) {
+    pi += (4 * (i % 2 === 0 ? 1 : -1)) / (2 * i + 1);
+  }
+  return pi;
+}
+
+// GET /api/pi - returns an approximation of PI
+// Note: Exact calculation of all decimal places is impossible due to transcendental nature.
+router.get("/", (req, res) => {
+  const iterations = Math.min(
+    parseInt(req.query.iterations, 10) || 1000000,
+    10000000
+  );
+  const startTime = Date.now();
+  const pi = calculatePiApproximation(iterations);
+  const elapsed = Date.now() - startTime;
+
+  res.json({
+    pi,
+    iterations,
+    elapsed_ms: elapsed,
+    precision: `Leibniz approximation with ${iterations} iterations`,
+    note: "PI is an irrational transcendental number; exact value cannot be computed in finite time or space. This endpoint returns a high-precision approximation."
+  });
+});
+
+export const piRoutes = router;


### PR DESCRIPTION
根据 Issue #2883 要求，新增计算 PI 近似值的 API 端点，使用莱布尼茨级数迭代计算。由于 PI 是无限不循环小数，无法精确计算出所有小数位，因此返回有限精度近似值。