### PR TITLE
Strip sensitive user fields

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,16 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(stripSensitiveFields);
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: `usr_${Date.now()}`, ...stripSensitiveFields(payload) };
   users.push(user);
   return user;
+}
+
+function stripSensitiveFields(user) {
+  const { password, passwordHash, ...publicUser } = user;
+  return publicUser;
 }

--- a/apps/api/src/tests/user-service-sensitive-fields.test.js
+++ b/apps/api/src/tests/user-service-sensitive-fields.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser omits password fields from stored and returned users", async () => {
+  const user = await createUser({
+    email: "santi@example.com",
+    fullName: "Santi",
+    password: "plain-text-password",
+    passwordHash: "hashed-password",
+    role: "client"
+  });
+
+  assert.equal(user.email, "santi@example.com");
+  assert.equal(user.fullName, "Santi");
+  assert.equal(user.role, "client");
+  assert.equal("password" in user, false);
+  assert.equal("passwordHash" in user, false);
+
+  const users = await listUsers();
+  const storedUser = users.find((item) => item.email === "santi@example.com");
+
+  assert.ok(storedUser);
+  assert.equal("password" in storedUser, false);
+  assert.equal("passwordHash" in storedUser, false);
+});


### PR DESCRIPTION
## Summary
- strip `password` and `passwordHash` from created user objects
- ensure listed users are returned without sensitive password fields
- add a focused service regression test for create/list behavior

Fixes #4301

## Tests
- `node --test apps/api/src/tests/*.test.js` ✅
- `npm test --workspace apps/api` currently fails because the existing script runs `node --test src/tests`, which Node tries to resolve as a module directory instead of the test files