### PR TITLE
fix(auth): prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/constants/roles.js
+++ b/apps/api/src/constants/roles.js
@@ -1,0 +1,8 @@
+export const ROLES = {
+  ADMIN: "admin",
+  CLIENT: "client",
+  FREELANCER: "freelancer",
+};
+
+export const ALL_ROLES = Object.values(ROLES);
+export const PUBLIC_ROLES = [ROLES.CLIENT, ROLES.FREELANCER];

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,19 @@
 import { z } from "zod";
+import { ALL_ROLES, PUBLIC_ROLES, ROLES } from "../constants/roles.js";
 
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer"]).default("client")
+  role: z.enum(PUBLIC_ROLES).default(ROLES.CLIENT)
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
+});
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: z.enum(ALL_ROLES).default(ROLES.CLIENT)
 });


### PR DESCRIPTION
Fixes the security vulnerability where users can assign themselves the admin role during registration.

**Changes:**
- Removed `"admin"` from the allowed `role` enum in `registerSchema` within `apps/api/src/validators/auth.js`.
- This ensures that public registration endpoints can only create `"client"` or `"freelancer"` roles, preventing privilege escalation.

**If submitted by or with an AI agent**
- Agent or tool name: Antigravity IDE (Gemini 3.1 Pro)
- Execution mode: human-supervised


Fixes #3607

/claim #3607