### PR TITLE
Preserve notification server-owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps id and read state server-owned", async () => {
+  const notification = await createNotification({
+    id: "ntf_client_controlled",
+    read: true,
+    userId: "usr_123",
+    type: "message",
+    message: "You have a new message"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_client_controlled");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "You have a new message");
+});


### PR DESCRIPTION
## Summary
- keep notification `id` and initial `read` state server-owned by spreading request payload first
- add a regression test proving client-supplied `id`/`read` values are ignored while normal fields are preserved

Fixes #4288

## Tests
- `node --test apps/api/src/tests/*.test.js` ✅
- `npm test --workspace apps/api` currently fails because the existing script runs `node --test src/tests`, which Node tries to resolve as a module directory instead of the test files