### PR TITLE
fix(upload): add file type and size validation to upload endpoint (Fixes #4021)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,8 +2,47 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const allowedMimeTypes = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024 // 5MB limit
+  },
+  fileFilter: (req, file, cb) => {
+    if (!allowedMimeTypes.includes(file.mimetype)) {
+      return cb(new Error("Invalid file type. Only JPEG, PNG, GIF, PDF, and DOC/DOCX files are allowed."));
+    }
+    cb(null, true);
+  }
+});
+
+const uploadSingle = upload.single("file");
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", (req, res, next) => {
+  uploadSingle(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({
+        success: false,
+        message: err.message || "File upload validation failed"
+      });
+    }
+    // Also validate empty upload if file is missing
+    if (!req.file) {
+      return res.status(400).json({
+        success: false,
+        message: "File is required"
+      });
+    }
+    next();
+  });
+}, uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Upload endpoint validation suite", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const uploadUrl = `http://127.0.0.1:${port}/api/uploads`;
+
+  await t.test("POST /api/uploads with valid image file should succeed", async () => {
+    const formData = new FormData();
+    const fileBlob = new Blob(["dummy png data"], { type: "image/png" });
+    formData.append("file", fileBlob, "test-avatar.png");
+
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      body: formData
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "test-avatar.png");
+    assert.equal(payload.data.status, "uploaded");
+  });
+
+  await t.test("POST /api/uploads with empty/missing file should be rejected with 400", async () => {
+    const formData = new FormData();
+    // No file appended
+
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      body: formData
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File is required");
+  });
+
+  await t.test("POST /api/uploads with invalid mime type should be rejected with 400", async () => {
+    const formData = new FormData();
+    const fileBlob = new Blob(["console.log('malicious script')"], { type: "application/javascript" });
+    formData.append("file", fileBlob, "malicious.js");
+
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      body: formData
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Only JPEG, PNG, GIF, PDF, and DOC\/DOCX files are allowed/);
+  });
+
+  await t.test("POST /api/uploads with oversized file should be rejected with 400", async () => {
+    const formData = new FormData();
+    // Generate a file larger than 5MB (e.g. 5.1MB)
+    const largeBuffer = new Uint8Array(5.1 * 1024 * 1024);
+    const fileBlob = new Blob([largeBuffer], { type: "image/jpeg" });
+    formData.append("file", fileBlob, "huge.jpg");
+
+    const response = await fetch(uploadUrl, {
+      method: "POST",
+      body: formData
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /File too large/i);
+  });
+
+  // Clean up server
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Parent bounty: #743
Closes #4021

## Description
Enforces file type restrictions (JPEG, PNG, GIF, PDF, DOC/DOCX) and a 5MB size limit on the upload endpoint to prevent arbitrary file uploads and DoS attacks.

## Changes:
- **Multer Settings:** Configured `limits.fileSize` of 5MB and a `fileFilter` checking mime types on multer memoryStorage configuration in `apps/api/src/routes/uploadRoutes.js`.
- **Empty File Check:** Checks for `req.file` being empty and returns a 400 Bad Request if missing.
- **Tests:** Created `apps/api/src/tests/upload.test.js` regression tests checking successful uploads, invalid mime types, oversized files, and missing files.
- **Test Script:** Cleaned up test scripts in `apps/api/package.json` to glob test files.

/claim #743