### PR TITLE
Reject duplicate user emails

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,18 @@
-import { ok } from "../utils/response.js";
-import { createUser, listUsers } from "../services/userService.js";
+import { fail, ok } from "../utils/response.js";
+import { createUser, DuplicateUserEmailError, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  try {
+    return ok(res, await createUser(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateUserEmailError) {
+      return fail(res, error.message, 409);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,10 +1,21 @@
 const users = [];
 
+export class DuplicateUserEmailError extends Error {
+  constructor(email) {
+    super(`User email already exists: ${email}`);
+    this.name = "DuplicateUserEmailError";
+  }
+}
+
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
+  if (users.some((user) => user.email === payload.email)) {
+    throw new DuplicateUserEmailError(payload.email);
+  }
+
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
   return user;

--- a/apps/api/src/tests/userDuplicateEmail.test.js
+++ b/apps/api/src/tests/userDuplicateEmail.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createUser, DuplicateUserEmailError, listUsers } from "../services/userService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createUser rejects duplicate email addresses", async () => {
+  const beforeCount = (await listUsers()).length;
+  await createUser({ email: "alex@example.com", fullName: "Alex One" });
+
+  await assert.rejects(
+    () => createUser({ email: "alex@example.com", fullName: "Alex Two" }),
+    DuplicateUserEmailError
+  );
+
+  assert.equal((await listUsers()).length, beforeCount + 1);
+});
+
+test("POST /api/users maps duplicate emails to HTTP 409", async () => {
+  await withServer(async (baseUrl) => {
+    const first = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "sam@example.com", fullName: "Sam One" })
+    });
+    const second = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "sam@example.com", fullName: "Sam Two" })
+    });
+    const payload = await second.json();
+
+    assert.equal(first.status, 201);
+    assert.equal(second.status, 409);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "User email already exists: sam@example.com"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4077
- Rejects duplicate user email addresses in `createUser()`
- Maps duplicate email service errors to HTTP 409 in the user controller
- Keeps first-time user creation behavior unchanged
- Adds focused service and route regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/userDuplicateEmail.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/userService.js; node --check apps/api/src/controllers/userController.js; node --check apps/api/src/tests/userDuplicateEmail.test.js; git diff --check`

## Demo evidence

The service test proves a second user with the same email throws without increasing the stored user count. The route test posts the same email twice and asserts the first request returns 201 while the second returns HTTP 409 with the existing API error envelope.

## Scope

This PR only changes duplicate email handling and focused tests. It does not change auth registration, password handling, role validation, route authentication, client-owned IDs, or persistence plumbing.
