### PR TITLE
Expose db workspace package entrypoint

### DIFF
--- a/apps/api/src/tests/db-package-entrypoint.test.js
+++ b/apps/api/src/tests/db-package-entrypoint.test.js
@@ -1,0 +1,8 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("@freelanceflow/db exposes a workspace package entrypoint", async () => {
+  const dbPackage = await import("@freelanceflow/db");
+
+  assert.equal(typeof dbPackage.PrismaClient, "function");
+});

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Summary

- add explicit `main`, `types`, and `exports` metadata for `@freelanceflow/db`
- add root `index.js` and `index.d.ts` entrypoints that re-export Prisma client APIs
- add a regression test that imports `@freelanceflow/db` through the workspace package name

## Root cause

The DB workspace had `src/index.ts`, but no package-level JavaScript entrypoint. Node resolved the workspace package name to a missing root `index.js`, so importing `@freelanceflow/db` failed.

Closes #2775
/claim #2775
/claim #743

## Checks

- direct dynamic import of `@freelanceflow/db`
- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`
