### PR TITLE
Fix: update API test script to target files and add regression check (Fixes #4111)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/package.test.js
+++ b/apps/api/src/tests/package.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test("package.json test script regression check", () => {
+  const packageJsonPath = path.resolve(__dirname, "../../package.json");
+  const packageJsonContent = fs.readFileSync(packageJsonPath, "utf8");
+  const packageJson = JSON.parse(packageJsonContent);
+
+  const testScript = packageJson.scripts?.test;
+  assert.ok(testScript, "test script should exist in package.json");
+  assert.ok(!testScript.endsWith("src/tests"), "test script should target files, not the directory 'src/tests'");
+  assert.ok(testScript.includes("src/tests/*.test.js") || testScript.includes("src/tests/**/*.test.js"), "test script should target test files pattern");
+});


### PR DESCRIPTION
This PR fixes issue #4111.

### Problem
The API package test script in `apps/api/package.json` was configured to run `node --test src/tests`. Because it targeted the directory instead of files, the Node.js test runner failed with `MODULE_NOT_FOUND` error when trying to resolve `apps/api/src/tests`.

### Solution
1. Updated the `test` script inside `apps/api/package.json` to target concrete test files: `node --test src/tests/*.test.js`.
2. Implemented a new regression check file `apps/api/src/tests/package.test.js` that reads `package.json` and asserts that the `test` script targets the files correctly and doesn't fall back to targeting the directory.

All tests passed successfully:
```bash
> test
> node --test src/tests/*.test.js

TAP version 13
# Subtest: GET /health returns ok payload
ok 1 - GET /health returns ok payload
  ---
  duration_ms: 41.828506
  type: 'test'
  ...
# Subtest: package.json test script regression check
ok 2 - package.json test script regression check
  ---
  duration_ms: 0.669546
  type: 'test'
  ...
1..2
# tests 2
# suites 0
# pass 2
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 244.246914
```

Closes #4111