### PR TITLE
fix: reject empty file submissions in upload endpoint

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file || req.file.size === 0) {
+    return fail(res, "File is required and must not be empty", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Closes #2850

Added validation to reject upload requests with no file or an empty file (0 bytes) with a 400 error.