### PR TITLE
Fix ui package runtime entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "peerDependencies": {
+        "react": ">=18.2.0 || ^19.0.0"
+      }
     }
   }
 }

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export declare function Button({ children }: { children: ReactNode }): JSX.Element;
+
+export declare function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}): JSX.Element;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,34 @@
+function Button({ children }) {
+  const React = require("react");
+
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer",
+      },
+    },
+    children,
+  );
+}
+
+function Card({ title, children }) {
+  const React = require("react");
+
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children),
+  );
+}
+
+module.exports = {
+  Button,
+  Card,
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,20 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "src"
+  ],
+  "peerDependencies": {
+    "react": ">=18.2.0 || ^19.0.0"
+  }
 }


### PR DESCRIPTION
Closes #2781

## Summary

- Replaces the TypeScript source `main` entrypoint with a runtime JavaScript package entrypoint.
- Adds `exports` and `types` metadata so Node/ESM consumers and TypeScript consumers resolve the same public package surface.
- Adds root `index.js` and `index.d.ts` files for `Button` and `Card`.
- Declares React as a peer dependency for the UI package.

## Verification

```sh
node -e "import('@freelanceflow/ui').then(m=>{ if (!m.Button || !m.Card) throw new Error('missing exports'); console.log('import-ok') })"
```

Result:

```text
import-ok
```