### PR TITLE
Keep review timestamps server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    ...payload,
+    id: `rev_${Date.now()}`,
+    createdAt: new Date().toISOString()
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps createdAt server-owned", async () => {
+  const before = Date.now();
+  const review = await createReview({
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5,
+    comment: "Great collaboration",
+    createdAt: "2000-01-01T00:00:00.000Z"
+  });
+  const after = Date.now();
+
+  const createdAt = Date.parse(review.createdAt);
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= after);
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great collaboration");
+});


### PR DESCRIPTION
Fixes #3730
/claim #743

## Summary
- keep review creation timestamps server-owned
- ignore caller-supplied `createdAt` while preserving ordinary review payload fields
- add focused service coverage proving client timestamps are not stored

## Validation
- `node --test apps/api/src/tests/reviewService.test.js` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
