### PR TITLE
Resolve mock freelancer profiles

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,30 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((candidate) => candidate.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer profile exists for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.name}</h2>
+      <p>{freelancer.headline}</p>
+      <p><strong>{freelancer.rate}</strong></p>
+      <p>{freelancer.bio}</p>
+      <p>{freelancer.skills.join(" | ")}</p>
+      <h3>Portfolio</h3>
+      <ul>
+        {freelancer.portfolio.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,22 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    headline: "Full-stack product engineer",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    bio: "Builds polished marketplace, SaaS, and AI-assisted workflow products.",
+    portfolio: ["AI support widget", "Marketplace onboarding"]
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Rivera",
+    headline: "Product designer and UX researcher",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    bio: "Turns complex user journeys into clear, conversion-focused product flows.",
+    portfolio: ["SaaS onboarding audit", "Mobile dashboard redesign"]
+  }
 ];


### PR DESCRIPTION
## Summary

- Fixes #4057
- Expands mock freelancer records with display name, headline, bio, and portfolio details
- Resolves `/freelancers/[username]` pages against `apps/web/lib/mock.ts`
- Renders useful profile details for known usernames
- Shows a clear fallback for unknown usernames

/claim #743

## Validation

- `npm run build -w apps/web`
- `git diff --check`

## Demo evidence

Known usernames such as `maya-dev` and `jordan-ux` now render matching mock profile data from the search page links. Unknown usernames render a `Freelancer not found` fallback instead of placeholder success copy.

## Scope

This PR only changes the web freelancer profile route and mock freelancer data shape. It does not change API behavior, authentication, payments, database schema, or unrelated pages.
