### PR TITLE
Redact production error logs

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,10 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  if (process.env.NODE_ENV === "production") {
+    console.error("Unhandled API error:", { name: err?.name ?? "Error" });
+  } else {
+    console.error("Unhandled API error:", err);
+  }
+
   if (res.headersSent) {
     return next(err);
   }

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler redacts raw errors in production logs", () => {
+  const originalEnv = process.env.NODE_ENV;
+  const originalError = console.error;
+  const calls = [];
+  process.env.NODE_ENV = "production";
+  console.error = (...args) => calls.push(args);
+
+  try {
+    const error = new Error("secret token: abc123");
+    const res = createResponse();
+
+    errorHandler(error, {}, res, () => {});
+
+    assert.deepEqual(calls, [["Unhandled API error:", { name: "Error" }]]);
+    assert.equal(res.statusCode, 500);
+    assert.deepEqual(res.body, {
+      success: false,
+      message: "Unexpected server error"
+    });
+  } finally {
+    process.env.NODE_ENV = originalEnv;
+    console.error = originalError;
+  }
+});
+
+test("errorHandler preserves raw error logging outside production", () => {
+  const originalEnv = process.env.NODE_ENV;
+  const originalError = console.error;
+  const calls = [];
+  process.env.NODE_ENV = "development";
+  console.error = (...args) => calls.push(args);
+
+  try {
+    const error = new Error("local debug detail");
+    const res = createResponse();
+
+    errorHandler(error, {}, res, () => {});
+
+    assert.equal(calls[0][0], "Unhandled API error:");
+    assert.equal(calls[0][1], error);
+    assert.equal(res.statusCode, 500);
+  } finally {
+    process.env.NODE_ENV = originalEnv;
+    console.error = originalError;
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes #4061
- Redacts raw error serialization from production error logs
- Preserves raw error logging outside production for local debugging
- Keeps the existing generic HTTP 500 response shape unchanged
- Adds focused middleware regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/errorHandler.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/middleware/errorHandler.js; node --check apps/api/src/tests/errorHandler.test.js; git diff --check`

## Demo evidence

The production test throws an error containing `secret token: abc123` and asserts the log call only receives `{ name: "Error" }`, while the response remains `{ success: false, message: "Unexpected server error" }`. The development test proves the raw error object is still logged outside production.

## Scope

This PR only changes API error-handler logging behavior and adds focused tests. It does not change HTTP response payloads, auth, request handling, payment logic, or unrelated middleware.
