### PR TITLE
Preserve job server-owned fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service.test.js
+++ b/apps/api/src/tests/job-service.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps id and initial status server-owned", async () => {
+  const job = await createJob({
+    id: "job_client_controlled",
+    status: "closed",
+    title: "Build a small landing page",
+    description: "Create and publish a focused marketing landing page.",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "web",
+    skills: ["nextjs", "css"]
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "job_client_controlled");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build a small landing page");
+  assert.deepEqual(job.skills, ["nextjs", "css"]);
+});


### PR DESCRIPTION
## Summary
- preserve job `id` and initial `status` as server-owned fields when creating jobs
- keep submitted job details intact while ignoring caller-supplied `id` and `status`
- add a focused regression test for job creation server-owned fields

Fixes #4285
/claim #4285

## Tests
- `node --test apps/api/src/tests/*.test.js` passes (2/2)
- `npm.cmd test --workspace apps/api` still fails because the existing script runs `node --test src/tests`, which Node treats as a missing module directory in this checkout