### PR TITLE
fix(api): validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message
+      }))
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+import { postMessage } from "../controllers/messageController.js";
+import { createMessageSchema } from "../validators/message.js";
+
+const validMessage = {
+  senderId: "usr_sender",
+  receiverId: "usr_receiver",
+  content: "Hello, I can help with this project."
+};
+
+test("createMessageSchema rejects empty message content", () => {
+  const result = createMessageSchema.safeParse({
+    ...validMessage,
+    content: "   "
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "content");
+});
+
+test("createMessageSchema rejects oversized content", () => {
+  const result = createMessageSchema.safeParse({
+    ...validMessage,
+    content: "a".repeat(5001)
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "content");
+});
+
+test("createMessageSchema rejects missing sender or receiver", () => {
+  assert.equal(createMessageSchema.safeParse({ ...validMessage, senderId: "" }).success, false);
+  assert.equal(createMessageSchema.safeParse({ ...validMessage, receiverId: "" }).success, false);
+});
+
+test("postMessage rejects invalid payloads before creating messages", async () => {
+  await assert.rejects(
+    () => postMessage(
+      { body: { senderId: "usr_sender", receiverId: "usr_receiver", content: "" } },
+      {}
+    ),
+    ZodError
+  );
+});
+
+test("errorHandler returns 400 for Zod validation errors", () => {
+  const error = createMessageSchema.safeParse({
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    content: ""
+  }).error;
+  const response = {
+    headersSent: false,
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+
+  errorHandler(error, {}, response, () => {});
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.success, false);
+  assert.equal(response.body.message, "Validation failed");
+  assert.equal(response.body.issues[0].path[0], "content");
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().trim().min(1),
+  receiverId: z.string().trim().min(1),
+  content: z.string().trim().min(1).max(5000)
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3926.

This PR adds message creation validation so invalid payloads are rejected before they reach the message service:

- require non-empty `senderId`
- require non-empty `receiverId`
- require non-empty `content`
- cap `content` at 5000 characters
- return a structured 400 response for Zod validation failures

/claim #743

## Demo / validation

- `node --test apps/api/src/tests/messageValidation.test.js` -> 5 passed
- `node --test apps/api/src/tests/*.test.js` -> 6 passed
- `git diff --check` -> passed

## Notes

The change is intentionally limited to message creation validation and the existing Zod error response path. No auth, storage, or unrelated route behavior is changed.
