### PR TITLE
Add actionable settings overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,109 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+.settings-shell { display: grid; gap: 1rem; }
+.settings-header {
+  align-items: flex-start;
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 12px;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+}
+.settings-kicker {
+  color: #93c5fd;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.25rem;
+  text-transform: uppercase;
+}
+.settings-header h2,
+.settings-panel h3 { margin: 0; }
+.settings-header p,
+.settings-panel p { color: #c7d2fe; }
+.settings-status {
+  background: #14532d;
+  border-radius: 999px;
+  color: #bbf7d0;
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.65rem;
+}
+.settings-summary,
+.settings-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+.settings-metric,
+.settings-panel {
+  background: #0f172a;
+  border: 1px solid #334155;
+  border-radius: 10px;
+  padding: 1rem;
+}
+.settings-metric span {
+  color: #c7d2fe;
+  display: block;
+  font-size: 0.85rem;
+}
+.settings-metric strong {
+  display: block;
+  font-size: 1.45rem;
+  margin-top: 0.25rem;
+}
+.settings-panel-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.85rem;
+}
+.settings-panel-header a {
+  background: #2563eb;
+  border-radius: 8px;
+  color: #fff;
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.65rem;
+}
+.settings-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+.settings-row {
+  border-top: 1px solid #26324f;
+  display: grid;
+  gap: 0.35rem;
+  padding-top: 0.65rem;
+}
+.settings-row dt {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+.settings-row dd {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
+  margin: 0;
+}
+.settings-row em {
+  background: #1e293b;
+  border: 1px solid #475569;
+  border-radius: 999px;
+  color: #bfdbfe;
+  font-size: 0.78rem;
+  font-style: normal;
+  padding: 0.2rem 0.5rem;
+}
+
+@media (max-width: 680px) {
+  .settings-header,
+  .settings-panel-header { display: grid; }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,126 @@
+import Link from "next/link";
+
+const accountSettings = [
+  { label: "Display name", value: "Avery Client" },
+  { label: "Account type", value: "Client workspace" },
+  { label: "Profile visibility", value: "Visible to matched freelancers" },
+  { label: "Timezone", value: "America/New_York" }
+];
+
+const notificationSettings = [
+  { label: "Proposal updates", value: "Email and in-app" },
+  { label: "Message alerts", value: "In-app only" },
+  { label: "Billing alerts", value: "Email required" },
+  { label: "Weekly digest", value: "Paused" }
+];
+
+const securitySettings = [
+  { label: "Password", value: "Updated 18 days ago", status: "Current" },
+  { label: "Two-step verification", value: "Authenticator app", status: "Enabled" },
+  { label: "Active sessions", value: "2 trusted devices", status: "Review" },
+  { label: "API access", value: "No personal tokens", status: "Locked" }
+];
+
+const billingSettings = [
+  { label: "Default payment method", value: "Visa ending in 4242" },
+  { label: "Payout profile", value: "Bank transfer verified" },
+  { label: "Tax form", value: "W-9 on file" },
+  { label: "Invoice delivery", value: "billing@example.com" }
+];
+
 export default function SettingsPage() {
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section className="settings-shell" aria-labelledby="settings-title">
+      <div className="settings-header">
+        <div>
+          <p className="settings-kicker">Account settings</p>
+          <h2 id="settings-title">Settings</h2>
+          <p>Profile visibility, notification delivery, security posture, and billing defaults for the active workspace.</p>
+        </div>
+        <span className="settings-status">Workspace healthy</span>
+      </div>
+
+      <div className="settings-summary" aria-label="Settings summary">
+        <SummaryMetric label="Profile" value="Public" />
+        <SummaryMetric label="Security" value="2FA on" />
+        <SummaryMetric label="Billing" value="Verified" />
+        <SummaryMetric label="Alerts" value="3 active" />
+      </div>
+
+      <div className="settings-grid">
+        <SettingsPanel
+          title="Account / profile"
+          description="Core identity and marketplace visibility."
+          href="/"
+          action="View workspace"
+          rows={accountSettings}
+        />
+        <SettingsPanel
+          title="Notifications"
+          description="Delivery preferences for marketplace events."
+          href="/notifications"
+          action="Open alerts"
+          rows={notificationSettings}
+        />
+        <SettingsPanel
+          title="Security"
+          description="Access safeguards and session state."
+          rows={securitySettings}
+        />
+        <SettingsPanel
+          title="Billing / payouts"
+          description="Default payment, payout, tax, and invoice details."
+          href="/billing"
+          action="Review billing"
+          rows={billingSettings}
+        />
+      </div>
     </section>
+  );
+}
+
+function SummaryMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <article className="settings-metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function SettingsPanel({
+  title,
+  description,
+  href,
+  action,
+  rows
+}: {
+  title: string;
+  description: string;
+  href?: string;
+  action?: string;
+  rows: Array<{ label: string; value: string; status?: string }>;
+}) {
+  return (
+    <article className="settings-panel">
+      <header className="settings-panel-header">
+        <div>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+        {href && action ? <Link href={href}>{action}</Link> : null}
+      </header>
+      <dl className="settings-list">
+        {rows.map((row) => (
+          <div className="settings-row" key={row.label}>
+            <dt>{row.label}</dt>
+            <dd>
+              <span>{row.value}</span>
+              {row.status ? <em>{row.status}</em> : null}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </article>
   );
 }


### PR DESCRIPTION
/claim #2822

## Summary
- Replaces the placeholder `/settings` route with a static but actionable account settings overview.
- Adds sections for account/profile, notifications, security, and billing/payout preferences.
- Adds scannable summary metrics and links to existing workspace, notifications, and billing surfaces.
- Keeps the change scoped to the settings page and global settings-specific styles; no backend/API behavior changed.

Closes #2822

## Validation
- `node node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json`
- `git diff --check`
- Playwright smoke of `/settings` at desktop and mobile widths with no console/page errors

## Local build note
- `node ../../node_modules/next/dist/bin/next build` could not complete in this local macOS/Codex environment because the installed `@next/swc-darwin-arm64` native binary fails code-signature validation and `npm` is not available on PATH for Next's SWC fallback download.