### PR TITLE
Expose db package entrypoint

### DIFF
--- a/packages/db/dbPackageEntry.test.cjs
+++ b/packages/db/dbPackageEntry.test.cjs
@@ -1,0 +1,8 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/db can be imported through its package entrypoint", () => {
+  const dbPackage = require("@freelanceflow/db");
+
+  assert.equal(typeof dbPackage.PrismaClient, "function");
+});

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Fixes #3734
/claim #743

## Summary
- add a root JavaScript entrypoint for `@freelanceflow/db`
- declare explicit `main`, `types`, and `exports` package metadata
- add focused coverage proving workspace consumers can import the package by name

## Validation
- `node --test packages/db/dbPackageEntry.test.cjs` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 1 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
