### PR TITLE
Remove admin role from public registration schema

### DIFF
--- a/apps/api/src/tests/admin-self-assign.test.js
+++ b/apps/api/src/tests/admin-self-assign.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registration rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: " attacker@example.com",
+    password: "validpass123",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false, "admin role should be rejected");
+  const msg = result.error.issues[0].message;
+  assert.ok(msg.includes("admin") || msg.includes("Invalid"), `error should mention invalid role, got: ${msg}`);
+});
+
+test("registration accepts client and freelancer roles", () => {
+  const client = registerSchema.parse({
+    email: "client@example.com",
+    password: "validpass123",
+    role: "client"
+  });
+  assert.equal(client.role, "client");
+
+  const freelancer = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "validpass123",
+    role: "freelancer"
+  });
+  assert.equal(freelancer.role, "freelancer");
+});
+
+test("registration defaults to client role when omitted", () => {
+  const result = registerSchema.parse({
+    email: "default@example.com",
+    password: "validpass123"
+  });
+  assert.equal(result.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #4359 (parent bounty: #743)

`registerSchema` in `apps/api/src/validators/auth.js` accepted `"admin"` as a valid role value, letting any new signup self-assign admin privileges. A caller could register with `role: "admin"` and immediately obtain a JWT with admin-level access.

## What changed

- **`apps/api/src/validators/auth.js`**: Removed `"admin"` from the role enum so only `"client"` and `"freelancer"` are accepted during registration.
- **`apps/api/src/tests/admin-self-assign.test.js`**: Added regression tests proving admin self-assignment is rejected, while client/freelancer roles and the default still work.

## Testing

```bash
node --test apps/api/src/tests/admin-self-assign.test.js
# ✔ registration rejects admin role
# ✔ registration accepts client and freelancer roles
# ✔ registration defaults to client role when omitted
# 3 pass, 0 fail
```