### PR TITLE
Require fullName during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { registerSchema } from "../validators/auth.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("registerSchema rejects missing fullName", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+});
+
+test("POST /api/auth/register preserves the validated fullName", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123",
+        fullName: "Ava Client",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.fullName, "Ava Client");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
+  fullName: z.string().trim().min(1),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });


### PR DESCRIPTION
## Summary
- require `fullName` in registration validation so accepted payloads match the required User model field
- preserve the validated `fullName` in the registration response payload
- add focused registration tests for missing-name rejection and successful name preservation

Fixes #3759
/claim #743

## Validation
- `node --test apps/api/src/tests/auth.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

## Payment fallback
- PayPal: https://www.paypal.com/ncp/payment/JYJKLSVEAKWZQ
- Wise: https://wise.com/pay/r/UVUvGSvyNXG1X0Q
