### PR TITLE
fix(reviews): add input validation and authentication to POST /api/reviews

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues, 400);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve) => {
+    server.once("listening", () => resolve(server));
+  });
+}
+
+function baseUrl(server) {
+  const { port } = server.address();
+  return `http://127.0.0.1:${port}`;
+}
+
+function authHeader() {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+}
+
+// ─── POST /api/reviews ────────────────────────────────────────
+
+test("POST /api/reviews without auth returns 401", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 5, text: "Great!", jobId: "j1", freelancerId: "f1" }),
+    });
+    const payload = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(payload.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/reviews with auth but missing required fields returns 400", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader() },
+      body: JSON.stringify({}),
+    });
+    const payload = await res.json();
+    assert.equal(res.status, 400);
+    assert.equal(payload.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/reviews with invalid rating returns 400", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader() },
+      body: JSON.stringify({ rating: 10, text: "Good job", jobId: "j1", freelancerId: "f1" }),
+    });
+    const payload = await res.json();
+    assert.equal(res.status, 400);
+    assert.equal(payload.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/reviews with valid payload returns 201", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader() },
+      body: JSON.stringify({ rating: 4, text: "Solid work", jobId: "j_123", freelancerId: "f_456" }),
+    });
+    const payload = await res.json();
+    assert.equal(res.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 4);
+    assert.equal(payload.data.jobId, "j_123");
+    assert.equal(payload.data.freelancerId, "f_456");
+    assert.ok(payload.data.id.startsWith("rev_"));
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/reviews rejects string rating (must be integer)", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeader() },
+      body: JSON.stringify({ rating: "five", text: "Nice", jobId: "j1", freelancerId: "f1" }),
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+// ─── GET /api/reviews ─────────────────────────────────────────
+
+test("GET /api/reviews returns array (no auth required)", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/reviews`);
+    const payload = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  } finally {
+    await closeServer(server);
+  }
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  text: z.string().min(1).max(2000),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+});
+
+export const updateReviewSchema = createReviewSchema.partial();


### PR DESCRIPTION
## What

Adds Zod input validation and authentication middleware to `POST /api/reviews`.

## Why

The review creation endpoint was completely unprotected:
- **No authentication** — anonymous users could submit reviews without logging in
- **No input validation** — rating could be any value (string, negative, >5), jobId/freelancerId were optional, text was untyped
- **Security risk** — anyone could spam fake reviews for any job/freelancer

## Changes

| File | Change |
|------|--------|
| `validators/review.js` | **New** — Zod schema: `rating` (int 1-5), `text` (1-2000 chars), `jobId`, `freelancerId` (all required) |
| `controllers/reviewController.js` | Use `safeParse` + return 400 with validation errors on failure |
| `routes/reviewRoutes.js` | Add `authMiddleware` to `POST /` route |
| `tests/review.test.js` | **New** — 6 tests covering auth rejection, validation errors, valid creation, type safety |

## Tests

All 6 new tests pass. Existing `health.test.js` still passes (0 regressions).

```
✔ POST /api/reviews without auth returns 401
✔ POST /api/reviews with auth but missing required fields returns 400
✔ POST /api/reviews with invalid rating returns 400
✔ POST /api/reviews with valid payload returns 201
✔ POST /api/reviews rejects string rating (must be integer)
✔ GET /api/reviews returns array (no auth required)
```

## How to verify

```bash
cd apps/api && node --test src/tests/review.test.js
```

Closes #4419 (ref #743)