### PR TITLE
Prevent admin self-registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,15 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload");
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/register-role.test.js
+++ b/apps/api/src/tests/register-role.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRegister(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/auth/register defaults public registrations to client role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+  });
+});
+
+test("POST /api/auth/register allows freelancer self-registration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/register rejects admin self-registration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid registration payload"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

## Summary
- Remove `admin` from the public registration role schema so callers cannot self-assign elevated privileges.
- Return a structured `400 Bad Request` for invalid registration payloads instead of letting the validation exception become a generic server error.
- Add regression tests covering default client registration, freelancer registration, and rejected admin self-registration.

Fixes #4359

## Validation
- `node --test .\src\tests\*.js` from `apps/api`
- `git diff --check`