### PR TITLE
fix: notification read-status injection + proposal ID injection via spread order

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Server-controlled fields (id, read) must come AFTER the spread so they
+  // cannot be overridden by client input. Previously read:false was before
+  // the spread, allowing callers to pre-mark notifications as read:true on
+  // creation, defeating the unread notification system entirely.
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }
+

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,9 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  // id must come after spread to prevent client from injecting a chosen id.
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }
+


### PR DESCRIPTION
## Summary

Two more spread ordering vulnerabilities (same pattern found across multiple services).

---

### 1. Medium: Notification Read-Status Injection

**File:** `apps/api/src/services/notificationService.js`

```js
// BEFORE (vulnerable)
{ id: `ntf_${Date.now()}`, read: false, ...payload }
```

`read: false` is placed **before** `...payload`, so any caller that includes `read: true` in their request body silently overwrites the server-enforced default. This allows:
- Creating notifications that are already marked as read on arrival
- Bypassing unread notification counts (making alerts invisible)
- Defeating the entire notification delivery system

**Fix:** Move server-controlled fields after the spread:
```js
{ ...payload, id: `ntf_${Date.now()}`, read: false }
```

---

### 2. Medium: Proposal ID Injection

**File:** `apps/api/src/services/proposalService.js`

```js
// BEFORE (vulnerable)
{ id: `prp_${Date.now()}`, ...payload }
```

`id` appears **before** `...payload`, allowing clients to supply a custom `id` field that overwrites the server-generated one. This enables:
- ID prediction and collision — overwriting another user's proposal record
- Choosing a specific ID to alias records in external systems
- Breaking uniqueness assumptions in the database layer

**Fix:** `{ ...payload, id: 'prp_...' }` — server ID is always authoritative.
