### PR TITLE
fix: add admin role check middleware to admin routes

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Add `adminMiddleware` that verifies `req.user.role === "admin"` before allowing access to admin endpoints. Non-admin users receive 403 Forbidden.

**New file:** `apps/api/src/middleware/admin.js`
- `adminMiddleware` — checks role and returns 403 if not admin

**Modified:** `apps/api/src/routes/adminRoutes.js`
- Added `adminRoutes.use(adminMiddleware)` after auth

Fixes #1770