### PR TITLE
Align registration token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-service.test.js
+++ b/apps/api/src/tests/auth-service.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs tokens with the returned user id", async () => {
+  const originalNow = Date.now;
+  let now = 1000;
+  Date.now = () => now++;
+
+  try {
+    const result = await registerUser({
+      email: "santiago@example.com",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- Generate a single registration user id and reuse it for the returned `id` and JWT `sub`.
- Add a focused regression test with a controlled clock so the mismatch cannot reappear.

## Validation
- `node --test apps/api/src/tests/auth-service.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Closes #4266
Refs #743
/claim #743