### PR TITLE
Reject duplicate job proposals

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,18 @@
-import { ok } from "../utils/response.js";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { fail, ok } from "../utils/response.js";
+import { createProposal, DuplicateProposalError, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    return ok(res, await createProposal(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateProposalError) {
+      return fail(res, error.message, 409);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,10 +1,24 @@
 const proposals = [];
 
+export class DuplicateProposalError extends Error {
+  constructor(jobId, freelancerId) {
+    super(`Proposal already exists for job ${jobId} and freelancer ${freelancerId}`);
+    this.name = "DuplicateProposalError";
+  }
+}
+
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
+  const duplicate = proposals.some(
+    (proposal) => proposal.jobId === payload.jobId && proposal.freelancerId === payload.freelancerId
+  );
+  if (duplicate) {
+    throw new DuplicateProposalError(payload.jobId, payload.freelancerId);
+  }
+
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
   return proposal;

--- a/apps/api/src/tests/proposalDuplicate.test.js
+++ b/apps/api/src/tests/proposalDuplicate.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createProposal, DuplicateProposalError, listProposals } from "../services/proposalService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createProposal rejects duplicate freelancer proposals for one job", async () => {
+  const beforeCount = (await listProposals()).length;
+  await createProposal({ jobId: "job_1", freelancerId: "usr_1", bidAmount: 100 });
+
+  await assert.rejects(
+    () => createProposal({ jobId: "job_1", freelancerId: "usr_1", bidAmount: 120 }),
+    DuplicateProposalError
+  );
+
+  assert.equal((await listProposals()).length, beforeCount + 1);
+});
+
+test("createProposal allows same freelancer on another job and another freelancer on same job", async () => {
+  const first = await createProposal({ jobId: "job_2", freelancerId: "usr_2", bidAmount: 100 });
+  const second = await createProposal({ jobId: "job_3", freelancerId: "usr_2", bidAmount: 100 });
+  const third = await createProposal({ jobId: "job_2", freelancerId: "usr_3", bidAmount: 100 });
+
+  assert.equal(first.jobId, "job_2");
+  assert.equal(second.jobId, "job_3");
+  assert.equal(third.freelancerId, "usr_3");
+});
+
+test("POST /api/proposals maps duplicate proposals to HTTP 409", async () => {
+  await withServer(async (baseUrl) => {
+    const payload = { jobId: "job_route", freelancerId: "usr_route", bidAmount: 100 };
+    const first = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const second = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...payload, bidAmount: 120 })
+    });
+    const errorPayload = await second.json();
+
+    assert.equal(first.status, 201);
+    assert.equal(second.status, 409);
+    assert.deepEqual(errorPayload, {
+      success: false,
+      message: "Proposal already exists for job job_route and freelancer usr_route"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4079
- Rejects duplicate proposal submissions for the same `(jobId, freelancerId)` pair
- Maps duplicate proposal service errors to HTTP 409 in the proposal controller
- Preserves proposal creation for different jobs or different freelancers
- Adds focused service and route regression coverage

/claim #743

## Validation

- `node --test apps/api/src/tests/proposalDuplicate.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/proposalService.js; node --check apps/api/src/controllers/proposalController.js; node --check apps/api/src/tests/proposalDuplicate.test.js; git diff --check`

## Demo evidence

The focused tests prove the service rejects a second proposal with the same job and freelancer without increasing stored proposal count, still allows different jobs or different freelancers, and maps duplicate HTTP submissions to 409 with the existing API error envelope.

## Scope

This PR only changes duplicate proposal handling and focused tests. It does not change unrelated proposal payload validation, user/job validation, payment behavior, timestamps, ids, or persistence plumbing.
