### PR TITLE
Declare React dependency in UI package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "dependencies": {
+        "react": "19.2.0"
+      }
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "dependencies": {
+    "react": "19.2.0"
+  }
 }


### PR DESCRIPTION
/claim #743

Fixes #3981

## Summary
- Add `react` as an explicit runtime dependency of the `@freelanceflow/ui` workspace package.
- Refresh the root package lock metadata so `packages/ui` records the dependency.
- Keep the version aligned with `apps/web` (`19.2.0`).

## Validation
- `node -e "const ui=require('./packages/ui/package.json'); const web=require('./apps/web/package.json'); if (ui.dependencies.react !== web.dependencies.react) throw new Error('react ranges differ: ' + ui.dependencies.react + ' vs ' + web.dependencies.react); const lock=require('./package-lock.json'); if (lock.packages['packages/ui'].dependencies.react !== web.dependencies.react) throw new Error('lock mismatch'); console.log('@freelanceflow/ui declares react ' + ui.dependencies.react);"`
- `npm.cmd ls react -w packages/ui --depth=0`
- `npm.cmd run build -w apps/web`
- `git diff --check`

## Demo evidence
This is a package metadata fix, so there is no visible UI flow to record. The validation above demonstrates the package now declares and resolves React from the UI workspace while the web workspace still builds successfully.
