### PR TITLE
Require finite job budgets

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build marketplace API",
+  description: "Create the marketplace job API",
+  budgetMin: 0,
+  budgetMax: 100,
+  categoryId: "cat_1",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts finite nonnegative budgets", () => {
+  const result = createJobSchema.parse(validJob);
+
+  assert.equal(result.budgetMin, 0);
+  assert.equal(result.budgetMax, 100);
+});
+
+test("createJobSchema rejects non-finite budget values", () => {
+  for (const value of [Infinity, -Infinity, NaN]) {
+    assert.throws(() => createJobSchema.parse({ ...validJob, budgetMin: value }));
+    assert.throws(() => createJobSchema.parse({ ...validJob, budgetMax: value }));
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
## Summary

- Fixes #4052
- Requires `budgetMin` and `budgetMax` to be finite nonnegative numbers in `createJobSchema`
- Preserves existing valid zero and positive budget behavior
- Adds focused schema coverage for valid budgets and non-finite values

/claim #743

## Validation

- `node --test apps/api/src/tests/jobValidator.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/validators/job.js; node --check apps/api/src/tests/jobValidator.test.js; git diff --check`

## Demo evidence

The focused schema tests prove valid finite budgets still parse successfully, while `Infinity`, `-Infinity`, and `NaN` are rejected for both `budgetMin` and `budgetMax`.

## Scope

This PR only changes job budget schema validation and adds focused tests. It does not change job storage, budget ordering, payment logic, UI behavior, or unrelated validation rules.
