### PR TITLE
Fix registration token subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token with the returned user id", async () => {
+  const result = await registerUser({
+    email: "new-user@example.com",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
Fixes #2768

## Summary
- Generate the registration user id once and reuse it for both the returned `id` and JWT `sub` claim.
- Add focused service coverage proving the decoded token subject matches `result.id`.

## Testing
- `node --test "src/tests/*.test.js"` from `apps/api` passes.
- Note: root `npm test` currently fails because `apps/api/package.json` runs `node --test src/tests`, which Node treats as a file path on this environment instead of discovering tests in the directory.
