### PR TITLE
fix: reject inverted budget ranges in job creation and update

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,29 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMax >= data.budgetMin, {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    // Only enforce ordering when both fields are provided
+    if (data.budgetMin != null && data.budgetMax != null) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
Fixes #2853

## Problem
`createJobSchema` accepts payloads where `budgetMax < budgetMin`, creating invalid job records (e.g., USD 500-100 budget range) that break filtering, sorting, and display.

## Fix
- Added `.refine()` to `createJobSchema` to enforce `budgetMax >= budgetMin`
- Added `.refine()` to `updateJobSchema` (partial) that validates ordering only when both budget fields are present
- Valid ranges continue to parse successfully

## Before
```js
createJobSchema.parse({ budgetMin: 500, budgetMax: 100 }) // ✅ (wrong!)
```

## After
```js
createJobSchema.parse({ budgetMin: 500, budgetMax: 100 }) // ❌ ZodError
createJobSchema.parse({ budgetMin: 100, budgetMax: 500 }) // ✅
```