### PR TITLE
Reject inverted job budget ranges in validation

### DIFF
--- a/apps/api/src/tests/budget-range-validation.test.js
+++ b/apps/api/src/tests/budget-range-validation.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects inverted budget range", () => {
+  assert.throws(
+    () => createJobSchema.parse({
+      title: "Test job",
+      description: "A valid description here",
+      budgetMin: 500,
+      budgetMax: 100,
+      categoryId: "web-dev"
+    }),
+    /budgetMax/
+  );
+});
+
+test("createJobSchema accepts valid ordered budget range", () => {
+  const result = createJobSchema.parse({
+    title: "Test job",
+    description: "A valid description here",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "web-dev"
+  });
+  assert.equal(result.budgetMin, 100);
+  assert.equal(result.budgetMax, 500);
+});
+
+test("createJobSchema accepts equal budget min and max", () => {
+  const result = createJobSchema.parse({
+    title: "Fixed price job",
+    description: "A valid description here",
+    budgetMin: 300,
+    budgetMax: 300,
+    categoryId: "design"
+  });
+  assert.equal(result.budgetMin, 300);
+  assert.equal(result.budgetMax, 300);
+});
+
+test("createJobSchema accepts zero budgets", () => {
+  const result = createJobSchema.parse({
+    title: "Volunteer work",
+    description: "A valid description here",
+    budgetMin: 0,
+    budgetMax: 0,
+    categoryId: "volunteer"
+  });
+  assert.equal(result.budgetMin, 0);
+  assert.equal(result.budgetMax, 0);
+});
+
+test("updateJobSchema rejects inverted budget range when both present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({
+      budgetMin: 1000,
+      budgetMax: 200
+    }),
+    /budgetMax/
+  );
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const result = updateJobSchema.parse({ budgetMin: 500 });
+  assert.equal(result.budgetMin, 500);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const result = updateJobSchema.parse({ budgetMax: 2000 });
+  assert.equal(result.budgetMax, 2000);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).default([]).optional()
+}).refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMin <= data.budgetMax;
+    }
+    return true;
+  },
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);


### PR DESCRIPTION
## Summary

Fixes #4299 (parent bounty #743)

`createJobSchema` accepted payloads where `budgetMax` was lower than `budgetMin`, creating invalid job records like a USD 500-100 budget range. The partial update schema had the same issue when both budget fields were present.

## What changed

- **`apps/api/src/validators/job.js`**:
  - Added a `.refine()` to `createJobSchema` that ensures `budgetMin <= budgetMax`
  - Rewrote `updateJobSchema` explicitly (instead of `createJobSchema.partial()`) so the refinement only runs when **both** budget fields are present — partial updates with just one field still work fine
- **`apps/api/src/tests/budget-range-validation.test.js`**: 7 unit tests covering:
  - Inverted range → rejected
  - Valid ordered range → accepted
  - Equal min/max → accepted
  - Zero budgets → accepted
  - Partial update with inverted range → rejected
  - Partial update with only budgetMin → accepted
  - Partial update with only budgetMax → accepted

## How to test

```bash
node --test apps/api/src/tests/budget-range-validation.test.js
```

All 7 tests pass.