### PR TITLE
fix: add admin role authorization to admin routes (#1764)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Fixes #1764 Bug: Missing admin role authorization check on admin metrics endpoint.

**Changes:**
- Added `requireAdmin` middleware to `auth.js` to strictly enforce the `admin` role constraint.
- Applied the middleware globally to `adminRoutes.js` ensuring all `/api/admin/*` endpoints are protected.

**If submitted by or with an AI agent**
- Agent or tool name: Antigravity IDE (Gemini 3.1 Pro)
- Execution mode: human-supervised


/claim #1764