### PR TITLE
fix: validate payment creation payload

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentValidator.test.js
+++ b/apps/api/src/tests/paymentValidator.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentSchema } from "../validators/payment.js";
+
+test("createPaymentSchema accepts positive payments", () => {
+  const payload = createPaymentSchema.parse({
+    amount: 25,
+    currency: "EUR",
+  });
+
+  assert.deepEqual(payload, {
+    amount: 25,
+    currency: "eur",
+  });
+});
+
+test("createPaymentSchema defaults currency to usd", () => {
+  const payload = createPaymentSchema.parse({ amount: 25 });
+
+  assert.deepEqual(payload, {
+    amount: 25,
+    currency: "usd",
+  });
+});
+
+test("createPaymentSchema rejects non-positive amounts", () => {
+  assert.equal(createPaymentSchema.safeParse({ amount: 0 }).success, false);
+  assert.equal(createPaymentSchema.safeParse({ amount: -10 }).success, false);
+});
+
+test("createPaymentSchema rejects malformed currencies", () => {
+  assert.equal(
+    createPaymentSchema.safeParse({ amount: 25, currency: "usdollar" }).success,
+    false,
+  );
+  assert.equal(
+    createPaymentSchema.safeParse({ amount: 25, currency: "12$" }).success,
+    false,
+  );
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z
+    .string()
+    .trim()
+    .length(3)
+    .regex(/^[a-z]{3}$/i)
+    .transform((currency) => currency.toLowerCase())
+    .default("usd"),
+});


### PR DESCRIPTION
Closes #3922.

## Summary
- Add a Zod schema for payment creation payloads.
- Reject invalid payment payloads with the API error shape and HTTP 400.
- Normalize valid currency values to lowercase and default missing currency to `usd`.
- Add focused validator coverage for valid, defaulted, and invalid payloads.

## Validation
- Passed: node --check apps/api/src/controllers/paymentController.js apps/api/src/validators/payment.js apps/api/src/tests/paymentValidator.test.js
- Passed: git diff --check
- Could not run node --test apps/api/src/tests/paymentValidator.test.js in this environment because dependencies are not installed and `zod` cannot be resolved; npm is unavailable here.