### PR TITLE
docs: add API endpoint examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,209 @@ Backend architecture follows:
 - Validation schemas (Zod)
 - Utility helpers
 
+## API Examples
+
+Examples assume the API is running at `http://localhost:4000`.
+
+### Health
+
+```bash
+curl http://localhost:4000/health
+```
+
+```json
+{ "ok": true, "service": "api" }
+```
+
+### Authentication
+
+Register a user:
+
+```bash
+curl -X POST http://localhost:4000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"client@example.com","password":"password123","role":"client"}'
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "usr_1710000000000",
+    "email": "client@example.com",
+    "role": "client",
+    "token": "jwt-token"
+  }
+}
+```
+
+Log in:
+
+```bash
+curl -X POST http://localhost:4000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"client@example.com","password":"password123"}'
+```
+
+Refresh an access token:
+
+```bash
+curl -X POST http://localhost:4000/api/auth/refresh
+```
+
+Handle an OAuth callback placeholder:
+
+```bash
+curl http://localhost:4000/api/auth/oauth/github/callback
+```
+
+### Resource Lists
+
+The current in-memory list endpoints return a shared success envelope:
+
+```bash
+curl http://localhost:4000/api/users
+curl http://localhost:4000/api/jobs
+curl http://localhost:4000/api/proposals
+curl http://localhost:4000/api/reviews
+curl http://localhost:4000/api/messages
+curl http://localhost:4000/api/notifications
+```
+
+```json
+{ "success": true, "data": [] }
+```
+
+### Jobs
+
+Create a job:
+
+```bash
+curl -X POST http://localhost:4000/api/jobs \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Build onboarding","description":"Create a guided onboarding flow","budgetMin":500,"budgetMax":1200,"categoryId":"design","skills":["UX","Next.js"]}'
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "job_1710000000000",
+    "status": "open",
+    "title": "Build onboarding",
+    "description": "Create a guided onboarding flow",
+    "budgetMin": 500,
+    "budgetMax": 1200,
+    "categoryId": "design",
+    "skills": ["UX", "Next.js"]
+  }
+}
+```
+
+### Proposals, Reviews, Messages, and Notifications
+
+Create related marketplace records with JSON payloads:
+
+```bash
+curl -X POST http://localhost:4000/api/proposals \
+  -H "Content-Type: application/json" \
+  -d '{"jobId":"job_1","freelancerId":"usr_2","coverLetter":"I can help with this.","bidAmount":900}'
+
+curl -X POST http://localhost:4000/api/reviews \
+  -H "Content-Type: application/json" \
+  -d '{"reviewerId":"usr_1","revieweeId":"usr_2","rating":5,"comment":"Excellent work."}'
+
+curl -X POST http://localhost:4000/api/messages \
+  -H "Content-Type: application/json" \
+  -d '{"threadId":"thr_1","senderId":"usr_1","content":"Can we discuss milestones?"}'
+
+curl -X POST http://localhost:4000/api/notifications \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"usr_1","type":"proposal","message":"New proposal received"}'
+```
+
+Each create route returns `201` with `{ "success": true, "data": ... }` and a generated in-memory record.
+
+### Payments
+
+Create a placeholder payment intent:
+
+```bash
+curl -X POST http://localhost:4000/api/payments \
+  -H "Content-Type: application/json" \
+  -d '{"amount":1200,"currency":"usd","jobId":"job_1"}'
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "paymentId": "pay_1710000000000",
+    "amount": 1200,
+    "currency": "usd",
+    "provider": "stripe"
+  }
+}
+```
+
+### Uploads
+
+Upload one file using the `file` form field:
+
+```bash
+curl -X POST http://localhost:4000/api/uploads \
+  -F "file=@./portfolio.pdf"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "filename": "portfolio.pdf",
+    "status": "uploaded"
+  }
+}
+```
+
+### Search
+
+```bash
+curl "http://localhost:4000/api/search?q=designer"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "query": "designer",
+    "users": [],
+    "jobs": [],
+    "freelancers": []
+  }
+}
+```
+
+### Admin Metrics
+
+The admin route uses the bearer token middleware:
+
+```bash
+curl http://localhost:4000/api/admin/metrics \
+  -H "Authorization: Bearer <token>"
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "openJobs": 42,
+    "activeFreelancers": 185,
+    "flaggedAccounts": 3,
+    "monthlyVolume": 128900
+  }
+}
+```
+
 ## Getting Started
 
 ```bash


### PR DESCRIPTION
/claim #743

Fixes #3559.

## Summary

- Add a focused `API Examples` section to `README.md`.
- Document the current Express route surface with concise curl examples and response shapes.
- Cover health, auth, resource lists, jobs, related marketplace records, payments, uploads, search, and admin metrics.

## Validation

- `git diff --check`
- Verified README examples include all scoped routes from issue #3559.
- Verified section headings for health, auth, resource routes, payments, uploads, search, and admin metrics.

## Scope

Documentation only. No application code, tests, dependencies, or generated assets changed.