### PR TITLE
Keep registration token subject consistent

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the access token for the returned user id", async () => {
+  const originalNow = Date.now;
+  let now = 1710000000000;
+
+  Date.now = () => now++;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1710000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3953 by generating the registration user id once and reusing it for both the returned `id` and JWT `sub` claim.
- Adds focused service coverage that stubs `Date.now()` across a millisecond boundary and verifies the decoded token subject matches `result.id`.

## Validation
- `node --test apps/api/src/tests/authService.test.js` -> 1 passed
- `node --check apps/api/src/services/authService.js; node --check apps/api/src/tests/authService.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The new regression test simulates the original failure mode by making sequential `Date.now()` calls return different values. The service now signs the token with the same generated id returned in the response.