### PR TITLE
Move navigation outside main landmark

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,8 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+header, main { max-width: 960px; margin: 0 auto; padding: 0 1rem; }
+header { padding-top: 2rem; }
+main { padding-bottom: 2rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,11 +10,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <main>
+        <header>
           <h1>FreelanceFlow</h1>
           <Navigation />
-          {children}
-        </main>
+        </header>
+        <main>{children}</main>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Move the repeated site title and global navigation from `main` into a sibling `header`.
- Keep `main` focused on route-specific page content.
- Preserve the existing max-width and page padding across the header/main split.

Closes #4370

/claim #743

## Demo

Short demo clip: https://github.com/tudorian95/bug-bounty/releases/download/demo-securebanana-4370-a15441b/securebanana-main-landmark-demo.gif

## Validation

- `docker run --rm -v /root/codex-bounty/securebanana-landmark-verify:/work -w /work node:20-bookworm-slim npm ci --ignore-scripts`
- `docker run --rm -v /root/codex-bounty/securebanana-landmark-verify:/work -w /work node:20-bookworm-slim npm run build -w apps/web`
- Checked generated `apps/web/.next/server/app/index.html`: `header nav` is present, `main nav` is absent, and `header` appears before `main`.