### PR TITLE
[codex] Hide admin link from public navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -6,8 +6,7 @@ const links = [
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
 export function Navigation() {

--- a/apps/web/tests/navigation-public-links.test.mjs
+++ b/apps/web/tests/navigation-public-links.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const navigationSource = await readFile(
+  new URL("../components/Navigation.tsx", import.meta.url),
+  "utf8",
+);
+
+function readConfiguredLinks() {
+  return [...navigationSource.matchAll(/\["([^"]+)",\s*"([^"]+)"\]/g)].map(
+    ([, href, label]) => ({ href, label }),
+  );
+}
+
+test("public navigation omits admin-only routes", () => {
+  const links = readConfiguredLinks();
+
+  assert.deepEqual(
+    links.map((link) => link.href),
+    [
+      "/",
+      "/jobs",
+      "/freelancers/search",
+      "/dashboard/client",
+      "/dashboard/freelancer",
+      "/messaging",
+    ],
+  );
+  assert.equal(links.some((link) => link.href === "/admin"), false);
+  assert.equal(links.some((link) => link.label === "Admin"), false);
+});


### PR DESCRIPTION
Fixes #3568
/claim #743

## What changed
- removed the `/admin` item from the default public navigation
- kept the `/admin` route itself intact for direct/admin access
- added a focused regression test that verifies the public nav omits admin-only routes

## Validation
- `node --test apps/web/tests/navigation-public-links.test.mjs`
- `npm run build -w apps/web`
- `git diff --check`

Note: `npm run build -w apps/web` updates the generated `apps/web/next-env.d.ts` route reference on this checkout; that generated change was restored before committing so the PR stays scoped.