### PR TITLE
Require finite job budgets

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+function validJob(overrides = {}) {
+  return {
+    title: "Build API",
+    description: "Build a reliable API service",
+    budgetMin: 0,
+    budgetMax: 1000,
+    categoryId: "cat_api",
+    skills: ["Node.js"],
+    ...overrides
+  };
+}
+
+test("createJobSchema accepts finite nonnegative budget values", () => {
+  const payload = createJobSchema.parse(validJob());
+
+  assert.equal(payload.budgetMin, 0);
+  assert.equal(payload.budgetMax, 1000);
+});
+
+test("createJobSchema rejects non-finite minimum budgets", () => {
+  for (const budgetMin of [Infinity, -Infinity, NaN]) {
+    assert.throws(
+      () => createJobSchema.parse(validJob({ budgetMin })),
+      /budgetMin/
+    );
+  }
+});
+
+test("createJobSchema rejects non-finite maximum budgets", () => {
+  for (const budgetMax of [Infinity, -Infinity, NaN]) {
+    assert.throws(
+      () => createJobSchema.parse(validJob({ budgetMax })),
+      /budgetMax/
+    );
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
Fixes #3748
/claim #743

## Summary
- require job `budgetMin` and `budgetMax` values to be finite as well as nonnegative
- preserve valid zero and positive budget behavior
- add focused schema coverage for `Infinity`, `-Infinity`, and `NaN` on both budget fields

## Validation
- `node --test src/tests/jobValidator.test.js src/tests/health.test.js` from `apps/api` -> 4 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q