### PR TITLE
[codex] Constrain memory uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,43 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const UPLOAD_MAX_BYTES = 5 * 1024 * 1024;
+
+const allowedMimeTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "application/pdf"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: UPLOAD_MAX_BYTES },
+  fileFilter(req, file, callback) {
+    if (allowedMimeTypes.has(file.mimetype)) {
+      return callback(null, true);
+    }
+
+    return callback(new Error("Unsupported file type"));
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+function uploadSingleFile(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, `File too large. Maximum upload size is ${UPLOAD_MAX_BYTES} bytes.`, 413);
+    }
+
+    return fail(res, "Unsupported file type", 400);
+  });
+}
+
+uploadRoutes.post("/", uploadSingleFile, uploadFile);

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createApp } from "../app.js";
+import { UPLOAD_MAX_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function uploadFile(port, { filename, content, type }) {
+  const form = new FormData();
+  form.append("file", new Blob([content], { type }), filename);
+
+  return fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+}
+
+test("POST /api/uploads accepts safe attachment types", async () => {
+  await withServer(async (port) => {
+    const response = await uploadFile(port, {
+      filename: "avatar.png",
+      content: "png-bytes",
+      type: "image/png"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "avatar.png",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (port) => {
+    const response = await uploadFile(port, {
+      filename: "note.txt",
+      content: "not an allowed attachment",
+      type: "text/plain"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects oversized memory uploads", async () => {
+  await withServer(async (port) => {
+    const response = await uploadFile(port, {
+      filename: "large.pdf",
+      content: new Uint8Array(UPLOAD_MAX_BYTES + 1),
+      type: "application/pdf"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: `File too large. Maximum upload size is ${UPLOAD_MAX_BYTES} bytes.`
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3576
/claim #743

## What changed
- cap memory-backed uploads at 5 MiB
- allow only JPEG, PNG, GIF, and PDF attachments
- return stable JSON API errors for unsupported and oversized uploads
- preserve the existing successful upload response for valid files
- add focused upload route coverage for valid, unsupported, and oversized files

## Validation
- `node --test apps/api/src/tests/uploadRoutes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/routes/uploadRoutes.js`
- `node --check apps/api/src/tests/uploadRoutes.test.js`
- `git diff --check`