### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema accepts valid budget range", () => {
+  const data = {
+    title: "Software Engineer",
+    description: "Looking for an experienced engineer to build the backend.",
+    budgetMin: 50,
+    budgetMax: 100,
+    categoryId: "tech",
+    skills: ["Node.js"]
+  };
+  const result = createJobSchema.safeParse(data);
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts equal min and max budget", () => {
+  const data = {
+    title: "Software Engineer",
+    description: "Looking for an experienced engineer to build the backend.",
+    budgetMin: 100,
+    budgetMax: 100,
+    categoryId: "tech",
+    skills: ["Node.js"]
+  };
+  const result = createJobSchema.safeParse(data);
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget range", () => {
+  const data = {
+    title: "Software Engineer",
+    description: "Looking for an experienced engineer to build the backend.",
+    budgetMin: 100,
+    budgetMax: 50,
+    categoryId: "tech",
+    skills: ["Node.js"]
+  };
+  const result = createJobSchema.safeParse(data);
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].message, "budgetMax cannot be lower than budgetMin");
+  }
+});
+
+test("updateJobSchema rejects inverted budget when both present", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 100, budgetMax: 50 });
+  assert.equal(result.success, false);
+  if (!result.success) {
+    assert.equal(result.error.issues[0].message, "budgetMax cannot be lower than budgetMin");
+  }
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 100 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const result = updateJobSchema.safeParse({ budgetMax: 100 });
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,19 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const refineBudget = (data) => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+};
+
+export const createJobSchema = baseJobSchema.refine(refineBudget, {
+  message: "budgetMax cannot be lower than budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = baseJobSchema.partial().refine(refineBudget, {
+  message: "budgetMax cannot be lower than budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
Separated base schema and added refine constraints to reject budgetMax < budgetMin for both create and update schemas. Added comprehensive test coverage.

Resolves #2853