### PR TITLE
fix: keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env.js";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser signs access token with the returned user id as subject", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "correct-horse-battery-staple",
+    role: "client"
+  });
+
+  const decoded = jwt.verify(result.token, env.jwtSecret);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once and reuse it for the returned `id`
- sign the registration access token with the same id as the JWT `sub`
- add focused regression coverage that verifies the decoded token subject matches `result.id`

Closes #3588.
References #743 and #2768.

## Verification
- `npm test` (passes: 2 tests, 2 pass, 0 fail)
