### PR TITLE
fix: redact raw errors in production logging

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,19 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  const isProduction = process.env.NODE_ENV === "production";
+
+  if (isProduction) {
+    console.error("Unhandled API error:", {
+      message: err?.message ? "Error occurred" : "Unknown error",
+      name: err?.name || "Error",
+      statusCode: err?.statusCode || 500,
+      path: req?.path,
+      method: req?.method,
+      timestamp: new Date().toISOString()
+    });
+  } else {
+    console.error("Unhandled API error:", err);
+  }
+
   if (res.headersSent) {
     return next(err);
   }


### PR DESCRIPTION
## Problem Summary

The API error handler logs raw error objects in every environment, potentially exposing sensitive values from upstream services or request-derived exceptions in production logs.

## Solution Approach

- **Production**: Log structured metadata only (error name, request path/method, timestamp) without serializing the raw error object
- **Development**: Preserve verbose `console.error(err)` for local debugging
- Public API response remains a generic 500 in all environments

## Changes

- `apps/api/src/middleware/errorHandler.js`: Environment-aware logging with redaction in production

## Fixes

- Fixes #3646 (reissue of #3584)
- Parent bounty: #743

/attempt #743