### PR TITLE
Cap job metadata size

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/job-metadata-size.test.js
+++ b/apps/api/src/tests/job-metadata-size.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function validJob(overrides = {}) {
+  return {
+    title: "Build checkout flow",
+    description: "Implement a checkout flow with payment status tracking.",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "web",
+    skills: ["node", "api"],
+    ...overrides
+  };
+}
+
+async function postJob(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/jobs accepts normal job metadata", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJob(baseUrl, validJob());
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, "Build checkout flow");
+    assert.deepEqual(payload.data.skills, ["node", "api"]);
+  });
+});
+
+test("POST /api/jobs rejects oversized titles", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJob(baseUrl, validJob({ title: "x".repeat(121) }));
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/jobs rejects too many skills", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJob(baseUrl, validJob({ skills: Array(26).fill("api") }));
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/jobs rejects oversized skill names", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJob(baseUrl, validJob({ skills: ["x".repeat(81)] }));
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().min(4).max(120),
+  description: z.string().min(10).max(5000),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: z.string().min(1).max(80),
+  skills: z.array(z.string().min(1).max(80)).max(25).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary

- Fixes #4347
- Caps job title, description, category id, skill name, and skills array sizes before storing a new job
- Returns the existing API error envelope with `400 Bad Request` for oversized job metadata
- Adds route regression tests for normal jobs, oversized titles, oversized skill arrays, and oversized skill names

/claim #743

## Validation

- `node --test src\\tests\\health.test.js src\\tests\\job-metadata-size.test.js` from `apps/api` -> 5 passed
- `git diff --check` -> clean

## Scope

This PR only changes job creation validation/error handling and focused tests. It does not change budget validation, job storage semantics, payment behavior, persistence, or unrelated API routes.