### PR TITLE
fix(proposal): add zod validation and preserve server-generated id

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,12 +1,20 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { ZodError } from "zod";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
-export async function postProposal(req, res) {
-  const payload = createProposalSchema.parse(req.body);
-  return ok(res, await createProposal(payload), 201);
+export async function postProposal(req, res, next) {
+  try {
+    const payload = createProposalSchema.parse(req.body);
+    return ok(res, await createProposal(payload), 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, error.errors, 400);
+    }
+    return next(error);
+  }
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -55,7 +55,7 @@ test("Proposal API", async (t) => {
       body: JSON.stringify(payload)
     });
 
-    assert.equal(response.status, 500); // errorHandler handles Zod validation errors as 500 currently
+    assert.equal(response.status, 400);
   });
 
   await t.test("POST /api/proposals rejects non-positive bidAmount", async () => {
@@ -73,7 +73,7 @@ test("Proposal API", async (t) => {
       body: JSON.stringify(payload)
     });
 
-    assert.equal(response.status, 500);
+    assert.equal(response.status, 400);
   });
 
   await t.test("POST /api/proposals ignores client-controlled id", async () => {

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Proposal API", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/proposals`;
+
+  await t.test("POST /api/proposals creates proposal successfully with valid data", async () => {
+    const payload = {
+      coverLetter: "This is a very professional cover letter for the project.",
+      bidAmount: 250,
+      estDuration: "5 days",
+      jobId: "job_123",
+      freelancerId: "usr_456"
+    };
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.ok(body.data.id.startsWith("prp_"));
+    assert.equal(body.data.coverLetter, payload.coverLetter);
+    assert.equal(body.data.bidAmount, payload.bidAmount);
+    assert.equal(body.data.estDuration, payload.estDuration);
+    assert.equal(body.data.jobId, payload.jobId);
+    assert.equal(body.data.freelancerId, payload.freelancerId);
+  });
+
+  await t.test("POST /api/proposals rejects short coverLetter", async () => {
+    const payload = {
+      coverLetter: "Short",
+      bidAmount: 250,
+      estDuration: "5 days",
+      jobId: "job_123",
+      freelancerId: "usr_456"
+    };
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    assert.equal(response.status, 500); // errorHandler handles Zod validation errors as 500 currently
+  });
+
+  await t.test("POST /api/proposals rejects non-positive bidAmount", async () => {
+    const payload = {
+      coverLetter: "This is a very professional cover letter for the project.",
+      bidAmount: -10,
+      estDuration: "5 days",
+      jobId: "job_123",
+      freelancerId: "usr_456"
+    };
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    assert.equal(response.status, 500);
+  });
+
+  await t.test("POST /api/proposals ignores client-controlled id", async () => {
+    const payload = {
+      id: "hacked_id_123",
+      coverLetter: "This is a very professional cover letter for the project.",
+      bidAmount: 500,
+      estDuration: "2 weeks",
+      jobId: "job_789",
+      freelancerId: "usr_999"
+    };
+
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.notEqual(body.data.id, "hacked_id_123");
+    assert.ok(body.data.id.startsWith("prp_"));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});
+
+export const updateProposalSchema = createProposalSchema.partial();


### PR DESCRIPTION
This PR resolves the missing input validation and the client-controlled \id\ bypass vulnerability for the proposal creation endpoint (\POST /api/proposals\).

### Changes:
1. Created \pps/api/src/validators/proposal.js\ with \createProposalSchema\ Zod validation schema.
2. Modified \pps/api/src/controllers/proposalController.js\ to parse request body with \createProposalSchema\ before creating proposal. This ensures input parameters (\coverLetter\, \idAmount\, \estDuration\, \jobId\, \reelancerId\) are properly validated, and any extra parameters (like \id\) are stripped, preserving the server-generated \id\.
3. Created \pps/api/src/tests/proposal.test.js\ to test valid proposal creation, validation limits (invalid bidAmount, short coverLetter), and client-supplied \id\ overrides.

/claim #743
Closes #4423