### PR TITLE
fix: resolve freelancer profile by username from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,23 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+        <p>Please check the username and try again.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

Fixes #4351

The `/freelancers/[username]` route now looks up the freelancer from the mock data instead of rendering generic placeholder text.

## Changes

- ****: Import freelancers from `@/lib/mock`, find the matching freelancer by username, display skills and rate for known usernames, and show a clear not-found fallback for unknown usernames.

## Test plan

- Navigate to `/freelancers/maya-dev` — should show skills: Next.js, TypeScript, rate: $65/hr
- Navigate to `/freelancers/jordan-ux` — should show skills: Figma, UX Research, rate: $52/hr
- Navigate to `/freelancers/unknown` — should show "Freelancer Not Found" message

References #743