### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { parseSearchQuery } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = parseSearchQuery(req.query);
+
+  if (!parsed.success) {
+    return fail(res, parsed.message, 400);
+  }
+
+  return ok(res, await globalSearch(parsed.query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search accepts an omitted query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "");
+  });
+});
+
+test("GET /api/search accepts a single query string", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=freelancer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "freelancer");
+  });
+});
+
+test("GET /api/search rejects repeated query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a single string up to 200 characters"
+    });
+  });
+});
+
+test("GET /api/search rejects oversized query values", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a single string up to 200 characters"
+    });
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const searchQuerySchema = z.object({
+  q: z.string().max(200).optional().default("")
+});
+
+export function parseSearchQuery(query) {
+  const parsed = searchQuerySchema.safeParse(query);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: "Search query must be a single string up to 200 characters"
+    };
+  }
+
+  return {
+    success: true,
+    query: parsed.data.q
+  };
+}


### PR DESCRIPTION
Closes #1579

/claim #743

## Summary
- Reject repeated `q` query parameters before they reach the search service.
- Reject search query values longer than 200 characters.
- Preserve omitted and valid single-string search queries.
- Add focused API regression coverage for omitted, valid, repeated, and oversized query cases.

## Validation
- `node --test apps/api/src/tests/search.test.js` -> 4 passed
- `node --test apps/api/src/tests/health.test.js` -> 1 passed
- `node --check apps/api/src/controllers/searchController.js`
- `node --check apps/api/src/validators/search.js`
- `node --check apps/api/src/tests/search.test.js`
- `git diff --check`

## Note
`npm test -w apps/api` still fails on the existing upstream script path `node --test src/tests`; direct Node test-file execution passes for the affected tests.