### PR TITLE
Preserve generated proposal ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal preserves the server-generated id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1762000000000;
+
+  try {
+    const proposal = await createProposal({
+      id: "client-controlled-id",
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      bidAmount: 250,
+      estimatedDuration: "3 days"
+    });
+
+    assert.equal(proposal.id, "prp_1762000000000");
+    assert.equal(proposal.jobId, "job_123");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #3707
/claim #743

## Summary
- keep proposal ids server-owned by applying the generated `prp_<timestamp>` id after spreading request payload fields
- add a focused regression test proving a client-supplied `id` cannot override the generated id

## Validation
- `node --test apps/api/src/tests/proposalService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

Note: `npm test -w apps/api` currently fails on the existing package script (`node --test src/tests`) because Node treats the directory path as a module entry. I kept this PR scoped and used the explicit test-file command already used by recent API PRs.

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q