### PR TITLE
fix(api): ensure immutability of notification ID and read fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification always starts unread with a server-owned id and preserves payload", async () => {
+  const notification = await createNotification({
+    id: "ntf_client_supplied",
+    read: true,
+    userId: "usr_1",
+    message: "New proposal",
+    type: "proposal"
+  });
+
+  assert.notEqual(notification.id, "ntf_client_supplied");
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_1");
+  assert.equal(notification.message, "New proposal");
+  assert.equal(notification.type, "proposal");
+});
+
+test("createNotification ignores attempts to create already-read notifications", async () => {
+  const notification = await createNotification({
+    read: true,
+    message: "Security alert"
+  });
+
+  assert.equal(notification.read, false);
+  assert.match(notification.id, /^ntf_\d+$/);
+});


### PR DESCRIPTION
This PR fixes the payload spread order in the notification service to ensure client-supplied payloads cannot overwrite server-assigned fields (ID, read). It includes unit tests verifying correctness. Collaborator: @lumen_lux