### PR TITLE
Keep notification creation fields server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps id and read state server-owned", async () => {
+  const notification = await createNotification({
+    id: "ntf_client_supplied",
+    userId: "usr_123",
+    type: "message",
+    title: "New message",
+    read: true
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.type, "message");
+  assert.equal(notification.title, "New message");
+});


### PR DESCRIPTION
Fixes #3721
/claim #743

## Summary
- keep notification creation `id` and initial `read` state server-owned
- ignore caller-supplied `id` and `read` fields while preserving ordinary notification payload fields
- add focused service coverage proving client input cannot override those fields

## Validation
- `node --test apps/api/src/tests/notificationService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
