### PR TITLE
Reject unsupported OAuth providers

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOAuthProviders = new Set(["github"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,13 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = req.params.provider?.toLowerCase();
+  if (!supportedOAuthProviders.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback accepts supported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});
+
+test("OAuth callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/not-a-provider/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});


### PR DESCRIPTION
/claim #3852

## Summary
- Rejects unsupported OAuth callback providers before returning a successful callback response.
- Keeps the existing `github` callback behavior working and normalizes the provider name.
- Adds focused API coverage for supported and unsupported provider callbacks.

Closes #3852

## Validation
- `node --test apps/api/src/tests/*.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/auth.test.js`
- `git diff --check`

## Local note
- `npm run test -w apps/api` could not be used because `npm` is not available on PATH in this Codex environment. The equivalent direct Node test command passed.