### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/proposals validates proposal creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const valid = await postProposal(baseUrl, {
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      coverLetter: "I can deliver this implementation with tests.",
+      bidAmount: 250,
+      estimatedDays: 5
+    });
+    const validPayload = await valid.json();
+
+    assert.equal(valid.status, 201);
+    assert.equal(validPayload.data.jobId, "job_123");
+    assert.equal(validPayload.data.freelancerId, "usr_freelancer");
+
+    const missingJob = await postProposal(baseUrl, {
+      jobId: "",
+      freelancerId: "usr_freelancer",
+      coverLetter: "I can deliver this implementation with tests.",
+      bidAmount: 250,
+      estimatedDays: 5
+    });
+    const negativeBid = await postProposal(baseUrl, {
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      coverLetter: "I can deliver this implementation with tests.",
+      bidAmount: -1,
+      estimatedDays: 5
+    });
+    const fractionalDays = await postProposal(baseUrl, {
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      coverLetter: "I can deliver this implementation with tests.",
+      bidAmount: 250,
+      estimatedDays: 1.5
+    });
+
+    assert.equal(missingJob.status, 400);
+    assert.equal(negativeBid.status, 400);
+    assert.equal(fractionalDays.status, 400);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1),
+  coverLetter: z.string().trim().min(1).max(5000),
+  bidAmount: z.number().nonnegative(),
+  estimatedDays: z.number().int().positive()
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3961 by validating `POST /api/proposals` payloads before service-layer creation.
- Adds `createProposalSchema` requiring non-empty `jobId`, `freelancerId`, bounded `coverLetter`, non-negative `bidAmount`, and positive integer `estimatedDays`.
- Adds route coverage for valid proposal creation and invalid job id, bid amount, and estimated days payloads.

## Validation
- `node --test apps/api/src/tests/proposalRoutes.test.js` -> 1 passed
- `node --check apps/api/src/controllers/proposalController.js; node --check apps/api/src/validators/proposal.js; node --check apps/api/src/tests/proposalRoutes.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The regression test starts the API app, creates a valid proposal, then confirms missing `jobId`, negative `bidAmount`, and fractional `estimatedDays` payloads return HTTP 400 before service-layer persistence.