### PR TITLE
Cap auth password length

### DIFF
--- a/apps/api/src/tests/authValidators.test.js
+++ b/apps/api/src/tests/authValidators.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+const validEmail = "alan@example.com";
+
+test("auth validators accept 128 character passwords", () => {
+  const password = "a".repeat(128);
+
+  assert.equal(registerSchema.safeParse({ email: validEmail, password }).success, true);
+  assert.equal(loginSchema.safeParse({ email: validEmail, password }).success, true);
+});
+
+test("auth validators reject passwords longer than 128 characters", () => {
+  const password = "a".repeat(129);
+
+  assert.equal(registerSchema.safeParse({ email: validEmail, password }).success, false);
+  assert.equal(loginSchema.safeParse({ email: validEmail, password }).success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+const passwordSchema = z.string().min(8).max(128);
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
/claim #743

Fixes #3973.

## Summary
- Reuse a shared auth password schema with the existing 8 character minimum and a new 128 character maximum.
- Apply the cap to both registration and login request validators.
- Add focused validator tests for the accepted 128 character boundary and rejected 129 character boundary.

## Validation
- `node --test apps/api/src/tests/authValidators.test.js` -> 2 passed
- `node --check apps/api/src/validators/auth.js; node --check apps/api/src/tests/authValidators.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 3 passed
- `git diff --check` -> passed

## Demo
The regression test demonstrates the behavior change: 128 character passwords pass validation, while 129 character passwords are rejected before auth processing.