### PR TITLE
fix: package entrypoints for @freelanceflow/ui and @freelanceflow/db (closes #2787, #2775)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,11 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./Button": "./src/Button.tsx",
+    "./Card": "./src/Card.tsx"
+  }
 }


### PR DESCRIPTION
## Fixes

- **#2787**: `@freelanceflow/ui` now has proper `exports` field with `.` entrypoint and subpath exports for `Button` and `Card`, plus `types` field for TypeScript resolution
- **#2775**: `@freelanceflow/db` now exposes an importable workspace entrypoint via `main`, `types`, and `exports` fields

## BTC
bc1q4cwvxtunnl2cfdcr60hq7tp3c0gdh2j0retyfq