### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a responsive marketing landing page.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "cat_design",
+  skills: ["design", "react"]
+};
+
+test("createJobSchema accepts equal or ascending budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJob).budgetMax, 1200);
+  assert.equal(createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 500 }).budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 1200, budgetMax: 500 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,15 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const budgetRangeSchema = (schema) => schema.refine(
+  ({ budgetMin, budgetMax }) =>
+    budgetMin === undefined || budgetMax === undefined || budgetMax >= budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
+
+export const createJobSchema = budgetRangeSchema(jobFieldsSchema);
+
+export const updateJobSchema = budgetRangeSchema(jobFieldsSchema.partial());


### PR DESCRIPTION
## Summary
- add a budget range refinement so job creation rejects `budgetMax < budgetMin`
- keep equal budget min/max valid
- apply the same range guard to partial job updates when both budget fields are present
- point the API workspace test script at concrete `*.test.js` files so `npm test -w apps/api` runs successfully

## Validation
- `node --test apps/api/src/tests/jobValidator.test.js --test-reporter=spec`
- `node --test apps/api/src/tests/*.test.js --test-reporter=spec`
- `npm test -w apps/api`
- `git diff --check`

Closes #3694
/claim #743
