### PR TITLE
🔒 FIX #2847 #2845 #2832 #2853 #2850 #2833: Auth, Validation, Upload & Search hardening

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,10 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return fail(res, "Missing refresh token", 401);
+  }
+  const result = await refreshToken(authHeader.slice(7));
   return ok(res, result);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,15 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function optionalAuth(req, _res, next) {
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith("Bearer ")) {
+    try {
+      req.user = verifyAccessToken(authHeader.slice(7));
+    } catch {
+      // token invalid — continue without user
+    }
+  }
+  return next();
+}

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,30 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+import { fail } from "../utils/response.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const id = "usr_existing";
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: id, role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  try {
+    const decoded = verifyAccessToken(token);
+    return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
+  } catch {
+    return fail(null, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/searchService.js
+++ b/apps/api/src/services/searchService.js
@@ -1,7 +1,9 @@
 export async function globalSearch(query) {
+  const MAX_QUERY_LENGTH = 500;
+  const safeQuery = String(query ?? "").slice(0, MAX_QUERY_LENGTH);
   // TODO: use PostgreSQL full-text search + ranking.
   return {
-    query,
+    query: safeQuery,
     users: [],
     jobs: [],
     freelancers: []

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,20 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMin"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMin <= data.budgetMax;
+    }
+    return true;
+  },
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMin"]
+  }
+);


### PR DESCRIPTION
## 🔒 6 Bounty Fixes — Kelthos-X Security

| Issue | Fix | Severity |
|---|---|---|
| **#2847** | Auth refresh now verifies requester token (was: no-op returning static user) | 🔴 Critical |
| **#2845** | registerUser token `sub` now references same `id` (was: race condition) | 🔴 Critical |
| **#2832** | Removed `admin` from self-registration role enum (was: anyone = admin) | 🔴 Critical |
| **#2853** | Job budget: `budgetMin <= budgetMax` enforced via Zod `.refine()` | 🟠 High |
| **#2850** | Upload endpoint rejects empty files with 400 (was: 201 on no-file) | 🟠 High |
| **#2833** | Search query capped at 500 chars + null-safe (was: unbounded) | 🟡 Medium |

### Changes
- **authService.js**: `refreshToken()` now takes + verifies existing token
- **authService.js**: `registerUser` uses single `Date.now()` for id+token
- **auth.js (validator)**: Removed `"admin"` from register role enum
- **job.js (validator)**: Added `.refine()` for budget range validation
- **uploadController.js**: 400 if no file, removes nullish fallback
- **searchService.js**: Query length capped, null input safe
- **auth.js (middleware)**: Added `optionalAuth` for mixed-auth routes

### BTC
`bc1q4cwvxtunnl2cfdcr60hq7tp3c0gdh2j0retyfq`

🦞 Kelthos was here.