### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = searchQuerySchema.safeParse(req.query.q ?? "");
+
+  if (!result.success) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  return ok(res, await globalSearch(result.data));
 }

--- a/apps/api/src/tests/searchValidator.test.js
+++ b/apps/api/src/tests/searchValidator.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { searchQuerySchema } from "../validators/search.js";
+
+test("searchQuerySchema trims search queries", () => {
+  assert.equal(searchQuerySchema.parse("  designer  "), "designer");
+});
+
+test("searchQuerySchema defaults missing search query to empty string", () => {
+  assert.equal(searchQuerySchema.parse(undefined), "");
+});
+
+test("searchQuerySchema rejects search queries longer than 200 characters", () => {
+  assert.equal(searchQuerySchema.safeParse("a".repeat(201)).success, false);
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z
+  .string()
+  .trim()
+  .max(200)
+  .default("");


### PR DESCRIPTION
Closes #3892.

## Summary
- Add a Zod schema for search query input.
- Trim valid queries before passing them to globalSearch.
- Reject queries longer than 200 characters with HTTP 400 and the API error shape.
- Add focused validator coverage.

## Validation
- Passed: node --check apps/api/src/controllers/searchController.js apps/api/src/validators/search.js apps/api/src/tests/searchValidator.test.js
- Passed: git diff --check
- Could not run node --test apps/api/src/tests/searchValidator.test.js in this environment because dependencies are not installed and `zod` cannot be resolved; npm is unavailable here.