### PR TITLE
fix: require JWT_SECRET in production environment

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,17 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: getJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+function getJwtSecret() {
+  const secret = process.env.JWT_SECRET;
+  if (process.env.NODE_ENV === "production" && !secret) {
+    throw new Error(
+      "JWT_SECRET environment variable is required in production"
+    );
+  }
+  return secret ?? "development-secret";
+}


### PR DESCRIPTION
## Problem Summary

The JWT secret falls back to `development-secret` when `JWT_SECRET` is not set. In production, this allows token forgery if the environment is misconfigured.

## Solution Approach

- Added `getJwtSecret()` helper function in `apps/api/src/config/env.js`
- Throws explicit error when `JWT_SECRET` is missing and `NODE_ENV=production`
- Preserves the `development-secret` fallback for local development
- No new dependencies added

## Changes

- `apps/api/src/config/env.js`: Replaced inline fallback with `getJwtSecret()` that validates in production

## Fixes

- Fixes #3643 (reissue of #3582)
- Parent bounty: #743

/attempt #743