### PR TITLE
fix(review): add Zod validation for review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,13 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  try {
+    const payload = createReviewSchema.parse(req.body);
+    return ok(res, await createReview(payload), 201);
+  } catch (error) {
+    if (error.name === "ZodError") {
+      return fail(res, error.errors.map(e => e.message).join(", "), 400);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1, "Reviewer ID is required"),
+  revieweeId: z.string().min(1, "Reviewee ID is required"),
+  rating: z.number().int().min(1, "Rating must be at least 1").max(5, "Rating must be at most 5"),
+  comment: z.string().optional()
+});
+
+export const updateReviewSchema = createReviewSchema.partial();


### PR DESCRIPTION
## Problem

`POST /api/reviews` forwarded `req.body` directly into `createReview()` without validation, allowing reviews with ratings outside 1-5 range and missing required fields.

## Solution

- Created `apps/api/src/validators/review.js` with `createReviewSchema`
- Validates: `reviewerId` (string, required), `revieweeId` (string, required), `rating` (integer, min 1, max 5), `comment` (string, optional)
- Updated `apps/api/src/controllers/reviewController.js` to parse and validate payloads
- Returns 400 with clear error messages for invalid payloads

## Changes

- `apps/api/src/validators/review.js`: New Zod validation schema
- `apps/api/src/controllers/reviewController.js`: Added validation before creation

## Test Evidence

- Rating 0 returns 400
- Rating 6 returns 400
- Missing reviewerId returns 400
- Valid ratings (1-5) continue to create reviews successfully

Fixes #3651