### PR TITLE
fix: target API test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #3596
/claim #743

## Summary
- update the API workspace test script to target the concrete `src/tests/*.test.js` files
- keep the root `npm test` path working through the existing workspace command
- leave application behavior and dependency versions unchanged

## Verification
- `npm test -w apps/api` -> 1 passed
- `npm test` -> 1 passed
- `git diff --check`

## Notes
Before this change, `npm test -w apps/api` failed on this checkout with `MODULE_NOT_FOUND` because `node --test src/tests` was treated as a missing file/module entry instead of discovering the existing `health.test.js` file.
