### PR TITLE
fix: remove admin from registration role enum

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Problem Summary

The `registerSchema` allows `admin` as a valid role, letting any unauthenticated user self-assign admin privileges during registration.

## Solution Approach

- Removed `"admin"` from the `z.enum()` in `registerSchema`
- Registration now only accepts `client` or `freelancer` roles
- No behavioral change for legitimate registrations

## Changes

- `apps/api/src/validators/auth.js`: Role enum limited to `["client", "freelancer"]`

## Fixes

- Fixes #3662 (reissue of #3403)
- Parent bounty: #743

/attempt #743