### PR TITLE
Reject invalid payment intent amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentIntentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentIntentSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Payment amount must be a positive number");
+  }
+
+  return ok(res, await createPaymentIntent(payload.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects non-positive and non-numeric amounts", async () => {
+  await withServer(async (baseUrl) => {
+    for (const amount of [0, -25, "100", null]) {
+      const response = await postPayment(baseUrl, { amount });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Payment amount must be a positive number"
+      });
+    }
+  });
+});
+
+test("POST /api/payments creates payment intents for positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 1250,
+      currency: "eur"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 1250);
+    assert.equal(payload.data.currency, "eur");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentIntentSchema = z.object({
+  amount: z.number().finite().positive(),
+  currency: z.string().min(1).default("usd")
+});


### PR DESCRIPTION
## Summary
- add a payment intent request schema that requires `amount` to be a finite positive number
- return `400 Bad Request` before creating an intent when amount is missing, non-numeric, zero, or negative
- add regression coverage for rejected invalid amounts and successful positive amounts

Fixes #4282
/claim #4282

## Tests
- `node --test apps/api/src/tests/*.test.js` passes (3/3)
- `npm.cmd test --workspace apps/api` still fails because the existing script runs `node --test src/tests`, which Node treats as a missing module directory in this checkout