### PR TITLE
fix(api): API workspace test script should target concrete test files (Fixes #3675)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
### Problem
The API workspace test script was defined as `"test": "node --test src/tests"`. On the Node.js test runner, this directory path was treated as a module/file entry rather than a directory containing test files, resulting in `MODULE_NOT_FOUND` errors when executing `npm test -w apps/api` or root `npm test`.

### Solution
Updated the package test script to target the concrete test files: `"test": "node --test src/tests/*.test.js"`. This allows both the local workspace test command and the root test script to discover and execute existing tests successfully.

- Fixes #3675
- Parent Algora bounty: #743