### PR TITLE
Assign proposal creation timestamps

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,11 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    ...payload,
+    createdAt: new Date().toISOString()
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal assigns server-owned createdAt timestamps", async () => {
+  const originalNow = Date.now;
+  const RealDate = Date;
+  const fixedDate = new RealDate("2026-06-03T12:00:00.000Z");
+
+  Date.now = () => 123456;
+  globalThis.Date = class extends RealDate {
+    constructor(...args) {
+      return args.length === 0 ? fixedDate : new RealDate(...args);
+    }
+
+    static now() {
+      return fixedDate.getTime();
+    }
+
+    static parse(value) {
+      return RealDate.parse(value);
+    }
+
+    static UTC(...args) {
+      return RealDate.UTC(...args);
+    }
+  };
+
+  try {
+    const proposal = await createProposal({
+      id: "prp_client_supplied",
+      jobId: "job_1",
+      freelancerId: "usr_1",
+      coverLetter: "I can help",
+      bidAmount: 100,
+      createdAt: "2000-01-01T00:00:00.000Z"
+    });
+
+    assert.equal(proposal.id, "prp_client_supplied");
+    assert.equal(proposal.createdAt, "2026-06-03T12:00:00.000Z");
+
+    const storedProposal = (await listProposals()).at(-1);
+    assert.equal(storedProposal.createdAt, "2026-06-03T12:00:00.000Z");
+  } finally {
+    Date.now = originalNow;
+    globalThis.Date = RealDate;
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes #4055
- Adds server-generated ISO `createdAt` timestamps to new proposals
- Ensures caller-supplied `createdAt` values cannot replace the server timestamp
- Adds focused service regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/proposalService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/proposalService.js; node --check apps/api/src/tests/proposalService.test.js; git diff --check`

## Demo evidence

The focused service test submits a proposal payload with `createdAt: "2000-01-01T00:00:00.000Z"` and asserts the returned and stored proposal use the server-generated `2026-06-03T12:00:00.000Z` timestamp instead.

## Scope

This PR only changes proposal creation timestamp ownership and adds focused tests. It does not change proposal ids, validation, persistence, payment behavior, or unrelated proposal fields.
