### PR TITLE
fix: keep user ids server-owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps generated ids server-owned", async () => {
+  const user = await createUser({ id: "usr_client_supplied", email: "alice@example.com", role: "client" });
+
+  assert.notEqual(user.id, "usr_client_supplied");
+  assert.match(user.id, /^usr_\d+$/);
+  assert.equal(user.email, "alice@example.com");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
## Summary
- Keeps `createUser()` generated IDs server-owned by applying the service-generated id after the request payload.
- Adds focused service coverage proving a caller-supplied `id` cannot replace the generated user id.

## Test plan
- `cd apps/api && node --test src/tests/userService.test.js --test-name-pattern 'createUser keeps generated ids server-owned'`
- `cd apps/api && node --test src/tests/*.test.js`

Closes #3440
