### PR TITLE
Reject empty upload requests

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withTestServer(async (baseUrl) => {
+    const formData = new FormData();
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes creator-owned issue #3602 by rejecting `POST /api/uploads` requests that do not include a `file` field.
- Uses the existing `fail()` helper to return a 400 JSON error for empty upload submissions.
- Adds focused API regression coverage for the missing-file case.

/claim #743

## Validation
- `node --test apps/api/src/tests/*.test.js` -> 2 tests passed
- `git diff --check` -> passed

## Demo
The regression test demonstrates the API behavior change: before the fix, the missing-file upload path returned 201; after the fix, `POST /api/uploads` without a file returns `{ success: false, message: "File is required" }` with HTTP 400.

## Payment fallback
If this claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q