### PR TITLE
fix: notification creation should reject blank messages

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,14 @@
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
-export async function getNotifications(req, res) {
-  return ok(res, await listNotifications());
+function asyncHandler(fn) {
+  return (req, res, next) => fn(req, res, next).catch(next);
 }
 
-export async function postNotification(req, res) {
+export const getNotifications = asyncHandler(async (req, res) => {
+  return ok(res, await listNotifications());
+});
+
+export const postNotification = asyncHandler(async (req, res) => {
   return ok(res, await createNotification(req.body), 201);
-}
+});

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,6 +5,11 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
+  if (!payload.message || typeof payload.message !== "string" || payload.message.trim().length === 0) {
+    const err = new Error("Message is required and must be a non-blank string");
+    err.status = 400;
+    throw err;
+  }
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
   return notification;


### PR DESCRIPTION
The createNotification endpoint allowed creating notifications with blank or missing messages. Added validation ensuring message is a non-empty, non-whitespace string.

Closes #3992