### PR TITLE
Link existing workflow pages from primary navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/billing", "Billing"],
+  ["/notifications", "Notifications"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
/claim #743

Fixes #4263

## Summary

- Adds primary navigation entries for existing Post Job, Billing, Notifications, and Settings pages.
- Keeps the change scoped to `apps/web/components/Navigation.tsx`.
- Does not add new routes, API behaviour, auth, persistence, or unrelated UI changes.

## Proof

Verified the added navigation targets already exist in the app:

- `/jobs/post` -> `apps/web/app/jobs/post/page.tsx`
- `/billing` -> `apps/web/app/billing/page.tsx`
- `/notifications` -> `apps/web/app/notifications/page.tsx`
- `/settings` -> `apps/web/app/settings/page.tsx`

The PR diff is one file with four added navigation links.

## Notes

I could not run the local web build in this environment because `npm` is unavailable on PATH here.