### PR TITLE
Resolve mock freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,34 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
+export default async function FreelancerProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+  const freelancer = freelancers.find((profile) => profile.username === username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer exists for <strong>{username}</strong>.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.name}</h2>
+      <p><strong>{freelancer.headline}</strong></p>
+      <p>{freelancer.bio}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <h3>Portfolio</h3>
+      <ul>
+        {freelancer.portfolio.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      <Link href="/freelancers/search">Back to freelancer search</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,22 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    headline: "Full-stack product engineer",
+    bio: "Builds responsive dashboards, API integrations, and production-ready React workflows.",
+    portfolio: ["SaaS analytics dashboard", "Customer support widget", "Billing portal migration"]
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Rivera",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    headline: "UX researcher and onboarding designer",
+    bio: "Designs clear user journeys for SaaS teams that need faster activation and fewer support tickets.",
+    portfolio: ["Onboarding audit", "Signup flow redesign", "Research interview synthesis"]
+  }
 ];


### PR DESCRIPTION
Fixes #3868.

## Summary
- resolves `/freelancers/[username]` against the mock `freelancers` collection
- renders the matching name, headline, bio, rate, skills, and portfolio for known usernames
- shows a clear fallback for unknown usernames

## Verification
- `npm run build -w apps/web`