### PR TITLE
fix: reject empty upload submissions with 400

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Problem Summary

The upload endpoint returns 201 with `no-file` status when no file is provided, instead of rejecting the request.

## Solution Approach

- Added early return with `fail(res, "File is required", 400)` when `req.file` is missing
- Imported `fail` utility for consistent error responses
- Valid uploads continue to return 201 with file details

## Changes

- `apps/api/src/controllers/uploadController.js`: Added empty file rejection

## Fixes

- Fixes #3668 (reissue of #3470)
- Parent bounty: #743

/attempt #743