### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/messageRoutes.test.js
+++ b/apps/api/src/tests/messageRoutes.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(baseUrl, body) {
+  return fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/messages validates message creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const valid = await postMessage(baseUrl, {
+      senderId: "usr_sender",
+      receiverId: "usr_receiver",
+      content: "Hello from sender"
+    });
+    const validPayload = await valid.json();
+
+    assert.equal(valid.status, 201);
+    assert.equal(validPayload.data.senderId, "usr_sender");
+    assert.equal(validPayload.data.receiverId, "usr_receiver");
+    assert.equal(validPayload.data.content, "Hello from sender");
+
+    const missingSender = await postMessage(baseUrl, {
+      senderId: "",
+      receiverId: "usr_receiver",
+      content: "Hello from sender"
+    });
+    const missingReceiver = await postMessage(baseUrl, {
+      senderId: "usr_sender",
+      receiverId: "",
+      content: "Hello from sender"
+    });
+    const emptyContent = await postMessage(baseUrl, {
+      senderId: "usr_sender",
+      receiverId: "usr_receiver",
+      content: ""
+    });
+
+    assert.equal(missingSender.status, 400);
+    assert.equal(missingReceiver.status, 400);
+    assert.equal(emptyContent.status, 400);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().trim().min(1),
+  receiverId: z.string().trim().min(1),
+  content: z.string().trim().min(1).max(5000)
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3963 by validating `POST /api/messages` payloads before service-layer creation.
- Adds `createMessageSchema` requiring non-empty `senderId`, non-empty `receiverId`, and bounded non-empty `content`.
- Adds route coverage for valid message creation and missing sender, missing receiver, and empty content payloads.

## Validation
- `node --test apps/api/src/tests/messageRoutes.test.js` -> 1 passed
- `node --check apps/api/src/controllers/messageController.js; node --check apps/api/src/validators/message.js; node --check apps/api/src/tests/messageRoutes.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The regression test starts the API app, creates a valid message, then confirms missing sender, missing receiver, and empty content payloads return HTTP 400 before service-layer persistence.