### PR TITLE
fix(db): expose package entrypoint for workspace consumers (Fixes #3734)

### DIFF
--- a/apps/api/src/tests/db.test.js
+++ b/apps/api/src/tests/db.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert";
+
+test("db package entrypoint validation", async (t) => {
+  await t.test("should successfully import PrismaClient and UserRole from @freelanceflow/db", async () => {
+    const { PrismaClient, UserRole } = await import("@freelanceflow/db");
+    assert.ok(PrismaClient);
+    assert.ok(UserRole);
+    assert.equal(typeof PrismaClient, "function");
+    assert.equal(typeof UserRole, "object");
+  });
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
+    "build": "npx tsc",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"
   },

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Parent bounty: #743
Source issue: #3608 / #3473 / #2775

## Scope & Implementation Details

- Configured a tsconfig.json compiler target to emit JavaScript entrypoint files under a build script for `packages/db`.
- Exposes explicit `main`, `types`, and `exports` configurations in `packages/db/package.json` ensuring robust workspace imports.
- Created robust test coverage verifying direct module import bounds inside Node workspaces.

EVM payout address: 0x9758AdAe878bd4EAD0aa24408c56D7d4aEC29a5