### PR TITLE
Add db package entrypoints

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Proposed Changes

- Adds explicit `main` and `types` entrypoints to `@freelanceflow/db`.
- Uses `src/index.ts`, matching the source-first workspace package style already used in this repo.
- Keeps the fix limited to package metadata.

## Proof

```bash
node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/db/package.json','utf8')); if (p.main !== 'src/index.ts' || p.types !== 'src/index.ts') process.exit(1); console.log(JSON.stringify({name:p.name,main:p.main,types:p.types}))"
# {"name":"@freelanceflow/db","main":"src/index.ts","types":"src/index.ts"}

git diff --check
# passed
```

## Related Issue

Fixes #4089

/claim #743
