### PR TITLE
fix: reject blank auth passwords

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects whitespace-only passwords", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "user@example.com",
+      password: "        ",
+      role: "client"
+    });
+  });
+});
+
+test("loginSchema rejects whitespace-only passwords", () => {
+  assert.throws(() => {
+    loginSchema.parse({
+      email: "user@example.com",
+      password: "        "
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
+const passwordSchema = z.string().min(8).refine((password) => password.trim().length > 0, {
+  message: "Password cannot be blank"
+});
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
## Summary
- add auth validator tests for whitespace-only registration and login passwords
- reuse a shared auth password schema that keeps the existing minimum length rule and rejects blank passwords

## Tests
- `node --test apps/api/src/tests/authValidator.test.js`
- `node --test apps/api/src/tests/*.test.js`

Closes #4409
/claim #743
