### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.parse({ email: "test@example.com", password: "password123", role: "client" });
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.parse({ email: "test@example.com", password: "password123", role: "freelancer" });
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerSchema defaults to client role when not provided", () => {
+  const result = registerSchema.parse({ email: "test@example.com", password: "password123" });
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema rejects admin role", () => {
+  assert.throws(() => {
+    registerSchema.parse({ email: "test@example.com", password: "password123", role: "admin" });
+  }, /Invalid enum value/);
+});
+
+test("registerSchema rejects invalid role", () => {
+  assert.throws(() => {
+    registerSchema.parse({ email: "test@example.com", password: "password123", role: "superadmin" });
+  }, /Invalid enum value/);
+});
+
+test("registerSchema rejects invalid email", () => {
+  assert.throws(() => {
+    registerSchema.parse({ email: "not-an-email", password: "password123" });
+  });
+});
+
+test("registerSchema rejects short password", () => {
+  assert.throws(() => {
+    registerSchema.parse({ email: "test@example.com", password: "short" });
+  });
+});
+

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,11 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+


### PR DESCRIPTION
## Problem
Public registration currently accepts `role: "admin"`, which lets a new user self-assign admin privileges and receive a token signed with the admin role. This is a privilege escalation vulnerability.

## Fix
- Restrict `registerSchema` role enum to `["client", "freelancer"]` only
- Remove `"admin" ` from the allowed registration roles
- Preserve default `"client"` role behavior

## Changes
- `apps/api/src/validators/auth.js`: Remove admin from allowed roles enum
- `apps/api/src/tests/auth.test.js`: Add 7 test cases covering role validation

## Testing
All tests pass:
```
✔ registerSchema accepts client role
✔ registerSchema accepts freelancer role
✔ registerSchema defaults to client role when not provided
✔ registerSchema rejects admin role
✔ registerSchema rejects invalid role
✔ registerSchema rejects invalid email
✔ registerSchema rejects short password
```

## Verification
`npm test -w apps/api` passes cleanly.

Closes #3627
Closes #2832
Refs #743