### PR TITLE
fix(api): add upload file type and size validation

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(400).json({
+      success: false,
+      message: "File too large"
+    });
+  }
+
+  if (err?.message === "Invalid file type") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid file type"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,32 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const allowedMimeTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+  "application/rtf",
+  "application/vnd.oasis.opendocument.text"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024
+  },
+  fileFilter(req, file, cb) {
+    if (allowedMimeTypes.has(file.mimetype)) {
+      return cb(null, true);
+    }
+
+    return cb(new Error("Invalid file type"));
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload-validation.test.js
+++ b/apps/api/src/tests/upload-validation.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads accepts allowed file types under the size limit", async () => {
+  await withServer(async (port) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob([Buffer.from("hello world")], { type: "application/pdf" }),
+      "document.pdf"
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "document.pdf");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (port) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob([Buffer.from("MZ")], { type: "application/octet-stream" }),
+      "malware.exe"
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid file type");
+  });
+});
+
+test("POST /api/uploads rejects files larger than 5MB", async () => {
+  await withServer(async (port) => {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob([Buffer.alloc(5 * 1024 * 1024 + 1, 0x61)], { type: "application/pdf" }),
+      "large.pdf"
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File too large");
+  });
+});


### PR DESCRIPTION
## Summary
- limit upload size to 5MB
- allow only common document/image MIME types
- return clear 400 errors for invalid uploads
- add focused regression tests for valid, invalid-type, and oversized uploads

Closes #3758
/claim #743

Validation:
- node --test src/tests/upload-validation.test.js src/tests/health.test.js
