### PR TITLE
fix: IDOR — reviewerId and senderId trusted from request body allowing identity spoofing in reviews and messages

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -6,5 +6,10 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  // senderId must come from the verified JWT, not from the request body.
+  // Trusting req.body.senderId allows any authenticated user to impersonate
+  // another sender — a classic IDOR: I can send messages as any user ID.
+  const payload = { ...req.body, senderId: req.user.sub };
+  return ok(res, await sendMessage(payload), 201);
 }
+

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -6,5 +6,10 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  // reviewerId must come from the verified JWT, not from the request body.
+  // Trusting req.body.reviewerId allows any authenticated user to impersonate
+  // another reviewer — a classic IDOR: I can post a review as any user ID.
+  const payload = { ...req.body, reviewerId: req.user.sub };
+  return ok(res, await createReview(payload), 201);
 }
+


### PR DESCRIPTION
## Summary\n\nFixes IDOR vulnerabilities in review and message controllers where the caller identity was read from the request body instead of the verified JWT. Related to #3827 (service-layer fix) — adds controller-layer enforcement.\n\n---\n\n### 1. High: Review Authorship IDOR — \eviewController\\n\nFile: \pps/api/src/controllers/reviewController.js\\n\n\createReview(req.body)\ passes \eviewerId\ from the request body directly. Any authenticated user can set \eviewerId\ to another user's ID, posting reviews under another identity. This enables:\n- Fake positive reviews attributed to respected platform members\n- Fake negative reviews to damage a competitor's reputation  \n- Reputation system manipulation at scale\n\n**Fix:** \{ ...req.body, reviewerId: req.user.sub }\ — override after spread.\n\n---\n\n### 2. High: Message Sender IDOR — \messageController\\n\nFile: \pps/api/src/controllers/messageController.js\\n\nSame pattern: \senderId\ read from body allows message spoofing. The receiver sees a message attributed to an admin, a trusted partner, or any user ID chosen by the attacker. Enables platform-internal phishing.\n\n**Fix:** \{ ...req.body, senderId: req.user.sub }\ — override after spread.