### PR TITLE
Keep user ids server-owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser keeps ids server-owned", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 123456;
+
+  try {
+    const user = await createUser({
+      id: "usr_attacker_supplied",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      role: "client"
+    });
+
+    assert.equal(user.id, "usr_123456");
+    assert.equal(user.name, "Ada Lovelace");
+    assert.notEqual(user.id, "usr_attacker_supplied");
+
+    const storedUser = (await listUsers()).at(-1);
+    assert.equal(storedUser.id, "usr_123456");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
﻿## Summary

- Fixes #4029
- Keeps `createUser()` generated `id` values server-owned by applying them after caller payload fields
- Adds focused regression coverage proving a caller-supplied user id cannot override the generated id

/claim #743

## Validation

- `node --test apps/api/src/tests/userService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/userService.js; node --check apps/api/src/tests/userService.test.js; git diff --check`

## Demo evidence

The targeted test sends a payload with `id: "usr_attacker_supplied"` and asserts the returned and stored user still use the generated `usr_<timestamp>` id while preserving normal user payload fields.

## Scope

This PR only changes user id ownership in `createUser()` and adds a regression test. It does not add database persistence, authentication, role validation, or unrelated user validation logic.
