### PR TITLE
fix: add file type and size validation to upload endpoint (#3758)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,8 +2,48 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+// 只放行常见的文档和图片格式，别让奇怪的文件混进来
+const ALLOWED_MIMETYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+  "text/csv"
+]);
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB，够用但不给攻击者留空间
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIMETYPES.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new multer.MulterError("LIMIT_UNEXPECTED_FILE", file.fieldname));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 
 uploadRoutes.post("/", upload.single("file"), uploadFile);
+
+// 兜住 multer 自己的错误（文件太大、类型不对），返回 400 而不是 500
+uploadRoutes.use((err, _req, res, next) => {
+  if (err instanceof multer.MulterError) {
+    const messages = {
+      LIMIT_FILE_SIZE: "File too large. Maximum size is 5MB.",
+      LIMIT_UNEXPECTED_FILE: "File type not allowed."
+    };
+    return res.status(400).json({
+      success: false,
+      message: messages[err.code] || "Upload error."
+    });
+  }
+  next(err);
+});

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+// 快速启动一个测试用的服务实例
+async function startApp() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return { port, close: () => new Promise((r) => server.close(r)) };
+}
+
+test("POST /api/uploads accepts a valid image file", async () => {
+  const { port, close } = await startApp();
+
+  const form = new FormData();
+  form.append("file", new Blob(["fake-png-content"], { type: "image/png" }), "test.png");
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+
+  await close();
+});
+
+test("POST /api/uploads rejects disallowed file type", async () => {
+  const { port, close } = await startApp();
+
+  // 试一个可执行文件类型，应该被拦
+  const form = new FormData();
+  form.append("file", new Blob(["malware"], { type: "application/x-msdownload" }), "evil.exe");
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close();
+});


### PR DESCRIPTION
## Summary

Adds file type and size validation to the upload endpoint to prevent abuse.

## Changes

- **`apps/api/src/routes/uploadRoutes.js`**: Added 5MB file size limit and MIME type allowlist (images, PDFs, documents). Added multer error handler middleware returning 400 with clear messages instead of 500.
- **`apps/api/src/tests/upload.test.js`**: New test file with 2 tests — valid image upload (201) and disallowed file type rejection (400).
- **`apps/api/package.json`**: Fixed test script glob pattern for Node 22 compatibility (`src/tests/**/*.test.js`).

## Test Results

```
✓ GET /health returns ok payload
✓ POST /api/uploads accepts a valid image file
✓ POST /api/uploads rejects disallowed file type
3/3 passing
```

Closes #3758