### PR TITLE
fix: add input validation and length limit to search query parameter (#4349)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
-export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+export async function search(req, res, next) {
+  try {
+    const { q } = searchQuerySchema.parse(req.query);
+    return ok(res, await globalSearch(q));
+  } catch (err) {
+    return next(err);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.name === "ZodError") {
+    return res.status(422).json({
+      success: false,
+      message: "Validation error",
+      errors: err.issues.map(i => ({ path: i.path.join("."), message: i.message }))
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/search should return results for valid query", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/search?q=developer`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(payload.data);
+  assert.equal(payload.data.query, "developer");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/search should reject queries over 200 characters", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const longQuery = "a".repeat(201);
+  const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${longQuery}`);
+
+  assert.equal(response.status, 422, "Should return 422 for query over 200 chars");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/search should handle missing query parameter", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/search`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.ok(payload.data);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().max(200, "Search query must be 200 characters or less").default("")
+});


### PR DESCRIPTION
## Summary
Fixes #4349. The search endpoint had no input validation on the query parameter, allowing arbitrarily long search queries.

## Changes
- Add `searchQuerySchema` with Zod validation (max 200 characters)
- Update search controller to validate query parameter before processing
- Add `ZodError` handling to error handler middleware (returns 422 with structured errors)
- Add 3 tests: valid query, oversized query, missing parameter

## Testing
- `node --test src/tests/search.test.js` — 3/3 tests pass

## Related
- Also fixes #4294 (auth and job validation errors escaping as unhandled Zod exceptions) via the ZodError handler in errorHandler middleware