### PR TITLE
fix: restrict CORS to configured origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: process.env.CORS_ORIGIN || "http://localhost:3000" }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Configure CORS with an explicit origin whitelist from environment variable `CORS_ORIGIN` instead of allowing all origins.

**Change:** `apps/api/src/app.js`
- `app.use(cors())` → `app.use(cors({ origin: process.env.CORS_ORIGIN || "http://localhost:3000" }))`

Fixes #1774