### PR TITLE
security(api): Fix unbounded file upload Memory Exhaustion (DoS)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ 
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 } // 5MB limit to prevent DoS
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
**Vulnerability: Unbounded File Upload Memory Exhaustion (DoS)**

The \uploadFile\ endpoint in \pps/api/src/routes/uploadRoutes.js\ used \multer.memoryStorage()\ without any \limits\ on file size. This allowed an attacker to upload arbitrarily large files, causing Multer to parse the entire file into RAM, which leads to immediate heap memory exhaustion and Node.js crashing (Denial of Service).

**Fix:**
Added a \limits: { fileSize: 5 * 1024 * 1024 }\ constraint to the Multer configuration to cap file uploads at 5MB.

Resolves #3916