### PR TITLE
Cap auth password length

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+const validEmail = "user@example.com";
+const maxLengthPassword = "a".repeat(128);
+const tooLongPassword = "a".repeat(129);
+
+test("registerSchema accepts passwords up to 128 characters", () => {
+  const payload = registerSchema.parse({
+    email: validEmail,
+    password: maxLengthPassword,
+    role: "client"
+  });
+
+  assert.equal(payload.password, maxLengthPassword);
+});
+
+test("registerSchema rejects passwords longer than 128 characters", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: validEmail,
+      password: tooLongPassword,
+      role: "client"
+    });
+  }, /String must contain at most 128 character/);
+});
+
+test("loginSchema accepts passwords up to 128 characters", () => {
+  const payload = loginSchema.parse({
+    email: validEmail,
+    password: maxLengthPassword
+  });
+
+  assert.equal(payload.password, maxLengthPassword);
+});
+
+test("loginSchema rejects passwords longer than 128 characters", () => {
+  assert.throws(() => {
+    loginSchema.parse({
+      email: validEmail,
+      password: tooLongPassword
+    });
+  }, /String must contain at most 128 character/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,11 +2,11 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: z.string().min(8).max(128),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8).max(128)
 });


### PR DESCRIPTION
Fixes #3740
/claim #743

## Summary
- cap registration and login passwords at 128 characters in the auth validators
- preserve the existing 8-character minimum and accepted public role behavior
- add focused validator coverage for accepted 128-character passwords and rejected 129-character passwords

## Validation
- `node --test src/tests/authValidator.test.js src/tests/health.test.js` from `apps/api` -> 5 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q