### PR TITLE
Add actionable settings account controls

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,212 @@
+import type { CSSProperties } from "react";
+
 export default function SettingsPage() {
+  const settingsGroups = [
+    {
+      title: "Account",
+      status: "Profile 86%",
+      statusTone: "#47d18c",
+      summary: "FreelanceFlow Studio",
+      details: ["Public freelancer profile", "Primary email verified", "Portfolio visible to clients"],
+      action: "Review profile",
+    },
+    {
+      title: "Notifications",
+      status: "3 enabled",
+      statusTone: "#8bc5ff",
+      summary: "Project and payout alerts",
+      details: ["Email project updates", "Weekly opportunity digest", "SMS disabled"],
+      action: "Edit alerts",
+    },
+    {
+      title: "Security",
+      status: "Action needed",
+      statusTone: "#ffcf6e",
+      summary: "Password updated 42 days ago",
+      details: ["Two-factor authentication off", "Trusted devices: 2", "Session review recommended"],
+      action: "Secure account",
+    },
+    {
+      title: "Billing",
+      status: "Ready",
+      statusTone: "#b6f06f",
+      summary: "ACH payouts to Mercury",
+      details: ["Next payout: Jun 14", "Tax profile complete", "Auto-invoice enabled"],
+      action: "Manage payout",
+    },
+  ];
+
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section style={styles.page}>
+      <div style={styles.header}>
+        <div>
+          <p style={styles.kicker}>Workspace settings</p>
+          <h2 style={styles.title}>Account controls</h2>
+        </div>
+        <button style={styles.primaryAction}>Save changes</button>
+      </div>
+
+      <div style={styles.summaryStrip}>
+        <div>
+          <span style={styles.summaryLabel}>Account owner</span>
+          <strong style={styles.summaryValue}>Maya Chen</strong>
+        </div>
+        <div>
+          <span style={styles.summaryLabel}>Plan</span>
+          <strong style={styles.summaryValue}>Creator Pro</strong>
+        </div>
+        <div>
+          <span style={styles.summaryLabel}>Payout status</span>
+          <strong style={styles.summaryValue}>Verified</strong>
+        </div>
+      </div>
+
+      <div style={styles.grid}>
+        {settingsGroups.map((group) => (
+          <article key={group.title} style={styles.panel}>
+            <div style={styles.panelHeader}>
+              <h3 style={styles.panelTitle}>{group.title}</h3>
+              <span style={{ ...styles.statusChip, borderColor: group.statusTone, color: group.statusTone }}>
+                {group.status}
+              </span>
+            </div>
+            <p style={styles.panelSummary}>{group.summary}</p>
+            <ul style={styles.detailList}>
+              {group.details.map((detail) => (
+                <li key={detail} style={styles.detailItem}>
+                  <span aria-hidden style={styles.detailDot} />
+                  {detail}
+                </li>
+              ))}
+            </ul>
+            <button style={styles.secondaryAction}>{group.action}</button>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }
+
+const styles: Record<string, CSSProperties> = {
+  page: {
+    display: "grid",
+    gap: "1rem",
+  },
+  header: {
+    alignItems: "center",
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    gap: "1rem",
+  },
+  kicker: {
+    color: "#9fb0da",
+    fontSize: "0.82rem",
+    fontWeight: 700,
+    letterSpacing: "0",
+    margin: "0 0 0.35rem",
+    textTransform: "uppercase" as const,
+  },
+  title: {
+    fontSize: "2rem",
+    lineHeight: 1.1,
+    margin: 0,
+  },
+  primaryAction: {
+    background: "#f2f5ff",
+    border: "0",
+    borderRadius: "8px",
+    color: "#0b1020",
+    cursor: "pointer",
+    fontWeight: 800,
+    minHeight: "2.6rem",
+    padding: "0 1rem",
+  },
+  summaryStrip: {
+    background: "#151c35",
+    border: "1px solid #2a3765",
+    borderRadius: "8px",
+    display: "grid",
+    gap: "1rem",
+    gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+    padding: "1rem",
+  },
+  summaryLabel: {
+    color: "#9fb0da",
+    display: "block",
+    fontSize: "0.78rem",
+    marginBottom: "0.25rem",
+  },
+  summaryValue: {
+    display: "block",
+    fontSize: "1rem",
+  },
+  grid: {
+    display: "grid",
+    gap: "1rem",
+    gridTemplateColumns: "repeat(auto-fit, minmax(230px, 1fr))",
+  },
+  panel: {
+    background: "#151c35",
+    border: "1px solid #2a3765",
+    borderRadius: "8px",
+    display: "grid",
+    gap: "0.9rem",
+    padding: "1rem",
+  },
+  panelHeader: {
+    alignItems: "center",
+    display: "flex",
+    gap: "0.75rem",
+    justifyContent: "space-between",
+  },
+  panelTitle: {
+    fontSize: "1.05rem",
+    margin: 0,
+  },
+  statusChip: {
+    border: "1px solid",
+    borderRadius: "999px",
+    fontSize: "0.76rem",
+    fontWeight: 800,
+    padding: "0.25rem 0.55rem",
+    whiteSpace: "nowrap" as const,
+  },
+  panelSummary: {
+    color: "#dbe4ff",
+    margin: 0,
+  },
+  detailList: {
+    display: "grid",
+    gap: "0.5rem",
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+  },
+  detailItem: {
+    alignItems: "center",
+    color: "#b8c5ec",
+    display: "flex",
+    fontSize: "0.92rem",
+    gap: "0.5rem",
+  },
+  detailDot: {
+    background: "#47d18c",
+    borderRadius: "999px",
+    display: "inline-block",
+    flex: "0 0 0.45rem",
+    height: "0.45rem",
+    width: "0.45rem",
+  },
+  secondaryAction: {
+    background: "#202a4f",
+    border: "1px solid #3a4a82",
+    borderRadius: "8px",
+    color: "#f2f5ff",
+    cursor: "pointer",
+    fontWeight: 800,
+    minHeight: "2.4rem",
+    padding: "0 0.9rem",
+    width: "100%",
+  },
+};

--- a/demos/settings-controls-demo.svg
+++ b/demos/settings-controls-demo.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc">
+  <title id="title">Settings account controls demo</title>
+  <desc id="desc">Demo preview of the settings page with account, notification, security, billing, payout, status, and action controls.</desc>
+  <style>
+    .bg { fill: #0b1020; }
+    .panel { fill: #151c35; stroke: #2a3765; stroke-width: 1.5; }
+    .button { fill: #202a4f; stroke: #3a4a82; stroke-width: 1.2; }
+    .primary { fill: #f2f5ff; }
+    .text { fill: #f2f5ff; font-family: Inter, Arial, sans-serif; }
+    .muted { fill: #b8c5ec; font-family: Inter, Arial, sans-serif; }
+    .label { fill: #9fb0da; font-family: Inter, Arial, sans-serif; }
+    .dark { fill: #0b1020; font-family: Inter, Arial, sans-serif; }
+    .dot { fill: #47d18c; }
+    .chip-green { fill: none; stroke: #47d18c; stroke-width: 1.5; }
+    .chip-blue { fill: none; stroke: #8bc5ff; stroke-width: 1.5; }
+    .chip-amber { fill: none; stroke: #ffcf6e; stroke-width: 1.5; }
+    .chip-lime { fill: none; stroke: #b6f06f; stroke-width: 1.5; }
+    .green { fill: #47d18c; font-family: Inter, Arial, sans-serif; }
+    .blue { fill: #8bc5ff; font-family: Inter, Arial, sans-serif; }
+    .amber { fill: #ffcf6e; font-family: Inter, Arial, sans-serif; }
+    .lime { fill: #b6f06f; font-family: Inter, Arial, sans-serif; }
+  </style>
+  <rect class="bg" width="1200" height="760"/>
+  <text x="120" y="92" class="text" font-size="32" font-weight="800">FreelanceFlow</text>
+  <g>
+    <rect x="120" y="122" width="68" height="36" rx="9" class="button"/>
+    <text x="137" y="145" class="text" font-size="15">Home</text>
+    <rect x="200" y="122" width="64" height="36" rx="9" class="button"/>
+    <text x="219" y="145" class="text" font-size="15">Jobs</text>
+    <rect x="276" y="122" width="148" height="36" rx="9" class="button"/>
+    <text x="293" y="145" class="text" font-size="15">Find Freelancers</text>
+    <rect x="436" y="122" width="154" height="36" rx="9" class="button"/>
+    <text x="453" y="145" class="text" font-size="15">Client Dashboard</text>
+    <rect x="602" y="122" width="190" height="36" rx="9" class="button"/>
+    <text x="619" y="145" class="text" font-size="15">Freelancer Dashboard</text>
+  </g>
+
+  <text x="120" y="214" class="label" font-size="14" font-weight="800">WORKSPACE SETTINGS</text>
+  <text x="120" y="252" class="text" font-size="34" font-weight="800">Account controls</text>
+  <rect x="900" y="214" width="126" height="44" rx="9" class="primary"/>
+  <text x="926" y="241" class="dark" font-size="14" font-weight="800">Save changes</text>
+
+  <rect x="120" y="284" width="906" height="70" rx="8" class="panel"/>
+  <text x="140" y="313" class="label" font-size="12">Account owner</text>
+  <text x="140" y="337" class="text" font-size="17" font-weight="800">Maya Chen</text>
+  <text x="440" y="313" class="label" font-size="12">Plan</text>
+  <text x="440" y="337" class="text" font-size="17" font-weight="800">Creator Pro</text>
+  <text x="742" y="313" class="label" font-size="12">Payout status</text>
+  <text x="742" y="337" class="text" font-size="17" font-weight="800">Verified</text>
+
+  <g transform="translate(120 374)">
+    <rect width="288" height="218" rx="8" class="panel"/>
+    <text x="18" y="36" class="text" font-size="18" font-weight="800">Account</text>
+    <rect x="188" y="18" width="82" height="28" rx="14" class="chip-green"/>
+    <text x="202" y="37" class="green" font-size="13" font-weight="800">Profile 86%</text>
+    <text x="18" y="74" class="text" font-size="17">FreelanceFlow Studio</text>
+    <circle cx="22" cy="102" r="4" class="dot"/>
+    <text x="36" y="107" class="muted" font-size="15">Public freelancer profile</text>
+    <circle cx="22" cy="126" r="4" class="dot"/>
+    <text x="36" y="131" class="muted" font-size="15">Primary email verified</text>
+    <circle cx="22" cy="150" r="4" class="dot"/>
+    <text x="36" y="155" class="muted" font-size="15">Portfolio visible to clients</text>
+    <rect x="18" y="168" width="252" height="40" rx="7" class="button"/>
+    <text x="94" y="193" class="text" font-size="15" font-weight="800">Review profile</text>
+  </g>
+
+  <g transform="translate(424 374)">
+    <rect width="288" height="218" rx="8" class="panel"/>
+    <text x="18" y="36" class="text" font-size="18" font-weight="800">Notifications</text>
+    <rect x="198" y="18" width="72" height="28" rx="14" class="chip-blue"/>
+    <text x="211" y="37" class="blue" font-size="13" font-weight="800">3 enabled</text>
+    <text x="18" y="74" class="text" font-size="17">Project and payout alerts</text>
+    <circle cx="22" cy="102" r="4" class="dot"/>
+    <text x="36" y="107" class="muted" font-size="15">Email project updates</text>
+    <circle cx="22" cy="126" r="4" class="dot"/>
+    <text x="36" y="131" class="muted" font-size="15">Weekly opportunity digest</text>
+    <circle cx="22" cy="150" r="4" class="dot"/>
+    <text x="36" y="155" class="muted" font-size="15">SMS disabled</text>
+    <rect x="18" y="168" width="252" height="40" rx="7" class="button"/>
+    <text x="106" y="193" class="text" font-size="15" font-weight="800">Edit alerts</text>
+  </g>
+
+  <g transform="translate(728 374)">
+    <rect width="288" height="218" rx="8" class="panel"/>
+    <text x="18" y="36" class="text" font-size="18" font-weight="800">Security</text>
+    <rect x="176" y="18" width="94" height="28" rx="14" class="chip-amber"/>
+    <text x="188" y="37" class="amber" font-size="13" font-weight="800">Action needed</text>
+    <text x="18" y="74" class="text" font-size="17">Password updated 42 days ago</text>
+    <circle cx="22" cy="102" r="4" class="dot"/>
+    <text x="36" y="107" class="muted" font-size="15">Two-factor authentication off</text>
+    <circle cx="22" cy="126" r="4" class="dot"/>
+    <text x="36" y="131" class="muted" font-size="15">Trusted devices: 2</text>
+    <circle cx="22" cy="150" r="4" class="dot"/>
+    <text x="36" y="155" class="muted" font-size="15">Session review recommended</text>
+    <rect x="18" y="168" width="252" height="40" rx="7" class="button"/>
+    <text x="93" y="193" class="text" font-size="15" font-weight="800">Secure account</text>
+  </g>
+
+  <g transform="translate(120 612)">
+    <rect width="288" height="116" rx="8" class="panel"/>
+    <text x="18" y="36" class="text" font-size="18" font-weight="800">Billing</text>
+    <rect x="218" y="18" width="52" height="28" rx="14" class="chip-lime"/>
+    <text x="229" y="37" class="lime" font-size="13" font-weight="800">Ready</text>
+    <text x="18" y="74" class="text" font-size="17">ACH payouts to Mercury</text>
+    <rect x="18" y="88" width="252" height="18" rx="7" class="button"/>
+    <text x="100" y="102" class="text" font-size="11" font-weight="800">Manage payout</text>
+  </g>
+</svg>


### PR DESCRIPTION
/claim #743

## Summary
- Replaced the settings placeholder with a static account settings overview.
- Added account/profile, notification, security, and billing/payout sections with status chips.
- Added next-action controls for each settings area while keeping the implementation scoped to `apps/web/app/settings/page.tsx`.
- Added a lightweight demo preview at `demos/settings-controls-demo.svg` for bounty review.

Fixes #4178
Related to #743

## Demo
https://raw.githubusercontent.com/AxisIV/bug-bounty/axisiv/settings-controls-4178/demos/settings-controls-demo.svg

## Validation
- `npm run build -w apps/web`
- `git diff --check`
- Browser check: `http://localhost:3000/settings` renders all required controls.
- `demos/settings-controls-demo.svg` validates as XML.