### PR TITLE
fix: use single id for registration response and JWT subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Problem Summary

`authService.registerUser()` calls `Date.now()` twice — once for the returned `id` and once for the JWT `sub` claim. If the two calls cross a millisecond boundary, the token subject differs from the user id returned to the client.

## Solution Approach

- Generate the user id once as `const id = usr_${Date.now()}`
- Reuse the same `id` variable for both `result.id` and `signAccessToken({ sub: id })`
- Zero behavioral change for existing callers

## Changes

- `apps/api/src/services/authService.js`: Single id generation, used for both response and JWT

## Fixes

- Fixes #3645 (reissue of #3588)
- Parent bounty: #743

/attempt #743