### PR TITLE
Preserve server-owned notification fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    read: true,
+    userId: "user_1",
+    message: "Your proposal was accepted",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_attacker");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "user_1");
+  assert.equal(notification.message, "Your proposal was accepted");
+});


### PR DESCRIPTION
## Summary
- Preserve server-generated notification ids and the initial unread state when clients send id or ead fields.
- Add a focused regression test for notification creation mass-assignment.
- Update the API test script to run explicit *.test.js files so the workspace test command runs under the current Node test runner.

Fixes #4255

## Validation
- 
ode --test apps/api/src/tests/notification-service.test.js
- 
pm test -w apps/api
- 
ode --check apps/api/src/services/notificationService.js
- 
ode --check apps/api/src/tests/notification-service.test.js
- git diff --check

/claim #743