### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a freelance client",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["nextjs"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error.issues[0].message, /budgetMax/i);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.match(result.error.issues[0].message, /budgetMax/i);
+});
+
+test("job schemas accept ordered budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(
+    updateJobSchema.safeParse({ budgetMin: 100, budgetMax: 500 }).success,
+    true
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const hasValidBudgetRange = (job) =>
+  job.budgetMin === undefined ||
+  job.budgetMax === undefined ||
+  job.budgetMax >= job.budgetMin;
+
+const budgetRangeMessage = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchemaBase.refine(
+  hasValidBudgetRange,
+  budgetRangeMessage
+);
+
+export const updateJobSchema = jobSchemaBase.partial().refine(
+  hasValidBudgetRange,
+  budgetRangeMessage
+);


### PR DESCRIPTION
## Summary

- Adds a shared budget range refinement for job creation and partial job updates.
- Rejects inverted ranges where `budgetMax` is lower than `budgetMin`.
- Adds regression coverage for create, update, and valid ordered ranges.

Closes #4403

/claim #743

## Validation

```sh
node --test apps/api/src/tests/jobValidator.test.js
node --test apps/api/src/tests/*.test.js
```

Both commands pass locally.

Note: `npm test -w apps/api` currently fails because the existing script invokes `node --test src/tests`, which Node resolves as a missing module path in this environment. Running the test files directly passes.
