### PR TITLE
Restrict production CORS origins

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,36 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+function parseAllowedOrigins() {
+  return (process.env.CORS_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function corsOptions() {
+  const allowedOrigins = parseAllowedOrigins();
+
+  if (process.env.NODE_ENV !== "production" && allowedOrigins.length === 0) {
+    return {};
+  }
+
+  return {
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+
+      return callback(null, false);
+    }
+  };
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(corsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function fetchFromApp(app, path, options = {}) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await fetch(`http://127.0.0.1:${port}${path}`, options);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("production API does not allow unconfigured CORS origins", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalAllowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+  process.env.NODE_ENV = "production";
+  delete process.env.CORS_ALLOWED_ORIGINS;
+
+  try {
+    const response = await fetchFromApp(createApp(), "/health", {
+      headers: { Origin: "https://attacker.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+  }
+});
+
+test("production API allows explicitly configured CORS origins", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalAllowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+  process.env.NODE_ENV = "production";
+  process.env.CORS_ALLOWED_ORIGINS = "https://app.example.com, https://admin.example.com";
+
+  try {
+    const response = await fetchFromApp(createApp(), "/health", {
+      headers: { Origin: "https://admin.example.com" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "https://admin.example.com");
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.CORS_ALLOWED_ORIGINS;
+    } else {
+      process.env.CORS_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- restrict production CORS responses to origins listed in `CORS_ALLOWED_ORIGINS`
- keep development permissive when no allowlist is configured
- add API regression coverage for denied and allowed production origins
- update the API test script to run `*.test.js` files explicitly

## Tests
- `npm test`

Fixes #4188
/claim #743