### PR TITLE
fix: restrict admin /metrics to admin role only

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,18 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+
+// Only allow users with admin role
+adminRoutes.use((req, res, next) => {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  next();
+});
+
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Closes #4245

Added middleware to check user role before granting access to /metrics endpoint. Only users with role='admin' can view metrics data.