### PR TITLE
Preserve review server id

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-service.test.js
+++ b/apps/api/src/tests/review-service.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview preserves the server-generated id", async () => {
+  const review = await createReview({
+    id: "client_controlled_id",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5,
+    comment: "Great work."
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "client_controlled_id");
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great work.");
+});


### PR DESCRIPTION
## Summary
- Preserve the generated `rev_...` id when creating reviews.
- Keep legitimate review payload fields intact.
- Add a regression test for client-supplied review ids.

## Validation
- node --test apps/api/src/tests/review-service.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check

Closes #4251
Refs #743
/claim #4251