### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,34 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+export const MAX_SEARCH_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(value) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (Array.isArray(value)) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return value.trim().replace(/[\u0000-\u001f\u007f]/g, "");
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = normalizeSearchQuery(req.query.q);
+
+  if (query === null) {
+    return fail(res, "Search query must be a string");
+  }
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, `Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer`);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims and strips control characters before searching", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%09%20freelance%0Aautomation%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "freelanceautomation");
+  });
+});
+
+test("GET /api/search rejects queries over the length limit", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a string"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize `/api/search` queries by trimming whitespace and removing ASCII control characters before calling the search service
- reject repeated/non-string `q` parameters with a 400 response
- enforce a 200-character search query limit to avoid oversized request work
- add API regression tests for sanitized input, overlong input, and repeated query parameters

Closes #3700.
References #743 and #1781.

## Validation
```text
npm test

# tests 4
# pass 4
# fail 0
```