### PR TITLE
fix(api): require finite job budgets

### DIFF
--- a/apps/api/src/tests/job-budget-validation.test.js
+++ b/apps/api/src/tests/job-budget-validation.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("createJobSchema accepts finite nonnegative budgets", () => {
+  const payload = createJobSchema.parse({
+    title: "Build feature",
+    description: "Implement a useful feature for the marketplace.",
+    budgetMin: 0,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    skills: ["nodejs"]
+  });
+
+  assert.equal(payload.budgetMin, 0);
+  assert.equal(payload.budgetMax, 500);
+});
+
+test("createJobSchema rejects non-finite budgets", () => {
+  assert.throws(() => {
+    createJobSchema.parse({
+      title: "Build feature",
+      description: "Implement a useful feature for the marketplace.",
+      budgetMin: Number.POSITIVE_INFINITY,
+      budgetMax: 500,
+      categoryId: "cat_1",
+      skills: ["nodejs"]
+    });
+  });
+
+  assert.throws(() => {
+    createJobSchema.parse({
+      title: "Build feature",
+      description: "Implement a useful feature for the marketplace.",
+      budgetMin: 0,
+      budgetMax: Number.NaN,
+      categoryId: "cat_1",
+      skills: ["nodejs"]
+    });
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
## Summary\n- reject Infinity, -Infinity, and NaN for job budgets\n- preserve valid zero and positive budget behavior\n- add focused schema regression tests\n\nCloses #3748\n/claim #743\n