### PR TITLE
Validate review ratings

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +6,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
+  if (!Number.isInteger(req.body?.rating) || req.body.rating < 1 || req.body.rating > 5) {
+    return fail(res, "Rating must be an integer between 1 and 5", 400);
+  }
+
   return ok(res, await createReview(req.body), 201);
 }

--- a/apps/api/src/tests/review-routes.test.js
+++ b/apps/api/src/tests/review-routes.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects ratings outside the 1-5 scale", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 6,
+        comment: "Invalid rating"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Rating must be an integer between 1 and 5"
+    });
+  });
+});
+
+test("POST /api/reviews accepts valid integer ratings", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 5,
+        comment: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great work");
+  });
+});


### PR DESCRIPTION
## Summary
- Reject review ratings that are not integers from 1 through 5.
- Return a focused 400 response for invalid review rating payloads.
- Add route-level regression coverage for invalid and valid ratings.

## Validation
- node --test apps/api/src/tests/review-routes.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check

Closes #4256
Refs #743
/claim #4256