### PR TITLE
Validate payment intent amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,10 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const status = Number.isInteger(err.status) ? err.status : 500;
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: status === 500 ? "Unexpected server error" : err.message
   });
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,16 @@
 export async function createPaymentIntent(payload) {
+  const amount = Number(payload?.amount);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    const error = new Error("Payment amount must be a positive number");
+    error.status = 400;
+    throw error;
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    for (const amount of [0, -1, "not-a-number"]) {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount })
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Payment amount must be a positive number"
+      });
+    }
+  });
+});
+
+test("POST /api/payments creates intent for positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 25, currency: "eur" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "eur");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_\d+$/);
+  });
+});


### PR DESCRIPTION
## Summary
- Reject non-finite, zero, and negative payment amounts with `400 Bad Request`
- Preserve successful payment intent creation for positive amounts
- Add regression coverage for invalid and valid payment amount requests

Closes #4282

## Validation
- `node --test apps/api/src/tests/*.js`
