### PR TITLE
Resolve mock job detail pages by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,32 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((item) => item.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job exists for <strong>{id}</strong>.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <h3>Milestones</h3>
+      <ul>
+        {job.milestones.map((milestone) => (
+          <li key={milestone}>{milestone}</li>
+        ))}
+      </ul>
+      <Link href="/jobs">Back to job listings</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,25 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create an embeddable support widget that can answer common customer questions and hand off complex cases.",
+    milestones: ["Widget UI prototype", "AI response workflow", "Client handoff notes"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Move a small legacy API into a maintainable Node.js service with matching endpoints and deployment notes.",
+    milestones: ["Endpoint audit", "Node.js migration", "Regression checklist"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Design concise onboarding screens that guide new SaaS users from signup to first useful action.",
+    milestones: ["Flow map", "Screen copy", "Handoff-ready wireframes"]
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
Fixes #3866.

## Summary
- resolves `/jobs/[id]` against the mock `jobs` collection
- renders the matching title, budget, summary, and milestones for known ids
- shows a clear fallback for unknown job ids

## Verification
- `npm run build -w apps/web`