### PR TITLE
Reject self-directed messages

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,18 @@
-import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { fail, ok } from "../utils/response.js";
+import { listMessages, MessageValidationError, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    return ok(res, await sendMessage(req.body), 201);
+  } catch (error) {
+    if (error instanceof MessageValidationError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,10 +1,21 @@
 const messages = [];
 
+export class MessageValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MessageValidationError";
+  }
+}
+
 export async function listMessages() {
   return messages;
 }
 
 export async function sendMessage(payload) {
+  if (payload?.senderId && payload.senderId === payload.receiverId) {
+    throw new MessageValidationError("Messages require distinct sender and receiver");
+  }
+
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;

--- a/apps/api/src/tests/messageRoutes.self.test.js
+++ b/apps/api/src/tests/messageRoutes.self.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects self-directed messages", async () => {
+  await withServer(async (baseUrl) => {
+    const beforeResponse = await fetch(`${baseUrl}/api/messages`);
+    const beforePayload = await beforeResponse.json();
+
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_123",
+        receiverId: "usr_123",
+        body: "hello myself",
+      }),
+    });
+    const payload = await response.json();
+
+    const afterResponse = await fetch(`${baseUrl}/api/messages`);
+    const afterPayload = await afterResponse.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Messages require distinct sender and receiver");
+    assert.equal(afterPayload.data.length, beforePayload.data.length);
+  });
+});

--- a/apps/api/src/tests/messageService.self.test.js
+++ b/apps/api/src/tests/messageService.self.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, MessageValidationError, sendMessage } from "../services/messageService.js";
+
+test("sendMessage rejects self-directed messages without storing them", async () => {
+  const before = await listMessages();
+
+  await assert.rejects(
+    () =>
+      sendMessage({
+        senderId: "usr_123",
+        receiverId: "usr_123",
+        body: "hello myself",
+      }),
+    MessageValidationError,
+  );
+
+  const after = await listMessages();
+  assert.equal(after.length, before.length);
+});

--- a/demos/reject-self-messages-demo.svg
+++ b/demos/reject-self-messages-demo.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="520" viewBox="0 0 1080 520" role="img" aria-labelledby="title desc">
+  <title id="title">Self-directed message rejection demo</title>
+  <desc id="desc">A demo showing that POST /api/messages returns 400 when senderId and receiverId are the same.</desc>
+  <style>
+    .bg { fill: #0b1020; }
+    .panel { fill: #151c35; stroke: #2a3765; stroke-width: 1.5; }
+    .bad { fill: #ff6b6b; }
+    .good { fill: #47d18c; }
+    .text { fill: #f2f5ff; font-family: Inter, Arial, sans-serif; }
+    .muted { fill: #b8c5ec; font-family: Inter, Arial, sans-serif; }
+    .code { fill: #dbe4ff; font-family: Consolas, "Courier New", monospace; }
+  </style>
+  <rect class="bg" width="1080" height="520"/>
+  <text x="70" y="72" class="text" font-size="34" font-weight="800">Self-directed messages are rejected</text>
+  <text x="70" y="108" class="muted" font-size="17">Regression path for SecureBananaLabs/bug-bounty #4228</text>
+
+  <rect x="70" y="150" width="430" height="230" rx="10" class="panel"/>
+  <text x="100" y="190" class="text" font-size="20" font-weight="800">POST /api/messages</text>
+  <text x="100" y="232" class="code" font-size="17">{</text>
+  <text x="126" y="262" class="code" font-size="17">senderId: "usr_123",</text>
+  <text x="126" y="292" class="code" font-size="17">receiverId: "usr_123",</text>
+  <text x="126" y="322" class="code" font-size="17">body: "hello myself"</text>
+  <text x="100" y="352" class="code" font-size="17">}</text>
+  <circle cx="112" cy="382" r="7" class="bad"/>
+  <text x="132" y="389" class="muted" font-size="16">same participant on both sides</text>
+
+  <path d="M 515 266 L 565 266" stroke="#8bc5ff" stroke-width="5" stroke-linecap="round"/>
+  <path d="M 565 266 L 548 250 M 565 266 L 548 282" stroke="#8bc5ff" stroke-width="5" stroke-linecap="round"/>
+
+  <rect x="585" y="150" width="425" height="230" rx="10" class="panel"/>
+  <text x="615" y="190" class="text" font-size="20" font-weight="800">API response</text>
+  <circle cx="625" cy="232" r="7" class="bad"/>
+  <text x="645" y="238" class="code" font-size="17">HTTP 400</text>
+  <circle cx="625" cy="272" r="7" class="good"/>
+  <text x="645" y="278" class="code" font-size="17">success: false</text>
+  <circle cx="625" cy="312" r="7" class="good"/>
+  <text x="645" y="318" class="code" font-size="17">message: distinct sender/receiver</text>
+  <circle cx="625" cy="352" r="7" class="good"/>
+  <text x="645" y="358" class="code" font-size="17">message count unchanged</text>
+
+  <rect x="70" y="420" width="940" height="58" rx="10" fill="#10243a" stroke="#285d8f" stroke-width="1.5"/>
+  <text x="100" y="455" class="text" font-size="18" font-weight="800">Verified by node --test apps/api/src/tests/messageRoutes.self.test.js</text>
+</svg>


### PR DESCRIPTION
/claim #743

## Summary
- Rejects self-directed message creation when `senderId` and `receiverId` are the same value.
- Maps the focused service validation error to an HTTP 400 response from `POST /api/messages`.
- Adds service and route regression tests proving the invalid message is rejected and not stored.

Fixes #4228
Related to #743

## Demo
https://raw.githubusercontent.com/AxisIV/bug-bounty/axisiv/reject-self-messages-4228/demos/reject-self-messages-demo.svg

## Validation
- `node --test apps/api/src/tests/messageService.self.test.js`
- `node --test apps/api/src/tests/messageRoutes.self.test.js`
- `node --test apps/api/src/tests/*.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/controllers/messageController.js`
- `node --check apps/api/src/tests/messageService.self.test.js`
- `node --check apps/api/src/tests/messageRoutes.self.test.js`
- `git diff --check`
- `demos/reject-self-messages-demo.svg` validates as XML.