### PR TITLE
Include initial status in payment intent responses

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "requires_confirmation"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("payment intents include the initial provider status", async () => {
+  const intent = await createPaymentIntent({
+    amount: 5000,
+    currency: "usd"
+  });
+
+  assert.match(intent.paymentId, /^pay_\d+$/);
+  assert.equal(intent.amount, 5000);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+  assert.equal(intent.status, "requires_confirmation");
+});
+
+test("payment intents still default missing currency to usd", async () => {
+  const intent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.status, "requires_confirmation");
+});


### PR DESCRIPTION
/claim #743

Fixes #4007.

## Summary
- Include an initial mock Stripe payment intent status in `createPaymentIntent()` responses.
- Preserve the existing `paymentId`, amount, currency default, and provider fields.
- Add focused service coverage for explicit and default-currency payment intent responses.

## Validation
- `node --test apps/api/src/tests/paymentService.test.js` -> 2 passed
- `node --check apps/api/src/services/paymentService.js; node --check apps/api/src/tests/paymentService.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 3 passed
- `git diff --check` -> passed

## Notes
This is limited to the mock payment intent response shape. It does not add real Stripe calls, payout logic, KYC, wallet handling, or payment provider configuration.