### PR TITLE
fix: remove admin from registration role enum to prevent self-assignment (#3662)

### DIFF
--- a/apps/api/src/tests/registerSchema.test.js
+++ b/apps/api/src/tests/registerSchema.test.js
@@ -1,0 +1,34 @@
+import { registerSchema } from '../validators/auth.js';
+
+// Test 1: Valid client role
+const r1 = registerSchema.safeParse({ email: "test@test.com", password: "password123", role: "client" });
+if (!r1.success) throw new Error("Test 1 failed: client role should be valid");
+console.log("PASS: client role accepted");
+
+// Test 2: Valid freelancer role
+const r2 = registerSchema.safeParse({ email: "test@test.com", password: "password123", role: "freelancer" });
+if (!r2.success) throw new Error("Test 2 failed: freelancer role should be valid");
+console.log("PASS: freelancer role accepted");
+
+// Test 3: Default role is client
+const r3 = registerSchema.safeParse({ email: "test@test.com", password: "password123" });
+if (!r3.success) throw new Error("Test 3 failed: default should work");
+if (r3.data.role !== "client") throw new Error("Test 3 failed: default role should be client");
+console.log("PASS: default role is client");
+
+// Test 4: Admin role is rejected
+const r4 = registerSchema.safeParse({ email: "test@test.com", password: "password123", role: "admin" });
+if (r4.success) throw new Error("Test 4 failed: admin role should be rejected");
+console.log("PASS: admin role rejected");
+
+// Test 5: Invalid role is rejected
+const r5 = registerSchema.safeParse({ email: "test@test.com", password: "password123", role: "superadmin" });
+if (r5.success) throw new Error("Test 5 failed: invalid role should be rejected");
+console.log("PASS: invalid role rejected");
+
+// Test 6: Missing email is rejected
+const r6 = registerSchema.safeParse({ password: "password123" });
+if (r6.success) throw new Error("Test 6 failed: missing email should be rejected");
+console.log("PASS: missing email rejected");
+
+console.log("\nAll 6 tests passed!");

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #3662 - Registration schema no longer allows self-assignment of admin role.

## Problem
`registerSchema` allowed `admin` as a valid role during registration:
```js
role: z.enum(["client", "freelancer", "admin"]).default("client")
```
This allowed any unauthenticated user to self-assign the ADMIN role.

## Fix
Removed `"admin"` from the role enum in `apps/api/src/validators/auth.js`. Registration now only accepts `client` or `freelancer`.

## Tests
Added `src/tests/registerSchema.test.js` with 6 tests:
- ✅ client role accepted
- ✅ freelancer role accepted
- ✅ default role is client
- ✅ admin role rejected
- ✅ invalid role rejected
- ✅ missing email rejected

## Verification
- [x] References exactly one issue (#3662)
- [x] Includes tests
- [x] Minimal, focused changes
- [x] No unrelated changes