### PR TITLE
fix: reject invalid auth token claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,20 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
+function hasValidIdentityClaims(payload) {
+  return (
+    payload &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    typeof payload.sub === "string" &&
+    payload.sub.trim().length > 0 &&
+    typeof payload.role === "string" &&
+    allowedRoles.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +22,12 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!hasValidIdentityClaims(payload)) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getAdminMetrics(token) {
+  return withServer((baseUrl) =>
+    fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+  );
+}
+
+test("auth middleware accepts valid access token claims", async () => {
+  const token = signAccessToken({ sub: "usr_123", role: "client" });
+  const response = await getAdminMetrics(token);
+
+  assert.equal(response.status, 200);
+});
+
+test("auth middleware rejects tokens missing subject claim", async () => {
+  const token = signAccessToken({ role: "client" });
+  const response = await getAdminMetrics(token);
+
+  assert.equal(response.status, 401);
+});
+
+test("auth middleware rejects tokens with unsupported roles", async () => {
+  const token = signAccessToken({ sub: "usr_123", role: "owner" });
+  const response = await getAdminMetrics(token);
+
+  assert.equal(response.status, 401);
+});
+
+test("auth middleware rejects non-object JWT payloads", async () => {
+  const token = jwt.sign("usr_123", env.jwtSecret);
+  const response = await getAdminMetrics(token);
+
+  assert.equal(response.status, 401);
+});


### PR DESCRIPTION
## Summary
- reject verified JWTs that are not object payloads
- reject auth tokens missing a non-empty subject claim
- reject auth tokens with unsupported role claims
- add route coverage for valid and invalid auth token claims

## Tests
- `node --test apps/api/src/tests/authMiddleware.test.js`
- `node --test apps/api/src/tests/*.test.js`

Closes #4417
/claim #743
