### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/userRoutes.test.js
+++ b/apps/api/src/tests/userRoutes.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, body) {
+  return fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/users validates user creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const valid = await postUser(baseUrl, {
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    });
+    const validPayload = await valid.json();
+
+    assert.equal(valid.status, 201);
+    assert.equal(validPayload.data.name, "Ada Lovelace");
+    assert.equal(validPayload.data.email, "ada@example.com");
+    assert.equal(validPayload.data.role, "client");
+
+    const invalidName = await postUser(baseUrl, {
+      name: "",
+      email: "name@example.com"
+    });
+    const invalidEmail = await postUser(baseUrl, {
+      name: "Grace Hopper",
+      email: "not-an-email"
+    });
+    const invalidRole = await postUser(baseUrl, {
+      name: "Katherine Johnson",
+      email: "katherine@example.com",
+      role: "owner"
+    });
+
+    assert.equal(invalidName.status, 400);
+    assert.equal(invalidEmail.status, 400);
+    assert.equal(invalidRole.status, 400);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  name: z.string().trim().min(1),
+  email: z.string().email(),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3958 by validating `POST /api/users` payloads before creating user records.
- Adds `createUserSchema` requiring non-empty `name`, valid `email`, and supported `role` values with a safe `client` default.
- Adds route coverage for a valid default-role user and invalid name/email/role payloads.

## Validation
- `node --test apps/api/src/tests/userRoutes.test.js` -> 1 passed
- `node --check apps/api/src/controllers/userController.js; node --check apps/api/src/validators/user.js; node --check apps/api/src/tests/userRoutes.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The regression test starts the API app, creates a valid user, verifies default `client` role behavior, then confirms empty names, malformed emails, and unsupported roles return HTTP 400 before service persistence.