### PR TITLE
Fix registration id/JWT subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registration-id.test.js
+++ b/apps/api/src/tests/registration-id.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registration returns matching user id and JWT subject", async () => {
+  const result = await registerUser({
+    email: "test@example.com",
+    role: "client"
+  });
+
+  // The returned id must be a string starting with usr_
+  assert.ok(result.id.startsWith("usr_"), "user id should start with usr_");
+
+  // The JWT sub claim must match the returned user id exactly
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, result.id, "JWT sub must match returned user id");
+});
+
+test("registration id is stable across property access", async () => {
+  const result = await registerUser({
+    email: "stable@example.com",
+    role: "freelancer"
+  });
+
+  const firstAccess = result.id;
+  const secondAccess = result.id;
+  assert.equal(firstAccess, secondAccess, "id should not change between accesses");
+});


### PR DESCRIPTION
## Summary

Fixes #4340 (parent bounty: #743)

`registerUser()` was calling `Date.now()` twice — once for the response `id` field and once for the JWT `sub` claim. If those calls straddled a millisecond boundary the returned user id would not match the identity embedded in the access token.

## What changed

- **`apps/api/src/services/authService.js`**: Generate the user id once (`usr_${Date.now()}`) into a local variable and reuse it for both the response object and the `signAccessToken()` call, so they are always identical.
- **`apps/api/src/tests/registration-id.test.js`**: Added regression tests proving the decoded JWT `sub` matches the created user id and that the id is stable.

## Testing

```bash
node --test apps/api/src/tests/registration-id.test.js
# ✔ registration returns matching user id and JWT subject
# ✔ registration id is stable across property access
# 2 pass, 0 fail
```

Verified that the existing health test still passes too.