### PR TITLE
Validate authenticated review creation

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid review payload");
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_reviewer", role: "client" });
+
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json"
+  };
+}
+
+async function postReview(baseUrl, payload, headers = authHeaders()) {
+  return fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/reviews rejects anonymous review creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(
+      baseUrl,
+      {
+        rating: 5,
+        text: "Great work",
+        jobId: "job_1",
+        freelancerId: "usr_freelancer"
+      },
+      { "Content-Type": "application/json" }
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/reviews rejects missing required review fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      rating: 5,
+      text: "Great work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews rejects ratings outside the 1-5 scale", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      rating: 6,
+      text: "Great work",
+      jobId: "job_1",
+      freelancerId: "usr_freelancer"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews creates valid authenticated reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      rating: 5,
+      text: "Great work",
+      jobId: "job_1",
+      freelancerId: "usr_freelancer"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_/);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.text, "Great work");
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.freelancerId, "usr_freelancer");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  text: z.string().min(1).max(2000),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
﻿## Summary
- protect `POST /api/reviews` with the existing bearer auth middleware
- add a focused review creation schema for `rating`, `text`, `jobId`, and `freelancerId`
- return a structured `400` for invalid review payloads
- add route-level coverage for missing auth, missing fields, invalid ratings, and valid creation

## Why
Review creation previously forwarded `req.body` directly into the service layer and did not require authentication. That allowed anonymous callers to create reviews with missing resource ids or ratings outside the expected 1-5 scale.

## Validation
- `node --test .\src\tests\*.js`

Fixes #4424
Related #4419
/claim #743
