### PR TITLE
fix: add input validation and length limit to search endpoint (#2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,24 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q;
+
+  if (typeof raw !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const q = raw.trim();
+
+  if (q.length === 0) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Description
Add input validation and length limit to the search endpoint to prevent potential DoS via overly long query strings or unexpected query shapes.

### Changes
- Validate that query parameter is a string (rejects repeated `q` params)
- Trim whitespace from query
- Reject empty queries with 400
- Limit query to 200 characters max
- Return proper error responses for invalid inputs

### Impact
Low-Medium - prevents resource exhaustion via unbounded query strings.

Fixes #2833