### PR TITLE
fix: wildcard CORS allows all origins + auth endpoints have no brute-force protection

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,8 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { apiLimiter, authLimiter } from "./middleware/rateLimit.js";
+
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -19,15 +20,27 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  // IMPORTANT: cors() with no options allows ALL origins (*), which lets
+  // any website make cross-origin requests to this API — including with
+  // credentials if the client sets withCredentials=true.
+  // Restrict to known allowed origins; use env var for flexibility.
+  app.use(cors({
+    origin: process.env.ALLOWED_ORIGINS
+      ? process.env.ALLOWED_ORIGINS.split(",")
+      : ["http://localhost:3000"],
+    credentials: true
+  }));
   app.use(express.json());
   app.use(apiLimiter);
+
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
 
-  app.use("/api/auth", authRoutes);
+  // Auth routes get a stricter rate limit to prevent credential brute-force.
+  app.use("/api/auth", authLimiter, authRoutes);
+
   app.use("/api/users", userRoutes);
   app.use("/api/jobs", jobRoutes);
   app.use("/api/proposals", proposalRoutes);

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,14 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+/** Stricter limiter for auth routes to prevent credential brute-forcing.
+ *  10 attempts per 15 minutes per IP prevents password spraying attacks. */
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { success: false, message: "Too many auth attempts. Try again in 15 minutes." }
+});
+


### PR DESCRIPTION
## Summary

This PR fixes **2 security misconfigurations** affecting CORS policy and auth rate limiting.

---

### 1. High: Wildcard CORS Allows Any Origin

**Files:** `apps/api/src/app.js`

`app.use(cors())` with no options sets `Access-Control-Allow-Origin: *` — a wildcard that allows any website to make cross-origin requests to this API. Attack scenarios:

- An attacker embeds `fetch("https://api.freelanceflow.com/api/messages")` on a malicious page
- The victim's browser sends the request with their session cookies or auth header
- The API responds with private data (messages, payment info, user details) which the attacker page can read

This is especially severe because the API stores financial and PII data.

**Fix:** Replace `cors()` with explicit origin allowlist driven by `ALLOWED_ORIGINS` environment variable (comma-separated list). Defaults to `http://localhost:3000` for development. Sets `credentials: true` to properly handle credentialed requests.

---

### 2. High: Auth Endpoints Have No Brute-Force Protection

**Files:** `apps/api/src/middleware/rateLimit.js`, `apps/api/src/app.js`

The only rate limiter was a global 200 requests/15 minutes — applied to all routes equally. For auth endpoints (`/api/auth/login`, `/api/auth/register`), this allows:

- **200 password attempts per IP per 15 minutes** — sufficient for targeted brute force against accounts with common passwords
- **Credential stuffing** — try breach datasets against user emails at scale

**Fix:** Export a dedicated `authLimiter` set to **10 requests per IP per 15 minutes** with a clear user-facing error message. Mount it specifically on the `/api/auth` router prefix.
