### PR TITLE
fix: auth refresh endpoint should verify the refresh token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.parse(req.body);
+  const result = await refreshToken(payload);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -6,7 +6,8 @@ export async function registerUser(payload) {
     id: `usr_${Date.now()}`,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };
 }
 
@@ -14,10 +15,15 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "client" }),
+    refreshToken: signRefreshToken({ sub: "usr_existing", role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(payload) {
+  const decoded = verifyRefreshToken(payload.refreshToken);
+  return {
+    token: signAccessToken({ sub: decoded.sub, role: decoded.role }),
+    refreshToken: signRefreshToken({ sub: decoded.sub, role: decoded.role })
+  };
 }

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -8,3 +8,11 @@ export function signAccessToken(payload) {
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }
+
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "7d" });
+}
+
+export function verifyRefreshToken(token) {
+  return jwt.verify(token, env.jwtSecret);
+}

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1, "refreshToken is required")
+});


### PR DESCRIPTION
Adds refreshSchema validation, refresh token signing/verification utilities, and updates the refresh endpoint to only issue new access tokens after verifying the provided refresh token.

Closes #2847