### PR TITLE
fix: require fullName on registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -4,6 +4,7 @@ export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+
+test("register schema requires fullName", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "test@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+});
+
+test("registerUser preserves fullName in returned payload", async () => {
+  const result = await registerUser({
+    fullName: "Hanif Nugraha",
+    email: "test@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(result.fullName, "Hanif Nugraha");
+  assert.equal(result.email, "test@example.com");
+  assert.equal(result.role, "freelancer");
+  assert.match(result.id, /^usr_/);
+  assert.match(result.token, /^eyJ/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Summary
- Require `fullName` in the registration schema
- Return `fullName` from `registerUser()`
- Add tests for schema validation and service output

## Verification
- `npm test`

Closes #2770
