### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Message body, senderId, and receiverId are required", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message-routes.test.js
+++ b/apps/api/src/tests/message-routes.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects incomplete payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        body: "   ",
+        senderId: "usr_sender"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Message body, senderId, and receiverId are required"
+    });
+  });
+});
+
+test("POST /api/messages creates valid messages", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        body: "Hello there",
+        senderId: "usr_sender",
+        receiverId: "usr_receiver"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^msg_\d+$/);
+    assert.equal(payload.data.body, "Hello there");
+    assert.equal(payload.data.senderId, "usr_sender");
+    assert.equal(payload.data.receiverId, "usr_receiver");
+    assert.match(payload.data.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  body: z.string().trim().min(1),
+  senderId: z.string().trim().min(1),
+  receiverId: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary
- Add a focused validator for `POST /api/messages` payloads.
- Reject missing/blank `body`, `senderId`, or `receiverId` with a controlled HTTP 400 response.
- Add route regression tests for invalid and valid message creation.

## Validation
- `node --test apps/api/src/tests/message-routes.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Closes #4269
Refs #743
/claim #743