### PR TITLE
fix: /api/users unauthenticated (PII + unauth account creation) + user ID injection + mass assignment

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,15 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { registerSchema } from "../validators/auth.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  // Validate and allowlist fields using the registration schema rather than
+  // passing raw req.body to createUser, which would allow arbitrary fields
+  // (role, isAdmin, creditBalance, etc.) to be set by the caller.
+  const payload = registerSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,11 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+// Both endpoints require authentication:
+// - GET / : listing all users (PII) must not be publicly accessible
+// - POST / : user creation without auth allows unauthenticated account seeding
+userRoutes.get("/", authMiddleware, getUsers);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,17 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  // Return a shallow copy — callers cannot mutate the in-memory store.
+  return [...users];
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Server-controlled id must come AFTER the spread so the client
+  // cannot supply their own user ID via the request body.
+  const user = {
+    ...payload,
+    id: `usr_${Date.now()}`
+  };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

4 bugs fixed across user routes, service, and controller. Closes #3884.

---

### 1. High: `/api/users` Routes Have No Authentication — Closes #3884

**File:** `apps/api/src/routes/userRoutes.js`

Both user endpoints were completely unauthenticated:

```js
// BEFORE (vulnerable)
userRoutes.get("/", getUsers);
userRoutes.post("/", postUser);
```

- **`GET /api/users`**: Listed all user records (email, role, id) to any anonymous caller — exposing PII to the public internet
- **`POST /api/users`**: Created new accounts without any JWT requirement, allowing unauthenticated account seeding and bypassing normal registration validation

**Fix:** Apply `authMiddleware` to both routes.

---

### 2. Medium: `createUser` ID Before Spread — ID Injection

**File:** `apps/api/src/services/userService.js`

```js
// BEFORE (vulnerable)
{ id: `usr_${Date.now()}`, ...payload }
```

`id` appears before the spread — a caller supplying `{ id: "usr_admin_1" }` overwrites the server-generated ID with an attacker-chosen value, enabling ID collision and aliasing attacks.

**Fix:** `{ ...payload, id: ... }` — server-controlled ID always wins.

---

### 3. Medium: `listUsers` Returns Mutable Live Array

`listUsers()` returned the direct module-level `users` array. Callers could mutate the shared store with `.push()` or `.splice()`.

**Fix:** Return `[...users]` shallow copy.

---

### 4. Medium: `postUser` Passes Raw `req.body` — Mass Assignment

**File:** `apps/api/src/controllers/userController.js`

`createUser(req.body)` stored any field sent in the body — including `role`, `isAdmin`, `creditBalance`, or any future privileged field — without validation.

**Fix:** Parse through `registerSchema` first to allowlist only `email`, `password`, `fullName`, and `role` (limited enum).
