### PR TITLE
Return defensive copies from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+const services = [
+  {
+    name: "users",
+    create: () => createUser({ email: "user@example.com", name: "User" }),
+    list: listUsers
+  },
+  {
+    name: "jobs",
+    create: () =>
+      createJob({
+        title: "Build API",
+        description: "Build a small API",
+        budgetMin: 100,
+        budgetMax: 200,
+        categoryId: "cat_1"
+      }),
+    list: listJobs
+  },
+  {
+    name: "proposals",
+    create: () =>
+      createProposal({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        bidAmount: 150,
+        estimatedDuration: "2 days"
+      }),
+    list: listProposals
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ reviewerId: "usr_1", revieweeId: "usr_2", rating: 5 }),
+    list: listReviews
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ senderId: "usr_1", recipientId: "usr_2", content: "hello" }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ userId: "usr_1", message: "hello" }),
+    list: listNotifications
+  }
+];
+
+for (const service of services) {
+  test(`${service.name} list returns a defensive copy`, async () => {
+    await service.create();
+
+    const firstList = await service.list();
+    const originalLength = firstList.length;
+    firstList.push({ id: `injected_${service.name}` });
+
+    const secondList = await service.list();
+
+    assert.equal(secondList.length, originalLength);
+    assert.equal(secondList.some((item) => item.id === `injected_${service.name}`), false);
+  });
+}


### PR DESCRIPTION
Fixes #3713
/claim #743

## Summary
- return shallow defensive copies from the six in-memory API list services
- preserve existing record objects and response shapes
- add focused service regression coverage proving callers cannot mutate backing arrays through returned lists

## Validation
- `node --test apps/api/src/tests/listServices.test.js` -> 6 passed
- `node --test apps/api/src/tests/*.test.js` -> 7 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q