### PR TITLE
fix(api): assign proposal createdAt server-side

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,12 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const createdAt = new Date().toISOString();
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    ...payload,
+    createdAt
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-createdAt.test.js
+++ b/apps/api/src/tests/proposal-createdAt.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal assigns server-created createdAt and ignores caller values", async () => {
+  const OriginalDate = Date;
+
+  class FixedDate extends OriginalDate {
+    constructor(...args) {
+      super(args.length > 0 ? args[0] : 1700000000000);
+    }
+
+    static now() {
+      return 1700000000000;
+    }
+  }
+
+  globalThis.Date = FixedDate;
+
+  try {
+    const result = await createProposal({
+      title: "Proposal title",
+      body: "Proposal body",
+      createdAt: "2000-01-01T00:00:00.000Z"
+    });
+
+    assert.equal(result.id, "prp_1700000000000");
+    assert.equal(result.createdAt, "2023-11-14T22:13:20.000Z");
+    assert.equal(result.title, "Proposal title");
+    assert.equal(result.body, "Proposal body");
+  } finally {
+    globalThis.Date = OriginalDate;
+  }
+});


### PR DESCRIPTION
## Summary\n- add a server-created createdAt timestamp to new proposals\n- ignore caller-supplied createdAt values\n- add focused regression coverage for server-owned timestamps\n\nCloses #3755\n/claim #743\n