### PR TITLE
fix: require admin role for metrics

### DIFF
--- a/apps/api/src/middleware/requireAdmin.js
+++ b/apps/api/src/middleware/requireAdmin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/requireAdmin.test.js
+++ b/apps/api/src/tests/requireAdmin.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { requireAdmin } from "../middleware/requireAdmin.js";
+
+function createResponse() {
+  const res = {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+}
+
+test("requireAdmin rejects missing users", () => {
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireAdmin({}, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireAdmin rejects non-admin users", () => {
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireAdmin({ user: { role: "client" } }, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireAdmin allows admin users", () => {
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireAdmin({ user: { role: "admin" } }, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.statusCode, undefined);
+  assert.equal(res.body, undefined);
+});


### PR DESCRIPTION
Closes #3936.

## Summary
- Add a requireAdmin middleware that returns 403 for missing or non-admin users.
- Apply the guard to admin routes after token authentication.
- Add node:test coverage for missing, non-admin, and admin users.

## Validation
- Passed: node --test apps/api/src/tests/requireAdmin.test.js
- Passed: node --check apps/api/src/middleware/requireAdmin.js apps/api/src/routes/adminRoutes.js apps/api/src/tests/requireAdmin.test.js
- Passed: git diff --check
- Full test pattern currently fails in this environment because dependencies are not installed (`cors` is missing) and npm is unavailable.