### PR TITLE
Preserve generated user ids

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-routes.test.js
+++ b/apps/api/src/tests/user-routes.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users keeps server-generated ids authoritative", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        name: "Santiago",
+        email: "santiago@example.com"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.name, "Santiago");
+    assert.equal(payload.data.email, "santiago@example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- Keep user ids server-owned by assigning the generated `usr_...` id after request payload fields.
- Add a route regression test proving a caller-supplied `id` cannot override the generated id while normal fields are preserved.

## Validation
- `node --test apps/api/src/tests/user-routes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Closes #4261
Refs #743
/claim #743