### PR TITLE
Validate review rating range

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -4,7 +4,15 @@ export async function listReviews() {
   return reviews;
 }
 
+function assertValidRating(rating) {
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    throw new RangeError("Review rating must be an integer from 1 to 5");
+  }
+}
+
 export async function createReview(payload) {
+  assertValidRating(payload.rating);
+
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("createReview accepts integer ratings from 1 through 5", async () => {
+  const review = await createReview({
+    reviewerId: "usr_client",
+    revieweeId: "usr_freelancer",
+    rating: 5,
+    comment: "Great delivery"
+  });
+
+  assert.equal(review.rating, 5);
+});
+
+test("createReview rejects invalid review ratings", async () => {
+  const invalidRatings = [0, 6, 4.5, "5"];
+  const beforeCount = (await listReviews()).length;
+
+  for (const rating of invalidRatings) {
+    await assert.rejects(
+      () =>
+        createReview({
+          reviewerId: "usr_client",
+          revieweeId: "usr_freelancer",
+          rating,
+          comment: "Invalid score"
+        }),
+      /integer from 1 to 5/
+    );
+  }
+
+  assert.equal((await listReviews()).length, beforeCount);
+});


### PR DESCRIPTION
/claim #743

Fixes #3975.

## Summary
- Add service-level review rating validation before reviews are stored.
- Accept only integer ratings from 1 through 5.
- Reject out-of-range, fractional, and non-number ratings without mutating the in-memory review list.
- Add focused service regression coverage.

## Validation
- `node --test apps/api/src/tests/reviewService.test.js` -> 2 passed
- `node --check apps/api/src/services/reviewService.js; node --check apps/api/src/tests/reviewService.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 3 passed
- `git diff --check` -> passed

## Demo
The regression test demonstrates that valid rating `5` is accepted, while `0`, `6`, `4.5`, and `5` are rejected before storage.