### PR TITLE
fix: restrict CORS to allowed origins from environment variable #1774

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,25 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+function getAllowedOrigins() {
+  const raw = process.env.CORS_ORIGIN;
+  if (!raw) {
+    // Default to local dev server
+    return ["http://localhost:3000"];
+  }
+  return raw.split(",").map((origin) => origin.trim());
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(
+    cors({
+      origin: getAllowedOrigins(),
+      credentials: true, // Allow cookies/auth headers
+    })
+  );
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
修改 CORS 中间件配置，从环境变量 CORS_ORIGIN 读取允许的域名列表（逗号分隔），若未设置则默认允许 http://localhost:3000，防止未授权跨域请求。