### PR TITLE
Add settings and billing navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -7,6 +7,8 @@ const links = [
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/settings", "Settings"],
+  ["/billing", "Billing"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
/claim #743

## Summary
- expose the existing `/settings` and `/billing` pages from the shared app navigation
- keep the change scoped to route discoverability; no page behavior changed

Fixes #4323

## Validation
- `..\..\node_modules\.bin\next.cmd build` from `apps/web`
- `git diff --check`
