### PR TITLE
Protect collaboration resource routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
+reviewRoutes.use(authMiddleware);
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/collaboration-routes-auth.test.js
+++ b/apps/api/src/tests/collaboration-routes-auth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const protectedRoutes = [
+  "/api/messages",
+  "/api/notifications",
+  "/api/proposals",
+  "/api/reviews"
+];
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("collaboration routes reject unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    for (const route of protectedRoutes) {
+      const getResponse = await fetch(`${baseUrl}${route}`);
+      const getPayload = await getResponse.json();
+
+      assert.equal(getResponse.status, 401);
+      assert.deepEqual(getPayload, { success: false, message: "Unauthorized" });
+
+      const postResponse = await fetch(`${baseUrl}${route}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({})
+      });
+      const postPayload = await postResponse.json();
+
+      assert.equal(postResponse.status, 401);
+      assert.deepEqual(postPayload, { success: false, message: "Unauthorized" });
+    }
+  });
+});
+
+test("collaboration routes accept a valid bearer token", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+
+  await withServer(async (baseUrl) => {
+    for (const route of protectedRoutes) {
+      const response = await fetch(`${baseUrl}${route}`, {
+        headers: { authorization: `Bearer ${token}` }
+      });
+
+      assert.equal(response.status, 200);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- require the existing bearer-token `authMiddleware` for messages, notifications, proposals, and reviews routes
- add regression coverage showing anonymous GET/POST requests are rejected with 401
- keep valid bearer-token access working for those collaboration resources

## Root cause

The route modules mounted collaboration controllers directly, so anonymous clients could list or create private workflow records without passing through the existing auth middleware.

Closes #4307
/claim #743

## Checks

- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`