### PR TITLE
fix: add input validation and length limit to search query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,26 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+
+  if (q === undefined || q === null) {
+    return fail(res, "Missing required query parameter \"q\".", 400);
+  }
+
+  if (typeof q !== "string") {
+    return fail(res, "Query parameter \"q\" must be a string.", 400);
+  }
+
+  const trimmed = q.trim();
+
+  if (trimmed.length === 0) {
+    return fail(res, "Query parameter \"q\" must not be empty.", 400);
+  }
+
+  if (trimmed.length > 200) {
+    return fail(res, "Query parameter \"q\" must be 200 characters or fewer.", 400);
+  }
+
+  return ok(res, await globalSearch(trimmed));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/search without q returns 400", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/search`);
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.match(body.message, /Missing required query parameter/);
+  await close(server);
+});
+
+test("GET /api/search with empty q returns 400", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=`);
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  await close(server);
+});
+
+test("GET /api/search with whitespace-only q returns 400", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=%20%20%20`);
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  await close(server);
+});
+
+test("GET /api/search with q longer than 200 chars returns 400", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+  const longQ = "a".repeat(201);
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=${longQ}`);
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.match(body.message, /200 characters/);
+  await close(server);
+});
+
+test("GET /api/search with valid q returns 200", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=hello`);
+  const body = await res.json();
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(body.data);
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Fixes #4349

Add input validation and length limit to the `GET /api/search` endpoint query parameter.

## Changes

- ****: Validate that `q` is a non-empty string, trim whitespace, and enforce a 200-character length limit. Return 400 for invalid input.
- ****: Add regression tests covering missing, empty, whitespace-only, too-long, and valid queries.

## Test plan

Run `npm test` in the `apps/api` directory to verify all new search validation tests pass.

References #743