### PR TITLE
fix: preserve job server-owned fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob preserves server-owned id and open status", async () => {
+  const job = await createJob({
+    id: "client_supplied_id",
+    title: "Build a dashboard",
+    status: "closed"
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "client_supplied_id");
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
## Summary

- Preserves the server-generated job `id` during job creation.
- Preserves the initial `status: "open"` value during job creation.
- Adds regression coverage proving client payload fields cannot override those server-owned values.

Closes #4405

/claim #743

## Validation

```sh
node --test apps/api/src/tests/jobService.test.js
node --test apps/api/src/tests/*.test.js
```

Both commands pass locally.
