### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+  if (typeof rawQuery !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const query = rawQuery.trim();
+  if (query.length > 200) {
+    return fail(res, "Search query must be 200 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/searchRoutes.test.js
+++ b/apps/api/src/tests/searchRoutes.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid search queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects search queries longer than 200 characters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});
+
+test("GET /api/search rejects non-string search query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a string"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4046
- Trims valid `GET /api/search?q=` strings before passing them to `globalSearch()`
- Rejects repeated/non-string query values with the existing API error envelope
- Rejects search queries longer than 200 characters
- Adds focused route coverage for trimmed, too-long, and repeated query values

/claim #743

## Validation

- `node --test apps/api/src/tests/searchRoutes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/controllers/searchController.js; node --check apps/api/src/tests/searchRoutes.test.js; git diff --check`

## Demo evidence

The route tests prove `q=%20designer%20` is passed to the search service as `designer`, a 201-character query returns HTTP 400, and repeated `q=one&q=two` values return HTTP 400 instead of being forwarded as a non-string query.

## Scope

This PR only changes search query validation and adds focused route tests. It does not change ranking, database search, result schemas, rate limits, or unrelated API behavior.
