### PR TITLE
Reject unknown auth logins

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,11 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+
+  if (!result) {
+    return fail(res, "Invalid email or password", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,46 @@
+import { createHash } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
+const usersByEmail = new Map();
+
+function normalizeEmail(email) {
+  return email.toLowerCase();
+}
+
+function hashPassword(password) {
+  return createHash("sha256").update(password).digest("hex");
+}
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+  const email = normalizeEmail(payload.email);
+  const user = {
+    id,
+    email,
+    passwordHash: hashPassword(payload.password),
+    role: payload.role
+  };
+
+  usersByEmail.set(email, user);
+
   return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    id,
+    email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const user = usersByEmail.get(normalizeEmail(payload.email));
+
+  if (!user || user.passwordHash !== hashPassword(payload.password)) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authLogin.test.js
+++ b/apps/api/src/tests/authLogin.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("login rejects unknown users and wrong passwords", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `auth-${Date.now()}@example.com`;
+
+    const unknownLogin = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "validpass123"
+    });
+    const unknownPayload = await unknownLogin.json();
+
+    assert.equal(unknownLogin.status, 401);
+    assert.deepEqual(unknownPayload, {
+      success: false,
+      message: "Invalid email or password"
+    });
+
+    const register = await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password: "validpass123",
+      role: "client"
+    });
+
+    assert.equal(register.status, 201);
+
+    const wrongPassword = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "wrongpass123"
+    });
+
+    assert.equal(wrongPassword.status, 401);
+
+    const validLogin = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "validpass123"
+    });
+    const validPayload = await validLogin.json();
+
+    assert.equal(validLogin.status, 200);
+    assert.equal(validPayload.success, true);
+    assert.equal(validPayload.data.email, email);
+    assert.equal(typeof validPayload.data.token, "string");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- keep a small in-memory auth user store for the demo API registration/login flow
- reject unknown users and wrong passwords with a 401 instead of issuing a token for any valid-shaped login payload
- add HTTP regression coverage for unknown login, wrong password, and valid registered-user login

Fixes #4318

## Validation
- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`
