### PR TITLE
Preserve payment intent job ids

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -2,6 +2,7 @@ export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
+    jobId: payload.jobId,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent includes the submitted job id", async () => {
+  const intent = await createPaymentIntent({
+    jobId: "job_123",
+    amount: 2500,
+    currency: "usd"
+  });
+
+  assert.equal(intent.jobId, "job_123");
+  assert.match(intent.paymentId, /^pay_\d+$/);
+  assert.equal(intent.amount, 2500);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+});


### PR DESCRIPTION
Fixes #3726
/claim #743

## Summary
- include the submitted `jobId` in mock payment intent responses
- keep the existing `paymentId`, `amount`, `currency`, and `provider` fields intact
- add focused service coverage for the response shape

## Validation
- `node --test apps/api/src/tests/paymentService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
