### PR TITLE
Cap job skills arrays

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a client",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web"
+};
+
+test("createJobSchema defaults missing skills to an empty array", () => {
+  const result = createJobSchema.parse(validJob);
+
+  assert.deepEqual(result.skills, []);
+});
+
+test("createJobSchema accepts normal skills arrays", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    skills: ["react", "typescript", "css"]
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects oversized skills arrays", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    skills: Array.from({ length: 21 }, (_, index) => `skill-${index}`)
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("updateJobSchema applies the same skills cap when skills are provided", () => {
+  const validUpdate = updateJobSchema.safeParse({ skills: ["node"] });
+  const invalidUpdate = updateJobSchema.safeParse({
+    skills: Array.from({ length: 21 }, (_, index) => `skill-${index}`)
+  });
+
+  assert.equal(validUpdate.success, true);
+  assert.equal(invalidUpdate.success, false);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,15 @@
 import { z } from "zod";
 
+const MAX_JOB_SKILLS = 20;
+const jobSkillsSchema = z.array(z.string().min(1)).max(MAX_JOB_SKILLS).default([]);
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: jobSkillsSchema
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary
- Add a shared 20-item cap for job `skills` payloads.
- Keep missing `skills` defaulting to an empty array.
- Cover create and update validation with API tests.

## Validation
- npm.cmd test -w apps/api
- git diff --check

Closes #4200
Refs #743
/claim #4200