### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a marketplace API",
+  description: "Create backend endpoints for the marketplace",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development",
+  skills: ["node"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const payload = createJobSchema.parse(validJob);
+
+  assert.equal(payload.budgetMin, 100);
+  assert.equal(payload.budgetMax, 500);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both budgets are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema permits partial budget updates", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMin: 250 }), { budgetMin: 250 });
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 750 }), { budgetMax: 750 });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function budgetRangeIsOrdered(payload) {
+  return (
+    payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMax >= payload.budgetMin
+  );
+}
+
+const orderedBudgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(budgetRangeIsOrdered, {
+  message: orderedBudgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(budgetRangeIsOrdered, {
+  message: orderedBudgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- Add budget range validation so job creation rejects payloads where `budgetMax` is lower than `budgetMin`.
- Apply the same ordered-range validation to partial job updates when both budget fields are present.
- Add node:test coverage for invalid, valid, and partial budget update cases.

## Verification
- Ran `cd apps/api && node --test "src/tests/*.test.js"`
- Result: 5 tests passed, 0 failed.

Closes #4299
