### PR TITLE
fix: add input validation and length limit on search query (#2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,31 @@
-import { ok } from "../utils/response.js";
-import { globalSearch } from "../services/searchService.js";
+import { z } from 'zod';
+import { searchService } from '../services/searchService.js';
 
-export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+const searchQuerySchema = z.object({
+  q: z.string().trim().min(1).max(200),
+});
+
+/**
+ * Search controller with input validation and sanitization.
+ * Trims the query, enforces a 200-character limit, and strips HTML tags.
+ */
+export async function searchController(req, res, next) {
+  try {
+    const queryResult = searchQuerySchema.safeParse(req.query);
+    if (!queryResult.success) {
+      return res.status(400).json({
+        error: 'Invalid query parameter',
+        details: queryResult.error.issues,
+      });
+    }
+
+    let query = queryResult.data.q;
+    // Basic sanitization: remove HTML tags and dangerous characters
+    query = query.replace(/<[^>]*>/g, '').replace(/[<>"'`]/g, '');
+
+    const results = await searchService.search(query);
+    res.json(results);
+  } catch (err) {
+    next(err);
+  }
 }


### PR DESCRIPTION
为 /api/search 端点的查询参数 q 添加输入验证，包括 trim、长度限制（最多200字符）和简单的 HTML 标签清理，防止恶意输入和资源消耗