### PR TITLE
fix: keep message id and sentAt properties server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,11 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/messages creates message with server-owned ID and sentAt", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Hello", senderId: "usr_1", receiverId: "usr_2" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(payload.success);
+    assert.ok(payload.data.id.startsWith("msg_"));
+    assert.ok(payload.data.sentAt);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/messages ignores client-supplied ID and sentAt", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "msg_client_hijack",
+        sentAt: "2020-01-01T00:00:00.000Z",
+        content: "Hello",
+        senderId: "usr_1",
+        receiverId: "usr_2",
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(payload.success);
+    assert.notEqual(payload.data.id, "msg_client_hijack");
+    assert.ok(payload.data.id.startsWith("msg_"));
+    assert.notEqual(payload.data.sentAt, "2020-01-01T00:00:00.000Z");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
This PR secures the message creation flow by reordering the properties inside the message object literal. The server-generated ID and sentAt properties now overwrite any properties sent in the client payload.