### PR TITLE
Forward standard props from shared Button

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const defaultButtonStyle: React.CSSProperties = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children, style, type = "button", ...props }: ButtonProps) {
   return (
     <button
-      style={{
-        background: "#5468ff",
-        color: "white",
-        border: "none",
-        borderRadius: 8,
-        padding: "0.6rem 0.9rem",
-        cursor: "pointer"
-      }}
+      {...props}
+      type={type}
+      style={{ ...defaultButtonStyle, ...style }}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary

Fixes #4380
/claim #743

The shared `Button` component in `packages/ui` only accepted `children`, so normal button attributes such as `onClick`, `type`, `disabled`, `className`, `aria-*`, and style overrides were dropped before reaching the underlying `<button>`.

This PR:
- types `Button` with `React.ButtonHTMLAttributes<HTMLButtonElement>`;
- forwards remaining button props to the rendered `<button>`;
- defaults `type` to `button` to avoid accidental form submission;
- preserves the existing default visual style while allowing caller `style` overrides.

## Validation

Validated in WSL Docker with `node:20-bookworm-slim` from pushed branch `fix-ui-button-props` at `7279a595b3492689bee9b6a9f2b912c20bf35725`:

```text
npm ci --ignore-scripts
npm run build -w apps/web
./node_modules/.bin/tsc --jsx react-jsx --module esnext --target es2022 --moduleResolution bundler --noEmit --skipLibCheck --esModuleInterop --strict packages/ui/src/Button.tsx packages/ui/src/index.ts
```

All commands completed successfully. The npm audit output still reports the existing 3 moderate dependency advisories; this PR does not change dependencies.