### PR TITLE
Fix: Proposal creation should preserve server-generated id (Fixes #3707)

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...rest } = payload || {};
+  const proposal = { ...rest, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal ignores client-supplied id and uses server-generated id", async () => {
+  const payload = {
+    id: "untrusted_client_id",
+    title: "Awesome Proposal",
+    description: "I will do the work.",
+    price: 500
+  };
+
+  const created = await createProposal(payload);
+
+  // Assert that the generated id starts with 'prp_' and is NOT the client-supplied one
+  assert.ok(created.id.startsWith("prp_"));
+  assert.notEqual(created.id, "untrusted_client_id");
+
+  // Assert that legitimate payload fields are preserved
+  assert.equal(created.title, "Awesome Proposal");
+  assert.equal(created.description, "I will do the work.");
+  assert.equal(created.price, 500);
+
+  // Assert it exists in listProposals
+  const list = await listProposals();
+  const found = list.find((p) => p.title === "Awesome Proposal");
+  assert.ok(found);
+  assert.notEqual(found.id, "untrusted_client_id");
+});


### PR DESCRIPTION
This pull request ensures that client-supplied IDs are ignored during proposal creation, and that only the server-generated id is assigned to newly created proposals. A focused service-level regression test is included.