### PR TITLE
fix(auth): prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("register schema defaults public users to client role", () => {
+    const payload = registerSchema.parse({
+          email: "new-user@example.com",
+          password: "password123"
+    });
+
+       assert.equal(payload.role, "client");
+});
+
+test("register schema accepts public registration roles", () => {
+    const clientPayload = registerSchema.parse({
+          email: "client@example.com",
+          password: "password123",
+          role: "client"
+    });
+
+       const freelancerPayload = registerSchema.parse({
+             email: "freelancer@example.com",
+             password: "password123",
+             role: "freelancer"
+       });
+
+       assert.equal(clientPayload.role, "client");
+    assert.equal(freelancerPayload.role, "freelancer");
+});
+
+test("register schema rejects admin self-assignment", () => {
+    assert.throws(
+          () =>
+                  registerSchema.parse({
+                            email: "admin@example.com",
+                            password: "password123",
+                            role: "admin"
+                  }),
+          /Invalid enum value/
+        );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- restrict public registration roles to `client` and `freelancer`
- preserve the default `client` role
- add focused tests for allowed roles and rejected admin self-assignment
- fix the API test script so Node runs the test files explicitly

## Tests
- npm test

Closes #4287
Refs #743