### PR TITLE
Preserve login token role

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -12,9 +12,11 @@ export async function registerUser(payload) {
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const role = payload.role ?? "client";
+
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("loginUser signs tokens with the supplied user role", async () => {
+  const result = await loginUser({
+    email: "freelancer@example.com",
+    password: "correct horse battery staple",
+    role: "freelancer"
+  });
+
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(result.email, "freelancer@example.com");
+  assert.equal(claims.role, "freelancer");
+});


### PR DESCRIPTION
Fixes #3715
/claim #743

## Summary
- preserve the login user's actual role when signing access tokens in the mock auth service
- keep the existing client-role fallback for login payloads without a role
- add focused service coverage proving a freelancer login receives a freelancer token claim

## Validation
- `node --test apps/api/src/tests/authService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
