### PR TITLE
Limit memory-backed upload size

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "Uploaded file exceeds the size limit"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,12 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const MAX_UPLOAD_FILE_SIZE_BYTES = 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_UPLOAD_FILE_SIZE_BYTES }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function uploadBody(size) {
+  const form = new FormData();
+  form.set("file", new Blob([Buffer.alloc(size, "a")]), "upload.txt");
+  return form;
+}
+
+test("POST /api/uploads rejects files above the memory upload limit", async () => {
+  await withServer(async (baseUrl) => {
+    const small = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody(16)
+    });
+    const smallPayload = await small.json();
+
+    assert.equal(small.status, 201);
+    assert.equal(smallPayload.data.filename, "upload.txt");
+    assert.equal(smallPayload.data.status, "uploaded");
+
+    const oversized = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody(MAX_UPLOAD_FILE_SIZE_BYTES + 1)
+    });
+    const oversizedPayload = await oversized.json();
+
+    assert.equal(oversized.status, 413);
+    assert.equal(oversizedPayload.success, false);
+    assert.equal(oversizedPayload.message, "Uploaded file exceeds the size limit");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3965 by adding an explicit 1 MiB limit to memory-backed Multer uploads.
- Returns HTTP 413 with a clear client-facing message when Multer rejects oversized files.
- Adds route coverage proving small uploads still work and oversized uploads are rejected before controller success handling.

## Validation
- `node --test apps/api/src/tests/uploadRoutes.test.js` -> 1 passed
- `node --check apps/api/src/routes/uploadRoutes.js; node --check apps/api/src/middleware/errorHandler.js; node --check apps/api/src/tests/uploadRoutes.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `git diff --check` -> passed

## Demo
The regression test starts the API app, uploads a small multipart file successfully, then uploads a file one byte over the configured limit and verifies the API returns HTTP 413 with the expected error payload.