### PR TITLE
Reject unsupported payment currencies

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  const currency = req.body.currency ?? "usd";
+
+  if (typeof currency !== "string" || currency.toLowerCase() !== "usd") {
+    return fail(res, "payment currency must be usd", 400);
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: "usd",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/payments defaults currency to usd", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, { amount: 25 });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments accepts uppercase usd and normalizes it", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, { amount: 25, currency: "USD" });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments rejects unsupported currencies", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, { amount: 25, currency: "eur" });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "payment currency must be usd"
+    });
+  });
+});
+
+test("POST /api/payments rejects non-string currencies", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, { amount: 25, currency: 840 });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "payment currency must be usd"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #4343
- Rejects unsupported or non-string payment intent currencies before creating the mock Stripe intent
- Preserves the existing default USD behavior and normalizes accepted USD values to `usd`
- Adds API regression tests for default, uppercase USD, unsupported, and non-string currency inputs

/claim #743

## Validation

- `node --test src\\tests\\health.test.js src\\tests\\payment.test.js` from `apps/api` -> 5 passed
- `git diff --check` -> clean

## Scope

This PR only changes mock payment intent currency validation and focused tests. It does not change real provider integration, payout flow, ledger behavior, secrets, or payment amount logic.