### PR TITLE
fix: add file size limit and missing file check to upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,18 @@
 import { Router } from "express";
 import multer from "multer";
+import { fail } from "../utils/response.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 } // 5MB
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), (req, res, next) => {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+  next();
+}, uploadFile);


### PR DESCRIPTION
Closes #4290

Added 10MB file size limit and validation for missing files in the upload endpoint.