### PR TITLE
Validate review rating range

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function fetchFromApp(app, path, options = {}) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await fetch(`http://127.0.0.1:${port}${path}`, options);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects ratings outside the 1-5 range", async () => {
+  const app = createApp();
+  const response = await fetchFromApp(app, "/api/reviews", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      rating: 6,
+      comment: "Great work",
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Invalid review payload"
+  });
+});
+
+test("POST /api/reviews accepts valid ratings", async () => {
+  const app = createApp();
+  const response = await fetchFromApp(app, "/api/reviews", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      rating: 5,
+      comment: "Great work",
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.rating, 5);
+  assert.equal(payload.data.comment, "Great work");
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1),
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add review payload validation for the `POST /api/reviews` endpoint
- reject ratings outside the 1-5 integer range with a 400 response
- keep valid review creation behavior unchanged
- add regression coverage for invalid and valid review ratings

## Tests
- Red before fix: `node --test apps/api/src/tests/review.test.js` failed because `rating: 6` returned 201
- Green after fix: `node --test apps/api/src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Fixes #4209
/claim #743