### PR TITLE
fix: auth refresh verification + empty upload rejection

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const refreshTokenValue = req.body.refreshToken || req.headers["x-refresh-token"];
+  const result = await refreshToken(refreshTokenValue);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,14 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return ok(res, { filename: null, status: "no-file" }, 400);
+  }
+  if (req.file.size === 0) {
+    return ok(res, { filename: req.file.originalname, status: "empty-file-rejected" }, 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,14 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  if (!refreshTokenValue) {
+    throw new Error("Refresh token is required");
+  }
+  // TODO: verify refresh token against stored tokens
+  const decoded = verifyRefreshToken(refreshTokenValue);
+  if (!decoded || !decoded.sub) {
+    throw new Error("Invalid refresh token");
+  }
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role || "client" }) };
 }


### PR DESCRIPTION
Fixes two security/validation issues:

1. **#2847** — Auth refresh endpoint now verifies the provided refresh token before issuing a new access token. Returns error if token is missing or invalid.

2. **#2850** — Upload endpoint now rejects empty files (0 bytes) with 400 status instead of accepting them as successful uploads.

Closes #2847, closes #2850