### PR TITLE
fix(api): Missing input validation on payment creation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentSchema } from "../validators/payment.js";
+
+test("createPaymentSchema accepts valid payload", () => {
+  const result = createPaymentSchema.safeParse({
+    jobId: "job-123",
+    amount: 100.50
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.currency, "USD");
+});
+
+test("createPaymentSchema rejects zero or negative amount", () => {
+  const result1 = createPaymentSchema.safeParse({
+    jobId: "job-123",
+    amount: 0
+  });
+  assert.equal(result1.success, false);
+
+  const result2 = createPaymentSchema.safeParse({
+    jobId: "job-123",
+    amount: -50
+  });
+  assert.equal(result2.success, false);
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  jobId: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(3).max(3).default("USD"),
+  paymentMethodId: z.string().min(1).optional()
+});


### PR DESCRIPTION
**Vulnerability: Missing Input Validation on Payment Creation**

The \createPayment\ endpoint in \pps/api/src/controllers/paymentController.js\ accepts payment payloads and passes them directly to the database layer without any Zod validation schema. This allows a user to submit a payment intent with an amount of \