### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/jobRoutes.budget.test.js
+++ b/apps/api/src/tests/jobRoutes.budget.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJob = {
+  title: "Build auth",
+  description: "Build an authentication flow",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "cat_web",
+  skills: ["Node.js"]
+};
+
+test("POST /api/jobs accepts valid budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 500);
+    assert.equal(payload.data.budgetMax, 1200);
+  });
+});
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...validJob, budgetMin: 1200, budgetMax: 500 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid job payload" });
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine((job) => job.budgetMax >= job.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial();


### PR DESCRIPTION
## Summary

Fixes #4400
/claim #743

POST /api/jobs accepted impossible budget ranges where budgetMin was greater than budgetMax. This PR adds a focused cross-field validation rule and returns a structured 400 response for invalid job payloads instead of creating the job.

## Changes

- Add a budget range refinement to createJobSchema.
- Preserve the existing updateJobSchema partial behavior by keeping the base job schema separate from the create-only refinement.
- Map invalid job creation payloads to `{ success: false, message: "Invalid job payload" }` with HTTP 400.
- Add route-level regression coverage for valid and inverted budget ranges.

## Validation

- `node --test apps/api/src/tests/jobRoutes.budget.test.js`
- `node --test apps/api/src/tests/*.js`
- `node --check apps/api/src/controllers/jobController.js`
- `node --check apps/api/src/validators/job.js`
- `git diff --check`
