### PR TITLE
Cap job creation skills array

### DIFF
--- a/apps/api/src/tests/jobValidators.test.js
+++ b/apps/api/src/tests/jobValidators.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { createJobSchema, MAX_JOB_SKILLS } from "../validators/job.js";
+
+const baseJob = {
+  title: "Build API",
+  description: "Build a production API",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "cat_backend"
+};
+
+test("createJobSchema defaults omitted skills to an empty array", () => {
+  const parsed = createJobSchema.parse(baseJob);
+
+  assert.deepEqual(parsed.skills, []);
+});
+
+test("createJobSchema accepts up to the configured skill limit", () => {
+  const skills = Array.from({ length: MAX_JOB_SKILLS }, (_, index) => `skill-${index}`);
+  const parsed = createJobSchema.parse({ ...baseJob, skills });
+
+  assert.deepEqual(parsed.skills, skills);
+});
+
+test("createJobSchema rejects oversized skills arrays", () => {
+  const skills = Array.from({ length: MAX_JOB_SKILLS + 1 }, (_, index) => `skill-${index}`);
+
+  assert.throws(
+    () => createJobSchema.parse({ ...baseJob, skills }),
+    (error) => {
+      assert.ok(error instanceof ZodError);
+      assert.equal(error.issues[0].path[0], "skills");
+      assert.equal(error.issues[0].code, "too_big");
+      return true;
+    }
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+export const MAX_JOB_SKILLS = 20;
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: z.array(z.string().min(1)).max(MAX_JOB_SKILLS).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
/claim #743

Closes #4107

## Summary

- Add a `MAX_JOB_SKILLS` limit to `createJobSchema`.
- Reject oversized job skills arrays before job creation.
- Cover omitted, boundary-sized, and oversized skills payloads with focused validator tests.

## Manual demo (non-UI)

This is an API validator fix, so the demo is the focused regression test behavior:

- omitted `skills` still defaults to an empty array
- exactly `MAX_JOB_SKILLS` entries is accepted
- more than `MAX_JOB_SKILLS` entries is rejected before job creation

The focused test file exercises all three paths and passes locally with:

```bash
node --test apps/api/src/tests/jobValidators.test.js
```

## Validation

- `node --test apps/api/src/tests/jobValidators.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/jobValidators.test.js`
- `git diff --check`
