### PR TITLE
fix: job status override via spread order + plaintext password storage risk in userService

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,11 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  // IMPORTANT: server-controlled fields (id, status) must come AFTER the
+  // payload spread so they cannot be overridden by client-supplied data.
+  // Previously `status: "open"` appeared before `...payload`, allowing a
+  // caller to set status="completed" or status="cancelled" at creation time.
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,17 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Explicitly exclude any password field from the stored user record.
+  // Passwords must be hashed by authService before reaching this layer;
+  // this guard prevents accidental plaintext storage if the call site
+  // changes and forgets to hash first.
+  const { password, passwordHash: _unused, ...safePayload } = payload;
+  if (password !== undefined) {
+    throw new Error(
+      "createUser received a plain-text password. Hash it in authService before calling createUser."
+    );
+  }
+  const user = { ...safePayload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

This PR fixes **2 security vulnerabilities** in the service layer.

---

### 1. High: Job Status Override via JavaScript Spread Order

**File:** `apps/api/src/services/jobService.js`

`createJob` constructed job objects as:
```js
{ id: `job_${Date.now()}`, status: "open", ...payload }
```

Because `...payload` spreads **after** `status: "open"`, any caller that includes `status` in their request body silently overwrites the server-intended value. An attacker can:
- Create a job with `status: "completed"` to bypass the normal job lifecycle
- Create a job with `status: "cancelled"` to immediately invalidate it
- Create a job with `status: "in_progress"` to fake active assignment

**Fix:** Move server-controlled fields **after** the payload spread:
```js
{ ...payload, id: `job_${Date.now()}`, status: "open" }
```

---

### 2. High: Plaintext Password Storage Risk in userService

**File:** `apps/api/src/services/userService.js`

`createUser` accepted raw `payload` and spread it directly into the stored user record without checking for or stripping password fields. If any call site passed an un-hashed password (e.g. after refactoring, during testing, or via a forgotten TODO), the password would be stored in plaintext — a critical credential exposure risk.

**Fix:**
- Destructure `payload` to explicitly extract `password` before building the user object
- Throw a hard `Error` if a plain-text password field is detected, enforcing the contract that hashing must occur in `authService` before `createUser` is called
