### PR TITLE
Validate review rating range

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,6 +5,10 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
+  if (!Number.isInteger(payload.rating) || payload.rating < 1 || payload.rating > 5) {
+    throw new Error("Review rating must be an integer between 1 and 5");
+  }
+
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+function validReview(rating) {
+  return {
+    rating,
+    comment: "Great collaboration",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee"
+  };
+}
+
+test("createReview accepts integer ratings from one through five", async () => {
+  const lowest = await createReview(validReview(1));
+  const highest = await createReview(validReview(5));
+
+  assert.equal(lowest.rating, 1);
+  assert.equal(highest.rating, 5);
+});
+
+test("createReview rejects ratings below one", async () => {
+  await assert.rejects(
+    () => createReview(validReview(0)),
+    /Review rating must be an integer between 1 and 5/
+  );
+});
+
+test("createReview rejects ratings above five", async () => {
+  await assert.rejects(
+    () => createReview(validReview(6)),
+    /Review rating must be an integer between 1 and 5/
+  );
+});
+
+test("createReview rejects non-integer ratings", async () => {
+  await assert.rejects(
+    () => createReview(validReview(4.5)),
+    /Review rating must be an integer between 1 and 5/
+  );
+});
+
+test("createReview rejects non-number ratings", async () => {
+  await assert.rejects(
+    () => createReview(validReview("5")),
+    /Review rating must be an integer between 1 and 5/
+  );
+});


### PR DESCRIPTION
Fixes #3742
/claim #743

## Summary
- reject review ratings that are not integers from 1 through 5
- keep valid boundary ratings accepted
- add focused service regression coverage for below-range, above-range, decimal, and non-number ratings

## Validation
- `node --test src/tests/reviewService.test.js src/tests/health.test.js` from `apps/api` -> 6 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q