### PR TITLE
Reject self-directed messages

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,18 @@
-import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { fail, ok } from "../utils/response.js";
+import { listMessages, SelfDirectedMessageError, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    return ok(res, await sendMessage(req.body), 201);
+  } catch (error) {
+    if (error instanceof SelfDirectedMessageError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,10 +1,21 @@
 const messages = [];
 
+export class SelfDirectedMessageError extends Error {
+  constructor() {
+    super("Messages require distinct sender and receiver");
+    this.name = "SelfDirectedMessageError";
+  }
+}
+
 export async function listMessages() {
   return messages;
 }
 
 export async function sendMessage(payload) {
+  if (payload.senderId === payload.receiverId) {
+    throw new SelfDirectedMessageError();
+  }
+
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;

--- a/apps/api/src/tests/messageSelfDirected.test.js
+++ b/apps/api/src/tests/messageSelfDirected.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { listMessages, SelfDirectedMessageError, sendMessage } from "../services/messageService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("sendMessage rejects self-directed messages without storing them", async () => {
+  const beforeCount = (await listMessages()).length;
+
+  await assert.rejects(
+    () => sendMessage({ senderId: "usr_1", receiverId: "usr_1", content: "hello myself" }),
+    SelfDirectedMessageError
+  );
+
+  assert.equal((await listMessages()).length, beforeCount);
+});
+
+test("POST /api/messages maps self-directed messages to HTTP 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_1",
+        receiverId: "usr_1",
+        content: "hello myself"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Messages require distinct sender and receiver"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4074
- Rejects self-directed messages where `senderId === receiverId`
- Maps the focused service error to HTTP 400 in the message controller
- Keeps valid message creation behavior unchanged
- Adds focused service and route regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/messageSelfDirected.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/messageService.js; node --check apps/api/src/controllers/messageController.js; node --check apps/api/src/tests/messageSelfDirected.test.js; git diff --check`

## Demo evidence

The service test proves self-directed messages throw without increasing the stored message count. The route test posts `senderId` and `receiverId` with the same value and asserts HTTP 400 with the existing API error envelope.

## Scope

This PR only changes self-directed message handling and focused tests. It does not add generic payload validation, auth changes, field allowlisting, unread-state defaults, timestamp changes, or persistence plumbing.
