### PR TITLE
fix(api): CORS allowlist, PORT validation, and search limits

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: process.env.CORS_ORIGIN || "http://localhost:3000" }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,11 @@
+const rawPort = Number(process.env.PORT ?? 4000);
+if (Number.isNaN(rawPort) || rawPort <= 0 || rawPort > 65535) {
+  throw new Error("Invalid PORT environment variable");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: rawPort,
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -2,5 +2,9 @@ import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+  if (q.length > 200) {
+    return res.status(400).json({ error: "Search query too long" });
+  }
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Three fixes:
1. CORS origin allowlist via CORS_ORIGIN env var, default localhost:3000
2. PORT validation rejecting invalid/zero/negative/out-of-range values
3. Search query length capped at 200 chars to prevent DoS

Resolves #3914