### PR TITLE
fix: job status injectable at creation (lifecycle bypass) + job ID injection + listJobs mutable reference

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,26 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  // Return a shallow copy — callers cannot mutate the in-memory store.
+  return [...jobs];
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  // Server-controlled fields must come AFTER the spread so clients cannot
+  // override them:
+  //
+  // - id: previously before the spread, allowing a caller to supply their
+  //   own job ID and alias or collide with an existing record.
+  //
+  // - status: previously before the spread, allowing a caller to supply
+  //   status:"closed" or status:"awarded" at creation time, bypassing
+  //   the intended job lifecycle (open -> awarded -> completed).
+  //   Jobs must always start as "open".
+  const job = {
+    ...payload,
+    id: `job_${Date.now()}`,
+    status: "open"
+  };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
## Summary

3 bugs fixed in `jobService.js` — all spread ordering vulnerabilities.

---

### 1. Medium: Job ID Client-Injectable — Spread Ordering

**File:** `apps/api/src/services/jobService.js`

```js
// BEFORE (vulnerable)
{ id: `job_${Date.now()}`, status: "open", ...payload }
```

`id` appears **before** the spread. A client supplying `{ id: "job_existing_001" }` overwrites the server-generated ID, enabling:
- ID collision attacks (alias an existing job)
- ID prediction (choose a deterministic ID that conflicts with future jobs)

**Fix:** `{ ...payload, id: ..., status: "open" }` — server fields always last.

---

### 2. High: Job Status Client-Injectable at Creation — Lifecycle Bypass

Same spread ordering puts `status: "open"` **before** the spread. A client can supply `{ status: "awarded" }` or `{ status: "completed" }` to immediately create a job in a post-lifecycle state:

- **`"awarded"`**: The job appears already matched — no freelancers can submit proposals
- **`"completed"`**: The job appears finished — bypasses all milestone/payment flows
- **`"closed"`**: The job disappears from listings immediately

This completely bypasses the intended `open → awarded → completed` state machine and could be used to manipulate search results, payment triggers, or reputation systems.

**Fix:** `status: "open"` is set after the spread — it is always server-owned and cannot be overridden at creation.

---

### 3. Medium: `listJobs` Returns Mutable Live Array

`listJobs()` returned the direct module-level `jobs` array reference. Callers could mutate the shared store.

**Fix:** Return `[...jobs]` shallow copy.
