### PR TITLE
Reject self reviews

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,6 +5,10 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
+  if (payload.reviewerId === payload.revieweeId) {
+    throw new Error("Reviews must be between different users");
+  }
+
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;

--- a/apps/api/src/tests/reviewSelfReview.test.js
+++ b/apps/api/src/tests/reviewSelfReview.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+function reviewPayload(overrides = {}) {
+  return {
+    rating: 5,
+    comment: "Great collaboration",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    ...overrides
+  };
+}
+
+test("createReview accepts reviews between different users", async () => {
+  const review = await createReview(reviewPayload());
+
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+});
+
+test("createReview rejects self-reviews", async () => {
+  await assert.rejects(
+    () => createReview(reviewPayload({ reviewerId: "usr_same", revieweeId: "usr_same" })),
+    /Reviews must be between different users/
+  );
+});


### PR DESCRIPTION
Fixes #3750
/claim #743

## Summary
- reject review payloads where `reviewerId` and `revieweeId` are the same account
- preserve valid reviews between different users
- add focused service coverage for both accepted and rejected paths

## Validation
- `node --test src/tests/reviewSelfReview.test.js src/tests/health.test.js` from `apps/api` -> 3 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q