### PR TITLE
Require JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+export function resolveJwtSecret(nodeEnv, jwtSecret) {
+  if (jwtSecret) {
+    return jwtSecret;
+  }
+
+  if (nodeEnv === "production") {
+    throw new Error("JWT_SECRET is required when NODE_ENV=production");
+  }
+
+  return "development-secret";
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(process.env.NODE_ENV ?? "development", process.env.JWT_SECRET),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveJwtSecret } from "../config/env.js";
+
+test("resolveJwtSecret keeps development fallback outside production", () => {
+  assert.equal(resolveJwtSecret("development", undefined), "development-secret");
+  assert.equal(resolveJwtSecret("test", ""), "development-secret");
+});
+
+test("resolveJwtSecret requires JWT_SECRET in production", () => {
+  assert.throws(
+    () => resolveJwtSecret("production", undefined),
+    /JWT_SECRET is required when NODE_ENV=production/
+  );
+});
+
+test("resolveJwtSecret accepts explicit production secret", () => {
+  assert.equal(resolveJwtSecret("production", "prod-secret"), "prod-secret");
+});


### PR DESCRIPTION
## Summary

- Fixes #4050
- Adds a focused `resolveJwtSecret()` helper for API secret configuration
- Keeps the existing development/test fallback when `JWT_SECRET` is missing outside production
- Rejects production startup configuration when `NODE_ENV=production` and `JWT_SECRET` is missing
- Adds focused config regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/env.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/env.js; node --check apps/api/src/tests/env.test.js; git diff --check`

## Demo evidence

The tests prove non-production environments still fall back to `development-secret`, production without a secret throws `JWT_SECRET is required when NODE_ENV=production`, and production with an explicit secret returns that configured value.

## Scope

This PR only changes JWT secret resolution in API environment config and adds focused tests. It does not read or change real environment variables, payment keys, database URLs, token signing logic, or unrelated configuration behavior.
