### PR TITLE
fix: test script targets directory + @freelanceflow/ui main points to TypeScript + @freelanceflow/db missing entrypoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
+
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,18 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "build": "tsc --outDir dist"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"
@@ -12,3 +21,4 @@
     "prisma": "^5.17.0"
   }
 }
+

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --outDir dist"
+  }
 }
+


### PR DESCRIPTION
## Summary

3 build and packaging fixes — closes #3675, #3736, #3734.

---

### 1. Low: API Test Script Targets Directory Instead of Glob — Closes #3675

**File:** `apps/api/package.json`

```json
"test": "node --test src/tests"
```

`node --test` with a directory argument behaves inconsistently across Node versions. On some versions it fails silently or doesn't recurse. The explicit glob is unambiguous and portable:

```json
"test": "node --test src/tests/*.js"
```

---

### 2. Medium: `@freelanceflow/ui` Entrypoint Points to TypeScript Source — Closes #3736

**File:** `packages/ui/package.json`

```json
"main": "src/index.ts"
```

Node.js cannot execute TypeScript directly. Any workspace consumer importing `@freelanceflow/ui` at runtime would get a syntax error or MODULE_NOT_FOUND.

**Fix:** Point `main`, `types`, and `exports` to `dist/index.js` / `dist/index.d.ts` (compiled output). Added `"build": "tsc --outDir dist"` script.

---

### 3. Medium: `@freelanceflow/db` Has No Package Entrypoint Fields — Closes #3734

**File:** `packages/db/package.json`

The `db` package had **no** `main`, `types`, or `exports` fields. Any import like:
```js
import { PrismaClient } from "@freelanceflow/db";
```
...would fail with `ERR_MODULE_NOT_FOUND` because Node doesn't know what file to resolve.

**Fix:** Add `main`, `types`, and `exports` fields pointing to the compiled `dist/` output. Added `"build": "tsc --outDir dist"` script.
