### PR TITLE
fix: make root lint validate API syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
-    "lint": "echo \"No root lint configured\"",
+    "lint": "find apps/api/src -name '*.js' -print0 | xargs -0 -n1 node --check",
     "test": "npm run test -w apps/api"
   }
 }


### PR DESCRIPTION
Fixes #3586
/claim #743

## Summary
- replace the root no-op lint placeholder with a dependency-free API JavaScript syntax check
- use `node --check` over `apps/api/src/**/*.js` via `find`/`xargs`
- keep the change scoped to root package scripts with no new dependencies

## Validation
- `npm run lint`
- temporary negative check: invalid `.js` file under `apps/api/src` caused `npm run lint` to fail with `SyntaxError: Unexpected end of input`; temporary file removed before commit
- `git diff --check`
