### PR TITLE
Reject non-positive payment amounts

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,11 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const statusCode = Number.isInteger(err.statusCode) ? err.statusCode : 500;
+  const message = statusCode >= 500 ? "Unexpected server error" : err.message;
+
+  return res.status(statusCode).json({
     success: false,
-    message: "Unexpected server error"
+    message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,10 @@
 export async function createPaymentIntent(payload) {
+  if (!Number.isFinite(payload.amount) || payload.amount <= 0) {
+    const error = new Error("Payment amount must be a positive number");
+    error.statusCode = 400;
+    throw error;
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent rejects non-positive payment amounts", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0, currency: "usd" }),
+    {
+      message: "Payment amount must be a positive number",
+      statusCode: 400
+    }
+  );
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: -10, currency: "usd" }),
+    {
+      message: "Payment amount must be a positive number",
+      statusCode: 400
+    }
+  );
+});
+
+test("createPaymentIntent accepts positive payment amounts", async () => {
+  const intent = await createPaymentIntent({ amount: 100, currency: "usd" });
+
+  assert.match(intent.paymentId, /^pay_/);
+  assert.equal(intent.amount, 100);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+});


### PR DESCRIPTION
## Summary

- Reject non-finite and non-positive payment intent amounts with a 400 error.
- Allow the API error handler to return intentional client error status codes instead of converting every thrown error to 500.
- Add service-level regression tests for invalid and valid payment amounts.

Closes #4276

## Tests

- `node --test apps/api/src/tests/paymentService.test.js`