### PR TITLE
Fix registration token subject

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  const id = `usr_${Date.now()}`;
+
   // TODO: persist new user via Prisma
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registration token subject matches returned user id", async () => {
+  const result = await registerUser({
+    email: "maya@example.com",
+    password: "strong-password",
+    role: "freelancer"
+  });
+
+  const payload = verifyAccessToken(result.token);
+
+  assert.equal(payload.sub, result.id);
+});


### PR DESCRIPTION
## Summary
- Generate the registration user id once
- Return that id and sign the access token with the same subject
- Add a focused token-subject regression test
- Make the API test script run test files directly

Closes #2768

## Verification
- npm.cmd test -w apps/api
- npm.cmd run build -w apps/web
- git diff --check