### PR TITLE
fix: search endpoint missing input validation and length limit

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = (req.query.q ?? "").trim();
+
+  if (!query) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Search query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }


### PR DESCRIPTION
Adds required query check and 200-character maximum length limit to the search endpoint, preventing empty or excessively long queries.

Closes #2833