### PR TITLE
fix: validate payment amount and currency before creating intent

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
+const VALID_CURRENCIES = ["usd", "eur", "gbp", "inr", "cad", "aud"];
+
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const { amount, currency } = req.body || {};
+  if (typeof amount !== "number" || amount <= 0) {
+    return fail(res, "Amount must be a positive number", 400);
+  }
+  if (typeof currency !== "string" || !VALID_CURRENCIES.includes(currency.toLowerCase())) {
+    return fail(res, "Invalid or unsupported currency", 400);
+  }
+  return ok(res, await createPaymentIntent({ amount, currency: currency.toLowerCase() }), 201);
 }


### PR DESCRIPTION
Closes #4240

Added server-side validation for payment amount (positive number) and currency (ISO 4217) before creating Stripe payment intent.