### PR TITLE
fix: reject empty upload submissions with 400 response

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }
+

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads without file returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  
+  const formData = new FormData();
+  formData.append("other", "value");
+  
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData
+  });
+  
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.error, "No file provided");
+  
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/uploads with file returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  
+  const formData = new FormData();
+  const blob = new Blob(["test file content"], { type: "text/plain" });
+  formData.append("file", blob, "test.txt");
+  
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData
+  });
+  
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.status, "uploaded");
+  assert.equal(payload.filename, "test.txt");
+  
+  await new Promise((resolve) => server.close(resolve));
+});
+


### PR DESCRIPTION
## Problem
`POST /api/uploads` currently returns `201` with `success: true` even when the multipart request does not include a `file` field. The response reports `status: "no-file"`, but it is still treated as a successful upload by HTTP status and response shape.

## Fix
- Reject upload requests that do not include a file with a clear `400` response
- Keep successful upload responses reserved for requests that actually include `req.file`
- Add route-level regression coverage for the missing-file case

## Changes
- `apps/api/src/controllers/uploadController.js`: Return 400 for missing file
- `apps/api/src/tests/upload.test.js`: Add 2 regression tests

## Testing
All tests pass:
```
✔ POST /api/uploads without file returns 400
✔ POST /api/uploads with file returns 201
```

## Verification
`npm test -w apps/api` passes cleanly.

Closes #3634
Closes #2850
Refs #743