### PR TITLE
fix: error handler leaks stack traces in production + always returns HTTP 500 regardless of error status

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,31 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  // In production, avoid logging raw error objects which may contain:
+  //  - Stack traces (expose internal file paths and line numbers)
+  //  - SQL query text (expose table/column names and query structure)
+  //  - Internal module paths (aid in targeted attacks)
+  // Log a sanitized summary in production; keep full details in dev/test.
+  const isProd = process.env.NODE_ENV === "production";
+  if (isProd) {
+    console.error("Unhandled API error:", err?.message ?? "Unknown error", {
+      path: req.path,
+      method: req.method,
+      status: err?.status ?? 500
+    });
+  } else {
+    console.error("Unhandled API error:", err);
+  }
+
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = (Number.isInteger(err?.status) && err.status >= 400 && err.status < 600)
+    ? err.status
+    : 500;
+
+  return res.status(status).json({
     success: false,
     message: "Unexpected server error"
   });
 }
+


### PR DESCRIPTION
## Summary\n\nFixes production error information disclosure and incorrect status code propagation. Closes #3746.\n\n---\n\n### 1. Medium: Raw Error Logged in Production — Closes #3746\n\nFile: \pps/api/src/middleware/errorHandler.js\\n\n\console.error('Unhandled API error:', err)\ logged the full error unconditionally. In production this exposes:\n- Stack traces with internal file paths and line numbers\n- SQL query text (table/column names, query structure)\n- Framework internals that aid targeted exploitation\n\nFix: In production log only \err.message + req.path/method/status\. Full error details kept in dev/test.\n\n---\n\n### 2. Bonus: Error Handler Always Returns HTTP 500\n\nMiddleware (Zod validation, authMiddleware, multer) sets \err.status\ to 4xx codes. The handler ignored this and always returned 500, masking the error category from monitoring tools and making 400/401/415/429 errors look like server failures.\n\nFix: Use \err.status\ when it is a valid 4xx/5xx integer.