### PR TITLE
fix(message): add Zod validation for message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,19 @@
-import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { ok, fail } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
+import { createMessage, listMessages } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    const payload = createMessageSchema.parse(req.body);
+    return ok(res, await createMessage(payload), 201);
+  } catch (error) {
+    if (error.name === "ZodError") {
+      return fail(res, error.errors.map(e => e.message).join(", "), 400);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().min(1, "Sender ID is required"),
+  recipientId: z.string().min(1, "Recipient ID is required"),
+  content: z.string().min(1, "Message content is required")
+});
+
+export const updateMessageSchema = createMessageSchema.partial();


### PR DESCRIPTION
## Problem

`POST /api/messages` forwarded `req.body` directly into `sendMessage()` without validation, allowing malformed payloads to be stored as successful message records.

## Solution

- Created `apps/api/src/validators/message.js` with `createMessageSchema`
- Validates: `senderId` (string, required), `recipientId` (string, required), `content` (string, min 1, required)
- Updated `apps/api/src/controllers/messageController.js` to parse and validate payloads
- Returns 400 with clear error messages for invalid payloads

## Changes

- `apps/api/src/validators/message.js`: New Zod validation schema
- `apps/api/src/controllers/messageController.js`: Added validation before creation

## Test Evidence

- Missing required fields returns 400
- Empty content returns 400
- Valid payloads continue to create messages successfully

Fixes #3650