### PR TITLE
Reject uploads without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("description", "metadata only");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads accepts valid file uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4033
- Rejects `POST /api/uploads` requests that do not include the expected multipart `file` field
- Keeps valid file uploads returning HTTP 201 with the existing success response shape
- Adds focused route coverage for missing-file and valid-file upload paths

/claim #743

## Validation

- `node --test apps/api/src/tests/uploadRoutes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/controllers/uploadController.js; node --check apps/api/src/tests/uploadRoutes.test.js; git diff --check`

## Demo evidence

The missing-file test posts multipart form data without a `file` field and asserts HTTP 400 with `{ success: false, message: "File is required" }`. The valid-file test posts `hello.txt` and asserts the existing HTTP 201 success path still returns the uploaded filename.

## Scope

This PR only changes upload controller behavior and adds route regression coverage. It does not change multer storage, file size limits, file type validation, authentication, or unrelated API behavior.
