### PR TITLE
Count malformed JSON requests in rate limiter

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON requests are counted by the API rate limiter", async () => {
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  await withServer(async (baseUrl) => {
+    try {
+      let lastStatus;
+
+      for (let i = 0; i < 201; i += 1) {
+        const response = await fetch(`${baseUrl}/api/jobs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{"
+        });
+        lastStatus = response.status;
+      }
+
+      assert.equal(lastStatus, 429);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});


### PR DESCRIPTION
## Proposed Changes

- Moves the global `apiLimiter` before `express.json()`.
- Ensures malformed JSON requests are counted by the shared API throttle before body parsing work happens.
- Adds a focused regression test proving repeated malformed JSON requests eventually return `429`.

## Proof

```bash
node --test apps/api/src/tests/rateLimit.test.js
# pass: malformed JSON requests are counted by the API rate limiter

node --check apps/api/src/app.js
# passed

node --check apps/api/src/tests/rateLimit.test.js
# passed

git diff --check
# passed
```

## Related Issue

Fixes #4095

/claim #743
