### PR TITLE
Reject oversized job metadata

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/job-metadata.test.js
+++ b/apps/api/src/tests/job-metadata.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validJobPayload = {
+  title: "Build search page",
+  description: "Implement a searchable job listing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react", "node"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJob(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/jobs accepts normal job metadata", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJob(baseUrl, validJobPayload);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJobPayload.title);
+    assert.equal(payload.data.description, validJobPayload.description);
+    assert.deepEqual(payload.data.skills, validJobPayload.skills);
+  });
+});
+
+test("POST /api/jobs rejects oversized job metadata", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedCases = [
+      { name: "title", payload: { ...validJobPayload, title: "t".repeat(121) } },
+      { name: "description", payload: { ...validJobPayload, description: "d".repeat(2001) } },
+      { name: "categoryId", payload: { ...validJobPayload, categoryId: "c".repeat(81) } },
+      { name: "skill name", payload: { ...validJobPayload, skills: ["s".repeat(61)] } },
+      { name: "skill list", payload: { ...validJobPayload, skills: Array.from({ length: 21 }, (_, index) => `skill-${index}`) } }
+    ];
+
+    for (const { name, payload } of oversizedCases) {
+      const response = await postJob(baseUrl, payload);
+      const body = await response.json();
+
+      assert.equal(response.status, 400, name);
+      assert.equal(body.success, false, name);
+      assert.equal(body.message, "Invalid job payload", name);
+    }
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
+const MAX_JOB_TITLE_LENGTH = 120;
+const MAX_JOB_DESCRIPTION_LENGTH = 2000;
+const MAX_JOB_CATEGORY_ID_LENGTH = 80;
+const MAX_JOB_SKILLS = 20;
+const MAX_JOB_SKILL_LENGTH = 60;
+
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().min(4).max(MAX_JOB_TITLE_LENGTH),
+  description: z.string().min(10).max(MAX_JOB_DESCRIPTION_LENGTH),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: z.string().min(1).max(MAX_JOB_CATEGORY_ID_LENGTH),
+  skills: z.array(z.string().min(1).max(MAX_JOB_SKILL_LENGTH)).max(MAX_JOB_SKILLS).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
/claim #743

## Summary
- Add explicit maximum lengths/counts for job title, description, category id, individual skills, and total skills.
- Return a clear `400 Bad Request` response for invalid job creation payloads instead of letting validation errors escape.
- Add regression tests for normal job creation and oversized metadata rejection.

Fixes #4364

## Validation
- `C:\Users\Santi\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe --test apps/api/src/tests/*.test.js`
- `git diff --check`