### PR TITLE
Return defensive copies from list services

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { listMessages, sendMessage } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListReturnsSnapshot({ create, list, payload }) {
+  const created = await create(payload);
+  const firstList = await list();
+
+  assert.ok(firstList.some((item) => item === created));
+  firstList.length = 0;
+  firstList.push({ id: "caller_mutation" });
+
+  const secondList = await list();
+  assert.ok(secondList.some((item) => item === created));
+  assert.equal(secondList.some((item) => item.id === "caller_mutation"), false);
+}
+
+test("list service responses are defensive array copies", async () => {
+  await assertListReturnsSnapshot({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "copy-user@example.com", role: "client" }
+  });
+  await assertListReturnsSnapshot({
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Copy test job", budgetMin: 100, budgetMax: 200 }
+  });
+  await assertListReturnsSnapshot({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_copy", freelancerId: "usr_copy", amount: 150 }
+  });
+  await assertListReturnsSnapshot({
+    create: createReview,
+    list: listReviews,
+    payload: { jobId: "job_copy", rating: 5, comment: "Great work" }
+  });
+  await assertListReturnsSnapshot({
+    create: sendMessage,
+    list: listMessages,
+    payload: { threadId: "thread_copy", body: "hello" }
+  });
+  await assertListReturnsSnapshot({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_copy", message: "copy test" }
+  });
+});


### PR DESCRIPTION
/claim #3854

## Summary
- Returns defensive shallow array copies from API list services.
- Preserves existing record objects and API response shapes.
- Adds focused regression coverage proving caller-side array mutations do not corrupt later list results.

Closes #3854

## Validation
- `node --test apps/api/src/tests/*.js`
- `node --check apps/api/src/tests/listServices.test.js`
- `node --check` for each changed service file
- `git diff --check`

## Local note
- `npm run test -w apps/api` could not be used because `npm` is not available on PATH in this Codex environment. The equivalent direct Node test command passed.