### PR TITLE
fix(proposal): add Zod validation for proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,13 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    const payload = createProposalSchema.parse(req.body);
+    return ok(res, await createProposal(payload), 201);
+  } catch (error) {
+    if (error.name === "ZodError") {
+      return fail(res, error.errors.map(e => e.message).join(", "), 400);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "Job ID is required"),
+  freelancerId: z.string().min(1, "Freelancer ID is required"),
+  bidAmount: z.number().positive("Bid amount must be positive"),
+  estimatedDuration: z.string().min(1, "Estimated duration is required"),
+  coverLetter: z.string().optional()
+});
+
+export const updateProposalSchema = createProposalSchema.partial();


### PR DESCRIPTION
## Problem

`POST /api/proposals` forwarded `req.body` directly into `createProposal()` without validation, allowing malformed payloads to be stored as successful records.

## Solution

- Created `apps/api/src/validators/proposal.js` with `createProposalSchema`
- Validates: `jobId` (string, required), `freelancerId` (string, required), `bidAmount` (positive number), `estimatedDuration` (string, required), `coverLetter` (string, optional)
- Updated `apps/api/src/controllers/proposalController.js` to parse and validate payloads
- Returns 400 with clear error messages for invalid payloads

## Changes

- `apps/api/src/validators/proposal.js`: New Zod validation schema
- `apps/api/src/controllers/proposalController.js`: Added validation before creation

## Test Evidence

- Missing required fields returns 400
- Negative bid amount returns 400
- Valid payloads continue to create proposals successfully

Fixes #3649