### PR TITLE
fix: add initial status to payment intent response

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "requires_payment_method"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments returns paymentId and initial status", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1000, currency: "usd" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(payload.success);
+    assert.ok(payload.data.paymentId.startsWith("pay_"));
+    assert.equal(payload.data.status, "requires_payment_method");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
This PR adds the initial status property to the payment intent response to conform with the requirements.