### PR TITLE
fix(api): guard process-local rate limiter in production

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,5 +1,16 @@
 import rateLimit from "express-rate-limit";
 
+if (
+  process.env.NODE_ENV === "production" &&
+  process.env.RATE_LIMIT_ALLOW_MEMORY_STORE !== "true"
+) {
+  throw new Error(
+    "RATE_LIMIT_ALLOW_MEMORY_STORE=true is required to use the process-local " +
+      "express-rate-limit MemoryStore in production. Configure a shared store " +
+      "for multi-instance deployments instead."
+  );
+}
+
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,

--- a/apps/api/src/tests/rateLimitStore.test.js
+++ b/apps/api/src/tests/rateLimitStore.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importRateLimitModule(caseName) {
+  return import(`../middleware/rateLimit.js?${caseName}-${Date.now()}`);
+}
+
+test("production refuses implicit process-local rate limit storage", async () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousAllowMemoryStore = process.env.RATE_LIMIT_ALLOW_MEMORY_STORE;
+
+  try {
+    process.env.NODE_ENV = "production";
+    delete process.env.RATE_LIMIT_ALLOW_MEMORY_STORE;
+
+    await assert.rejects(
+      () => importRateLimitModule("prod-memory-store-guard"),
+      /RATE_LIMIT_ALLOW_MEMORY_STORE/
+    );
+  } finally {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    if (previousAllowMemoryStore === undefined) {
+      delete process.env.RATE_LIMIT_ALLOW_MEMORY_STORE;
+    } else {
+      process.env.RATE_LIMIT_ALLOW_MEMORY_STORE = previousAllowMemoryStore;
+    }
+  }
+});
+
+test("production can explicitly opt in to process-local rate limit storage", async () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousAllowMemoryStore = process.env.RATE_LIMIT_ALLOW_MEMORY_STORE;
+
+  try {
+    process.env.NODE_ENV = "production";
+    process.env.RATE_LIMIT_ALLOW_MEMORY_STORE = "true";
+
+    const { apiLimiter } = await importRateLimitModule("prod-memory-store-opt-in");
+
+    assert.equal(typeof apiLimiter, "function");
+  } finally {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    if (previousAllowMemoryStore === undefined) {
+      delete process.env.RATE_LIMIT_ALLOW_MEMORY_STORE;
+    } else {
+      process.env.RATE_LIMIT_ALLOW_MEMORY_STORE = previousAllowMemoryStore;
+    }
+  }
+});


### PR DESCRIPTION
Closes #4377

/claim #743

## Summary

- Adds an explicit production guard for the default process-local `express-rate-limit` MemoryStore.
- Requires `RATE_LIMIT_ALLOW_MEMORY_STORE=true` before production can intentionally run with isolated in-memory counters.
- Adds focused regression coverage for both the unsafe implicit production path and the explicit opt-in path.

## Why

`apiLimiter` currently omits a shared `store`, so each Node process/API instance owns its own hit counter. In multi-instance deployments, that silently multiplies the effective limit by the number of processes. This PR keeps the existing limiter settings but prevents production from silently relying on process-local counters.

## Reproduction of the original problem

I reproduced the issue by starting two independent Node processes serving the same `createApp()` endpoint, exhausting the limiter on process A, then sending requests to process B:

```json
{
  "a_first_200": { "200": 200 },
  "a_201st": { "429": 1 },
  "b_first_200_after_a_exhausted": { "200": 200 },
  "b_201st": { "429": 1 }
}
```

That proves the current quota is process-local, not shared across API instances.

## Changes

| File | Change |
| --- | --- |
| `apps/api/src/middleware/rateLimit.js` | Throws in production unless process-local MemoryStore usage is explicitly allowed. |
| `apps/api/src/tests/rateLimitStore.test.js` | Adds regression tests for implicit production rejection and explicit opt-in. |

## Verification

- [x] `node --test apps/api/src/tests/rateLimitStore.test.js`
- [x] `node --test apps/api/src/tests/*.test.js`
- [x] `node --check apps/api/src/middleware/rateLimit.js`
- [x] `node --check apps/api/src/tests/rateLimitStore.test.js`

Known upstream issue, not changed here to keep this PR scoped to #4377:

- `npm test -w apps/api` currently fails because `apps/api/package.json` runs `node --test src/tests`, and Node v24 treats that directory path as a missing module entry point.

## Scope control

This does not change malformed JSON ordering, health-check exemptions, trust-proxy behavior, auth-specific limits, 429 response shape, or limiter thresholds.