### PR TITLE
fix: expose db package entrypoint

### DIFF
--- a/apps/api/src/tests/db-package.test.js
+++ b/apps/api/src/tests/db-package.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+test("@freelanceflow/db is importable via the workspace package name", () => {
+  const db = require("@freelanceflow/db");
+
+  assert.ok(db);
+  assert.equal(typeof db.PrismaClient, "function");
+});

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,4 @@
+const prisma = require("@prisma/client");
+
+module.exports = prisma;
+module.exports.default = prisma;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Summary
- Add explicit `main`, `types`, and `exports` metadata for `@freelanceflow/db`
- Add a CommonJS `index.js` entrypoint and TypeScript declarations
- Add a test that imports the package through the workspace package name

## Verification
- `npm test`

Closes #2775
