### PR TITLE
fix: resolve freelancer profile by username from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Problem
The `/freelancers/[username]` route renders placeholder text with the requested username instead of looking up the selected freelancer from `apps/web/lib/mock.ts`. Search cards link to `/freelancers/maya-dev` and `/freelancers/jordan-ux`, but the profile page does not show matching skills or hourly rate. Unknown usernames also appear successful.

## Fix
- Known freelancer usernames render the matching mock profile details
- The profile page exposes useful skills/rate context instead of generic placeholder copy
- Unknown usernames render a clear not-found fallback

## Changes
- `apps/web/app/freelancers/[username]/page.tsx`: Resolve mock profiles by username, add not-found fallback

## Verification
- Known usernames (maya-dev, jordan-ux) display matching skills and rate
- Unknown usernames show a clear "Not Found" message

Closes #3635
Closes #2849
Refs #743