### PR TITLE
Fix server-owned job id and status override vulnerability

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-server-owned-fields.test.js
+++ b/apps/api/src/tests/job-server-owned-fields.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob ignores caller-supplied id", async () => {
+  const job = await createJob({
+    id: "job_attacker_controlled",
+    title: "Test job",
+    description: "Testing server-owned fields",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "security"
+  });
+  assert.ok(job.id.startsWith("job_"));
+  assert.notEqual(job.id, "job_attacker_controlled");
+});
+
+test("createJob ignores caller-supplied status", async () => {
+  const job = await createJob({
+    status: "closed",
+    title: "Test job",
+    description: "Testing server-owned status",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "security"
+  });
+  assert.equal(job.status, "open");
+  assert.notEqual(job.status, "closed");
+});
+
+test("createJob preserves valid fields from payload", async () => {
+  const job = await createJob({
+    id: "job_should_be_ignored",
+    status: "closed",
+    title: "Real title",
+    description: "Real description that is long enough",
+    budgetMin: 200,
+    budgetMax: 800,
+    categoryId: "web"
+  });
+  assert.equal(job.title, "Real title");
+  assert.equal(job.description, "Real description that is long enough");
+  assert.equal(job.budgetMin, 200);
+  assert.equal(job.budgetMax, 800);
+  assert.equal(job.categoryId, "web");
+  assert.ok(job.id.startsWith("job_"));
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
## Summary

Fixes #4285 (parent bounty #743)

The `createJob()` function in `jobService.js` was building job records as `{ id, status, ...payload }`. Because the untrusted payload is spread last, a caller could override the server-generated `id` and initial `status` by including those fields in the request body.

## What changed

- **`apps/api/src/services/jobService.js`**: Reordered the object spread so payload fields come first, then server-owned fields (`id`, `status`) are applied last. This ensures caller-supplied `id` and `status` values are always overwritten by server-generated ones.
- **`apps/api/src/tests/job-server-owned-fields.test.js`**: Added regression tests confirming:
  - Caller-supplied `id` is ignored
  - Caller-supplied `status` is ignored
  - Valid payload fields (title, description, etc.) are preserved

## How to test

```bash
node --test apps/api/src/tests/job-server-owned-fields.test.js
```

All 3 tests pass.