### PR TITLE
Prevent duplicate freelancer proposals

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,22 @@
-import { ok } from "../utils/response.js";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  DuplicateProposalError,
+  createProposal,
+  listProposals
+} from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    return ok(res, await createProposal(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateProposalError) {
+      return fail(res, error.message, 409);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,10 +1,30 @@
 const proposals = [];
 
+export class DuplicateProposalError extends Error {
+  constructor(jobId, freelancerId) {
+    super(`Freelancer ${freelancerId} already has a proposal for job ${jobId}`);
+    this.name = "DuplicateProposalError";
+  }
+}
+
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
+  const hasProposalIdentity = payload.jobId != null && payload.freelancerId != null;
+  const existingProposal = hasProposalIdentity
+    ? proposals.find(
+        (proposal) =>
+          proposal.jobId === payload.jobId &&
+          proposal.freelancerId === payload.freelancerId
+      )
+    : null;
+
+  if (existingProposal) {
+    throw new DuplicateProposalError(payload.jobId, payload.freelancerId);
+  }
+
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
   return proposal;

--- a/apps/api/src/tests/proposalRoutes.test.js
+++ b/apps/api/src/tests/proposalRoutes.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function proposalPayload() {
+  const suffix = `${Date.now()}-${Math.random()}`;
+
+  return {
+    jobId: `job_${suffix}`,
+    freelancerId: `usr_${suffix}`,
+    coverLetter: "I can deliver the scoped implementation.",
+    bidAmount: 250,
+    estDuration: "3 days"
+  };
+}
+
+test("POST /api/proposals returns 409 for duplicate job/freelancer proposals", async () => {
+  await withServer(async (baseUrl) => {
+    const payload = proposalPayload();
+
+    const firstResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const secondResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...payload, bidAmount: 300 })
+    });
+    const secondPayload = await secondResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondPayload, {
+      success: false,
+      message: `Freelancer ${payload.freelancerId} already has a proposal for job ${payload.jobId}`
+    });
+
+    const listResponse = await fetch(`${baseUrl}/api/proposals`);
+    const listPayload = await listResponse.json();
+    const matchingProposals = listPayload.data.filter(
+      (proposal) =>
+        proposal.jobId === payload.jobId &&
+        proposal.freelancerId === payload.freelancerId
+    );
+
+    assert.equal(matchingProposals.length, 1);
+    assert.equal(matchingProposals[0].bidAmount, 250);
+  });
+});

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DuplicateProposalError,
+  createProposal,
+  listProposals
+} from "../services/proposalService.js";
+
+function proposalPayload(overrides = {}) {
+  const suffix = `${Date.now()}-${Math.random()}`;
+
+  return {
+    jobId: `job_${suffix}`,
+    freelancerId: `usr_${suffix}`,
+    coverLetter: "I can deliver the scoped implementation.",
+    bidAmount: 250,
+    estDuration: "3 days",
+    ...overrides
+  };
+}
+
+test("createProposal rejects a duplicate proposal for the same job and freelancer", async () => {
+  const payload = proposalPayload();
+
+  const created = await createProposal(payload);
+  assert.equal(created.jobId, payload.jobId);
+  assert.equal(created.freelancerId, payload.freelancerId);
+
+  await assert.rejects(
+    () => createProposal({ ...payload, bidAmount: 300 }),
+    DuplicateProposalError
+  );
+
+  const matchingProposals = (await listProposals()).filter(
+    (proposal) =>
+      proposal.jobId === payload.jobId &&
+      proposal.freelancerId === payload.freelancerId
+  );
+
+  assert.equal(matchingProposals.length, 1);
+  assert.equal(matchingProposals[0].bidAmount, 250);
+});
+
+test("createProposal allows the same freelancer on different jobs", async () => {
+  const freelancerId = `usr_same_freelancer_${Date.now()}-${Math.random()}`;
+  const first = await createProposal(proposalPayload({ freelancerId }));
+  const second = await createProposal(proposalPayload({ freelancerId }));
+
+  assert.equal(first.freelancerId, freelancerId);
+  assert.equal(second.freelancerId, freelancerId);
+  assert.notEqual(first.jobId, second.jobId);
+});
+
+test("createProposal allows different freelancers on the same job", async () => {
+  const jobId = `job_same_job_${Date.now()}-${Math.random()}`;
+  const first = await createProposal(proposalPayload({ jobId }));
+  const second = await createProposal(proposalPayload({ jobId }));
+
+  assert.equal(first.jobId, jobId);
+  assert.equal(second.jobId, jobId);
+  assert.notEqual(first.freelancerId, second.freelancerId);
+});

--- a/demos/unique-proposals-demo.svg
+++ b/demos/unique-proposals-demo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Duplicate proposal prevention demo</title>
+  <desc id="desc">A static API flow demo showing the first proposal accepted and the duplicate proposal rejected with HTTP 409.</desc>
+  <rect width="960" height="540" fill="#0f172a"/>
+  <rect x="56" y="48" width="848" height="444" rx="14" fill="#111827" stroke="#334155" stroke-width="2"/>
+  <text x="88" y="96" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="700">Duplicate proposal guard</text>
+  <text x="88" y="128" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="16">Same freelancer, same job: store one proposal and reject the duplicate.</text>
+
+  <rect x="88" y="168" width="784" height="104" rx="10" fill="#172554" stroke="#2563eb" stroke-width="2"/>
+  <text x="112" y="203" fill="#bfdbfe" font-family="Consolas, monospace" font-size="18">POST /api/proposals</text>
+  <text x="112" y="233" fill="#e0f2fe" font-family="Consolas, monospace" font-size="16">{ jobId: "job_42", freelancerId: "usr_7", bidAmount: 250 }</text>
+  <text x="724" y="233" fill="#86efac" font-family="Arial, sans-serif" font-size="20" font-weight="700">201 Created</text>
+
+  <path d="M480 286 L480 320" stroke="#94a3b8" stroke-width="3" stroke-linecap="round"/>
+  <path d="M468 309 L480 324 L492 309" fill="none" stroke="#94a3b8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="88" y="336" width="784" height="104" rx="10" fill="#450a0a" stroke="#dc2626" stroke-width="2"/>
+  <text x="112" y="371" fill="#fecaca" font-family="Consolas, monospace" font-size="18">POST /api/proposals</text>
+  <text x="112" y="401" fill="#fee2e2" font-family="Consolas, monospace" font-size="16">{ jobId: "job_42", freelancerId: "usr_7", bidAmount: 300 }</text>
+  <text x="724" y="401" fill="#fca5a5" font-family="Arial, sans-serif" font-size="20" font-weight="700">409 Conflict</text>
+  <text x="112" y="456" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="15">Result: listProposals() still contains one matching job/freelancer proposal.</text>
+</svg>


### PR DESCRIPTION
Fixes #4028
References #743
/claim #743

## Summary
- reject a second proposal from the same `freelancerId` for the same `jobId`
- return HTTP 409 for duplicate proposal submissions instead of storing another active bid
- preserve normal proposals for different jobs or different freelancers
- add focused service and route regression coverage

## Demo
![Duplicate proposal prevention demo](https://raw.githubusercontent.com/cedar323/bug-bounty/4e03c5e6471f15e2cb947aaca0a4f6f445f8a554/demos/unique-proposals-demo.svg)

## Validation
- `node --check apps/api/src/services/proposalService.js`
- `node --check apps/api/src/controllers/proposalController.js`
- `node --check apps/api/src/tests/proposalService.test.js`
- `node --check apps/api/src/tests/proposalRoutes.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposalService.test.js apps/api/src/tests/proposalRoutes.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` currently invokes `node --test src/tests`, which fails on this Windows/Node setup because the script passes the directory path directly. The explicit test-file command above validates the existing health test plus the new proposal tests without changing the test script in this scoped PR.