### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a client",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema rejects inverted budget ranges when both values are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema allows one-sided budget updates", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, context) {
+  if (
+    payload.budgetMin !== undefined &&
+    payload.budgetMax !== undefined &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary

- Reject job payloads where `budgetMax` is lower than `budgetMin`.
- Apply the same range check to partial job updates when both budget fields are present.
- Add focused validator coverage for ordered, inverted, and one-sided update budget ranges.

Fixes #3600
Parent bounty: #743

## Tests

- `node --test apps/api/src/tests/*.test.js`
  - pass: 5
- `npm test`
  - currently fails before executing tests because `apps/api/package.json` passes `src/tests` as a module path under Node v26; left out of this PR because a separate open PR appears to cover the test-script glob.
