### PR TITLE
fix: require authentication on payment creation endpoint

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);
+

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/payments without token returns 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 100, currency: "usd" })
+  });
+  
+  assert.equal(response.status, 401);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/payments with valid token returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  
+  const token = signAccessToken({ sub: "usr_test123", role: "client" });
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`
+    },
+    body: JSON.stringify({ amount: 100, currency: "usd" })
+  });
+  
+  assert.equal(response.status, 201);
+  await new Promise((resolve) => server.close(resolve));
+});
+


### PR DESCRIPTION
## Problem
`POST /api/payments` currently allows unauthenticated callers to create payment intent records. Payment creation is account-scoped and should require the same bearer-token authentication middleware already used by protected API routes.

## Fix
- Apply the existing `authMiddleware` to payment routes
- Add focused API tests for unauthenticated rejection and valid-token payment creation
- Keep payment service behavior unchanged for authenticated requests

## Changes
- `apps/api/src/routes/paymentRoutes.js`: Add authMiddleware to POST route
- `apps/api/src/tests/payment.test.js`: Add 2 regression tests

## Testing
All tests pass:
```
✔ POST /api/payments without token returns 401
✔ POST /api/payments with valid token returns 201
```

## Verification
`npm test -w apps/api` passes cleanly.

Closes #3636
Closes #2757
Refs #743