### PR TITLE
fix: make root lint validate API source syntax (#3654)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
-    "lint": "echo \"No root lint configured\"",
+    "lint": "node scripts/lint.js",
     "test": "npm run test -w apps/api"
   }
 }

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Lint script: validates syntax of all JS files under apps/api/src/
+ * Uses Node.js --check flag to detect syntax errors without executing.
+ * No new dependencies required.
+ */
+const { execSync } = require('child_process');
+const { readdirSync, statSync, readFileSync } = require('fs');
+const { join } = require('path');
+
+function findJsFiles(dir) {
+  let results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results = results.concat(findJsFiles(full));
+    } else if (entry.endsWith('.js')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const files = findJsFiles(join(__dirname, '..', 'apps', 'api', 'src'));
+let failed = false;
+
+for (const file of files) {
+  try {
+    // Use node --check to validate syntax without executing
+    execSync(`node --check "${file}"`, { stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 });
+    console.log(`OK  ${file}`);
+  } catch (e) {
+    console.error(`FAIL ${file}`);
+    console.error(`  ${e.stderr?.toString().trim() || e.message}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('\nSome files failed syntax check.');
+  process.exit(1);
+} else {
+  console.log(`\nAll ${files.length} files passed syntax check.`);
+}


### PR DESCRIPTION
## Summary

Fixes #3654 - Root lint script now validates API source syntax.

## Problem
The root `npm run lint` script only printed a placeholder and exited successfully, allowing syntax regressions in API JavaScript files to pass without validation.

## Fix
- Created `scripts/lint.js` - a dependency-free syntax checker
- Uses `node --check` to validate each .js file under `apps/api/src/`
- Exits non-zero with error details on any syntax failure
- No new dependencies added
- Updated root `package.json` lint script to run the new checker

## Verification
- [x] References exactly one issue (#3654)
- [x] Minimal, focused changes
- [x] No unrelated changes
- [x] All existing API source files pass syntax check