### PR TITLE
[codex] Fix API test script glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/packageScripts.test.js
+++ b/apps/api/src/tests/packageScripts.test.js
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+test("API test script targets test files", async () => {
+  const packageJson = JSON.parse(
+    await readFile(new URL("../../package.json", import.meta.url), "utf8")
+  );
+
+  assert.equal(packageJson.scripts.test, 'node --test "src/tests/*.test.js"');
+});


### PR DESCRIPTION
Fixes #3572
/claim #743

## What changed
- update the API package test script to target `src/tests/*.test.js` files instead of the `src/tests` directory
- add a focused regression test for the package test script

## Validation
- `npm test -w apps/api`
- `node --test apps/api/src/tests/packageScripts.test.js`
- `node --check apps/api/src/tests/packageScripts.test.js`
- `git diff --check`