### PR TITLE
fix: validate JWT identity claims in auth middleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,8 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const ALLOWED_ROLES = ["client", "freelancer", "admin"];
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +10,24 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    
+    // Validate payload is a plain object
+    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+      return fail(res, "Invalid token payload", 401);
+    }
+    
+    // Validate sub claim exists and is a non-empty string
+    if (typeof payload.sub !== "string" || payload.sub.trim() === "") {
+      return fail(res, "Invalid token: missing subject", 401);
+    }
+    
+    // Validate role claim exists and is an allowed value
+    if (!ALLOWED_ROLES.includes(payload.role)) {
+      return fail(res, "Invalid token: invalid role", 401);
+    }
+    
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,183 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+
+const API_DIR = "/tmp/bug-bounty/apps/api";
+
+test("auth middleware: rejects non-object payloads", async () => {
+  // Create a token with string payload
+  const result = execSync(
+    `node -e "
+      const jwt = require('jsonwebtoken');
+      const token = jwt.sign('string-payload', 'development-secret', { expiresIn: '15m' });
+      console.log(token);
+    "`,
+    { cwd: API_DIR, encoding: "utf8" }
+  ).trim();
+  
+  // Try to access protected route with invalid token
+  try {
+    execSync(
+      `node -e "
+        import('express').then(({default: express}) => {
+          import('./src/middleware/auth.js').then(({authMiddleware}) => {
+            const app = express();
+            app.use(express.json());
+            app.get('/test', authMiddleware, (req, res) => res.json({ user: req.user }));
+            
+            const server = app.listen(0, async () => {
+              const port = server.address().port;
+              try {
+                const res = await fetch('http://127.0.0.1:' + port + '/test', {
+                  headers: { 'Authorization': 'Bearer ${result}' }
+                });
+                const data = await res.json();
+                console.log(JSON.stringify({ status: res.status, data }));
+              } catch (e) {
+                console.log(JSON.stringify({ error: e.message }));
+              }
+              server.close();
+            });
+          });
+        });
+      "`,
+      { cwd: API_DIR, encoding: "utf8" }
+    );
+  } catch (e) {
+    // Expected to fail
+    assert.ok(e.stdout.includes("401") || e.message.includes("401"));
+  }
+});
+
+test("auth middleware: rejects tokens without sub claim", async () => {
+  // Create a token without sub
+  const result = execSync(
+    `node -e "
+      const jwt = require('jsonwebtoken');
+      const token = jwt.sign({ role: 'client' }, 'development-secret', { expiresIn: '15m' });
+      console.log(token);
+    "`,
+    { cwd: API_DIR, encoding: "utf8" }
+  ).trim();
+  
+  try {
+    execSync(
+      `node -e "
+        import('express').then(({default: express}) => {
+          import('./src/middleware/auth.js').then(({authMiddleware}) => {
+            const app = express();
+            app.use(express.json());
+            app.get('/test', authMiddleware, (req, res) => res.json({ user: req.user }));
+            
+            const server = app.listen(0, async () => {
+              const port = server.address().port;
+              try {
+                const res = await fetch('http://127.0.0.1:' + port + '/test', {
+                  headers: { 'Authorization': 'Bearer ${result}' }
+                });
+                const data = await res.json();
+                console.log(JSON.stringify({ status: res.status, data }));
+              } catch (e) {
+                console.log(JSON.stringify({ error: e.message }));
+              }
+              server.close();
+            });
+          });
+        });
+      "`,
+      { cwd: API_DIR, encoding: "utf8" }
+    );
+  } catch (e) {
+    assert.ok(e.stdout.includes("401") || e.message.includes("401"));
+  }
+});
+
+test("auth middleware: rejects tokens with invalid role", async () => {
+  // Create a token with invalid role
+  const result = execSync(
+    `node -e "
+      const jwt = require('jsonwebtoken');
+      const token = jwt.sign({ sub: 'user123', role: 'invalid' }, 'development-secret', { expiresIn: '15m' });
+      console.log(token);
+    "`,
+    { cwd: API_DIR, encoding: "utf8" }
+  ).trim();
+  
+  try {
+    execSync(
+      `node -e "
+        import('express').then(({default: express}) => {
+          import('./src/middleware/auth.js').then(({authMiddleware}) => {
+            const app = express();
+            app.use(express.json());
+            app.get('/test', authMiddleware, (req, res) => res.json({ user: req.user }));
+            
+            const server = app.listen(0, async () => {
+              const port = server.address().port;
+              try {
+                const res = await fetch('http://127.0.0.1:' + port + '/test', {
+                  headers: { 'Authorization': 'Bearer ${result}' }
+                });
+                const data = await res.json();
+                console.log(JSON.stringify({ status: res.status, data }));
+              } catch (e) {
+                console.log(JSON.stringify({ error: e.message }));
+              }
+              server.close();
+            });
+          });
+        });
+      "`,
+      { cwd: API_DIR, encoding: "utf8" }
+    );
+  } catch (e) {
+    assert.ok(e.stdout.includes("401") || e.message.includes("401"));
+  }
+});
+
+test("auth middleware: accepts valid tokens", async () => {
+  // Create a valid token
+  const result = execSync(
+    `node -e "
+      const jwt = require('jsonwebtoken');
+      const token = jwt.sign({ sub: 'user123', role: 'client' }, 'development-secret', { expiresIn: '15m' });
+      console.log(token);
+    "`,
+    { cwd: API_DIR, encoding: "utf8" }
+  ).trim();
+  
+  try {
+    const output = execSync(
+      `node -e "
+        import('express').then(({default: express}) => {
+          import('./src/middleware/auth.js').then(({authMiddleware}) => {
+            const app = express();
+            app.use(express.json());
+            app.get('/test', authMiddleware, (req, res) => res.json({ user: req.user }));
+            
+            const server = app.listen(0, async () => {
+              const port = server.address().port;
+              try {
+                const res = await fetch('http://127.0.0.1:' + port + '/test', {
+                  headers: { 'Authorization': 'Bearer ${result}' }
+                });
+                const data = await res.json();
+                console.log(JSON.stringify({ status: res.status, data }));
+              } catch (e) {
+                console.log(JSON.stringify({ error: e.message }));
+              }
+              server.close();
+            });
+          });
+        });
+      "`,
+      { cwd: API_DIR, encoding: "utf8" }
+    );
+    const data = JSON.parse(output.trim());
+    assert.equal(data.status, 200);
+    assert.equal(data.data.user.sub, "user123");
+    assert.equal(data.data.user.role, "client");
+  } catch (e) {
+    assert.fail(`Expected success but got error: ${e.message}`);
+  }
+});


### PR DESCRIPTION
## Problem
The `authMiddleware` accepts any successfully verified JWT payload as `req.user`. A token signed with the app secret can contain a string payload, an object without `sub`, or an object with an unsupported `role`, and the middleware will still treat the request as authenticated.

This leaves protected routes without a guaranteed requester identity or role and can make downstream authorization checks fail open or behave inconsistently.

## Fix
- Reject decoded JWT payloads that are not plain objects
- Reject tokens missing a non-empty string `sub`
- Reject tokens missing an allowed `role` value (client, freelancer, admin)
- Preserve valid app-issued access tokens

## Changes
- `apps/api/src/middleware/auth.js`: Add identity-claim validation
- `apps/api/src/tests/auth.test.js`: Add comprehensive test coverage

## Testing
Added 4 test cases covering:
1. Rejects non-object payloads
2. Rejects tokens without sub claim
3. Rejects tokens with invalid role
4. Accepts valid tokens

Closes #3579