### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validCreatePayload = {
+  title: "Build landing page",
+  description: "Create a conversion-focused landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["copywriting", "html"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validCreatePayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues.map((issue) => issue.path), [["budgetMax"]]);
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validCreatePayload);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.budgetMin, 100);
+  assert.equal(result.data.budgetMax, 500);
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 300,
+    budgetMax: 299
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues.map((issue) => issue.path), [["budgetMax"]]);
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 300 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 500 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function budgetRangeIsOrdered(data, ctx) {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(budgetRangeIsOrdered);
+
+export const updateJobSchema = jobSchema.partial().superRefine(budgetRangeIsOrdered);


### PR DESCRIPTION
Fixes #3864.

## Summary
- rejects inverted job budget ranges with a shared Zod refinement
- applies the rule to create and update schemas
- keeps single-field budget updates valid
- fixes the API test script on Windows/Node by using an explicit test-file glob

## Tests
- `npm test -w apps/api`