### PR TITLE
fix: run web build from root script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "build": "npm run build -w apps/web",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
Fixes #3577
/claim #743

## Summary
- replace the root placeholder build script with the actual web workspace build command
- make `npm run build` from the repository root execute the Next.js production build instead of only echoing instructions
- keep the PR scoped to `package.json`; generated build artifacts are not included

## Validation
- `npm run build` from the repository root
  - reached `npm run build -w apps/web`
  - completed `next build` successfully for 13 app routes
- `git diff --check`

Note: the clean worktree needed `npm install --ignore-scripts` before the build because dependencies were not installed locally. `next build` updates the tracked generated `apps/web/next-env.d.ts` route reference on this checkout; that generated change was restored before committing so this PR only changes the root script.