### PR TITLE
fix: upload endpoint should reject empty files and validate file types

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,36 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg", "image/png", "image/gif", "image/webp",
+  "application/pdf",
+  "text/plain", "text/csv",
+  "application/json",
+  "application/zip", "application/x-zip-compressed"
+];
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+
+  if (req.file.size === 0) {
+    return fail(res, "Empty file submitted", 400);
+  }
+
+  if (req.file.size > MAX_FILE_SIZE) {
+    return fail(res, "File exceeds maximum size of 10MB", 400);
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(req.file.mimetype)) {
+    return fail(res, `File type '${req.file.mimetype}' is not allowed`, 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    size: req.file.size,
+    mimetype: req.file.mimetype,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Adds file size check (rejects empty files and files >10MB), MIME type whitelist validation, and proper error responses.

Closes #2850