### PR TITLE
fix: reject upload requests without a file with 400 status (fixes #4411)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in upload request", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads rejects request without file with 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const url = "http://127.0.0.1:" + port + "/api/uploads";
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "multipart/form-data; boundary=testboundary" },
+    body: "--testboundary\r\nContent-Disposition: form-data; name=\"not-a-file\"\r\n\r\nhello\r\n--testboundary--"
+  });
+
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+  assert.ok(payload.message);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads accepts request with file and returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const url = "http://127.0.0.1:" + port + "/api/uploads";
+  const boundary = "----boundary123";
+  const body = [
+    "--" + boundary,
+    'Content-Disposition: form-data; name="file"; filename="test.txt"',
+    "Content-Type: text/plain",
+    "",
+    "hello world",
+    "--" + boundary + "--"
+  ].join("\r\n");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "multipart/form-data; boundary=" + boundary },
+    body
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.status, "uploaded");
+  assert.equal(payload.data.filename, "test.txt");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Fix: reject empty upload submissions with 400

**What:** `POST /api/uploads` now rejects requests that do not include a `file` field with a clear `400` response. The `uploadFile` controller checks `req.file` before proceeding and calls `fail()` with a descriptive message when no file is present.

**Why:** The endpoint previously returned `201` with `success: true` and `status: "no-file"` even when no file was uploaded, making it impossible for clients to distinguish successful uploads from empty submissions. This is a contract violation — a 2xx response implies success.

**Testing:** Added two route-level tests using `node:test`:
- No-file request → asserts `400` status, `success: false`, and a non-empty error message
- Valid file request → asserts `201` status, `success: true`, `status: "uploaded"`, and correct filename

Fixes: #4411