### PR TITLE
Fix API workspace test script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- point the API workspace test script at concrete `*.test.js` files
- restore `npm test -w apps/api` without changing API behavior
- keep the root `npm test` command working through the workspace script

## Verification
- `npm test -w apps/api`
- `npm test`
- `git diff --check origin/main...HEAD`

Refs #3673
Refs #3614
