### PR TITLE
Return JSON 404 for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,10 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use("/api", (req, res) => {
+    res.status(404).json({ success: false, message: "Not found" });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/apiNotFound.test.js
+++ b/apps/api/src/tests/apiNotFound.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("unknown API routes return structured JSON 404 responses", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
/claim #743

Fixes #4322.

## Summary
- Add a JSON 404 fallback for unknown `/api/*` routes after all registered API routers.
- Preserve existing route behavior and leave non-API fallthrough untouched.
- Add a regression test for the standard `{ success: false, message: "Not found" }` error envelope.

## Validation
- `node --test apps/api/src/tests/apiNotFound.test.js` -> passed
- `node --test apps/api/src/tests/*.test.js` -> 2 passed
- `node --check apps/api/src/app.js; node --check apps/api/src/tests/apiNotFound.test.js` -> passed
- `git diff --check` -> passed

## Demo
The regression test starts the API on an ephemeral port, requests `/api/does-not-exist`, and verifies HTTP 404 plus JSON content type and body.
