### PR TITLE
fix: count malformed json before parsing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid JSON payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/rate-limit.test.js
+++ b/apps/api/src/tests/rate-limit.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("malformed JSON is rejected with 400 before rate limit exhaustion", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  try {
+    const firstResponse = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: "{"
+    });
+    const firstPayload = await firstResponse.json();
+
+    assert.equal(firstResponse.status, 400);
+    assert.deepEqual(firstPayload, {
+      success: false,
+      message: "Invalid JSON payload"
+    });
+
+    let finalResponse;
+    for (let i = 1; i < 201; i += 1) {
+      finalResponse = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: "{"
+      });
+      await finalResponse.text();
+    }
+
+    assert.equal(finalResponse.status, 429);
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Move the global API rate limiter ahead of JSON body parsing so malformed requests are counted before parser work runs
- Return a 400 JSON response for malformed JSON instead of a generic 500
- Add a regression test proving repeated malformed JSON eventually hits the 429 limit

## Verification
- `npm test`

Closes #1735
