### PR TITLE
fix: add Zod validation for review creation (#3664)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues, 400);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,43 @@
+import { createReviewSchema } from '../validators/review.js';
+
+// Test 1: Valid review
+const r1 = createReviewSchema.safeParse({ rating: 5, comment: "Great work!", jobId: "job_1", reviewerId: "usr_1" });
+if (!r1.success) throw new Error("Test 1 failed: valid review should pass");
+console.log("PASS: valid review accepted");
+
+// Test 2: Rating too high (6)
+const r2 = createReviewSchema.safeParse({ rating: 6, comment: "Too high", jobId: "job_1", reviewerId: "usr_1" });
+if (r2.success) throw new Error("Test 2 failed: rating 6 should be rejected");
+console.log("PASS: rating 6 rejected");
+
+// Test 3: Rating too low (0)
+const r3 = createReviewSchema.safeParse({ rating: 0, comment: "Too low", jobId: "job_1", reviewerId: "usr_1" });
+if (r3.success) throw new Error("Test 3 failed: rating 0 should be rejected");
+console.log("PASS: rating 0 rejected");
+
+// Test 4: Empty comment
+const r4 = createReviewSchema.safeParse({ rating: 3, comment: "", jobId: "job_1", reviewerId: "usr_1" });
+if (r4.success) throw new Error("Test 4 failed: empty comment should be rejected");
+console.log("PASS: empty comment rejected");
+
+// Test 5: Rating 1 (min valid)
+const r5 = createReviewSchema.safeParse({ rating: 1, comment: "Poor", jobId: "job_1", reviewerId: "usr_1" });
+if (!r5.success) throw new Error("Test 5 failed: rating 1 should be valid");
+console.log("PASS: rating 1 accepted");
+
+// Test 6: Rating 5 (max valid)
+const r6 = createReviewSchema.safeParse({ rating: 5, comment: "Excellent", jobId: "job_1", reviewerId: "usr_1" });
+if (!r6.success) throw new Error("Test 6 failed: rating 5 should be valid");
+console.log("PASS: rating 5 accepted");
+
+// Test 7: Non-integer rating
+const r7 = createReviewSchema.safeParse({ rating: 3.5, comment: "Okay", jobId: "job_1", reviewerId: "usr_1" });
+if (r7.success) throw new Error("Test 7 failed: non-integer rating should be rejected");
+console.log("PASS: non-integer rating rejected");
+
+// Test 8: Missing jobId
+const r8 = createReviewSchema.safeParse({ rating: 3, comment: "No job", reviewerId: "usr_1" });
+if (r8.success) throw new Error("Test 8 failed: missing jobId should be rejected");
+console.log("PASS: missing jobId rejected");
+
+console.log("\nAll 8 tests passed!");

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).max(1000),
+  jobId: z.string().min(1),
+  reviewerId: z.string().min(1),
+});


### PR DESCRIPTION
## Summary

Fixes #3664 - POST /api/reviews now validates input using Zod.

## Problem
The review endpoint processed payloads directly from req.body without validation, allowing invalid ratings (0, 6, etc.) and empty comments.

## Fix
- Created `apps/api/src/validators/review.js` with `createReviewSchema` enforcing: rating (int, 1-5), comment (non-empty, max 1000), jobId, reviewerId
- Updated `reviewController.js` to validate req.body against the schema before processing
- Returns 400 with validation errors on invalid input

## Tests
Added `src/tests/reviewValidation.test.js` with 8 tests:
- ✅ Valid review accepted
- ✅ Rating 6 rejected
- ✅ Rating 0 rejected
- ✅ Empty comment rejected
- ✅ Rating 1 (min) accepted
- ✅ Rating 5 (max) accepted
- ✅ Non-integer rating rejected
- ✅ Missing jobId rejected

All 8 tests pass.

## Verification
- [x] References exactly one issue (#3664)
- [x] Includes tests
- [x] Minimal, focused changes
- [x] No unrelated changes