### PR TITLE
fix: privilege escalation, unauthenticated refresh, RBAC bypass, mass assignment & budget validation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  // req.user is populated by authMiddleware; the route must apply it.
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/middleware/requireRole.js
+++ b/apps/api/src/middleware/requireRole.js
@@ -1,0 +1,19 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Middleware that enforces a minimum role requirement.
+ * Must be applied after authMiddleware (which populates req.user).
+ *
+ * @param {...string} allowedRoles - Roles permitted to access the route.
+ */
+export function requireRole(...allowedRoles) {
+  return function roleGuard(req, res, next) {
+    if (!req.user) {
+      return fail(res, "Unauthorized", 401);
+    }
+    if (!allowedRoles.includes(req.user.role)) {
+      return fail(res, "Forbidden: insufficient role", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/requireRole.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,16 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+/**
+ * Re-issue an access token for an already-authenticated user.
+ * The caller's identity comes from the verified JWT payload passed
+ * by authMiddleware — never from untrusted request body data.
+ *
+ * @param {{ sub: string; role: string }} user - Verified token claims.
+ */
+export async function refreshToken(user) {
+  if (!user?.sub) {
+    throw new Error("Cannot refresh: missing token subject");
+  }
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMax >= data.budgetMin, {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  });
 
 export const updateJobSchema = createJobSchema.partial();

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(20),
+  bidAmount: z.number().positive(),
+  deliveryDays: z.number().int().positive()
+});
+
+export const updateProposalSchema = createProposalSchema.partial();


### PR DESCRIPTION
## Summary

This PR fixes **5 security vulnerabilities** found during a comprehensive audit of the FreelanceFlow API.

---

### 1. Critical: Privilege Escalation via Self-Assigned Admin Role
**File:** \pps/api/src/validators/auth.js\

The \egisterSchema\ allowed any caller to pass \ole: 'admin'\ in the registration body, instantly gaining admin privileges. The \dmin\ role must only be assigned server-side.

**Fix:** Restrict the registration role enum to \['client', 'freelancer']\.

---

### 2. Critical: Unauthenticated Token Refresh
**Files:** \pps/api/src/services/authService.js\, \pps/api/src/controllers/authController.js\, \pps/api/src/routes/authRoutes.js\

\POST /auth/refresh\ issued valid JWTs with a hardcoded subject (\usr_existing\) and no authentication check. Any anonymous attacker could call this endpoint and receive a valid access token.

**Fix:** Apply \uthMiddleware\ to the \/refresh\ route; pass \eq.user\ (verified JWT claims) to \efreshToken()\ so new tokens carry the caller's real identity.

---

### 3. High: Broken Admin RBAC — Any User Reads Admin Metrics
**Files:** \pps/api/src/routes/adminRoutes.js\, \pps/api/src/middleware/requireRole.js\

\GET /admin/metrics\ checked authentication but not authorization. Any logged-in \client\ or \reelancer\ could access sensitive system metrics.

**Fix:** Introduce \equireRole('admin')\ middleware and apply it to all admin routes.

---

### 4. High: Mass Assignment on Proposals
**Files:** \pps/api/src/controllers/proposalController.js\, \pps/api/src/validators/proposal.js\

\POST /proposals\ forwarded the raw \eq.body\ to the service layer without any schema validation, allowing clients to inject internal fields (\id\, \status\, \cceptedAt\, etc.).

**Fix:** Parse the body through a new \createProposalSchema\ (Zod) before passing to the service.

---

### 5. Medium: Invalid Budget Range on Jobs
**File:** \pps/api/src/validators/job.js\

\createJobSchema\ validated \udgetMin\ and \udgetMax\ independently but had no cross-field constraint. \udgetMax < budgetMin\ was silently accepted.

**Fix:** Add a \.refine()\ check to enforce \udgetMax >= budgetMin\.

---

### Files Changed
- \pps/api/src/validators/auth.js\ — remove admin from registration enum
- \pps/api/src/validators/job.js\ — add cross-field budget constraint
- \pps/api/src/validators/proposal.js\ — new file: Zod schema for proposals
- \pps/api/src/controllers/authController.js\ — pass \eq.user\ to \efreshToken()\
- \pps/api/src/controllers/proposalController.js\ — validate body before service call
- \pps/api/src/routes/authRoutes.js\ — protect \/refresh\ with \uthMiddleware\
- \pps/api/src/routes/adminRoutes.js\ — add \equireRole('admin')\
- \pps/api/src/routes/notificationRoutes.js\ — protect all notification endpoints
- \pps/api/src/services/authService.js\ — fix \efreshToken(user)\ signature
- \pps/api/src/middleware/requireRole.js\ — new file: role-based auth middleware