### PR TITLE
fix: make ui package directly importable

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    }
+  }
 }

--- a/packages/ui/src/Button.d.ts
+++ b/packages/ui/src/Button.d.ts
@@ -1,0 +1,3 @@
+import type { ReactNode } from "react";
+
+export declare function Button(props: { children: ReactNode }): React.ReactElement;

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#111827",
+        color: "white",
+        border: "none",
+        borderRadius: 9999,
+        padding: "0.65rem 1rem"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/src/Card.d.ts
+++ b/packages/ui/src/Card.d.ts
@@ -1,0 +1,3 @@
+import type { ReactNode } from "react";
+
+export declare function Card(props: { title: string; children: ReactNode }): React.ReactElement;

--- a/packages/ui/src/Card.js
+++ b/packages/ui/src/Card.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    {
+      style: {
+        border: "1px solid #ddd",
+        borderRadius: 8,
+        padding: "1rem"
+      }
+    },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,0 +1,2 @@
+export { Button } from "./Button.js";
+export { Card } from "./Card.js";

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,2 @@
+export { Button } from "./Button.js";
+export { Card } from "./Card.js";


### PR DESCRIPTION
## Summary
- Point `@freelanceflow/ui` at a real JavaScript entrypoint
- Export `Button` and `Card` from ESM runtime modules
- Add TypeScript declaration files for the package root and component modules

## Verification
- `node -e "import('@freelanceflow/ui')"` succeeded and exported `Button` and `Card`

Closes #2781
