### PR TITLE
fix: render freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/not-found.tsx
+++ b/apps/web/app/freelancers/[username]/not-found.tsx
@@ -1,0 +1,9 @@
+export default function FreelancerNotFound() {
+  return (
+    <section className="card">
+      <h2>Freelancer not found</h2>
+      <p>The requested freelancer does not exist in the mock dataset.</p>
+      <p>Return to freelancer search and open a valid username.</p>
+    </section>
+  );
+}

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,20 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
+export default async function FreelancerProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+  const freelancer = freelancers.find((entry) => entry.username === username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>Skills: <strong>{freelancer.skills.join(" · ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
+      <p>Portfolio, reviews, and active proposals for {freelancer.username} appear here.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Resolve `/freelancers/[username]` from the shared mock dataset
- Render matching freelancer skills and hourly rate for known usernames
- Return a route-specific not-found fallback for unknown usernames

## Verification
- `npm run build -w apps/web`
- `next start` on the built app, then `GET /freelancers/maya-dev` returned `200 OK` with username, skills, and rate
- `GET /freelancers/ghost-user` returned `404 Not Found` with the custom fallback text

Closes #2849
