### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobBudgetRange.test.js
+++ b/apps/api/src/tests/jobBudgetRange.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build marketplace API",
+  description: "Create the marketplace job API",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_1",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.parse(validJob);
+
+  assert.equal(result.budgetMin, 100);
+  assert.equal(result.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 500 }), { budgetMin: 500 });
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 100 }), { budgetMax: 100 });
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function validateBudgetRange(payload, ctx) {
+  if (
+    payload.budgetMin !== undefined &&
+    payload.budgetMax !== undefined &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,5 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary

- Fixes #4065
- Adds shared Zod budget-range validation for job payloads
- Rejects `budgetMax < budgetMin` when both fields are present
- Preserves partial update behavior when only one budget field is supplied
- Adds focused schema regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/jobBudgetRange.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/validators/job.js; node --check apps/api/src/tests/jobBudgetRange.test.js; git diff --check`

## Demo evidence

The focused schema tests prove ordered create payloads pass, inverted create payloads fail, partial update payloads with only one budget field still pass, and inverted update payloads with both fields fail.

## Scope

This PR only changes job budget range validation and adds focused tests. It does not change budget finiteness, job persistence, payment logic, UI behavior, or unrelated validation rules.
