### PR TITLE
fix: registerUser token subject matches generated user ID (#2845)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -6,7 +6,7 @@ export async function registerUser(payload) {
     id: `usr_${Date.now()}`,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: payload.id || `usr_${Date.now()}`, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Fixes #2845 where the JWT token subject was generated with a different random ID than the returned user ID, causing auth mismatches. Closes #2845