### PR TITLE
fix: hardcoded JWT secret fallback + unpinned algorithm enables token forgery

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
+function requireEnv(name, fallback) {
+  const val = process.env[name] ?? fallback;
+  // In production, secrets must be explicitly provided — never fall back to
+  // a hardcoded string. A known fallback (e.g. "development-secret") allows
+  // anyone to forge valid JWTs if the env var is accidentally unset.
+  if (process.env.NODE_ENV === "production" && !process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  if (name === "JWT_SECRET" && val.length < 32) {
+    throw new Error(`JWT_SECRET must be at least 32 characters (got ${val.length})`);
+  }
+  return val;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: requireEnv("JWT_SECRET", "development-secret-replace-in-prod"),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -1,10 +1,17 @@
 import jwt from "jsonwebtoken";
 import { env } from "../config/env.js";
 
+/** Algorithm pinned to HS256. Explicit algorithm prevents confusion attacks
+ *  where an attacker changes the alg header (e.g. alg:"none" or RS256)
+ *  to bypass signature verification. Always pass algorithms to jwt.verify. */
+const ALGORITHM = "HS256";
+
 export function signAccessToken(payload) {
-  return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m", algorithm: ALGORITHM });
 }
 
 export function verifyAccessToken(token) {
-  return jwt.verify(token, env.jwtSecret);
+  // algorithms array prevents alg:none and algorithm substitution attacks.
+  return jwt.verify(token, env.jwtSecret, { algorithms: [ALGORITHM] });
 }
+


### PR DESCRIPTION
## Summary

This PR fixes **2 critical JWT security vulnerabilities** affecting authentication integrity across the entire platform.

---

### 1. Critical: Hardcoded JWT Secret Fallback Enables Token Forgery

**File:** `apps/api/src/config/env.js`

```js
jwtSecret: process.env.JWT_SECRET ?? "development-secret"
```

If the `JWT_SECRET` environment variable is not set (e.g. forgotten in a production deployment, rotated incorrectly, or cleared during a deploy), the application silently falls back to `"development-secret"` — a string **publicly visible in this repository**.

An attacker who knows this key can:
- Forge a JWT with any `sub` (user ID) — impersonating any account including admins
- Set any `role` claim in the payload
- Completely bypass all authentication and RBAC

**Fix:** Introduce a `requireEnv()` function that:
- **Throws immediately at startup** in production if the env var is absent (fail-fast prevents silent degradation)
- **Validates minimum secret length** (32 chars minimum — prevents trivially weak secrets)
- Uses a clearly-named dev fallback `"development-secret-replace-in-prod"` to signal replacement is required

---

### 2. High: JWT Algorithm Not Pinned — Enables Algorithm Confusion Attacks

**File:** `apps/api/src/utils/jwt.js`

`jwt.sign()` and `jwt.verify()` were called without specifying an algorithm. Attack scenarios:

- **`alg: "none"` attack**: Attacker crafts a token with `"alg": "none"` in the header and removes the signature. Some JWT implementations accept unsigned tokens.
- **Algorithm substitution (RS256/HS256 confusion)**: If a public key is accessible, an attacker can sign with it as an HMAC secret while the server expects HMAC verification — cross-algorithm confusion.

**Fix:** Define `ALGORITHM = "HS256"` and explicitly pass:
- `{ algorithm: ALGORITHM }` to `jwt.sign()`
- `{ algorithms: [ALGORITHM] }` to `jwt.verify()` — this whitelist rejects any token claiming a different algorithm.
