### PR TITLE
fix: validate PORT configuration values to reject invalid entries (#3904)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,17 @@
+function validatePort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(
+      `Invalid PORT value: "${value}". Must be an integer between 1024 and 65535.`
+    );
+  }
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: validatePort(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
 };


### PR DESCRIPTION
## Summary

`apps/api/src/config/env.js` parsed PORT with `Number(process.env.PORT ?? 4000)` without validation. Invalid values like `0`, negative numbers, or non-integers were silently accepted.

## Changes
- Added `validatePort()` function that checks:
  - Value must be an integer
  - Value must be between 1024 and 65535
- Throws descriptive error for invalid PORT values

## Tests
- PORT=0 throws
- PORT=-1 throws
- PORT=80 throws
- PORT=4000 accepted