### PR TITLE
fix: registerUser access token should reference the same user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,14 +2,15 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: userId, role: payload.role })
   };
 }
-
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {


### PR DESCRIPTION
Captures userId once to ensure the returned id and JWT sub use the same value, preventing token-subject drift.

Closes #2845