### PR TITLE
fix: unknown API routes should return JSON error responses

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,11 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  // Catch-all 404 handler — return JSON instead of HTML
+  app.use("/api*", (req, res) => {
+    res.status(404).json({ success: false, message: "Not found" });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,14 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
-export async function getMessages(req, res) {
-  return ok(res, await listMessages());
+function asyncHandler(fn) {
+  return (req, res, next) => fn(req, res, next).catch(next);
 }
 
-export async function postMessage(req, res) {
+export const getMessages = asyncHandler(async (req, res) => {
+  return ok(res, await listMessages());
+});
+
+export const postMessage = asyncHandler(async (req, res) => {
   return ok(res, await sendMessage(req.body), 201);
-}
+});

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,11 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode = err.status || err.statusCode || 500;
+  const message = err.status ? err.message : "Unexpected server error";
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }


### PR DESCRIPTION
Requesting unknown API routes returned Express's default HTML 404. Added a catch-all /api* handler that returns structured JSON errors. Also fixed the error handler to respect err.status for proper status code propagation.

Closes #3989