### PR TITLE
fix: validate credentials on user login

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -3,15 +3,32 @@ import { loginUser, refreshToken, registerUser } from "../services/authService.j
 import { ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error.name === "ZodError") {
+      return res.status(400).json({ success: false, error: error.errors[0].message });
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    if (error.name === "ZodError") {
+      return res.status(400).json({ success: false, error: error.errors[0].message });
+    }
+    if (error.message === "Invalid email or password") {
+      return res.status(401).json({ success: false, error: error.message });
+    }
+    throw error;
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,27 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createUser, listUsers } from "./userService.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const user = await createUser(payload);
   return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const allUsers = await listUsers();
+  const user = allUsers.find((u) => u.email === payload.email);
+
+  if (!user || user.password !== payload.password) {
+    throw new Error("Invalid email or password");
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,4 +1,11 @@
-const users = [];
+const users = [
+  {
+    id: "usr_existing",
+    email: "user@example.com",
+    password: "password123",
+    role: "client"
+  }
+];
 
 export async function listUsers() {
   return users;

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/login allows login with seeded default credentials", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", password: "password123" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.ok(payload.success);
+    assert.ok(payload.data.token);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/auth/register and then login with newly created credentials", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const uniqueEmail = `new_${Date.now()}@example.com`;
+
+    // 1. Register new user
+    const regResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: uniqueEmail, password: "password123", role: "client" }),
+    });
+    const regPayload = await regResponse.json();
+
+    assert.equal(regResponse.status, 201);
+    assert.ok(regPayload.success);
+
+    // 2. Login with new credentials
+    const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: uniqueEmail, password: "password123" }),
+    });
+    const loginPayload = await loginResponse.json();
+
+    assert.equal(loginResponse.status, 200);
+    assert.ok(loginPayload.success);
+    assert.ok(loginPayload.data.token);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/auth/login rejects unknown email", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "unknown@example.com", password: "password123" }),
+    });
+
+    assert.equal(response.status, 401);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/auth/login rejects incorrect password", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user@example.com", password: "wrong_password" }),
+    });
+
+    assert.equal(response.status, 401);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
This PR configures credential validation for the user login flow. Requests to POST /api/auth/login are now validated against registered users in the in-memory store and a seeded default user. Invalid emails or mismatched passwords return HTTP 401.