### PR TITLE
fix: make ui package directly importable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "peerDependencies": {
+        "react": ">=18"
+      }
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,12 +2,14 @@
   "name": "@freelanceflow/ui",
   "private": true,
   "type": "module",
-  "main": "./src/index.js",
-  "types": "./src/index.ts",
+  "main": "./src/index.cjs",
+  "module": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./src/index.d.ts",
       "import": "./src/index.js",
+      "require": "./src/index.cjs",
       "default": "./src/index.js"
     }
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,20 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test src/index.test.js"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, type = "button", style, ...props }: ButtonProps) {
   return (
     <button
+      type={type}
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+};
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...props}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>

--- a/packages/ui/src/index.cjs
+++ b/packages/ui/src/index.cjs
@@ -1,4 +1,4 @@
-import React from "react";
+const React = require("react");
 
 const buttonStyle = {
   background: "#5468ff",
@@ -15,7 +15,7 @@ const cardStyle = {
   padding: "1rem"
 };
 
-export function Button({ children, type = "button", style, ...props }) {
+function Button({ children, type = "button", style, ...props }) {
   return React.createElement(
     "button",
     {
@@ -27,7 +27,7 @@ export function Button({ children, type = "button", style, ...props }) {
   );
 }
 
-export function Card({ title, children, style, ...props }) {
+function Card({ title, children, style, ...props }) {
   return React.createElement(
     "section",
     { ...props, style: { ...cardStyle, ...style } },
@@ -35,3 +35,8 @@ export function Card({ title, children, style, ...props }) {
     React.createElement("div", null, children)
   );
 }
+
+module.exports = {
+  Button,
+  Card
+};

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,0 +1,17 @@
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactElement,
+  ReactNode
+} from "react";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+
+export declare function Button(props: ButtonProps): ReactElement;
+
+export type CardProps = HTMLAttributes<HTMLElement> & {
+  title: string;
+  children?: ReactNode;
+};
+
+export declare function Card(props: CardProps): ReactElement;

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/index.test.js
+++ b/packages/ui/src/index.test.js
@@ -1,9 +1,23 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 
 test("@freelanceflow/ui exposes runtime component exports", async () => {
   const ui = await import("@freelanceflow/ui");
+  const require = createRequire(import.meta.url);
+  const cjs = require("@freelanceflow/ui");
 
   assert.equal(typeof ui.Button, "function");
   assert.equal(typeof ui.Card, "function");
+  assert.equal(typeof cjs.Button, "function");
+  assert.equal(typeof cjs.Card, "function");
+
+  const onClick = () => {};
+  const button = ui.Button({ children: "Save", onClick, disabled: true });
+  assert.equal(button.props.type, "button");
+  assert.equal(button.props.onClick, onClick);
+  assert.equal(button.props.disabled, true);
+
+  const card = ui.Card({ title: "Profile", children: "Ready", className: "panel" });
+  assert.equal(card.props.className, "panel");
 });

--- a/packages/ui/src/index.test.js
+++ b/packages/ui/src/index.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("@freelanceflow/ui exposes runtime component exports", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});


### PR DESCRIPTION
## Summary

Fixes #3698.

This updates `@freelanceflow/ui` so package consumers can import it at runtime without resolving directly to TypeScript source.

Changes:
- add ESM and CJS runtime entrypoints for `Button` and `Card`
- update `packages/ui/package.json` with `main`, `module`, `types`, and conditional `exports`
- add explicit `src/index.d.ts` declarations for TypeScript consumers
- default `Button` to `type="button"` and forward common props/styles
- forward common props/styles through `Card`
- add a package-level Node test that verifies package-name ESM import, CJS require, and prop forwarding
- sync package-lock workspace metadata for the React peer dependency

## Verification

- `npm test -w packages/ui`
- `node -e "import('@freelanceflow/ui').then(m => console.log('esm', typeof m.Button, typeof m.Card))"`
- `node -e "const m=require('@freelanceflow/ui'); console.log('cjs', typeof m.Button, typeof m.Card)"`
- `node --test apps/api/src/tests/health.test.js`
- `npm run build -w apps/web`

Note: local root `npm test` currently fails on Windows/Node 24 because the existing API script runs `node --test src/tests`, which Node resolves as a missing entry module in this environment. The underlying existing API health test passes when run directly.
