### PR TITLE
Reject self-directed message creation

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,22 @@
-import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  SelfMessageError,
+  listMessages,
+  sendMessage
+} from "../services/messageService.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    return ok(res, await sendMessage(req.body), 201);
+  } catch (error) {
+    if (error instanceof SelfMessageError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,10 +1,24 @@
 const messages = [];
 
+export class SelfMessageError extends Error {
+  constructor(userId) {
+    super(`User ${userId} cannot send a message to themselves`);
+    this.name = "SelfMessageError";
+  }
+}
+
 export async function listMessages() {
   return messages;
 }
 
 export async function sendMessage(payload) {
+  if (
+    payload?.senderId != null &&
+    payload.senderId === payload.receiverId
+  ) {
+    throw new SelfMessageError(payload.senderId);
+  }
+
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;

--- a/apps/api/src/tests/messageRoutes.test.js
+++ b/apps/api/src/tests/messageRoutes.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages returns 400 for self-directed messages", async () => {
+  await withServer(async (baseUrl) => {
+    const userId = `usr_self_${Date.now()}-${Math.random()}`;
+    const payload = {
+      senderId: userId,
+      receiverId: userId,
+      body: "Hello myself"
+    };
+
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const responsePayload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(responsePayload, {
+      success: false,
+      message: `User ${userId} cannot send a message to themselves`
+    });
+
+    const listResponse = await fetch(`${baseUrl}/api/messages`);
+    const listPayload = await listResponse.json();
+    const matchingMessages = listPayload.data.filter(
+      (message) => message.senderId === userId || message.receiverId === userId
+    );
+
+    assert.equal(matchingMessages.length, 0);
+  });
+});

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  SelfMessageError,
+  listMessages,
+  sendMessage
+} from "../services/messageService.js";
+
+function messagePayload(overrides = {}) {
+  const suffix = `${Date.now()}-${Math.random()}`;
+
+  return {
+    senderId: `usr_sender_${suffix}`,
+    receiverId: `usr_receiver_${suffix}`,
+    body: "Hello from the marketplace inbox.",
+    ...overrides
+  };
+}
+
+test("sendMessage rejects self-directed messages", async () => {
+  const userId = `usr_self_${Date.now()}-${Math.random()}`;
+
+  await assert.rejects(
+    () => sendMessage(messagePayload({ senderId: userId, receiverId: userId })),
+    SelfMessageError
+  );
+
+  const matchingMessages = (await listMessages()).filter(
+    (message) => message.senderId === userId || message.receiverId === userId
+  );
+
+  assert.equal(matchingMessages.length, 0);
+});
+
+test("sendMessage allows messages between different users", async () => {
+  const payload = messagePayload();
+  const created = await sendMessage(payload);
+
+  assert.equal(created.senderId, payload.senderId);
+  assert.equal(created.receiverId, payload.receiverId);
+  assert.notEqual(created.senderId, created.receiverId);
+});

--- a/demos/reject-self-messages-demo.svg
+++ b/demos/reject-self-messages-demo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Self-directed message rejection demo</title>
+  <desc id="desc">A static API flow demo showing a self-directed message rejected and a two-party message accepted.</desc>
+  <rect width="960" height="540" fill="#0f172a"/>
+  <rect x="56" y="48" width="848" height="444" rx="12" fill="#f8fafc" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="88" y="96" fill="#0f172a" font-family="Arial, sans-serif" font-size="28" font-weight="700">Reject self-directed messages</text>
+  <text x="88" y="128" fill="#475569" font-family="Arial, sans-serif" font-size="16">Messages must have two distinct marketplace participants.</text>
+
+  <rect x="88" y="168" width="784" height="104" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+  <text x="112" y="203" fill="#991b1b" font-family="Consolas, monospace" font-size="18">POST /api/messages</text>
+  <text x="112" y="233" fill="#7f1d1d" font-family="Consolas, monospace" font-size="16">{ senderId: "usr_7", receiverId: "usr_7", body: "hello" }</text>
+  <text x="728" y="233" fill="#b91c1c" font-family="Arial, sans-serif" font-size="20" font-weight="700">400 Bad Request</text>
+
+  <path d="M480 286 L480 320" stroke="#64748b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M468 309 L480 324 L492 309" fill="none" stroke="#64748b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="88" y="336" width="784" height="104" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+  <text x="112" y="371" fill="#065f46" font-family="Consolas, monospace" font-size="18">POST /api/messages</text>
+  <text x="112" y="401" fill="#064e3b" font-family="Consolas, monospace" font-size="16">{ senderId: "usr_7", receiverId: "usr_9", body: "hello" }</text>
+  <text x="728" y="401" fill="#047857" font-family="Arial, sans-serif" font-size="20" font-weight="700">201 Created</text>
+  <text x="112" y="456" fill="#475569" font-family="Arial, sans-serif" font-size="15">Result: self-directed messages are not stored; normal two-party messages still work.</text>
+</svg>


### PR DESCRIPTION
Fixes #4073
References #743
/claim #743

## Summary
- reject message creation when `senderId` and `receiverId` are the same user
- return HTTP 400 for self-directed `/api/messages` submissions instead of storing the record
- preserve normal message creation between distinct users
- add focused service and route regression coverage

## Demo
![Self-directed message rejection demo](https://raw.githubusercontent.com/cedar323/bug-bounty/4e5244f5db4e47bfae5c501f535ca6bab776b2a7/demos/reject-self-messages-demo.svg)

## Validation
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/controllers/messageController.js`
- `node --check apps/api/src/tests/messageService.test.js`
- `node --check apps/api/src/tests/messageRoutes.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/messageService.test.js apps/api/src/tests/messageRoutes.test.js`
- `git diff --check`

Note: `npm run test -w apps/api` currently invokes `node --test src/tests`, which fails on this Windows/Node setup because the script passes the directory path directly. The explicit test-file command above validates the existing health test plus the new message tests without changing the test script in this scoped PR.