### PR TITLE
fix(api): reject invalid TCP port values and expose parsePort with unit tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,17 @@
+export function parsePort(val) {
+  if (val === undefined || val === null || val === '') {
+    return 4000;
+  }
+  const num = Number(val);
+  if (!Number.isInteger(num) || num < 1 || num > 65535) {
+    throw new Error(`Invalid PORT: "${val}" must be an integer between 1 and 65535.`);
+  }
+  return num;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { parsePort } from "../config/env.js";
+
+test("env port parsing", () => {
+  // Default values
+  assert.strictEqual(parsePort(undefined), 4000);
+  assert.strictEqual(parsePort(null), 4000);
+  assert.strictEqual(parsePort(""), 4000);
+
+  // Valid values
+  assert.strictEqual(parsePort("4000"), 4000);
+  assert.strictEqual(parsePort("80"), 80);
+  assert.strictEqual(parsePort("65535"), 65535);
+  assert.strictEqual(parsePort(3000), 3000);
+
+  // Invalid values
+  assert.throws(() => parsePort("invalid"), /Invalid PORT/);
+  assert.throws(() => parsePort("0"), /Invalid PORT/);
+  assert.throws(() => parsePort("-100"), /Invalid PORT/);
+  assert.throws(() => parsePort("65536"), /Invalid PORT/);
+  assert.throws(() => parsePort("80.5"), /Invalid PORT/);
+});


### PR DESCRIPTION
Fixes #3904

### Changes:
- **Port Parsing Logic:** Replaced the direct parsing of `PORT` with a robust `parsePort` function in `apps/api/src/config/env.js` that rejects invalid, empty, fractional, zero, negative, or out-of-range TCP port values (must be `1..65535`).
- **Defaulting:** Properly defaults to `4000` only when `PORT` is unset/empty.
- **Unit Testing:** Created `apps/api/src/tests/env.test.js` to cover the parser with comprehensive edge cases.
- **Test Runner Fix:** Fixed the `test` script in `apps/api/package.json` to properly glob test files using `node --test src/tests/*.test.js` instead of pointing to a directory, which resolves a runtime launch crash in Node.js v22.