### PR TITLE
Reject unsupported payment currencies

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { createPaymentIntent, isSupportedPaymentCurrency } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  if (!isSupportedPaymentCurrency(req.body?.currency)) {
+    return fail(res, "Unsupported payment currency");
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,29 @@
+const SUPPORTED_PAYMENT_CURRENCIES = new Set(["usd"]);
+
+export function normalizePaymentCurrency(currency) {
+  if (currency == null) {
+    return "usd";
+  }
+
+  if (typeof currency !== "string") {
+    return "";
+  }
+
+  return currency.trim().toLowerCase();
+}
+
+export function isSupportedPaymentCurrency(currency) {
+  return SUPPORTED_PAYMENT_CURRENCIES.has(normalizePaymentCurrency(currency));
+}
+
 export async function createPaymentIntent(payload) {
+  const currency = normalizePaymentCurrency(payload.currency);
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-currency.test.js
+++ b/apps/api/src/tests/payment-currency.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/payments defaults supported currency to usd", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 5000 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments normalizes supported currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 5000, currency: " USD " });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments rejects unsupported currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 5000, currency: "eur" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported payment currency"
+    });
+  });
+});
+
+test("POST /api/payments rejects non-string currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 5000, currency: 123 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported payment currency"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Reject payment intents that request currencies outside the supported `usd` set.
- Normalize accepted USD currency values before returning the mock Stripe intent.
- Add regression coverage for default, normalized, unsupported, and non-string currencies.

Fixes #4343

## Validation
- `node --test .\src\tests\*.js` from `apps/api`
- `git diff --check`

Note: `npm.cmd test --workspace apps/api` fails locally on Windows because `node --test src/tests` resolves the directory as a module path under Node v24; the direct test-file invocation above passes.