### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a dashboard",
+  description: "Create a useful analytics dashboard",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development",
+  skills: ["javascript"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.budgetMin, 100);
+  assert.equal(result.data.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMax must be greater than or equal to budgetMin"
+  );
+});
+
+test("updateJobSchema rejects inverted budget ranges when both bounds are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 800,
+    budgetMax: 300
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema accepts partial budget updates with one bound", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 800 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 300 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,17 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeRefinement = (data) => (
+  data.budgetMin === undefined ||
+  data.budgetMax === undefined ||
+  data.budgetMax >= data.budgetMin
+);
+
+const budgetRangeMessage = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +20,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine(
+  budgetRangeRefinement,
+  budgetRangeMessage
+);
+
+export const updateJobSchema = baseJobSchema.partial().refine(
+  budgetRangeRefinement,
+  budgetRangeMessage
+);


### PR DESCRIPTION
## Summary
- add a shared budget range refinement for job creation and partial updates
- reject payloads where `budgetMax` is lower than `budgetMin`
- add node:test regression coverage for valid ranges, inverted creates, inverted updates, and one-sided partial updates

Closes #3553.
References #743 and #2853.

## Validation
```text
npm test
# tests 5
# pass 5
# fail 0
```
