### PR TITLE
[codex] Validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build API validation",
+  description: "Add robust validation for job creation payloads.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_security",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJobPayload).budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJobPayload, budgetMin: 500, budgetMax: 100 }),
+    (error) =>
+      error.issues?.some(
+        (issue) =>
+          issue.path.join(".") === "budgetMax" &&
+          issue.message === "budgetMax must be greater than or equal to budgetMin"
+      )
+  );
+});
+
+test("updateJobSchema allows a partial budget update with one side present", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 500 }), { budgetMin: 500 });
+});
+
+test("updateJobSchema rejects inverted budget ranges when both sides are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    (error) => error.issues?.some((issue) => issue.path.join(".") === "budgetMax")
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function requireOrderedBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+export const createJobSchema = jobFieldsSchema.superRefine(requireOrderedBudgetRange);
+
+export const updateJobSchema = jobFieldsSchema.partial().superRefine(requireOrderedBudgetRange);


### PR DESCRIPTION
Fixes #3563
/claim #743

## What changed
- added shared budget range validation to job create/update schemas
- rejects `budgetMax < budgetMin` while allowing partial updates with only one budget side
- added focused validator regression tests

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Note: `npm test -w apps/api` currently fails because its script runs `node --test src/tests`, which Node resolves as a missing module path on this setup; the explicit test-file command passes.