### PR TITLE
fix: add structured JSON 404 handler for unknown routes (#4361)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,13 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use((req, res) => {
+    res.status(404).json({
+      success: false,
+      message: `Route ${req.method} ${req.path} not found`
+    });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/notfound.test.js
+++ b/apps/api/src/tests/notfound.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Unknown API routes should return structured JSON 404", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/nonexistent`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.includes("not found"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("Unknown root routes should return structured JSON 404", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/unknown-path`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.includes("not found"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("Known routes should still work after 404 handler", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/health`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload, { ok: true, service: "api" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #4361. Unknown API routes were falling through without a structured JSON response.

## Changes
- Add catch-all 404 handler after all route definitions, before error handler
- Returns structured JSON: `{ success: false, message: "Route METHOD /path not found" }`
- Add 3 tests verifying 404 behavior and that known routes still work

## Testing
- `node --test src/tests/notfound.test.js` — 3/3 tests pass