### PR TITLE
fix: resolve freelancer profile by username with mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find((f) => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Username: <strong>{profile.username}</strong></p>
+      <p>Skills: {profile.skills.join(", ")}</p>
+      <p>Rate: {profile.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #2849

Imported mock freelancers data and resolved the profile page by matching the URL username parameter. Added a not-found fallback for unknown usernames.