### PR TITLE
fix: add input validation and length limit on search query (#2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,32 @@
-import { ok } from "../utils/response.js";
-import { globalSearch } from "../services/searchService.js";
+import { z } from 'zod';
+import * as searchService from '../services/searchService.js';
 
-export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .min(1, 'Search query is required')
+    .max(200, 'Search query must be at most 200 characters'),
+});
+
+/**
+ * Handle GET /api/search
+ * Validates and sanitizes the query before passing to the search service.
+ */
+export async function search(req, res, next) {
+  try {
+    const { q } = searchQuerySchema.parse(req.query);
+    // Basic sanitization: remove potential harmful characters (HTML tags, quotes)
+    const sanitizedQ = q.replace(/[<>"'&]/g, '');
+    const results = await searchService.search(sanitizedQ);
+    res.json({ results });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({
+        error: 'Invalid search query',
+        details: err.errors,
+      });
+    }
+    next(err);
+  }
 }


### PR DESCRIPTION
为搜索端点添加输入验证，包括修剪、最大长度200字符和基本消毒，防止恶意查询消耗资源