### PR TITLE
Resolve mock job details by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,25 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job exists for <strong>{params.id}</strong>.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Responsibilities, milestones, and proposals for <strong>{job.id}</strong> would be shown here.</p>
+      <Link href="/jobs">Back to job listings</Link>
     </section>
   );
 }


### PR DESCRIPTION
/claim #743

## Summary
- Fixes #3967 by resolving `/jobs/[id]` against the mock jobs list instead of rendering placeholder route text.
- Shows the selected job title and budget for known ids.
- Adds a clear not-found fallback for unknown job ids with a link back to listings.

## Validation
- `npm.cmd run build -w apps/web` -> passed
- `git diff --check` -> passed

## Demo
The Next build includes `/jobs/[id]` as a dynamic route. The page now renders concrete mock job details for ids linked from `/jobs` and a clear fallback when the id is not present in `apps/web/lib/mock.ts`.