### PR TITLE
Handle auth and job validation errors

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,25 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  const result = registerSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const user = await registerUser(result.data);
+  return ok(res, user, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  const result = loginSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid login payload", 400);
+  }
+
+  const user = await loginUser(result.data);
+  return ok(res, user);
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/validation-routes.test.js
+++ b/apps/api/src/tests/validation-routes.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/jobs returns 400 for invalid job payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/jobs", {
+      title: "",
+      budgetMin: "bad"
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/auth/register returns 400 for invalid registration payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/register", {
+      email: "not-an-email",
+      password: "short"
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid registration payload"
+    });
+  });
+});
+
+test("POST /api/auth/login returns 400 for invalid login payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "not-an-email",
+      password: "short"
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid login payload"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace auth/job `schema.parse()` calls with `safeParse()`
- return explicit `400` responses for invalid registration, login, and job payloads
- add route-level regression tests proving invalid requests do not escape as unhandled Zod exceptions

Fixes #4294

## Tests
- `node --test apps/api/src/tests/*.test.js` ✅
- `npm test --workspace apps/api` currently fails because the existing script runs `node --test src/tests`, which Node tries to resolve as a module directory instead of the test files