### PR TITLE
Reject invalid payment creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid payment payload",
+      issues: result.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments defaults currency and creates a valid payment intent", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 125 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});
+
+test("POST /api/payments normalizes valid currency codes", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 42, currency: "EUR" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.currency, "eur");
+  });
+});
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const zeroResponse = await postPayment(baseUrl, { amount: 0 });
+    const negativeResponse = await postPayment(baseUrl, { amount: -1 });
+
+    assert.equal(zeroResponse.status, 400);
+    assert.equal(negativeResponse.status, 400);
+  });
+});
+
+test("POST /api/payments rejects malformed currency codes", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 10, currency: "USDT" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid payment payload");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().finite().positive(),
+  currency: z
+    .string()
+    .trim()
+    .regex(/^[A-Za-z]{3}$/, "currency must be a three-letter code")
+    .transform((value) => value.toLowerCase())
+    .default("usd")
+});


### PR DESCRIPTION
## Summary
- Add a Zod payment creation schema requiring positive finite amounts.
- Normalize valid three-letter currency codes to lowercase and default missing currency to usd.
- Return a structured 400 response for invalid payment payloads before creating a mock intent.
- Update the API test script to target test files and add payment validation coverage.

## Verification
- npm.cmd test -w apps/api
- node --test apps/api/src/tests/payment.test.js
- git diff --check

Closes #4181
Refs #743
/claim #4181