### PR TITLE
fix(api): reject missing JWT_SECRET in production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+   "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,16 @@
+const jwtSecret = process.env.JWT_SECRET ?? "development-secret";
+
+if (process.env.NODE_ENV === "production" && jwtSecret === "development-secret") {
+  throw new Error(
+    "JWT_SECRET must be set in production. " +
+    "Remove the development fallback by setting the JWT_SECRET environment variable."
+  );
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("env: development uses fallback jwtSecret", async () => {
+  const original = process.env.NODE_ENV;
+  const originalJwt = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "development";
+  delete process.env.JWT_SECRET;
+
+  const mod = await import("../config/env.js?" + Date.now());
+  assert.equal(mod.env.jwtSecret, "development-secret");
+
+  process.env.NODE_ENV = original;
+  if (originalJwt) process.env.JWT_SECRET = originalJwt;
+});
+
+test("env: production throws when JWT_SECRET is missing", async () => {
+  const original = process.env.NODE_ENV;
+  const originalJwt = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  await assert.rejects(
+    () => import("../config/env.js?" + Date.now()),
+    /JWT_SECRET must be set in production/
+  );
+
+  process.env.NODE_ENV = original;
+  if (originalJwt) process.env.JWT_SECRET = originalJwt;
+});
+
+test("env: production accepts explicit JWT_SECRET", async () => {
+  const original = process.env.NODE_ENV;
+  const originalJwt = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "production";
+  process.env.JWT_SECRET = "my-real-secret";
+
+  const mod = await import("../config/env.js?" + Date.now());
+  assert.equal(mod.env.jwtSecret, "my-real-secret");
+
+  process.env.NODE_ENV = original;
+  if (originalJwt) process.env.JWT_SECRET = originalJwt;
+  else delete process.env.JWT_SECRET;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
### Problem
`env.js` silently falls back to `"development-secret"` when `JWT_SECRET` is not set. In production, this allows token forgery if the environment is misconfigured.

### Solution
- Added a production guard that throws if `JWT_SECRET` is not explicitly set
- Preserved the development fallback for local use
- Added config regression tests covering all three scenarios
- Fixed API test script to target concrete test files

### Changes
- `apps/api/src/config/env.js` — added production JWT_SECRET validation
- `apps/api/src/tests/env.test.js` — new config test file
- `apps/api/package.json` — fixed test script glob pattern

### Testing
All 4 tests pass:
- ✔ env: development uses fallback jwtSecret
- ✔ env: production throws when JWT_SECRET is missing
- ✔ env: production accepts explicit JWT_SECRET
- ✔ GET /health returns ok payload

Fixes #3582
Parent Algora bounty: #743