### PR TITLE
[codex] Require production JWT secret

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET || (nodeEnv === "production" ? "" : "development-secret");
+
+if (nodeEnv === "production" && !jwtSecret) {
+  throw new Error("JWT_SECRET is required in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/envConfig.test.js
+++ b/apps/api/src/tests/envConfig.test.js
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const originalEnv = {
+  NODE_ENV: process.env.NODE_ENV,
+  JWT_SECRET: process.env.JWT_SECRET
+};
+
+function setEnvValue(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+async function withEnv(values, callback) {
+  setEnvValue("NODE_ENV", values.NODE_ENV);
+  setEnvValue("JWT_SECRET", values.JWT_SECRET);
+
+  try {
+    return await callback();
+  } finally {
+    setEnvValue("NODE_ENV", originalEnv.NODE_ENV);
+    setEnvValue("JWT_SECRET", originalEnv.JWT_SECRET);
+  }
+}
+
+function importFreshEnv(name) {
+  return import(`../config/env.js?case=${name}-${Date.now()}-${Math.random()}`);
+}
+
+test("env keeps the local development JWT secret fallback", async () => {
+  await withEnv({ NODE_ENV: undefined, JWT_SECRET: undefined }, async () => {
+    const { env } = await importFreshEnv("development-fallback");
+
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.jwtSecret, "development-secret");
+  });
+});
+
+test("env requires JWT_SECRET in production", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: undefined }, async () => {
+    await assert.rejects(
+      importFreshEnv("production-missing-secret"),
+      /JWT_SECRET is required in production/
+    );
+  });
+});
+
+test("env accepts an explicit production JWT secret", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret" }, async () => {
+    const { env } = await importFreshEnv("production-secret");
+
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.jwtSecret, "prod-secret");
+  });
+});


### PR DESCRIPTION
Fixes #3582
/claim #743

## What changed
- keep the local development `development-secret` fallback
- require `JWT_SECRET` when `NODE_ENV=production`
- fail fast with a clear production config error when the secret is missing
- add config regression coverage for development fallback, missing production secret, and explicit production secret

## Validation
- `node --test apps/api/src/tests/envConfig.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/envConfig.test.js`
- `git diff --check`