### PR TITLE
Forward standard props from shared Card

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,19 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+const defaultCardStyle: React.CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: "1rem"
+};
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section {...props} style={{ ...defaultCardStyle, ...style }}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
## Summary

Fixes #4383
/claim #743

The shared `Card` component in `packages/ui` only accepted `title` and `children`, so normal section/container attributes such as `id`, `className`, `aria-*`, `data-*`, and style overrides were dropped before reaching the rendered `<section>`.

This PR:
- types `Card` with standard React HTML attributes for its section container;
- forwards remaining props to the rendered `<section>`;
- preserves the existing default card style while allowing caller `style` overrides.

## Validation

Validated in WSL Docker with `node:20-bookworm-slim` from pushed branch `fix-ui-card-props` at `f60668747f777684b7e012d7f5380201ec621c28`:

```text
npm ci --ignore-scripts
npm run build -w apps/web
./node_modules/.bin/tsc --jsx react-jsx --module esnext --target es2022 --moduleResolution bundler --noEmit --skipLibCheck --esModuleInterop --strict packages/ui/src/Card.tsx packages/ui/src/index.ts
```

All commands completed successfully. The npm audit output still reports the existing 3 moderate dependency advisories; this PR does not change dependencies.