### PR TITLE
Keep message ids server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps generated fields server-owned", async () => {
+  const message = await sendMessage({
+    id: "msg_client_supplied",
+    senderId: "usr_sender",
+    recipientId: "usr_recipient",
+    body: "Hello from the sender"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_client_supplied");
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.recipientId, "usr_recipient");
+  assert.equal(message.body, "Hello from the sender");
+  assert.equal(Number.isNaN(Date.parse(message.sentAt)), false);
+});


### PR DESCRIPTION
## Summary

- Fixes #3951
- Keeps `sendMessage()` generated `id` values server-owned by applying them after caller payload fields
- Adds focused regression coverage proving a caller-supplied message id cannot override the generated id

/claim #743

## Validation

- `node --test apps/api/src/tests/messageService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); console.log('package json ok')"`
- `git diff --check`

## Demo evidence

The targeted test demonstrates the bug fix by sending a payload with `id: "msg_client_supplied"` and asserting the returned message still uses a generated `msg_<timestamp>` id while preserving normal payload fields and a parseable server `sentAt` timestamp.

## Scope

This PR only changes message id ownership in `sendMessage()` and adds a regression test. It does not add database persistence, authentication, notification fanout, WebSocket delivery, or unrelated validation logic.
