### PR TITLE
fix: JWT claim validation + password max + fullName + admin self-assign + budget Infinity + self-review + rating + proposal timestamp

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -8,9 +8,22 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const claims = verifyAccessToken(authHeader.slice(7));
+
+    // Validate required identity claims are present and non-empty.
+    // A token signed with the correct secret but missing 'sub' or 'role'
+    // could bypass identity checks in controllers that read req.user.sub.
+    if (!claims.sub || typeof claims.sub !== "string") {
+      return fail(res, "Invalid token: missing subject claim", 401);
+    }
+    if (!claims.role || typeof claims.role !== "string") {
+      return fail(res, "Invalid token: missing role claim", 401);
+    }
+
+    req.user = claims;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);
   }
 }
+

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,16 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  // Server-controlled fields after the spread so they cannot be overridden.
+  const proposal = {
+    ...payload,
+    id: `prp_${Date.now()}`,
+    createdAt: new Date().toISOString()
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,34 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  // Prevent self-reviews — a user reviewing themselves inflates their own
+  // reputation score. The reviewerId comes from req.user.sub (server-side),
+  // so this check cannot be bypassed by manipulating the request body.
+  if (payload.reviewerId === payload.revieweeId) {
+    throw Object.assign(new Error("Self-reviews are not permitted."), { status: 400 });
+  }
+
+  // Enforce integer rating in 1–5 range at service layer as a second
+  // defence, even though the controller validator already checks this.
+  const rating = payload.rating;
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    throw Object.assign(
+      new Error("Rating must be an integer between 1 and 5."),
+      { status: 400 }
+    );
+  }
+
+  // Server-controlled fields come after the spread so they cannot be
+  // overridden by client-supplied values.
+  const review = {
+    ...payload,
+    id: `rev_${Date.now()}`,
+    createdAt: new Date().toISOString()
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,11 +2,18 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  // bcrypt silently truncates passwords at 72 bytes. A password longer than
+  // 72 chars gives a false sense of security AND costs extra CPU to hash.
+  // Cap at 72 to enforce clarity. Min 8 for strength baseline.
+  password: z.string().min(8).max(72),
+  // fullName is required by the Prisma User model.
+  fullName: z.string().min(1).max(100),
+  // Block admin self-assignment — role must be assigned by an existing admin.
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8).max(72)
 });
+

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,10 +3,21 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  // .finite() rejects Infinity and NaN which .nonnegative() alone allows.
+  budgetMin: z.number().nonnegative().finite(),
+  budgetMax: z.number().nonnegative().finite(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).superRefine((data, ctx) => {
+  // Reject inverted budget ranges (e.g. min:1200, max:500).
+  if (data.budgetMax < data.budgetMin) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
 });
 
 export const updateJobSchema = createJobSchema.partial();
+


### PR DESCRIPTION
## Summary

8 bugs fixed across validators, auth middleware, and review/proposal services.
Closes #3847, #3759, #3740, #3748, #3694, #3750, #3742, #3755.

---

### 1. High: `authMiddleware` Accepts Tokens Missing Required Claims — Closes #3847

**File:** `apps/api/src/middleware/auth.js`

`verifyAccessToken()` result was assigned directly to `req.user` without checking for `sub` or `role`. A token signed with the application secret but lacking these claims would pass the middleware and leave `req.user.sub` undefined, potentially bypassing user-identity checks in controllers.

**Fix:** Validate `claims.sub` and `claims.role` are present non-empty strings; return `401` otherwise.

---

### 2. Medium: `registerSchema` Allows Admin Self-Assignment — Closes #3662

Admin role should only be granted by an existing admin, not self-declared at registration. The schema included `"admin"` in the role enum, allowing `{"role": "admin"}` in a registration payload.

**Fix:** `role` enum is `["client", "freelancer"]` only.

---

### 3. Medium: No Password Max Length — Closes #3740

`bcrypt` silently truncates passwords at 72 bytes. Accepting longer passwords:
- Gives users a false sense of security (extra characters are ignored)
- Enables CPU DoS by submitting very long strings to bcrypt

**Fix:** `password.max(72)` on both `registerSchema` and `loginSchema`.

---

### 4. Medium: `fullName` Missing from Registration Schema — Closes #3759

The Prisma `User` model requires `fullName`, but `registerSchema` never validated or included it. Every registered user was missing a required DB field.

**Fix:** Add `fullName: z.string().min(1).max(100)` to `registerSchema`.

---

### 5. Medium: Budget Accepts `Infinity` and `NaN` — Closes #3748 / #3694

`z.number().nonnegative()` does not reject `Infinity` or `NaN`. Jobs with infinite budgets break all range comparison logic.

**Fix:** Add `.finite()` to both `budgetMin` and `budgetMax`. Also add `.superRefine()` to reject inverted ranges where `budgetMax < budgetMin`.

---

### 6. High: Self-Reviews Not Prevented — Closes #3750

`createReview()` never checked `reviewerId !== revieweeId`. A user could write their own glowing reviews to inflate their marketplace rating.

**Fix:** Throw `400` at the service layer if `reviewerId === revieweeId`.

---

### 7. Medium: Review Rating Not Validated at Service Layer — Closes #3742

The service stored raw `payload.rating` with no integer or range validation as a second defence. Non-integers like `4.5` or out-of-range values like `10` could persist.

**Fix:** Check `Number.isInteger(rating) && rating >= 1 && rating <= 5`.

---

### 8. Medium: Proposal Missing Server-Owned `createdAt` — Closes #3755

`createProposal()` spread the payload without stamping a creation timestamp, allowing clients to omit or forge it.

**Fix:** Add `createdAt: new Date().toISOString()` as a server-controlled field after the spread.
