### PR TITLE
fix: prevent user ID and JWT subject drift during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const timestamp = Date.now();
+  const userId = `usr_${timestamp}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+import { env } from "../config/env.js";
+import { registerUser } from "../services/authService.js";
+
+// Helper to construct mock res
+function mockResponse() {
+  const res = {
+    status: (code) => {
+      res.statusCode = code;
+      return res;
+    },
+    json: (data) => {
+      res.body = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+test("authMiddleware - allows valid client token", () => {
+  const token = signAccessToken({ sub: "usr_client1", role: "client" });
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = mockResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.ok(nextCalled);
+  assert.equal(req.user.sub, "usr_client1");
+  assert.equal(req.user.role, "client");
+});
+
+test("authMiddleware - allows valid freelancer token", () => {
+  const token = signAccessToken({ sub: "usr_freelance1", role: "freelancer" });
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = mockResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.ok(nextCalled);
+  assert.equal(req.user.role, "freelancer");
+});
+
+test("authMiddleware - allows valid admin token", () => {
+  const token = signAccessToken({ sub: "usr_admin1", role: "admin" });
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = mockResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.ok(nextCalled);
+  assert.equal(req.user.role, "admin");
+});
+
+
+
+test("authMiddleware - rejects invalid Bearer header format", () => {
+  const req = { headers: { authorization: "invalid_format_without_bearer" } };
+  const res = mockResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.ok(!nextCalled);
+  assert.equal(res.statusCode, 401);
+});
+
+test("registerUser - returned user ID matches JWT sub payload exactly", async () => {
+  const payload = { email: "test@example.com", role: "client" };
+  const user = await registerUser(payload);
+
+  assert.ok(user.id);
+  assert.ok(user.token);
+
+  const decoded = jwt.verify(user.token, env.jwtSecret);
+  assert.equal(user.id, decoded.sub);
+});


### PR DESCRIPTION
This PR fixes user registration where the returned user ID and the JWT token subject (sub) could drift if the clock ticked over between the two Date.now() calls in registerUser().