### PR TITLE
fix: return JSON 404 response for unknown routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,11 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  // Fallback for unknown API routes
+  app.use((req, res) => {
+    res.status(404).json({ success: false, error: "Not Found" });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,24 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("GET /api/nonexistent-route returns 404 JSON error", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/nonexistent-route`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(payload, { success: false, error: "Not Found" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
This PR configures a fallback middleware to catch all unmatched API routes and return a JSON 404 response instead of the default HTML page.