### PR TITLE
Validate API port configuration

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,23 @@
+export function parsePort(value) {
+  if (value === undefined) {
+    return 4000;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    throw new Error("PORT must be an integer between 1 and 65535");
+  }
+
+  const port = Number(value);
+  if (port < 1 || port > 65535) {
+    throw new Error("PORT must be an integer between 1 and 65535");
+  }
+
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parsePort } from "../config/env.js";
+
+test("parsePort defaults only when PORT is unset", () => {
+  assert.equal(parsePort(undefined), 4000);
+});
+
+test("parsePort accepts integer TCP ports", () => {
+  assert.equal(parsePort("1"), 1);
+  assert.equal(parsePort("4000"), 4000);
+  assert.equal(parsePort("65535"), 65535);
+});
+
+test("parsePort rejects invalid PORT values", () => {
+  for (const value of ["", "0", "-1", "3.14", "abc", "65536", " 4000 "]) {
+    assert.throws(
+      () => parsePort(value),
+      /PORT must be an integer between 1 and 65535/
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes #3904
- Adds a focused `parsePort()` helper for API port configuration
- Defaults to `4000` only when `PORT` is unset
- Rejects empty, fractional, negative, zero, non-numeric, whitespace-padded, and out-of-range port values
- Adds config regression coverage for default, valid, and invalid values

/claim #743

## Validation

- `node --test apps/api/src/tests/env.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/env.js; node --check apps/api/src/tests/env.test.js; git diff --check`

## Demo evidence

The focused tests prove `parsePort(undefined)` keeps the existing `4000` default, valid TCP ports such as `1`, `4000`, and `65535` are accepted, and invalid values such as empty strings, `0`, negative numbers, decimals, text, whitespace-padded values, and `65536` are rejected before reaching `app.listen()`.

## Scope

This PR only changes API environment port parsing and adds focused config tests. It does not change server startup flow, database configuration, JWT secrets, payment keys, or unrelated environment behavior.
