### PR TITLE
fix: review endpoint should reject ratings outside 1-5

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,14 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
-export async function getReviews(req, res) {
-  return ok(res, await listReviews());
+function asyncHandler(fn) {
+  return (req, res, next) => fn(req, res, next).catch(next);
 }
 
-export async function postReview(req, res) {
+export const getReviews = asyncHandler(async (req, res) => {
+  return ok(res, await listReviews());
+});
+
+export const postReview = asyncHandler(async (req, res) => {
   return ok(res, await createReview(req.body), 201);
-}
+});

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,6 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
+  if (!payload.rating || !Number.isInteger(payload.rating) || payload.rating < 1 || payload.rating > 5) {
+    const err = new Error("Rating must be an integer between 1 and 5");
+    err.status = 400;
+    throw err;
+  }
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;


### PR DESCRIPTION
The createReview endpoint accepted ratings outside the allowed 1-5 range without validation. Added range check that rejects non-integer, missing, or out-of-range values.

Closes #3996