### PR TITLE
fix(api): cap in-memory upload size

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,13 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "Uploaded file exceeds the maximum allowed size"
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,14 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const UPLOAD_FILE_SIZE_LIMIT_BYTES = 5 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: UPLOAD_FILE_SIZE_LIMIT_BYTES
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/uploadLimit.test.js
+++ b/apps/api/src/tests/uploadLimit.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { UPLOAD_FILE_SIZE_LIMIT_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects files larger than the memory upload limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const oversized = new Blob([new Uint8Array(UPLOAD_FILE_SIZE_LIMIT_BYTES + 1)]);
+    form.append("file", oversized, "oversized.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file exceeds the maximum allowed size"
+    });
+  });
+});
+
+test("POST /api/uploads still accepts files within the memory upload limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const allowed = new Blob([new Uint8Array(16)]);
+    form.append("file", allowed, "small.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "small.bin",
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3928.

This PR caps memory-backed uploads to prevent oversized multipart payloads from being buffered unboundedly in API process memory:

- adds a 5 MiB `multer.memoryStorage()` file-size limit
- returns a structured HTTP 413 response for `LIMIT_FILE_SIZE`
- keeps valid small uploads working unchanged

/claim #743

## Demo / validation

- `node --test apps/api/src/tests/uploadLimit.test.js` -> 2 passed
- `node --test apps/api/src/tests/*.test.js` -> 3 passed
- `git diff --check` -> passed

## Notes

The change is intentionally limited to upload route Multer configuration and file-size error handling. It does not alter storage, auth, or unrelated API routes.
