### PR TITLE
Expose ui package entrypoint

### DIFF
--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,2 @@
+export { Button } from "./src/Button";
+export { Card } from "./src/Card";

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,39 @@
+const React = require("react");
+
+function Button({ children, ...props }) {
+  return React.createElement(
+    "button",
+    {
+      ...props,
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer",
+        ...props.style
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children, ...props }) {
+  return React.createElement(
+    "section",
+    {
+      ...props,
+      style: {
+        border: "1px solid #ddd",
+        borderRadius: 8,
+        padding: "1rem",
+        ...props.style
+      }
+    },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Button, Card };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
 }

--- a/packages/ui/uiPackageEntry.test.cjs
+++ b/packages/ui/uiPackageEntry.test.cjs
@@ -1,0 +1,9 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/ui can be imported through its package entrypoint", async () => {
+  const uiPackage = await import("@freelanceflow/ui");
+
+  assert.equal(typeof uiPackage.Button, "function");
+  assert.equal(typeof uiPackage.Card, "function");
+});


### PR DESCRIPTION
Fixes #3736
/claim #743

## Summary
- add a runtime JavaScript entrypoint for `@freelanceflow/ui`
- declare explicit `main`, `types`, and `exports` package metadata
- add focused coverage proving workspace consumers can import the package by name

## Validation
- `node --test packages/ui/uiPackageEntry.test.cjs` -> 1 passed
- `node --test apps/api/src/tests/*.test.js` -> 1 passed
- `git diff --check` -> passed

Payment fallback if this #743 claim is handled manually rather than through Algora payout settings:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
