### PR TITLE
Protect user resource routes

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/user-routes-auth.test.js
+++ b/apps/api/src/tests/user-routes-auth.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("user routes reject unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const getResponse = await fetch(`${baseUrl}/api/users`);
+    const getPayload = await getResponse.json();
+
+    assert.equal(getResponse.status, 401);
+    assert.deepEqual(getPayload, { success: false, message: "Unauthorized" });
+
+    const postResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "test@example.com" })
+    });
+    const postPayload = await postResponse.json();
+
+    assert.equal(postResponse.status, 401);
+    assert.deepEqual(postPayload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("user routes accept a valid bearer token", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+
+    assert.equal(response.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary

- require the existing bearer-token `authMiddleware` before `/api/users` handlers run
- add regression coverage for anonymous GET/POST requests returning 401
- verify valid bearer-token access still reaches the users route

## Root cause

`userRoutes` mounted the user controller directly. That let anonymous callers list user records or create users through the generic resource route, even though public account creation already exists under `/api/auth/register`.

Closes #4311
/claim #743

## Checks

- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`