### PR TITLE
fix: authenticate auth refresh endpoint and preserve token subject

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);
+

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -8,4 +8,3 @@ authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
 authRoutes.post("/refresh", authMiddleware, refresh);
-

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth/refresh without token returns 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" }
+  });
+  assert.equal(response.status, 401);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/auth/refresh with valid token returns new token for same user", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  
+  const token = signAccessToken({ sub: "usr_test123", role: "client" });
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`
+    }
+  });
+  
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.ok(payload.token);
+  
+  // Verify the new token has the same subject
+  const decoded = JSON.parse(Buffer.from(payload.token.split(".")[1], "base64").toString());
+  assert.equal(decoded.sub, "usr_test123");
+  assert.equal(decoded.role, "client");
+  
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/auth/refresh with invalid token returns 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer invalid-token-here"
+    }
+  });
+  assert.equal(response.status, 401);
+  await new Promise((resolve) => server.close(resolve));
+});
+


### PR DESCRIPTION
## Problem
`POST /api/auth/refresh` currently issues a fresh access token without checking the requester at all. The service also signs that token for the hard-coded subject `usr_existing` with role `client`, so even an authenticated caller does not get a token for their own subject and role.

## Fix
- Protect the refresh route with the existing bearer-token auth middleware
- Pass the verified user payload (`req.user`) into the refresh service
- Sign the refreshed token for that authenticated subject and role
- Add route-level tests for unauthenticated rejection and authenticated subject preservation

## Changes
- `apps/api/src/routes/authRoutes.js`: Add authMiddleware to refresh route
- `apps/api/src/services/authService.js`: Accept user payload in refreshToken
- `apps/api/src/controllers/authController.js`: Pass req.user to service
- `apps/api/src/tests/authRefresh.test.js`: Add 3 regression tests

## Testing
All tests pass:
```
✔ POST /api/auth/refresh without token returns 401
✔ POST /api/auth/refresh with valid token returns new token for same user
✔ POST /api/auth/refresh with invalid token returns 401
```

## Verification
`npm test -w apps/api` passes cleanly.

Closes #3629
Closes #2847
Refs #743