### PR TITLE
Add proposal creation timestamps

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalCreatedAt.test.js
+++ b/apps/api/src/tests/proposalCreatedAt.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+function proposalPayload(overrides = {}) {
+  return {
+    coverLetter: "I can deliver this quickly.",
+    bidAmount: 1200,
+    estDuration: "2 weeks",
+    jobId: "job_123",
+    freelancerId: "usr_freelancer",
+    ...overrides
+  };
+}
+
+test("createProposal assigns a server-owned createdAt timestamp", async () => {
+  const proposal = await createProposal(proposalPayload());
+
+  assert.equal(typeof proposal.createdAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(proposal.createdAt)));
+});
+
+test("createProposal ignores caller-supplied createdAt timestamps", async () => {
+  const callerTimestamp = "1999-01-01T00:00:00.000Z";
+  const proposal = await createProposal(proposalPayload({ createdAt: callerTimestamp }));
+
+  assert.notEqual(proposal.createdAt, callerTimestamp);
+  assert.ok(!Number.isNaN(Date.parse(proposal.createdAt)));
+});


### PR DESCRIPTION
Fixes #3755
/claim #743

## Summary
- add a server-owned ISO `createdAt` timestamp when proposals are created
- ensure caller-supplied `createdAt` values cannot control the stored timestamp
- add focused service coverage for generated and caller-supplied timestamp behavior

## Validation
- `node --test src/tests/proposalCreatedAt.test.js src/tests/health.test.js` from `apps/api` -> 3 passing tests
- `git diff --check`

## Payout fallback
If this is accepted outside Algora automation, payout can be sent via:
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q