### PR TITLE
fix: require JWT secret in production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,27 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+const DEFAULT_DEVELOPMENT_JWT_SECRET = "development-secret";
+
+function requireProductionSecret(name, value) {
+  if (!value) {
+    throw new Error(`${name} must be set in production`);
+  }
+
+  return value;
+}
+
+export function loadEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret =
+    nodeEnv === "production"
+      ? requireProductionSecret("JWT_SECRET", source.JWT_SECRET)
+      : source.JWT_SECRET ?? DEFAULT_DEVELOPMENT_JWT_SECRET;
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret,
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: source.DATABASE_URL ?? ""
+  };
+}
+
+export const env = loadEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadEnv } from "../config/env.js";
+
+test("loadEnv keeps the development JWT fallback outside production", () => {
+  const env = loadEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("loadEnv requires JWT_SECRET in production", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production" }),
+    /JWT_SECRET must be set in production/
+  );
+});
+
+test("loadEnv accepts an explicit production JWT_SECRET", () => {
+  const env = loadEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret" });
+
+  assert.equal(env.jwtSecret, "prod-secret");
+});


### PR DESCRIPTION
## Summary
- require JWT_SECRET when NODE_ENV=production so production cannot sign tokens with the public development fallback
- keep the existing development fallback for local/dev runs
- update the API test script to target concrete test files so node --test runs reliably
- add env config tests for development fallback and production enforcement

## Security
This avoids production instances silently using the hardcoded development JWT signing secret when JWT_SECRET is missing.

## Verification
- npm run test -w apps/api