### PR TITLE
Fix: Proposal creation preserves server-generated id (Fixes #3671)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...cleanPayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...cleanPayload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /proposals preserves server-generated id", async () => {
+  const app = createApp();
+  // Disable rate limiting for testing
+  app._router.stack = app._router.stack.filter(
+    (layer) => layer.handle.name !== "rateLimit"
+  );
+  
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        id: "client-malicious-id",
+        title: "Test Proposal",
+        description: "Let's see if this works",
+      }),
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(payload.data.id.startsWith("prp_"));
+    assert.notEqual(payload.data.id, "client-malicious-id");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
This PR fixes a bug where the client could provide their own ID on proposal creation, bypassing the server-generated format. It strips the client-provided ID from the payload to enforce server-generated IDs, and implements integration tests to verify correctness.