### PR TITLE
Preserve notification server fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client_controlled_id",
+    read: true,
+    userId: "usr_123",
+    message: "New proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "client_controlled_id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "New proposal received");
+});


### PR DESCRIPTION
## Summary
- Preserve the generated `ntf_...` id when creating notifications.
- Force new notifications to start unread regardless of client payload fields.
- Add a regression test for client-supplied `id` and `read` overrides.

## Validation
- node --test apps/api/src/tests/notification-service.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check

Closes #4247
Refs #743
/claim #4247