### PR TITLE
fix: add user creation timestamps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}`, createdAt: new Date().toISOString() };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser stores a server-owned createdAt timestamp", async () => {
+  const user = await createUser({
+    id: "client_supplied_id",
+    name: "Test User",
+    createdAt: "client_supplied_timestamp",
+  });
+
+  assert.match(user.id, /^usr_/);
+  assert.notEqual(user.id, "client_supplied_id");
+  assert.notEqual(user.createdAt, "client_supplied_timestamp");
+  assert.equal(new Date(user.createdAt).toISOString(), user.createdAt);
+
+  const users = await listUsers();
+  assert.equal(users.at(-1), user);
+});


### PR DESCRIPTION
## Summary
- Adds a server-owned `createdAt` timestamp when `createUser` creates in-memory user records.
- Keeps caller-provided payload fields from overriding the generated `id` or `createdAt` values.
- Updates the API test script so the existing Node test files are executed, and adds coverage for the user creation timestamp behavior.

## Validation
- `npm test -w apps/api`
- `git diff --check`

Closes #3320

/claim #743