### PR TITLE
fix(api): validate payment intent payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid payment payload");
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentValidation.test.js
+++ b/apps/api/src/tests/paymentValidation.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPayment } from "../controllers/paymentController.js";
+import { createPaymentSchema } from "../validators/payment.js";
+
+function createResponse() {
+  return {
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("createPaymentSchema rejects non-positive amounts and malformed currencies", () => {
+  assert.equal(createPaymentSchema.safeParse({ amount: 0, currency: "usd" }).success, false);
+  assert.equal(createPaymentSchema.safeParse({ amount: -1, currency: "usd" }).success, false);
+  assert.equal(createPaymentSchema.safeParse({ amount: 10, currency: "" }).success, false);
+  assert.equal(createPaymentSchema.safeParse({ amount: 10, currency: "usdt" }).success, false);
+});
+
+test("createPaymentSchema defaults currency to usd and normalizes case", () => {
+  const defaulted = createPaymentSchema.safeParse({ amount: 10 });
+  const normalized = createPaymentSchema.safeParse({ amount: 10, currency: "EUR" });
+
+  assert.equal(defaulted.success, true);
+  assert.equal(defaulted.data.currency, "usd");
+  assert.equal(normalized.success, true);
+  assert.equal(normalized.data.currency, "eur");
+});
+
+test("createPayment returns 400 before creating invalid payment intents", async () => {
+  const response = createResponse();
+
+  await createPayment({ body: { amount: -25, currency: "usd" } }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "Invalid payment payload"
+  });
+});
+
+test("createPayment creates intents from validated payloads", async () => {
+  const response = createResponse();
+
+  await createPayment({ body: { amount: 125, currency: "EUR" } }, response);
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.body.success, true);
+  assert.match(response.body.data.paymentId, /^pay_/);
+  assert.equal(response.body.data.amount, 125);
+  assert.equal(response.body.data.currency, "eur");
+  assert.equal(response.body.data.provider, "stripe");
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().trim().toLowerCase().regex(/^[a-z]{3}$/).default("usd")
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3934.

This PR validates payment intent payloads before service-layer intent creation:

- require positive `amount`
- default missing `currency` to `usd`
- normalize `currency` to lowercase
- require three-letter ISO-style currency codes
- return a 400 validation response before invalid payment intents are created

/claim #743

## Demo / validation

- `node --test apps/api/src/tests/paymentValidation.test.js` -> 4 passed
- `node --test apps/api/src/tests/*.test.js` -> 5 passed
- `git diff --check` -> passed

## Notes

The change is intentionally limited to API payment intent payload validation. It does not add real Stripe calls, payout logic, KYC, wallet handling, or unrelated payment-route behavior.
