### PR TITLE
Preserve collaboration resource ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/collaborationIds.test.js
+++ b/apps/api/src/tests/collaborationIds.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sendMessage } from "../services/messageService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+
+test("collaboration resource ids remain server-owned", async () => {
+  const message = await sendMessage({ id: "client-message-id", body: "hello" });
+  const proposal = await createProposal({ id: "client-proposal-id", coverLetter: "ready" });
+  const review = await createReview({ id: "client-review-id", rating: 5 });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.match(review.id, /^rev_\d+$/);
+
+  assert.notEqual(message.id, "client-message-id");
+  assert.notEqual(proposal.id, "client-proposal-id");
+  assert.notEqual(review.id, "client-review-id");
+});


### PR DESCRIPTION
/claim #743

## Summary
- keep message, proposal, and review ids server-owned by applying client payload fields before generated ids
- add a regression test that sends spoofed ids and verifies the `msg_`, `prp_`, and `rev_` prefixes still come from the service layer

Fixes #4316

## Validation
- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`
