### PR TITLE
fix: require fullName in registration to match User model

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().min(1, "fullName is required"),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
## Fix for #2770

### Problem
The registration schema only accepts , , and , but the Prisma  model requires . This means registration payloads accepted by the API are missing a required user field.

### Changes
1. **** — Added  to 
2. **** — Included  in  return payload

### Testing
- Registration without  now returns a validation error
- Registration with empty  returns a validation error
-  response includes the validated  field

Fixes #2770