### PR TITLE
fix(security): add input validation to search endpoint

### DIFF
--- a/MODIFY: apps/api/src/controllers/searchController.js
+++ b/MODIFY: apps/api/src/controllers/searchController.js
@@ -1,0 +1,11 @@
+// MODIFY: apps/api/src/controllers/searchController.js (around line 4)
+import { ok } from "../utils/response.js";
+import { globalSearch } from "../services/searchService.js";
+
+export async function search(req, res) {
+  const query = req.query.q ?? ""; // FIX: extract query parameter
+  if (typeof query !== 'string' || query.length > 100) { // FIX: validate input type and length
+    return res.status(400).json({ error: 'Invalid search query' }); // FIX: return error for invalid input
+  }
+  return ok(res, await globalSearch(query));
+}


### PR DESCRIPTION
# Fix: Add Input Validation to Search Endpoint

## Summary
Adds input validation to the search endpoint to prevent invalid queries and potential abuse. Validates that the search query parameter is a string and does not exceed 100 characters.

## Changes
- **apps/api/src/controllers/searchController.js**
  - Extract `q` query parameter with empty string default
  - Validate query is a string type
  - Enforce maximum query length of 100 characters
  - Return 400 Bad Request with descriptive error message for invalid input

## Testing
- [x] Invalid query types (non-string) are rejected with 400 status
- [x] Queries exceeding 100 characters are rejected with 400 status
- [x] Valid string queries under 100 characters proceed normally
- [x] Empty string queries are accepted (default behavior)

## Bounty Reference
Bounty: fix(security): add input validation to search endpoint

---
*Submitted for bounty: $780*