### PR TITLE
Reject non-positive payment amounts with 400 Bad Request

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  const { amount } = req.body;
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return fail(res, "Amount must be a positive number", 400);
+  }
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,13 @@
 export async function createPaymentIntent(payload) {
+  const { amount } = payload;
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    throw new Error("Amount must be a positive number");
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/payment-validation.test.js
+++ b/apps/api/src/tests/payment-validation.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+let server, baseUrl;
+
+test.before(async () => {
+  const app = createApp();
+  server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(() => {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+test("POST /api/payments rejects zero amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 0 })
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.success, false);
+});
+
+test("POST /api/payments rejects negative amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: -50 })
+  });
+  assert.equal(res.status, 400);
+});
+
+test("POST /api/payments rejects NaN amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: NaN })
+  });
+  assert.equal(res.status, 400);
+});
+
+test("POST /api/payments rejects string amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: "one hundred" })
+  });
+  assert.equal(res.status, 400);
+});
+
+test("POST /api/payments rejects missing amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  assert.equal(res.status, 400);
+});
+
+test("POST /api/payments accepts valid positive amount", async () => {
+  const res = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 5000 })
+  });
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(body.data.amount, 5000);
+});


### PR DESCRIPTION
## Summary

Fixes #4282 (parent bounty #743)

`createPaymentIntent()` was accepting any value for `amount`, including `0`, negative numbers, `NaN`, and non-numeric input. This allowed invalid payment amounts to enter the payment flow.

## What changed

- **`apps/api/src/controllers/paymentController.js`**: Added input validation before calling the service — non-finite or non-positive amounts now return `400 Bad Request` with a clear error message.
- **`apps/api/src/services/paymentService.js`**: Added a defensive guard that throws if called directly with an invalid amount.
- **`apps/api/src/tests/payment-validation.test.js`**: Added E2E regression tests covering:
  - Zero amount → 400
  - Negative amount → 400
  - NaN amount → 400
  - String amount → 400
  - Missing amount → 400
  - Valid positive amount → 201 (still works)

## How to test

```bash
node --test apps/api/src/tests/payment-validation.test.js
```

All 6 tests pass.