### PR TITLE
fix: resolve freelancer profile by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((entry) => entry.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Profile</h2>
+        <p>No freelancer profile found for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Rate: {freelancer.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Resolve freelancer profile data by username from the shared mock data
- Render skills and hourly rate for known profiles
- Show a clear not-found fallback for unknown usernames

## Verification
- `npm run build -w apps/web`

Closes #3635
