### PR TITLE
Return 400 for validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/error-handler.test.js
+++ b/apps/api/src/tests/error-handler.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createMockResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("Zod validation errors return a 400 validation response", () => {
+  const schema = z.object({
+    email: z.string().email(),
+    password: z.string().min(8)
+  });
+  const result = schema.safeParse({
+    email: "not-an-email",
+    password: "short"
+  });
+  assert.equal(result.success, false);
+
+  const res = createMockResponse();
+  errorHandler(result.error, {}, res, () => {
+    throw new Error("next should not be called for ZodError");
+  });
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, "Validation failed");
+  assert.ok(Array.isArray(res.body.errors));
+  assert.ok(res.body.errors.length > 0);
+});


### PR DESCRIPTION
## Summary
- Fixes creator-owned issue #3610 by returning HTTP 400 for `ZodError` validation failures.
- Keeps the existing generic 500 response path for non-validation errors.
- Adds focused regression coverage for the validation error response shape.

/claim #743

## Validation
- `node --test apps/api/src/tests/*.test.js` -> 2 tests passed
- `git diff --check` -> passed

## Demo
The regression test demonstrates the behavior change at the global error handler: Zod schema failures now return `{ success: false, message: "Validation failed", errors: [...] }` with HTTP 400 instead of falling through to the generic 500 response.

## Payment fallback
If this claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q