### PR TITLE
fix: reject empty upload submissions with 400 response (reissue #2850 / #3634)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in upload request", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads rejects request without file with 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { "content-type": "multipart/form-data; boundary=test-boundary" },
+    body: "--test-boundary\r\nContent-Disposition: form-data; name=\"not-file\"\r\n\r\nhello\r\n--test-boundary--"
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads accepts request with file and returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Build a proper multipart request with a file
+  const boundary = "----FormBoundary" + Math.random().toString(36).slice(2);
+  const fileName = "test.txt";
+  const fileContent = "hello world";
+  const body = [
+    `--${boundary}`,
+    `Content-Disposition: form-data; name="file"; filename="${fileName}"`,
+    "Content-Type: text/plain",
+    "",
+    fileContent,
+    `--${boundary}--`
+  ].join("\r\n");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+    body
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.filename, fileName);
+  assert.equal(payload.data.status, "uploaded");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## fix: reject empty upload submissions with 400 response

### Issue
The upload endpoint (`POST /api/uploads`) returns HTTP 201 `success: true` even when no file is provided in the multipart request.

### Fix
Added a guard in `uploadController.js` that checks for `req.file`. When no file is provided, it returns HTTP 400.

### Testing
Added unit test coverage for empty upload rejection.

Refs: #3634 (reissue of #2850)
Closes: #3634