### PR TITLE
fix: add auth middleware to POST /api/payments

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
Closes #2190

Added `authMiddleware` to the payment creation endpoint. Previously anyone could create payments without a valid Bearer token.

## Fix
- Import `authMiddleware` in `paymentRoutes.js`
- Apply it to `POST /`