### PR TITLE
Use Decimal for Prisma monetary fields

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -45,8 +45,8 @@ model Job {
   id            String      @id @default(cuid())
   title         String
   description   String
-  budgetMin     Float
-  budgetMax     Float
+  budgetMin     Decimal     @db.Decimal(12, 2)
+  budgetMax     Decimal     @db.Decimal(12, 2)
   status        JobStatus   @default(OPEN)
   clientId      String
   client        User        @relation("ClientJobs", fields: [clientId], references: [id])
@@ -61,7 +61,7 @@ model Job {
 model Proposal {
   id            String      @id @default(cuid())
   coverLetter   String
-  bidAmount     Float
+  bidAmount     Decimal     @db.Decimal(12, 2)
   estDuration   String
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])
@@ -72,7 +72,7 @@ model Proposal {
 
 model Payment {
   id            String      @id @default(cuid())
-  amount        Float
+  amount        Decimal     @db.Decimal(12, 2)
   currency      String      @default("USD")
   status        String
   stripeRef     String?


### PR DESCRIPTION
/claim #743

Closes #4105

## Summary

- Switch budget, proposal bid, and payment amount fields from Prisma `Float` to fixed-precision `Decimal`.
- Use `@db.Decimal(12, 2)` so monetary values avoid binary floating-point rounding artifacts.
- Keep the change limited to the Prisma schema.

## Manual demo (non-UI)

This is a database schema precision fix, so the demo is the generated schema behavior rather than a browser flow.

Before this change, the Prisma schema stored money-like values as binary floating-point `Float` fields:

- `Job.budgetMin`
- `Job.budgetMax`
- `Proposal.bidAmount`
- `Payment.amount`

After this change, those fields are fixed-precision decimal columns:

```prisma
budgetMin Decimal @db.Decimal(12, 2)
budgetMax Decimal @db.Decimal(12, 2)
bidAmount Decimal @db.Decimal(12, 2)
amount Decimal @db.Decimal(12, 2)
```

The Prisma schema validates with a PostgreSQL `DATABASE_URL`, demonstrating the new field types are accepted by Prisma for the configured provider.

## Validation

- `DATABASE_URL='postgresql://user:pass@localhost:5432/db' npm exec --workspace @freelanceflow/db -- prisma validate --schema prisma/schema.prisma`
- `git diff --check`
