### PR TITLE
Prevent clients from marking new notifications as read

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores client-supplied read state", async () => {
+  const notification = await createNotification({
+    userId: "usr_1",
+    title: "New proposal",
+    read: true
+  });
+
+  assert.equal(notification.read, false);
+});


### PR DESCRIPTION
Closes #4355

## Summary
- preserve service-owned notification fields after applying client payloads
- prevent `read: true` input from overriding the default unread state
- add a regression test for notification creation

## Tests
- `node --test apps/api/src/tests/notificationService.test.js`