### PR TITLE
fix: multer accepts any file type and unlimited size (memory DoS) + notification read-status injection

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,8 +2,36 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+/** Permitted MIME types for uploaded files.
+ *  Executables, scripts, and arbitrary binaries are blocked by default. */
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  // 5 MB in-memory limit prevents memory exhaustion from large uploads.
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter(_req, file, cb) {
+    if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(Object.assign(
+        new Error(`File type '${file.mimetype}' is not allowed.`),
+        { status: 415 }
+      ));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 
 uploadRoutes.post("/", upload.single("file"), uploadFile);
+

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,21 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  // Return a shallow copy — callers cannot mutate the in-memory store.
+  return [...notifications];
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Server-controlled fields must come AFTER the spread so the client
+  // cannot override them. Previously id and read were BEFORE the spread,
+  // allowing { read: true } in the payload to silently mark notifications
+  // as already-read on creation, defeating unread notification counts.
+  const notification = {
+    ...payload,
+    id: `ntf_${Date.now()}`,
+    read: false,
+    createdAt: new Date().toISOString()
+  };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Summary

2 bugs fixed across upload middleware and notification service. Closes #3758, #3721.

---

### 1. High: Multer Accepts Arbitrary File Types and Unlimited Sizes — Closes #3758

**File:** `apps/api/src/routes/uploadRoutes.js`

The upload route used `multer({ storage: memoryStorage() })` with no configuration beyond storage. This means:

- **Executable uploads accepted**: `.exe`, `.sh`, `.js`, `.php` files pass without rejection, creating a stored malware vector if files are later served
- **Unlimited file size**: A single multipart upload of multiple GBs can exhaust Node.js heap memory, causing an OOM crash (memory DoS)
- **MIME type spoofing risk**: Without a fileFilter, attackers only need to set any Content-Type header

**Fix:** Add `limits: { fileSize: 5 * 1024 * 1024 }` (5 MB cap) and a `fileFilter` that allowlists permitted MIME types:
- `image/jpeg`, `image/png`, `image/gif`, `image/webp`
- `application/pdf`
- `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
- `text/plain`

All other types receive `HTTP 415 Unsupported Media Type`.

---

### 2. Medium: Notification Spread Order Exposes Read-Status Injection — Closes #3721

**File:** `apps/api/src/services/notificationService.js`

`createNotification` placed server-controlled fields **before** the spread:
```js
// BEFORE (vulnerable)
{ id: `ntf_${Date.now()}`, read: false, ...payload }
```

A caller including `{ read: true }` in the body overwrites the `read: false` default, creating notifications that are pre-marked as already-read. This:
- Makes the notification invisible in "unread" feeds
- Defeats real-time notification counts
- Could allow notification suppression attacks

Additionally, `listNotifications` returned the live module-level array directly, allowing callers to silently corrupt the store with `.push()` or `.splice()`.

**Fix:** Move server fields after the spread; also add a server-owned `createdAt` timestamp and return `[...notifications]` from the list function.
