### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid user payload");
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { postUser } from "../controllers/userController.js";
+import { createUserSchema } from "../validators/user.js";
+
+const validUser = {
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  role: "client"
+};
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("createUserSchema rejects empty or malformed profiles", () => {
+  assert.equal(createUserSchema.safeParse({ ...validUser, name: "" }).success, false);
+  assert.equal(createUserSchema.safeParse({ ...validUser, email: "not-an-email" }).success, false);
+  assert.equal(createUserSchema.safeParse({ ...validUser, role: "owner" }).success, false);
+});
+
+test("createUserSchema defaults missing role to client", () => {
+  const result = createUserSchema.safeParse({
+    name: "Grace Hopper",
+    email: "grace@example.com"
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});
+
+test("postUser returns 400 before persisting invalid payloads", async () => {
+  const response = createResponse();
+
+  await postUser({ body: { name: "", email: "bad", role: "owner" } }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "Invalid user payload"
+  });
+});
+
+test("postUser persists validated user payloads", async () => {
+  const response = createResponse();
+
+  await postUser({ body: validUser }, response);
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.body.success, true);
+  assert.match(response.body.data.id, /^usr_/);
+  assert.deepEqual(
+    {
+      name: response.body.data.name,
+      email: response.body.data.email,
+      role: response.body.data.role
+    },
+    validUser
+  );
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  name: z.string().trim().min(1),
+  email: z.string().trim().email(),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3930.

This PR validates user creation payloads before service-layer persistence:

- require non-empty `name`
- require valid `email`
- restrict `role` to `client`, `freelancer`, or `admin`
- default missing `role` to `client`
- return a 400 validation response before invalid profiles are persisted

/claim #743

## Demo / validation

- `node --test apps/api/src/tests/userValidation.test.js` -> 4 passed
- `node --test apps/api/src/tests/*.test.js` -> 5 passed
- `git diff --check` -> passed

## Notes

The change is intentionally limited to API user creation validation. It does not alter authentication, login, JWT handling, or unrelated user routes.
