### PR TITLE
Harden upload file handling

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,18 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.name === "MulterError") {
+    const isTooLarge = err.code === "LIMIT_FILE_SIZE";
+
+    return res.status(isTooLarge ? 413 : 400).json({
+      success: false,
+      message: isTooLarge ? "File exceeds the 5 MB upload limit" : "Invalid file upload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,11 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const maxUploadSizeBytes = 5 * 1024 * 1024;
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: maxUploadSizeBytes }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload-routes.test.js
+++ b/apps/api/src/tests/upload-routes.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects missing files", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("description", "metadata without a file");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads accepts a valid file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads rejects files larger than 5 MB", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const oversizedBytes = new Uint8Array(5 * 1024 * 1024 + 1);
+    form.append("file", new Blob([oversizedBytes], { type: "application/octet-stream" }), "large.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File exceeds the 5 MB upload limit"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require `/api/uploads` requests to include an actual file instead of returning `201` for empty uploads
- cap in-memory multer uploads at 5 MB
- return clear upload errors, including `413` for over-limit files
- add route tests for missing, valid, and oversized uploads

Fixes #4290

## Tests
- `node --test apps/api/src/tests/*.test.js` ✅
- `npm test --workspace apps/api` currently fails because the existing script runs `node --test src/tests`, which Node tries to resolve as a module directory instead of the test files