### PR TITLE
Use server-owned payment pricing

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload");
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,27 @@
+export const paymentPriceCatalog = {
+  project_deposit: {
+    amount: 100,
+    currency: "usd"
+  },
+  featured_job: {
+    amount: 25,
+    currency: "usd"
+  }
+};
+
 export async function createPaymentIntent(payload) {
+  const price = paymentPriceCatalog[payload.priceId];
+
+  if (!price) {
+    throw new Error(`Unknown payment price: ${payload.priceId}`);
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    priceId: payload.priceId,
+    amount: price.amount,
+    currency: price.currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/payments uses server-owned pricing for payment intents", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      priceId: "project_deposit",
+      amount: 1,
+      currency: "eur"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.priceId, "project_deposit");
+    assert.equal(payload.data.amount, 100);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments rejects client-supplied amounts without a server price", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 1,
+      currency: "usd"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+import { paymentPriceCatalog } from "../services/paymentService.js";
+
+export const createPaymentSchema = z.object({
+  priceId: z.string().min(1).refine((priceId) => Object.hasOwn(paymentPriceCatalog, priceId))
+});


### PR DESCRIPTION
﻿## Summary
- add a server-side payment price catalog keyed by `priceId`
- validate payment creation requests against known server-owned price ids
- resolve payment intent `amount` and `currency` from the server catalog instead of request body values
- add route coverage proving client-supplied monetary fields cannot override the server price

## Why
`POST /api/payments` previously forwarded `req.body` to `createPaymentIntent()`, allowing callers to control the amount/currency used for a payment intent. The payment flow should accept a server-owned price reference, then derive money fields on the API side.

## Validation
- `node --test .\src\tests\*.js`

Fixes #4421
Related #4376
/claim #743
