### PR TITLE
Preserve proposal server id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-service.test.js
+++ b/apps/api/src/tests/proposal-service.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal preserves the server-generated id", async () => {
+  const proposal = await createProposal({
+    id: "client_controlled_id",
+    jobId: "job_123",
+    freelancerId: "usr_123",
+    bidAmount: 250,
+    coverLetter: "I can help with this project."
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "client_controlled_id");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_123");
+  assert.equal(proposal.bidAmount, 250);
+  assert.equal(proposal.coverLetter, "I can help with this project.");
+});


### PR DESCRIPTION
## Summary
- Preserve the generated `prp_...` id when creating proposals.
- Keep legitimate proposal payload fields intact.
- Add a regression test for client-supplied proposal ids.

## Validation
- node --test apps/api/src/tests/proposal-service.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check

Closes #4249
Refs #743
/claim #4249