### PR TITLE
fix: IDOR allows any user to submit reviews/messages as another user

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,14 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { sendMessageSchema } from "../validators/review.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  // Sender identity bound to JWT user — prevents senderId spoofing.
+  return ok(res, await sendMessage({ ...payload, senderId: req.user.sub }), 201);
 }
+

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  // Reviewer identity comes from the verified JWT, not client-supplied body.
+  // This prevents User A from submitting a review as User B by setting
+  // reviewerId in the request body.
+  return ok(res, await createReview({ ...payload, reviewerId: req.user.sub }), 201);
 }
+

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,9 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  // Server-controlled id must come AFTER spread to prevent injection.
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }
+

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  revieweeId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).max(2000)
+});
+
+export const sendMessageSchema = z.object({
+  receiverId: z.string().min(1),
+  body: z.string().min(1).max(10000)
+});


### PR DESCRIPTION
## Summary

This PR fixes **3 vulnerabilities** — IDOR (Insecure Direct Object Reference) and mass assignment in the review and message endpoints.

---

### 1. High: IDOR — Any User Can Submit Reviews as Another User

**File:** `apps/api/src/controllers/reviewController.js`

`postReview` forwarded raw `req.body` to `createReview`, which means a caller could include `reviewerId: "user-id-of-someone-else"` in the request body. This allows:
- User A submitting a 5-star review that appears to come from a high-profile User B
- User A submitting a 1-star review that harms User B's reputation while framing User C as the author
- Systematic reputation manipulation by injecting fake reviewer identities

**Fix:** Parse through `createReviewSchema` (only accepts `revieweeId`, `rating`, `comment`). Set `reviewerId = req.user.sub` from the verified JWT — the server enforces identity, not the client.

---

### 2. High: IDOR — Any User Can Send Messages as Another User

**File:** `apps/api/src/controllers/messageController.js`

`postMessage` forwarded raw `req.body` to `sendMessage`, allowing a caller to include `senderId: "victim-user-id"`. Attack scenarios:
- Impersonating another user in private conversations
- Sending messages that appear from an admin to manipulate recipients
- Creating fake message trails for social engineering

**Fix:** Parse through `sendMessageSchema` (only `receiverId`, `body`). Bind `senderId = req.user.sub` from JWT.

---

### 3. Medium: Review ID Injection via Spread Ordering

**File:** `apps/api/src/services/reviewService.js`

`{ id: 'rev_...', ...payload }` — id comes before the spread, so a client-supplied `id` field overwrites the server-generated one. This allows choosing arbitrary review IDs to predict, overwrite, or alias records.

**Fix:** Move server-controlled `id` after the spread: `{ ...payload, id: 'rev_...' }`.
