### PR TITLE
[codex] Validate auth token identity claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,20 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
+function hasIdentityClaims(payload) {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    !Array.isArray(payload) &&
+    typeof payload.sub === "string" &&
+    payload.sub.trim().length > 0 &&
+    typeof payload.role === "string" &&
+    allowedRoles.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +22,12 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!hasIdentityClaims(payload)) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getMetrics(port, token) {
+  return fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+test("auth middleware rejects string JWT payloads", async () => {
+  await withServer(async (port) => {
+    const token = jwt.sign("usr_123", env.jwtSecret);
+    const response = await getMetrics(port, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("auth middleware rejects tokens without a subject", async () => {
+  await withServer(async (port) => {
+    const token = jwt.sign({ role: "client" }, env.jwtSecret);
+    const response = await getMetrics(port, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("auth middleware rejects unsupported roles", async () => {
+  await withServer(async (port) => {
+    const token = jwt.sign({ sub: "usr_123", role: "owner" }, env.jwtSecret);
+    const response = await getMetrics(port, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("auth middleware preserves valid access tokens", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_123", role: "admin" });
+    const response = await getMetrics(port, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});


### PR DESCRIPTION
Fixes #3579
/claim #743

## What changed
- reject verified JWT payloads that are not object claims
- require a non-empty string `sub` claim
- require `role` to be one of `client`, `freelancer`, or `admin`
- preserve valid app-issued access token behavior
- add focused auth middleware coverage through the protected admin metrics route

## Validation
- `node --test apps/api/src/tests/authMiddleware.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/middleware/auth.js`
- `node --check apps/api/src/tests/authMiddleware.test.js`
- `git diff --check`