### PR TITLE
fix: reject empty file uploads with 400 response

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,15 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({
+      success: false,
+      error: "No file provided"
+    });
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Fixes #2850

## Problem
`POST /api/uploads` returns `201` with `success: true` even when no file is included. The response says `status: "no-file"` but HTTP status and shape indicate success.

## Fix
- Return `400` with `{ success: false, error: "No file provided" }` when `req.file` is missing
- Keep `201` response only for successful uploads with actual files
- Removed nullish coalescing for `originalname` since file is now guaranteed to exist

## Before
```js
// No file attached
POST /api/uploads → 201 { success: true, filename: null, status: "no-file" }
```

## After
```js
// No file attached
POST /api/uploads → 400 { success: false, error: "No file provided" }
```