### PR TITLE
Require auth for message routes

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -2,9 +2,9 @@ import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
-  return ok(res, await listMessages());
+  return ok(res, await listMessages(req.user.sub));
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  return ok(res, await sendMessage(req.body, req.user.sub), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,18 @@
 const messages = [];
 
-export async function listMessages() {
-  return messages;
+export async function listMessages(userId) {
+  return messages.filter(
+    (message) => message.senderId === userId || message.receiverId === userId
+  );
 }
 
-export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+export async function sendMessage(payload, senderId) {
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...payload,
+    senderId,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageRoutes.test.js
+++ b/apps/api/src/tests/messageRoutes.test.js
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function listen() {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function authHeaders(userId) {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: userId, role: "client" })}`
+  };
+}
+
+test("message routes require authentication", async () => {
+  const { server, baseUrl } = await listen();
+
+  try {
+    const listResponse = await fetch(`${baseUrl}/api/messages`);
+    assert.equal(listResponse.status, 401);
+
+    const createResponse = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_public",
+        receiverId: "usr_target",
+        content: "hello"
+      })
+    });
+    assert.equal(createResponse.status, 401);
+  } finally {
+    await close(server);
+  }
+});
+
+test("message routes use authenticated sender and return only participant messages", async () => {
+  const { server, baseUrl } = await listen();
+  const alice = `usr_alice_${Date.now()}`;
+  const bob = `usr_bob_${Date.now()}`;
+  const carol = `usr_carol_${Date.now()}`;
+
+  try {
+    const aliceCreate = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders(alice)
+      },
+      body: JSON.stringify({
+        senderId: "usr_spoofed",
+        receiverId: bob,
+        content: "alice to bob"
+      })
+    });
+    const alicePayload = await aliceCreate.json();
+
+    assert.equal(aliceCreate.status, 201);
+    assert.equal(alicePayload.data.senderId, alice);
+    assert.equal(alicePayload.data.receiverId, bob);
+
+    const carolCreate = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders(carol)
+      },
+      body: JSON.stringify({
+        senderId: "usr_spoofed",
+        receiverId: bob,
+        content: "carol to bob"
+      })
+    });
+    const carolPayload = await carolCreate.json();
+
+    assert.equal(carolCreate.status, 201);
+    assert.equal(carolPayload.data.senderId, carol);
+
+    const aliceList = await fetch(`${baseUrl}/api/messages`, {
+      headers: authHeaders(alice)
+    });
+    const aliceListPayload = await aliceList.json();
+
+    assert.equal(aliceList.status, 200);
+    assert.equal(aliceListPayload.data.length, 1);
+    assert.equal(aliceListPayload.data[0].senderId, alice);
+    assert.equal(aliceListPayload.data[0].receiverId, bob);
+
+    const bobList = await fetch(`${baseUrl}/api/messages`, {
+      headers: authHeaders(bob)
+    });
+    const bobListPayload = await bobList.json();
+
+    assert.equal(bobList.status, 200);
+    assert.equal(bobListPayload.data.length, 2);
+    assert.deepEqual(
+      bobListPayload.data.map((message) => message.senderId).sort(),
+      [alice, carol].sort()
+    );
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #4101

## Summary

- Require `authMiddleware` for `GET /api/messages` and `POST /api/messages`.
- Store new messages with the authenticated token subject as `senderId`.
- Return only messages where the authenticated user is the sender or receiver.

## Demo evidence

The API behavior is covered by `apps/api/src/tests/messageRoutes.test.js`:

- unauthenticated list/create requests return `401`
- a spoofed request body `senderId` is ignored in favor of the authenticated user
- list responses are scoped to sender/receiver participation

## Validation

- `node --test apps/api/src/tests/messageRoutes.test.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/controllers/messageController.js`
- `node --check apps/api/src/routes/messageRoutes.js`
- `node --check apps/api/src/tests/messageRoutes.test.js`
- `git diff --check`
