### PR TITLE
fix: return jobId in payment intent response

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    jobId: payload.jobId
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments preserves jobId in response", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1000, currency: "usd", jobId: "job_12345" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(payload.success);
+    assert.equal(payload.data.jobId, "job_12345");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
This PR ensures that the payment intent creation response preserves the submitted jobId field.