### PR TITLE
fix(auth): keep registration token subject stable

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token for the returned user id", async () => {
+  const originalDateNow = Date.now;
+  let now = 1_700_000_000_000;
+
+  Date.now = () => now++;
+
+  try {
+    const result = await registerUser({
+      email: "new-client@example.com",
+      password: "password123",
+      role: "client"
+    });
+
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, result.role);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
## Summary

- Generate the registration user id once and reuse it for the response and access-token subject.
- Add a regression test that forces sequential `Date.now()` values and verifies `decoded.sub === result.id`.
- Update the API test script so service tests under `src/tests/**/*.test.js` run reliably.

## Test

- `npm test -w apps/api`

Closes #2768.