### PR TITLE
fix: add Zod validation for review creation

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0].message, 400);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).max(1000),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
## Problem Summary

The POST /api/reviews endpoint processes payloads directly from `req.body` without validation, allowing invalid ratings (0, 6, etc.) and empty comments.

## Solution Approach

- Created `apps/api/src/validators/review.js` with Zod schema:
  - `rating`: integer 1-5
  - `comment`: string, 1-1000 chars
  - `jobId`: required string
  - `freelancerId`: required string
- Updated `postReview` controller to validate input before processing
- Returns 400 with descriptive error on invalid input

## Changes

- `apps/api/src/validators/review.js`: New validation schema
- `apps/api/src/controllers/reviewController.js`: Added safeParse validation

## Fixes

- Fixes #3664 (reissue of #3419)
- Parent bounty: #743

/attempt #743