### PR TITLE
Keep registration token subject in sync with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const originalDateNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now++;
+
+  try {
+    const user = await registerUser({
+      email: "new-user@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const tokenPayload = verifyAccessToken(user.token);
+
+    assert.equal(user.id, "usr_1000");
+    assert.equal(tokenPayload.sub, user.id);
+    assert.equal(tokenPayload.role, "freelancer");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Fixes #3873.

## Summary
- computes the registration user id once
- signs the access token with the same id returned in the response
- adds regression coverage that forces `Date.now()` to advance between calls

## Verification
- `node --test "src/tests/*.test.js"` from `apps/api`