### PR TITLE
fix: require JWT_SECRET in production environment

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,3 +1,9 @@
+const isProduction = (process.env.NODE_ENV ?? "development") === "production";
+
+if (isProduction && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is required in production");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const apiDir = join(__dirname, "..", "..");
+
+test("development fallback: JWT_SECRET defaults to development-secret", async () => {
+  const result = execSync(
+    "node -e \"const {env} = await import('./src/config/env.js'); console.log(JSON.stringify(env))\"",
+    { cwd: apiDir, encoding: "utf8", env: { ...process.env, NODE_ENV: "development" } }
+  );
+  const env = JSON.parse(result.trim());
+  assert.equal(env.jwtSecret, "development-secret");
+  assert.equal(env.nodeEnv, "development");
+});
+
+test("production: throws when JWT_SECRET is not set", async () => {
+  try {
+    execSync(
+      "node -e \"import('./src/config/env.js')\"",
+      { cwd: apiDir, encoding: "utf8", env: { ...process.env, NODE_ENV: "production" } }
+    );
+    assert.fail("Should have thrown");
+  } catch (e) {
+    assert.ok(e.stderr.includes("JWT_SECRET") || e.message.includes("JWT_SECRET"));
+  }
+});
+
+test("production: uses provided JWT_SECRET", async () => {
+  const result = execSync(
+    "node -e \"const {env} = await import('./src/config/env.js'); console.log(JSON.stringify(env))\"",
+    { cwd: apiDir, encoding: "utf8", env: { ...process.env, NODE_ENV: "production", JWT_SECRET: "my-secret-key" } }
+  );
+  const env = JSON.parse(result.trim());
+  assert.equal(env.jwtSecret, "my-secret-key");
+  assert.equal(env.nodeEnv, "production");
+});
+
+test("development: does not require JWT_SECRET", async () => {
+  const result = execSync(
+    "node -e \"const {env} = await import('./src/config/env.js'); console.log(JSON.stringify(env))\"",
+    { cwd: apiDir, encoding: "utf8", env: { ...process.env, NODE_ENV: "development" } }
+  );
+  const env = JSON.parse(result.trim());
+  assert.equal(env.jwtSecret, "development-secret");
+});


### PR DESCRIPTION
## Problem
The JWT secret falls back to `development-secret` when `JWT_SECRET` is not set. That fallback is useful for local development, but in production it lets anyone who knows the default forge valid tokens if the environment is misconfigured.

## Fix
- Add production check that throws if `JWT_SECRET` is not set
- Keep development fallback for local development
- Add config regression tests for all scenarios

## Changes
- `apps/api/src/config/env.js`: Add production environment check
- `apps/api/src/tests/env.test.js`: Add 4 test cases for config validation

## Testing
All tests pass:
```
✔ development fallback: JWT_SECRET defaults to development-secret
✔ production: throws when JWT_SECRET is not set
✔ production: uses provided JWT_SECRET
✔ development: does not require JWT_SECRET
```

Closes #3582