### PR TITLE
Reject whitespace-only auth passwords

### DIFF
--- a/apps/api/src/tests/authValidators.test.js
+++ b/apps/api/src/tests/authValidators.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects whitespace-only passwords", () => {
+  assert.throws(
+    () => registerSchema.parse({ email: "client@example.com", password: "        " }),
+    (error) => {
+      assert.ok(error instanceof ZodError);
+      assert.equal(error.issues[0].path[0], "password");
+      assert.equal(error.issues[0].code, "custom");
+      return true;
+    }
+  );
+});
+
+test("loginSchema rejects passwords without enough non-whitespace characters", () => {
+  assert.throws(
+    () => loginSchema.parse({ email: "client@example.com", password: "abcd    " }),
+    (error) => {
+      assert.ok(error instanceof ZodError);
+      assert.equal(error.issues[0].path[0], "password");
+      assert.equal(error.issues[0].code, "custom");
+      return true;
+    }
+  );
+});
+
+test("auth validators preserve valid passwords without trimming", () => {
+  const password = "  abcdefgh  ";
+  const registerPayload = registerSchema.parse({ email: "client@example.com", password });
+  const loginPayload = loginSchema.parse({ email: "client@example.com", password });
+
+  assert.equal(registerPayload.password, password);
+  assert.equal(loginPayload.password, password);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,21 @@
 import { z } from "zod";
 
+export const MIN_PASSWORD_NON_WHITESPACE_CHARS = 8;
+
+export const passwordSchema = z.string()
+  .min(MIN_PASSWORD_NON_WHITESPACE_CHARS)
+  .refine(
+    (password) => password.replace(/\s/g, "").length >= MIN_PASSWORD_NON_WHITESPACE_CHARS,
+    "Password must contain at least 8 non-whitespace characters"
+  );
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
/claim #743

Closes #4109

## Summary

- Share an auth password schema between registration and login validators.
- Require passwords to contain at least eight non-whitespace characters.
- Preserve valid password values without trimming or rewriting the submitted string.

## Manual demo (non-UI)

This is an auth validator fix, so the demo is the focused regression test behavior:

- registration rejects whitespace-only passwords that previously satisfied the raw 8-character minimum
- login rejects passwords with fewer than eight non-whitespace characters
- valid passwords are preserved exactly, without trimming or rewriting the submitted string

The focused test file exercises those paths and passes locally with:

```bash
node --test apps/api/src/tests/authValidators.test.js
```

## Validation

- `node --test apps/api/src/tests/authValidators.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/validators/auth.js`
- `node --check apps/api/src/tests/authValidators.test.js`
- `git diff --check`
