### PR TITLE
fix: add entrypoint fields to @freelanceflow/db package

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
The @freelanceflow/db package is missing `main`, `types`, and `exports` fields in its package.json, so consumers can't reliably import it by workspace name.

Added the three entrypoint fields pointing to `./src/index.ts`, matching the pattern already used by `@freelanceflow/ui`.

Closes #2775.