### PR TITLE
Reject whitespace-only auth passwords

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("auth validators reject whitespace-only passwords", () => {
+  const registerResult = registerSchema.safeParse({
+    email: "new@example.com",
+    password: "        "
+  });
+  const loginResult = loginSchema.safeParse({
+    email: "new@example.com",
+    password: "        "
+  });
+
+  assert.equal(registerResult.success, false);
+  assert.equal(loginResult.success, false);
+});
+
+test("auth validators require eight non-whitespace password characters", () => {
+  const tooShortResult = registerSchema.safeParse({
+    email: "new@example.com",
+    password: "abcd    "
+  });
+  const validResult = registerSchema.safeParse({
+    email: "new@example.com",
+    password: "abcd efgh"
+  });
+
+  assert.equal(tooShortResult.success, false);
+  assert.equal(validResult.success, true);
+  assert.equal(validResult.data.password, "abcd efgh");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
+const passwordSchema = z
+  .string()
+  .refine((value) => value.replace(/\s/g, "").length >= 8, {
+    message: "password must contain at least 8 non-whitespace characters"
+  });
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
## Summary
- Add a shared auth password validator requiring at least eight non-whitespace characters.
- Apply it to both registration and login schemas without trimming or rewriting valid submitted values.
- Add focused validator tests for whitespace-only and mixed-space passwords.
- Update the API test script to target test files so the package test command runs correctly.

## Verification
- npm.cmd test -w apps/api
- node --test apps/api/src/tests/auth.test.js
- git diff --check

Closes #4186
Refs #743
/claim #4186