### PR TITLE
fix: reject inverted job budget ranges in validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Closes #2853

Added refine() validation to createJobSchema to reject jobs where budgetMax < budgetMin.