### PR TITLE
fix: render job details from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/not-found.tsx
+++ b/apps/web/app/jobs/[id]/not-found.tsx
@@ -1,0 +1,9 @@
+export default function JobNotFound() {
+  return (
+    <section className="card">
+      <h2>Job not found</h2>
+      <p>The requested job does not exist in the mock dataset.</p>
+      <p>Return to the jobs list and open a valid job id.</p>
+    </section>
+  );
+}

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,19 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((entry) => entry.id === id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
+      <p>Responsibilities, milestones, and proposals for {job.id} would be shown here.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Load the matching job from the shared mock dataset
- Render the job title and budget on `/jobs/[id]`
- Return a clear route-specific not-found fallback for unknown ids

## Verification
- `npm run build -w apps/web`
- `next start` on the built app, then `GET /jobs/job-101` returned `200 OK` with the job title and budget
- `GET /jobs/does-not-exist` returned `404 Not Found` with the custom fallback text

Closes #2755
