### PR TITLE
[codex] Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messageRoutes.test.js
+++ b/apps/api/src/tests/messageRoutes.test.js
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(port, body) {
+  return fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/messages rejects blank content", async () => {
+  await withServer(async (port) => {
+    const response = await postMessage(port, {
+      recipientId: "usr_123",
+      content: "   "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages requires a recipient id", async () => {
+  await withServer(async (port) => {
+    const response = await postMessage(port, { content: "Hello" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages accepts valid content", async () => {
+  await withServer(async (port) => {
+    const response = await postMessage(port, {
+      recipientId: "usr_123",
+      content: " Hello "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^msg_/);
+    assert.equal(payload.data.recipientId, "usr_123");
+    assert.equal(payload.data.content, "Hello");
+    assert.ok(Date.parse(payload.data.sentAt));
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().trim().min(1),
+  content: z.string().trim().min(1)
+});


### PR DESCRIPTION
Fixes #3389
/claim #743

## What changed
- validate message creation payloads before storing them
- reject missing recipient ids and whitespace-only content with a 400 response
- trim accepted recipient ids/content and preserve existing sent message response behavior
- add route coverage for invalid and valid message creation

## Validation
- `node --test apps/api/src/tests/messageRoutes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/controllers/messageController.js`
- `node --check apps/api/src/validators/message.js`
- `node --check apps/api/src/tests/messageRoutes.test.js`
- `git diff --check`