### PR TITLE
fix: PORT accepts NaN/0 + /jobs/[id] and /freelancers/[username] render raw params without data lookup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,21 @@
+function parsePort(raw, defaultPort) {
+  // Number("") === 0, Number("abc") === NaN — both cause app.listen() to
+  // bind on port 0 (random) or throw, with no useful error message.
+  // Fail fast here with a clear diagnostic instead.
+  const n = raw !== undefined ? Number(raw) : defaultPort;
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(
+      `Invalid PORT value '${raw}'. Must be an integer between 1 and 65535.`
+    );
+  }
+  return n;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT, 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,28 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { freelancers } from "../../lib/mock";
+
+export default function FreelancerProfilePage({
+  params,
+}: {
+  params: { username: string };
+}) {
+  // Resolve the freelancer profile from the mock store by username.
+  // Previously the page displayed params.username as-is without checking
+  // whether the profile existed, so any path like /freelancers/hacker
+  // would render a page with no real data instead of returning 404.
+  const freelancer = freelancers.find((f) => f.username === params.username);
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>
+        <strong>{freelancer.username}</strong>
+      </p>
+      <p>Rate: {freelancer.rate}</p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,23 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  // Resolve the job from the mock store by id.
+  // Previously the page displayed params.id as-is without checking whether
+  // the job actually existed, so any arbitrary path like /jobs/evil would
+  // render a page with no real data instead of returning 404.
+  const job = jobs.find((j) => j.id === params.id);
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>
+        <strong>{job.title}</strong>
+      </p>
+      <p>Budget: {job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

3 bugs fixed: PORT validation, job detail page resolution, and freelancer profile resolution. Closes #3872, #3866, #3868.

---

### 1. Low: `PORT` Config Accepts Invalid Values — Closes #3872

**File:** `apps/api/src/config/env.js`

```js
// BEFORE (broken)
port: Number(process.env.PORT ?? 4000)
```

`Number()` coercion silently produces problematic values:
- `PORT=""` → `Number("") === 0` — reserved port, requires root privileges
- `PORT="abc"` → `Number("abc") === NaN` — `app.listen(NaN)` behaves unpredictably

The server would either fail to start or bind on an unexpected port with no useful error message.

**Fix:** `parsePort()` validates the value is an integer in the 1–65535 range and throws a descriptive error at startup if invalid, so misconfiguration is caught immediately.

---

### 2. Medium: `/jobs/[id]` Doesn't Resolve Job from Data Store — Closes #3866

**File:** `apps/web/app/jobs/[id]/page.tsx`

The page rendered `params.id` directly without looking up the job:
```tsx
<p>Viewing details for <strong>{params.id}</strong>.</p>
```

Any path like `/jobs/evil` or `/jobs/12345-nonexistent` would render a page with user-supplied input as content instead of returning 404.

**Fix:** Look up the job from `mock.ts` by `params.id`; call `notFound()` if not found. Displays actual job title and budget.

---

### 3. Medium: `/freelancers/[username]` Doesn't Resolve Profile — Closes #3868

**File:** `apps/web/app/freelancers/[username]/page.tsx`

Same issue: `params.username` was displayed as-is without resolution from the data store.

**Fix:** Look up the freelancer by `params.username` from `mock.ts`; call `notFound()` if not found. Displays actual username, rate, and skills.
