### PR TITLE
fix: keep auth token subject aligned with returned user id

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token with the same user id it returns", async () => {
+  const originalNow = Date.now;
+  const calls = [1234567890, 1234567891];
+  let index = 0;
+
+  Date.now = () => calls[Math.min(index++, calls.length - 1)];
+
+  try {
+    const result = await registerUser({
+      email: "test@example.com",
+      password: "supersecret",
+      role: "client"
+    });
+
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1234567890");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- Generate the registration user id once
- Use that same id for the returned payload and JWT sub claim
- Add a regression test that decodes the token and checks sub == result.id
- Fix the test script so node:test picks up the suite

## Verification
- npm test

Closes #2768