### PR TITLE
Return defensive copies from list services

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListIsDefensive({ create, list, payload }) {
+  const created = await create(payload);
+  const exposedList = await list();
+
+  exposedList.length = 0;
+  exposedList.push({ id: "injected" });
+
+  const freshList = await list();
+  assert.ok(freshList.some((item) => item.id === created.id));
+  assert.equal(freshList.some((item) => item.id === "injected"), false);
+}
+
+test("list services return defensive array copies", async () => {
+  await assertListIsDefensive({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "copy-user@example.com", role: "client" }
+  });
+
+  await assertListIsDefensive({
+    create: createJob,
+    list: listJobs,
+    payload: {
+      title: "Build landing page",
+      description: "Create a polished landing page",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "cat_design",
+      skills: ["design"]
+    }
+  });
+
+  await assertListIsDefensive({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_1", freelancerId: "usr_1", bidAmount: 250, coverLetter: "I can help" }
+  });
+
+  await assertListIsDefensive({
+    create: createReview,
+    list: listReviews,
+    payload: { reviewerId: "usr_1", revieweeId: "usr_2", rating: 5, comment: "Great work" }
+  });
+
+  await assertListIsDefensive({
+    create: sendMessage,
+    list: listMessages,
+    payload: { senderId: "usr_1", receiverId: "usr_2", body: "Hello" }
+  });
+
+  await assertListIsDefensive({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_1", title: "Update", body: "You have a new message" }
+  });
+});


### PR DESCRIPTION
## Summary

- Return shallow defensive copies from all in-memory list service functions.
- Add regression coverage that mutates returned lists and verifies the backing stores remain intact.
- Update the API test script to run explicit `*.test.js` files on Windows/Node where passing the test directory directly is treated as a module path.

Closes #3623

## Tests

npm test

Result: 2 tests passed.