### PR TITLE
Reject duplicate user email creation

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,22 @@
-import { ok } from "../utils/response.js";
-import { createUser, listUsers } from "../services/userService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  DuplicateUserEmailError,
+  createUser,
+  listUsers
+} from "../services/userService.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  try {
+    return ok(res, await createUser(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateUserEmailError) {
+      return fail(res, error.message, 409);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,10 +1,26 @@
 const users = [];
 
+export class DuplicateUserEmailError extends Error {
+  constructor(email) {
+    super(`User with email ${email} already exists`);
+    this.name = "DuplicateUserEmailError";
+  }
+}
+
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
+  const email = payload?.email;
+  const existingUser = email != null
+    ? users.find((user) => user.email === email)
+    : null;
+
+  if (existingUser) {
+    throw new DuplicateUserEmailError(email);
+  }
+
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
   return user;

--- a/apps/api/src/tests/userRoutes.test.js
+++ b/apps/api/src/tests/userRoutes.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function userPayload() {
+  const suffix = `${Date.now()}-${Math.random()}`;
+
+  return {
+    email: `user-${suffix}@example.com`,
+    fullName: "Alex User",
+    role: "client"
+  };
+}
+
+test("POST /api/users returns 409 for duplicate email addresses", async () => {
+  await withServer(async (baseUrl) => {
+    const payload = userPayload();
+
+    const firstResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const secondResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...payload, fullName: "Alex Duplicate" })
+    });
+    const secondPayload = await secondResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondPayload, {
+      success: false,
+      message: `User with email ${payload.email} already exists`
+    });
+
+    const listResponse = await fetch(`${baseUrl}/api/users`);
+    const listPayload = await listResponse.json();
+    const matchingUsers = listPayload.data.filter(
+      (user) => user.email === payload.email
+    );
+
+    assert.equal(matchingUsers.length, 1);
+    assert.equal(matchingUsers[0].fullName, "Alex User");
+  });
+});

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DuplicateUserEmailError,
+  createUser,
+  listUsers
+} from "../services/userService.js";
+
+function userPayload(overrides = {}) {
+  const suffix = `${Date.now()}-${Math.random()}`;
+
+  return {
+    email: `user-${suffix}@example.com`,
+    fullName: "Alex User",
+    role: "client",
+    ...overrides
+  };
+}
+
+test("createUser rejects a duplicate email address", async () => {
+  const payload = userPayload();
+
+  const created = await createUser(payload);
+  assert.equal(created.email, payload.email);
+
+  await assert.rejects(
+    () => createUser({ ...payload, fullName: "Alex Duplicate" }),
+    DuplicateUserEmailError
+  );
+
+  const matchingUsers = (await listUsers()).filter(
+    (user) => user.email === payload.email
+  );
+
+  assert.equal(matchingUsers.length, 1);
+  assert.equal(matchingUsers[0].fullName, "Alex User");
+});
+
+test("createUser allows different email addresses", async () => {
+  const first = await createUser(userPayload());
+  const second = await createUser(userPayload());
+
+  assert.notEqual(first.email, second.email);
+});

--- a/demos/unique-user-emails-demo.svg
+++ b/demos/unique-user-emails-demo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Duplicate user email prevention demo</title>
+  <desc id="desc">A static API flow demo showing the first user creation accepted and the duplicate email rejected with HTTP 409.</desc>
+  <rect width="960" height="540" fill="#111827"/>
+  <rect x="56" y="48" width="848" height="444" rx="12" fill="#f8fafc" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="88" y="96" fill="#0f172a" font-family="Arial, sans-serif" font-size="28" font-weight="700">Unique user email guard</text>
+  <text x="88" y="128" fill="#475569" font-family="Arial, sans-serif" font-size="16">Same email: store one user identity and reject the duplicate account record.</text>
+
+  <rect x="88" y="168" width="784" height="104" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+  <text x="112" y="203" fill="#065f46" font-family="Consolas, monospace" font-size="18">POST /api/users</text>
+  <text x="112" y="233" fill="#064e3b" font-family="Consolas, monospace" font-size="16">{ email: "alex@example.com", fullName: "Alex User" }</text>
+  <text x="728" y="233" fill="#047857" font-family="Arial, sans-serif" font-size="20" font-weight="700">201 Created</text>
+
+  <path d="M480 286 L480 320" stroke="#64748b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M468 309 L480 324 L492 309" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="88" y="336" width="784" height="104" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="112" y="371" fill="#991b1b" font-family="Consolas, monospace" font-size="18">POST /api/users</text>
+  <text x="112" y="401" fill="#7f1d1d" font-family="Consolas, monospace" font-size="16">{ email: "alex@example.com", fullName: "Alex Duplicate" }</text>
+  <text x="728" y="401" fill="#b91c1c" font-family="Arial, sans-serif" font-size="20" font-weight="700">409 Conflict</text>
+  <text x="112" y="456" fill="#475569" font-family="Arial, sans-serif" font-size="15">Result: listUsers() still contains one matching email record.</text>
+</svg>


### PR DESCRIPTION
Fixes #4062
References #743
/claim #743

## Summary
- reject a second user creation request with the same `email`
- return HTTP 409 for duplicate `/api/users` submissions instead of storing another identity
- preserve normal creation for different email addresses
- add focused service and route regression coverage

## Demo
![Duplicate user email prevention demo](https://raw.githubusercontent.com/cedar323/bug-bounty/9bfd576ccd3fd28831eda1d39c1d329352b88c82/demos/unique-user-emails-demo.svg)

## Validation
- `node --check apps/api/src/services/userService.js`
- `node --check apps/api/src/controllers/userController.js`
- `node --check apps/api/src/tests/userService.test.js`
- `node --check apps/api/src/tests/userRoutes.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/userService.test.js apps/api/src/tests/userRoutes.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` currently invokes `node --test src/tests`, which fails on this Windows/Node setup because the script passes the directory path directly. The explicit test-file command above validates the existing health test plus the new user tests without changing the test script in this scoped PR.