### PR TITLE
fix: preserve notification-owned fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/notifications ignores caller supplied id and read state", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client-owned-id",
+        read: true,
+        title: "New proposal",
+        body: "You have a new proposal to review"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_/);
+    assert.notEqual(payload.data.id, "client-owned-id");
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.title, "New proposal");
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Make notification creation keep server-owned `id` and `read` values
- Ignore caller-supplied `id` and `read` during creation
- Add regression coverage proving a malicious payload cannot override those fields

## Verification
- `npm test`

Closes #2762
