### PR TITLE
Add FreelanceFlow state poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# The State Machine of Trust
+
+Brief enters as `draft`, a quiet shape of need,
+a client sets the budget, scope, and gate;
+the queue holds every promise like a seed,
+waiting for skill to make the record state.
+
+Proposal turns to `open`, measured, signed,
+with rate, receipt, and milestone in its frame;
+the freelancer maps the edge cases in kind,
+then names the work before the work has name.
+
+Proof moves through `review`, visible and still,
+tests like lanterns on the merge-room floor;
+each comment narrows guesswork into will,
+until the patch explains what changed before.
+
+Payment settles `done`, not loud, but clear,
+a ledger line where trust and craft agree;
+FreelanceFlow keeps the handoff plain and near,
+so shipped work earns its simple history.


### PR DESCRIPTION
/claim #76

## Summary
- Adds an original root-level `POEM.md` written specifically for FreelanceFlow.
- Uses a state-machine motif across `draft`, `open`, `review`, and `done` to mirror the marketplace flow from scope to payout.

## Creative decision
I chose a compact state-machine form because FreelanceFlow turns trust into visible workflow states: scope, proposal, proof, review, and payout.

## Validation
- `git diff --check`
- Confirmed `POEM.md` exists in the project root and has four stanzas.