### PR TITLE
fix: add requireRole() RBAC middleware + /admin/metrics accessible to any authenticated user

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,20 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+/**
+ * Middleware factory that enforces role-based access control.
+ * Must be applied after authMiddleware (req.user must be set).
+ *
+ * Example:
+ *   router.use(authMiddleware, requireRole("admin"));
+ */
+export function requireRole(...allowedRoles) {
+  return function roleguard(req, res, next) {
+    if (!req.user?.role || !allowedRoles.includes(req.user.role)) {
+      return fail(res, "Forbidden: insufficient role", 403);
+    }
+    return next();
+  };
+}
+

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,12 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+// authMiddleware verifies the token; requireRole("admin") checks the role.
+// Previously authMiddleware was applied but there was no role check —
+// any authenticated user (client, freelancer) could read admin metrics.
+adminRoutes.use(authMiddleware, requireRole("admin"));
 adminRoutes.get("/metrics", metrics);
+


### PR DESCRIPTION
## Summary

2 changes: adds `requireRole()` RBAC middleware and applies admin-only gate on `/admin` routes.

---

### 1. Medium: Add `requireRole()` Middleware Factory — Foundational RBAC

**File:** `apps/api/src/middleware/auth.js`

The codebase had `authMiddleware` for identity verification but no mechanism to enforce role-based access control on specific routes. Without a `requireRole` primitive, every developer who adds a protected route must implement role checks ad-hoc in the controller.

**Added:** `requireRole(...roles)` — returns an Express middleware that:
- Checks `req.user.role` is present (must run after `authMiddleware`)
- Checks the role is in the `allowedRoles` set
- Returns `HTTP 403 Forbidden` with a descriptive message if not

```js
// Usage:
adminRoutes.use(authMiddleware, requireRole("admin"));
```

---

### 2. High: `/admin/metrics` Accessible to Any Authenticated User

**File:** `apps/api/src/routes/adminRoutes.js`

The admin routes applied `authMiddleware` but never checked the role:
```js
// BEFORE (broken)
adminRoutes.use(authMiddleware);
```

Any authenticated `"client"` or `"freelancer"` with a valid JWT could call `GET /api/admin/metrics` and receive sensitive business intelligence:
- `flaggedAccounts: 3` — security-sensitive operational data
- `monthlyVolume: 128900` — confidential revenue figures
- `activeFreelancers: 185` — competitive market data
- `openJobs: 42` — business metrics

**Fix:** Apply `requireRole("admin")` after `authMiddleware`. Non-admins receive `HTTP 403`.

```js
adminRoutes.use(authMiddleware, requireRole("admin"));
```
