### PR TITLE
fix(auth): require fullName registration field and carry to returned payload (Fixes #3759)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,26 +2,42 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    next(error);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    next(error);
+  }
 }
 
-export async function oauthCallback(req, res) {
-  return ok(res, {
-    provider: req.params.provider,
-    status: "callback-received"
-  });
+export async function oauthCallback(req, res, next) {
+  try {
+    return ok(res, {
+      provider: req.params.provider,
+      status: "callback-received"
+    });
+  } catch (error) {
+    next(error);
+  }
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export async function refresh(req, res, next) {
+  try {
+    const result = await refreshToken();
+    return ok(res, result);
+  } catch (error) {
+    next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+import { createApp } from "../app.js";
+
+test("Registration with fullName validation tests", async (t) => {
+  await t.test("registerSchema should require non-empty fullName", () => {
+    // Missing fullName
+    const result1 = registerSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      role: "client"
+    });
+    assert.equal(result1.success, false);
+    
+    // Empty fullName
+    const result2 = registerSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      fullName: "",
+      role: "client"
+    });
+    assert.equal(result2.success, false);
+
+    // Valid fullName
+    const result3 = registerSchema.safeParse({
+      email: "test@example.com",
+      password: "password123",
+      fullName: "John Doe",
+      role: "client"
+    });
+    assert.equal(result3.success, true);
+    assert.equal(result3.data.fullName, "John Doe");
+  });
+
+  await t.test("registerUser service should carry fullName in the returned payload", async () => {
+    const payload = {
+      email: "test@example.com",
+      password: "password123",
+      fullName: "Alice Smith",
+      role: "freelancer"
+    };
+    const result = await registerUser(payload);
+    assert.equal(result.fullName, "Alice Smith");
+    assert.ok(result.id);
+    assert.ok(result.token);
+  });
+
+  await t.test("POST /api/auth/register E2E integration test", async () => {
+    const app = createApp();
+    const server = app.listen(0);
+
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const url = `http://127.0.0.1:${port}/api/auth/register`;
+
+    // 1. Request missing fullName
+    const failResponse = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "fail@example.com",
+        password: "password123",
+        role: "client"
+      })
+    });
+    // It should be rejected (either 400 or 500 depending on middleware, but definitely not 201)
+    assert.notEqual(failResponse.status, 201);
+
+    // 2. Request with valid fullName
+    const successResponse = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "success@example.com",
+        password: "password123",
+        fullName: "Jane Doe",
+        role: "client"
+      })
+    });
+    
+    assert.equal(successResponse.status, 201);
+    const payload = await successResponse.json();
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fullName, "Jane Doe");
+
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().min(1, "fullName is required"),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
This PR implements full registration payload validation requiring a non-empty `fullName` field, carries the validated `fullName` in the `registerUser()` returned payload, handles validation error exceptions (ZodErrors) with clear 400 Bad Request responses in the Express middleware/controllers instead of causing 500 Unhandled exceptions, and introduces complete unit/E2E integration test coverage under `apps/api/src/tests/auth.test.js`.