### PR TITLE
Remove stale Next.js version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
+- `apps/web` — Next.js App Router frontend
 - `apps/api` — Express.js backend with layered REST API
 - `packages/db` — Prisma schema and database package
 - `packages/ui` — Shared UI components


### PR DESCRIPTION
﻿## Summary

Fixes #4386
/claim #743

The README said `apps/web` is a "Next.js 14 App Router frontend", but `apps/web/package.json` currently depends on Next `16.2.6`. This PR removes the stale major-version claim and keeps the README accurate without needing a version bump every time the frontend package updates.

## Validation

```text
rg -n 'Next\.js 14' README.md
# no matches

rg -n 'Next\.js App Router' README.md
# README.md:10:- `apps/web` ? Next.js App Router frontend

rg -n '"next"' apps/web/package.json
# apps/web/package.json:15:    "next": "16.2.6",

git diff --check
# clean; Git emitted the existing Windows line-ending warning for README.md
```
