### PR TITLE
fix(api): restrict admin metrics to admins

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return (req, res, next) => {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuth.test.js
+++ b/apps/api/src/tests/adminAuth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("admin metrics requires an authenticated admin token", async () => {
+  await withServer(async (baseUrl) => {
+    const missingToken = await fetch(`${baseUrl}/api/admin/metrics`);
+    assert.equal(missingToken.status, 401);
+
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${clientToken}` }
+    });
+    const clientPayload = await clientResponse.json();
+
+    assert.equal(clientResponse.status, 403);
+    assert.deepEqual(clientPayload, {
+      success: false,
+      message: "Forbidden"
+    });
+
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const adminResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+    const adminPayload = await adminResponse.json();
+
+    assert.equal(adminResponse.status, 200);
+    assert.equal(adminPayload.success, true);
+    assert.equal(adminPayload.data.flaggedAccounts, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes creator-owned issue #3936.

This PR restricts the admin metrics route to authenticated users whose JWT role is admin:

- add a reusable role guard after authentication
- apply the admin role guard to /api/admin routes
- return 403 for authenticated non-admin users
- keep missing/invalid tokens on the existing 401 path

/claim #743

## Demo / validation

- \✔ admin metrics requires an authenticated admin token (25.497458ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 177.192083 -> 1 passed
- \✔ admin metrics requires an authenticated admin token (24.993584ms)
✔ GET /health returns ok payload (20.685125ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 111.658458 -> 2 passed
- \ -> passed

## Notes

The change is intentionally limited to admin route authorization. It does not change token issuance, KYC, payout logic, or unrelated auth endpoints.