### PR TITLE
security(api): Admin metrics endpoint allows any authenticated role

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
**Vulnerability: Admin metrics endpoint allows any authenticated role**

The \dminRoutes\ in \pps/api/src/routes/adminRoutes.js\ uses the standard \uthMiddleware\ but fails to check if the authenticated user has the \dmin\ role. This allows any authenticated user (e.g., freelancers, clients) to access sensitive administrative metrics via \/api/admin/metrics\, which is a Broken Access Control (IDOR) vulnerability.

**Fix:**
Created an \dminMiddleware\ that verifies \eq.user.role === 'admin'\ and applied it to the \dminRoutes\.

Resolves #4245