### PR TITLE
Require admin role for admin metrics endpoint

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,15 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use((req, res, next) => {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  next();
+});
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-role-check.test.js
+++ b/apps/api/src/tests/admin-role-check.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+let server, baseUrl;
+
+test.before(async () => {
+  const app = createApp();
+  server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(() => {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin client token", async () => {
+  const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+  const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${clientToken}` }
+  });
+  assert.equal(res.status, 403);
+  const body = await res.json();
+  assert.equal(body.success, false);
+});
+
+test("GET /api/admin/metrics rejects non-admin freelancer token", async () => {
+  const freelancerToken = signAccessToken({ sub: "usr_freelancer", role: "freelancer" });
+  const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${freelancerToken}` }
+  });
+  assert.equal(res.status, 403);
+});
+
+test("GET /api/admin/metrics allows admin token", async () => {
+  const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+  const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${adminToken}` }
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.success, true);
+});
+
+test("GET /api/admin/metrics requires auth", async () => {
+  const res = await fetch(`${baseUrl}/api/admin/metrics`);
+  assert.equal(res.status, 401);
+});


### PR DESCRIPTION
## Summary

Fixes #4278 (parent bounty #743)

`/api/admin/metrics` used `authMiddleware` but never checked whether the authenticated user has the `admin` role. Any valid non-admin token (e.g. a `client` token) could read admin-only metrics.

## What changed

- **`apps/api/src/routes/adminRoutes.js`**: Added a middleware after `authMiddleware` that checks `req.user.role === 'admin'` and returns `403 Forbidden` for non-admin users.
- **`apps/api/src/tests/admin-role-check.test.js`**: Added E2E regression tests:
  - Client token → 403
  - Freelancer token → 403
  - Admin token → 200 (still works)
  - No token → 401 (still works)

## How to test

```bash
node --test apps/api/src/tests/admin-role-check.test.js
```

All 4 tests pass.