### PR TITLE
fix: make root lint validate API source syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
-    "lint": "echo \"No root lint configured\"",
+    "lint": "node -e \"const fs=require('fs');const cp=require('child_process');const files=cp.execSync('find apps/api/src -name \\\"*.js\\\" -type f').toString().trim().split('\\n');let ok=true;files.forEach(f=>{try{new Function(fs.readFileSync(f,'utf8'))}catch(e){console.error(f+': '+e.message);ok=false}});if(!ok)process.exit(1);console.log('All JS files pass syntax check')\"",
     "test": "npm run test -w apps/api"
   }
 }


### PR DESCRIPTION
## Problem Summary

The root `npm run lint` script only prints a placeholder and exits successfully, allowing syntax regressions in API JavaScript files to pass without validation.

## Solution Approach

- Replaced the placeholder `echo` with a dependency-free syntax checker
- Uses `node -e` with `child_process.execSync` to find all `.js` files under `apps/api/src/`
- Validates each file with `new Function()` (syntax-only check, no execution)
- Exits non-zero with error details on any syntax failure
- No new dependencies added

## Changes

- `package.json`: Updated `lint` script to run actual syntax validation

## Fixes

- Fixes #3647 (reissue of #3586)
- Parent bounty: #743

/attempt #743