### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -6,7 +6,11 @@ export async function getJobs(req, res) {
   return ok(res, await listJobs());
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload",
+      issues: err.issues
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs creates jobs with a valid budget range", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build landing page",
+        description: "Create a polished landing page for launch.",
+        budgetMin: 500,
+        budgetMax: 1200,
+        categoryId: "design",
+        skills: ["nextjs"]
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 500);
+    assert.equal(payload.data.budgetMax, 1200);
+  });
+});
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build landing page",
+        description: "Create a polished landing page for launch.",
+        budgetMin: 1200,
+        budgetMax: 500,
+        categoryId: "design"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request payload");
+    assert.equal(payload.issues[0].path[0], "budgetMax");
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,15 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const budgetRangeSchema = (schema) => schema.refine((job) => (
+  job.budgetMin === undefined ||
+  job.budgetMax === undefined ||
+  job.budgetMax >= job.budgetMin
+), {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const createJobSchema = budgetRangeSchema(jobFieldsSchema);
+
+export const updateJobSchema = budgetRangeSchema(jobFieldsSchema.partial());


### PR DESCRIPTION
## Summary

- reject inverted job budget ranges at the job schema layer
- forward job validation failures to the API error middleware so clients receive a 400 response
- return structured Zod validation errors from the error handler
- fix the API test script glob and add route-level regression coverage

## Tests

```bash
npm test
```

Result: 3 tests passed.

Closes #4320
/claim #4320
/claim #743
