### PR TITLE
fix(api): target concrete test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Fixes the API workspace test script so `npm test` discovers and runs the existing Node test files instead of failing on the `src/tests` directory path.

/claim #743

## Problem

Before this change, the root test command failed:

text
Error: Cannot find module '.../apps/api/src/tests'
not ok 1 - src/tests

The repo already has a valid test file at:

text
apps/api/src/tests/health.test.js

But `apps/api/package.json` invoked:

json
"test": "node --test src/tests"

## Fix

Use an explicit test-file glob:

json
"test": "node --test \"src/tests/*/.test.js\""

## Validation

Ran:

bash
npm install
npm test

Result:

text
Subtest: GET /health returns ok payload
ok 1 - GET /health returns ok payload
1..1
tests 1
pass 1
fail 0

## Scope

Single focused fix for the test script only.