### PR TITLE
Gate admin navigation link by role

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,19 +1,23 @@
 import Link from "next/link";
 
-const links = [
-  ["/", "Home"],
-  ["/jobs", "Jobs"],
-  ["/freelancers/search", "Find Freelancers"],
-  ["/dashboard/client", "Client Dashboard"],
-  ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
-];
+type UserRole = "client" | "freelancer" | "admin";
 
-export function Navigation() {
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/jobs", label: "Jobs" },
+  { href: "/freelancers/search", label: "Find Freelancers" },
+  { href: "/dashboard/client", label: "Client Dashboard" },
+  { href: "/dashboard/freelancer", label: "Freelancer Dashboard" },
+  { href: "/messaging", label: "Messaging" },
+  { href: "/admin", label: "Admin", requiredRole: "admin" }
+] as const;
+
+export function Navigation({ userRole = "client" }: { userRole?: UserRole } = {}) {
+  const visibleLinks = links.filter((link) => !("requiredRole" in link) || link.requiredRole === userRole);
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
-      {links.map(([href, label]) => (
+      {visibleLinks.map(({ href, label }) => (
         <Link key={href} href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
           {label}
         </Link>


### PR DESCRIPTION
/claim #743

Fixes #3984

## Summary
- Make `Navigation` role-aware with a default non-admin role.
- Hide the `/admin` navigation link unless `userRole="admin"` is explicitly supplied.
- Preserve the existing root layout behavior by leaving `<Navigation />` as a non-admin render.

## Validation
- `npm.cmd run build -w apps/web`
- `git diff --check`

## Demo evidence
This is a static navigation visibility change. The root layout still renders `<Navigation />`, which now defaults to `userRole="client"`, so the Admin link is not exposed to regular visitors. Admin navigation remains available for future authenticated callers via `<Navigation userRole="admin" />`.
