### PR TITLE
fix: root lint is no-op placeholder + message sendAt server-owned + listMessages returns mutable reference

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,19 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  // Return a shallow copy — callers cannot mutate the in-memory store.
+  return [...messages];
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  // Server-controlled fields must come AFTER the spread so the client
+  // cannot override them. The id was previously BEFORE the spread,
+  // allowing a client to supply their own message ID via the request body.
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   ],
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
-    "lint": "echo \"No root lint configured\"",
+    "lint": "node --check apps/api/src/**/*.js",
     "test": "npm run test -w apps/api"
   }
 }
+


### PR DESCRIPTION
## Summary

3 bugs fixed. Closes #3647, plus message service security improvements.

---

### 1. Low: Root Lint Script Is a No-Op Placeholder — Closes #3647

**File:** `package.json`

```json
"lint": "echo \"No root lint configured\""
```

`npm run lint` always exited with code 0, giving a false green in CI even when source files contained syntax errors. Any CI workflow relying on the lint gate was effectively disabled.

**Fix:** `node --check apps/api/src/**/*.js` — validates JavaScript syntax across all API source files without executing them. This is a zero-dependency, fast syntax check using the built-in Node.js parser.

---

### 2. Medium: `sendMessage` ID Before Spread Allows Client ID Injection

**File:** `apps/api/src/services/messageService.js`

```js
// BEFORE (vulnerable)
{ id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() }
```

`id` appears **before** the spread, so a client supplying `{ id: "msg_existing_123" }` in the request body overwrites the server-generated ID. This enables:
- ID prediction attacks — choosing an ID that aliases another message
- Collision attacks — overwriting an existing message record

**Fix:** `{ ...payload, id: ..., sentAt: ... }` — server-controlled fields always come last and cannot be overridden.

---

### 3. Medium: `listMessages` Returns Live Mutable Array

`listMessages()` returned the direct module-level `messages` array reference. Any caller could mutate the shared store with `.push()`, `.splice()`, or `.sort()`.

**Fix:** Return `[...messages]` shallow copy.
