### PR TITLE
fix(api): validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid proposal payload");
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { postProposal } from "../controllers/proposalController.js";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_freelancer",
+  coverLetter: "I can deliver this API work with tests.",
+  bidAmount: 250,
+  estimatedDays: 5
+};
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("createProposalSchema rejects invalid proposal economics and empty cover letters", () => {
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, bidAmount: -1 }).success, false);
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, estimatedDays: 0 }).success, false);
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, estimatedDays: 1.5 }).success, false);
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, coverLetter: "" }).success, false);
+});
+
+test("createProposalSchema rejects missing identifiers", () => {
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, jobId: "" }).success, false);
+  assert.equal(createProposalSchema.safeParse({ ...validProposal, freelancerId: "" }).success, false);
+});
+
+test("postProposal returns 400 before persisting invalid payloads", async () => {
+  const response = createResponse();
+
+  await postProposal({
+    body: {
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      coverLetter: "",
+      bidAmount: -25,
+      estimatedDays: -2
+    }
+  }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "Invalid proposal payload"
+  });
+});
+
+test("postProposal persists validated proposal payloads", async () => {
+  const response = createResponse();
+
+  await postProposal({ body: validProposal }, response);
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.body.success, true);
+  assert.match(response.body.data.id, /^prp_/);
+  assert.deepEqual(
+    {
+      jobId: response.body.data.jobId,
+      freelancerId: response.body.data.freelancerId,
+      coverLetter: response.body.data.coverLetter,
+      bidAmount: response.body.data.bidAmount,
+      estimatedDays: response.body.data.estimatedDays
+    },
+    validProposal
+  );
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1),
+  coverLetter: z.string().trim().min(1).max(5000),
+  bidAmount: z.number().nonnegative(),
+  estimatedDays: z.number().int().positive()
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3932.

This PR validates proposal creation payloads before service-layer persistence:

- require non-empty `jobId`
- require non-empty `freelancerId`
- require non-empty, bounded `coverLetter`
- require non-negative `bidAmount`
- require positive integer `estimatedDays`
- return a 400 validation response before invalid proposals are persisted

/claim #743

## Demo / validation

- `node --test apps/api/src/tests/proposalValidation.test.js` -> 4 passed
- `node --test apps/api/src/tests/*.test.js` -> 5 passed
- `git diff --check` -> passed

## Notes

The change is intentionally limited to API proposal creation validation. It does not alter proposal listing, job creation, auth, or unrelated API routes.
