### PR TITLE
Keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,22 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser signs the access token with the created user id", async () => {
+  const dateNow = mock.method(Date, "now", mock.fn(() => 1700000000000));
+
+  try {
+    const user = await registerUser({
+      email: "client@example.com",
+      role: "client"
+    });
+    const tokenPayload = jwt.decode(user.token);
+
+    assert.equal(user.id, "usr_1700000000000");
+    assert.equal(tokenPayload.sub, user.id);
+    assert.equal(tokenPayload.role, user.role);
+  } finally {
+    dateNow.mock.restore();
+  }
+});


### PR DESCRIPTION
## Summary

- Generate the registration user id once and reuse it for both the response id and JWT subject.
- Add a regression test proving the registration token subject matches the created user id.

Closes #4330

## Tests

- Not run locally (missing workspace `node_modules` in this environment).