### PR TITLE
Redact production error logs

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,10 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  if (process.env.NODE_ENV === "production") {
+    console.error("Unhandled API error:", { name: err?.name ?? "Error" });
+  } else {
+    console.error("Unhandled API error:", err);
+  }
+
   if (res.headersSent) {
     return next(err);
   }

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function withConsoleErrorSpy(callback) {
+  const original = console.error;
+  const calls = [];
+  console.error = (...args) => {
+    calls.push(args);
+  };
+
+  try {
+    callback(calls);
+  } finally {
+    console.error = original;
+  }
+}
+
+test("production error logging does not serialize raw error details", () => {
+  const previousEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+
+  try {
+    const error = new Error("database password secret-token leaked");
+    error.stack = "stack with secret-token";
+    const res = createResponse();
+
+    withConsoleErrorSpy((calls) => {
+      errorHandler(error, {}, res, () => {});
+
+      assert.equal(res.statusCode, 500);
+      assert.deepEqual(res.body, {
+        success: false,
+        message: "Unexpected server error"
+      });
+
+      assert.equal(calls.length, 1);
+      assert.notEqual(calls[0][1], error);
+      assert.doesNotMatch(JSON.stringify(calls[0]), /secret-token|database password/);
+    });
+  } finally {
+    process.env.NODE_ENV = previousEnv;
+  }
+});
+
+test("development error logging preserves the raw error object", () => {
+  const previousEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+
+  try {
+    const error = new Error("local debugging detail");
+    const res = createResponse();
+
+    withConsoleErrorSpy((calls) => {
+      errorHandler(error, {}, res, () => {});
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0][1], error);
+    });
+  } finally {
+    process.env.NODE_ENV = previousEnv;
+  }
+});


### PR DESCRIPTION
Fixes #3746
/claim #743

## Summary
- avoid logging raw error objects in production
- keep non-production raw error logging for local debugging
- preserve the existing generic 500 response shape
- add focused middleware coverage for production redaction and development logging

## Validation
- `node --test src/tests/errorHandler.test.js src/tests/health.test.js` from `apps/api` -> 3 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q