### PR TITLE
Preserve generated message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage preserves the server-generated message id", async () => {
+  const message = await sendMessage({
+    id: "client_supplied",
+    senderId: "usr_sender",
+    recipientId: "usr_recipient",
+    body: "Hello"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "client_supplied");
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.recipientId, "usr_recipient");
+  assert.equal(message.body, "Hello");
+  assert.match(message.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+});


### PR DESCRIPTION
## Summary
- Preserve the server-generated `msg_...` id when creating messages.
- Keep legitimate payload fields and the server-owned `sentAt` timestamp intact.
- Add a regression test for client-supplied message ids.

## Validation
- node --test apps/api/src/tests/message-service.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check

Note: `npm.cmd test -w apps/api` still fails on upstream `node --test src/tests` directory handling; this is the separate test-script issue covered by PR #4201.

Closes #4211
Refs #743
/claim #4211