### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidators.test.js
+++ b/apps/api/src/tests/jobValidators.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a clean landing page for a client project.",
+  budgetMin: 50,
+  budgetMax: 100,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema accepts a normal budget range", () => {
+  const payload = createJobSchema.parse(validJobPayload);
+
+  assert.equal(payload.budgetMin, 50);
+  assert.equal(payload.budgetMax, 100);
+});
+
+test("createJobSchema rejects an inverted budget range", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJobPayload, budgetMin: 100, budgetMax: 50 }),
+    /budgetMin must be less than or equal to budgetMax/
+  );
+});
+
+test("updateJobSchema rejects an inverted budget range when both fields are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 100, budgetMax: 50 }),
+    /budgetMin must be less than or equal to budgetMax/
+  );
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  const payload = updateJobSchema.parse({ budgetMin: 100 });
+
+  assert.deepEqual(payload, { budgetMin: 100 });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,32 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchemaFields = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+const budgetRangeValidator = (payload) => {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+
+  return payload.budgetMin <= payload.budgetMax;
+};
+
+const budgetRangeRefinement = {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = z
+  .object(jobSchemaFields)
+  .refine(budgetRangeValidator, budgetRangeRefinement);
+
+export const updateJobSchema = z
+  .object(jobSchemaFields)
+  .partial()
+  .refine(budgetRangeValidator, budgetRangeRefinement);


### PR DESCRIPTION
﻿## Summary
- reject job creation/update payloads where `budgetMin` is greater than `budgetMax`
- keep partial job updates valid when only one budget field is provided
- add focused validator regression tests for valid, inverted, and partial ranges
- update the API package test script so `npm test -w apps/api` runs the test files directly

Fixes #4119

## Validation
- `npm test -w apps/api` -> 5 passed
- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/jobValidators.test.js`
- `git diff --check`

/claim #743
