### PR TITLE
fix: preserve server-generated proposal id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...proposalFields } = payload;
+  const proposal = { ...proposalFields, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal preserves the server-generated proposal id", async () => {
+  const proposal = await createProposal({
+    id: "attacker-controlled-id",
+    jobId: "job_123",
+    freelancerId: "usr_456",
+    coverLetter: "I can complete this project safely.",
+    amount: 500
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "attacker-controlled-id");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_456");
+});


### PR DESCRIPTION
## Summary

- Preserve the server-generated proposal id during proposal creation.
- Ignore a client-supplied `id` while keeping legitimate proposal fields intact.
- Add a regression test for the attacker-controlled id override case.

Closes #3671
/claim #743

## Validation

```bash
node --test apps/api/src/tests/proposalService.test.js
# pass 1, fail 0

node --test apps/api/src/tests/health.test.js
# pass 1, fail 0

git diff --check
# no output
```

## Baseline note

The broader `npm test` command currently fails on upstream `apps/api` configuration because `node --test src/tests` treats the test directory as a module path on this Node version. I did not change that here to keep this PR scoped to #3671.
