### PR TITLE
fix: upload returns 201 on empty file + OAuth accepts any provider + refresh issues hardcoded identity token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,11 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
+
+/** Supported OAuth providers. Any callback for a provider not in this set
+ *  is rejected immediately to prevent probing of unsupported providers. */
+const SUPPORTED_OAUTH_PROVIDERS = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,13 +20,22 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
-  return ok(res, {
-    provider: req.params.provider,
-    status: "callback-received"
-  });
+  // Reject unsupported providers before processing the callback.
+  // Without this check, any :provider value is accepted and returns 200,
+  // leaking that the OAuth callback route exists and potentially creating
+  // an open redirect / unintended processing path for future providers.
+  const provider = req.params.provider;
+  if (!SUPPORTED_OAUTH_PROVIDERS.has(provider)) {
+    return fail(res, `OAuth provider '${provider}' is not supported.`, 400);
+  }
+  return ok(res, { provider, status: "callback-received" });
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  // Pass req.user (populated by authMiddleware on the route) so refreshToken
+  // preserves the caller's actual sub and role — previously called with no args
+  // causing refreshToken to hardcode sub and role, re-introducing the same
+  // role:client bug as loginUser.
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
-  return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
-  }, 201);
+  // Reject empty submissions with 400 instead of returning 201 with
+  // status:'no-file' — HTTP status code must be authoritative, callers
+  // should not need to inspect the response body to detect upload failure.
+  if (!req.file) {
+    return fail(res, "No file provided. Upload requires a multipart file field.", 400);
+  }
+  return ok(res, { filename: req.file.originalname, status: "uploaded" }, 201);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+// Refresh requires a valid current token to issue a new one.
+authRoutes.post("/refresh", authMiddleware, refresh);
+


### PR DESCRIPTION
## Summary

3 bugs fixed in upload and auth layers. Closes #3668, #3853, related to #3722.

---

### 1. Medium: Upload Returns HTTP 201 on Empty Submission — Closes #3668

**File:** `apps/api/src/controllers/uploadController.js`

When no file was provided, the endpoint returned:
```json
HTTP 201 { "status": "no-file", "filename": null }
```

Callers must not need to inspect a response body to detect client errors. HTTP status codes are the contract — a 201 means success. This caused any client checking only the status code to believe the upload succeeded.

**Fix:** Return `HTTP 400` with a descriptive message when `req.file` is absent.

---

### 2. Medium: OAuth Callback Accepts Any Provider String — Closes #3853

**File:** `apps/api/src/controllers/authController.js`

`GET /api/auth/oauth/:provider/callback` returned `HTTP 200` for any `:provider` value, including unsupported ones like `evil`, `test`, `paypal`. This:
- Leaks the existence and structure of the OAuth callback endpoint
- May trigger unintended behavior as new providers are wired in
- Creates an open-ended processing path with no validation gate

**Fix:** Maintain a `SUPPORTED_OAUTH_PROVIDERS` Set (`["github", "google"]`). Any provider not in the set receives `HTTP 400`.

---

### 3. High: `/auth/refresh` Issues Tokens with Hardcoded Identity — Related to #3722

**Files:** `apps/api/src/controllers/authController.js`, `apps/api/src/routes/authRoutes.js`

`POST /auth/refresh` called `refreshToken()` with no arguments. The service hardcoded `sub: "usr_existing"` and `role: "client"` on every new token — the same identity bug as `loginUser` (fixed in #3857). This means:
- Any authenticated user calling `/refresh` received a token as a different user ID
- All non-client roles were silently downgraded to `"client"` on token refresh

**Fix:** Apply `authMiddleware` to the `/refresh` route (so `req.user` is populated), then pass `req.user` to `refreshToken()` which uses the verified JWT claims to issue the renewed token.
