### PR TITLE
fix: strip password field from user service responses (#4301)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,15 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(u => {
+    const { password, ...safe } = u;
+    return safe;
+  });
 }
 
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  const { password, ...safe } = user;
+  return safe;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users should not return password in response", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "test@example.com", password: "secret123", name: "Test User" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.password, undefined, "Password should not be returned");
+  assert.equal(payload.data.email, "test@example.com");
+  assert.equal(payload.data.name, "Test User");
+  assert.ok(payload.data.id.startsWith("usr_"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/users should not return passwords", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Create a user first
+  await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "test2@example.com", password: "secret456", name: "Test User 2" })
+  });
+
+  // List users
+  const response = await fetch(`http://127.0.0.1:${port}/api/users`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(Array.isArray(payload.data));
+  for (const user of payload.data) {
+    assert.equal(user.password, undefined, "Password should not be in any user object");
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #4301. The user service was returning the full user object including password field in API responses.

## Changes
- `listUsers()` now maps users to strip password field
- `createUser()` returns user object without password
- Adds 2 tests verifying password exclusion

## Testing
- `node --test src/tests/user.test.js` — 2/2 tests pass

## Security Impact
Prevents password hash exposure through GET /api/users and POST /api/users endpoints.