### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMin"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Problem Summary

The API allows creating jobs where `budgetMin` > `budgetMax`, which is semantically invalid.

## Solution Approach

- Added `.refine()` validation to `createJobSchema` ensuring `budgetMin <= budgetMax`
- Returns 400 with descriptive error message when budget range is inverted
- No new dependencies

## Changes

- `apps/api/src/validators/job.js`: Added refinement check

## Fixes

- Fixes #3663 (reissue of #3395)
- Parent bounty: #743

/attempt #743