### PR TITLE
fix: reject upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided. Please include a file in the \"file\" field.", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startApp(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/uploads without file returns 400", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+
+  const formData = new FormData();
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.match(body.message, /No file provided/);
+  await close(server);
+});
+
+test("POST /api/uploads with file returns 201", async () => {
+  const server = await startApp(createApp());
+  const { port } = server.address();
+
+  const formData = new FormData();
+  const blob = new Blob(["hello world"], { type: "text/plain" });
+  formData.append("file", blob, "test.txt");
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+  assert.equal(body.data.status, "uploaded");
+  assert.equal(body.data.filename, "test.txt");
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Fixes #4350

Reject `POST /api/uploads` requests that do not include a file with a 400 error instead of returning 201 with a `no-file` status.

## Changes

- ****: Check for `req.file` and return 400 with a descriptive error message when no file is provided.
- ****: Add regression tests for the missing-file case and the successful upload case.

## Test plan

Run `npm test` in the `apps/api` directory to verify all upload validation tests pass.

References #743