### PR TITLE
Restrict admin metrics to admin tokens

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics requires an admin token", async () => {
+  await withServer(async (baseUrl) => {
+    const unauthenticated = await fetch(`${baseUrl}/api/admin/metrics`);
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${clientToken}` }
+    });
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const adminResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    const adminPayload = await adminResponse.json();
+
+    assert.equal(unauthenticated.status, 401);
+    assert.equal(clientResponse.status, 403);
+    assert.equal(adminResponse.status, 200);
+    assert.equal(adminPayload.success, true);
+    assert.equal(adminPayload.data.openJobs, 42);
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3956 by adding a small `requireAdmin` guard after authentication on admin routes.
- Keeps existing unauthenticated behavior as 401 and returns 403 for authenticated non-admin users.
- Adds route coverage for missing token, non-admin token, and admin token access to `/api/admin/metrics`.

## Validation
- `node --test apps/api/src/tests/adminRoutes.test.js` -> 1 passed
- `node --check apps/api/src/middleware/auth.js; node --check apps/api/src/routes/adminRoutes.js; node --check apps/api/src/tests/adminRoutes.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The regression test starts the API app, calls `/api/admin/metrics` with no token, a client token, and an admin token, and verifies the expected 401/403/200 behavior.