### PR TITLE
Reject non-positive payment amounts in createPaymentIntent

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    const result = await createPaymentIntent(req.body);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err.status === 400) {
+      return fail(res, err.message, 400);
+    }
+    throw err;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,8 @@
 export async function createPaymentIntent(payload) {
+  if (typeof payload.amount !== "number" || !Number.isFinite(payload.amount) || payload.amount <= 0) {
+    throw Object.assign(new Error("Amount must be a positive number"), { status: 400 });
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/payment-amount-validation.test.js
+++ b/apps/api/src/tests/payment-amount-validation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent rejects zero amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent rejects negative amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: -10 }),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent rejects NaN amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: NaN }),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent rejects Infinity amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: Infinity }),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent rejects string amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: "fifty" }),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent rejects undefined amount", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({}),
+    { message: "Amount must be a positive number" }
+  );
+});
+
+test("createPaymentIntent accepts valid positive amount", async () => {
+  const result = await createPaymentIntent({ amount: 29.99 });
+  assert.equal(result.amount, 29.99);
+  assert.ok(result.paymentId.startsWith("pay_"));
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});
+
+test("createPaymentIntent accepts custom currency with valid amount", async () => {
+  const result = await createPaymentIntent({ amount: 100, currency: "eur" });
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "eur");
+});
+
+test("rejected amounts throw with status 400", async () => {
+  try {
+    await createPaymentIntent({ amount: -5 });
+    assert.fail("Should have thrown");
+  } catch (err) {
+    assert.equal(err.status, 400);
+  }
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentIntentSchema = z.object({
+  amount: z.number().positive({ message: "Amount must be a positive number" }).finite({ message: "Amount must be a finite number" }),
+  currency: z.string().min(1).optional().default("usd")
+});


### PR DESCRIPTION
## Summary

Fixes #4282 (parent bounty: #743)

`createPaymentIntent()` was accepting any value for the amount field — zero, negatives, NaN, Infinity, even strings and undefined. These bogus values would sail through and hit downstream payment code.

## What changed

- **paymentService.js**: Added a guard at the top of `createPaymentIntent()` that checks `typeof amount !== 'number'`, `!Number.isFinite(amount)`, and `amount <= 0`. Throws with `status: 400` and a clear message.
- **paymentController.js**: Wraps the service call in try/catch to return a proper 400 JSON response on validation failures instead of a 500.
- **validators/payment.js**: Added a Zod schema for the payment intent payload (available for future route-level validation).
- **payment-amount-validation.test.js**: 9 regression tests covering zero, negative, NaN, Infinity, string, missing amount, valid positive, custom currency, and error status code.

## Testing

```
node --test src/tests/*.test.js
✔ 10 tests pass (all existing + new)
```

No existing behavior is affected — valid positive amounts still work exactly as before.