### PR TITLE
[codex] Preserve payment job ids

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -2,6 +2,7 @@ export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
+    jobId: payload.jobId,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent preserves the submitted job id", async () => {
+  const payment = await createPaymentIntent({
+    jobId: "job_123",
+    amount: 250,
+    currency: "usd",
+  });
+
+  assert.equal(payment.jobId, "job_123");
+  assert.equal(payment.amount, 250);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+});
+
+test("createPaymentIntent keeps the default currency behavior", async () => {
+  const payment = await createPaymentIntent({
+    jobId: "job_default_currency",
+    amount: 125,
+  });
+
+  assert.equal(payment.jobId, "job_default_currency");
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
Fixes #3570
/claim #743

## What changed
- include the submitted `jobId` in payment intent responses
- preserve existing amount, currency/default currency, provider, and payment id behavior
- add focused payment service regression coverage

## Validation
- `node --test apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `git diff --check`