### PR TITLE
Protect notification server-owned fields from client override

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-server-fields.test.js
+++ b/apps/api/src/tests/notification-server-fields.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("notification id and read state cannot be overridden by payload", async () => {
+  const before = (await listNotifications()).length;
+
+  const result = await createNotification({
+    userId: "usr_test",
+    title: "Test notification",
+    read: true,
+    id: "ntf_evil"
+  });
+
+  // Server-owned fields must not reflect client input
+  assert.equal(result.read, false, "read should always be false on creation");
+  assert.ok(result.id.startsWith("ntf_"), "id should start with ntf_");
+  assert.notEqual(result.id, "ntf_evil", "id should not be client-supplied value");
+
+  // But user data should be preserved
+  assert.equal(result.userId, "usr_test");
+  assert.equal(result.title, "Test notification");
+});
+
+test("notification without override attempts works normally", async () => {
+  const result = await createNotification({
+    userId: "usr_normal",
+    title: "Normal notification"
+  });
+
+  assert.equal(result.read, false);
+  assert.ok(result.id.startsWith("ntf_"));
+  assert.equal(result.userId, "usr_normal");
+  assert.equal(result.title, "Normal notification");
+});


### PR DESCRIPTION
## Summary

Fixes #4357 (parent bounty: #743)

`createNotification()` was building the object as `{ id, read: false, ...payload }`. Because the client payload is spread last, callers could send `read: true` or `id: "ntf_evil"` and override the server-generated values.

## What changed

- **`apps/api/src/services/notificationService.js`**: Spread `payload` first, then apply `id` and `read: false` so they always win.
- **`apps/api/src/tests/notification-server-fields.test.js`**: Added regression tests proving `id` and `read` stay server-controlled even when the caller tries to set them.

## Testing

```bash
node --test apps/api/src/tests/notification-server-fields.test.js
# ✔ notification id and read state cannot be overridden by payload
# ✔ notification without override attempts works normally
# 2 pass, 0 fail
```