### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload");
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+function validProposal(overrides = {}) {
+  return {
+    coverLetter: "I can complete this project with a focused implementation plan.",
+    bidAmount: 250,
+    estDuration: "2 weeks",
+    jobId: "job_1",
+    freelancerId: "usr_freelancer",
+    ...overrides
+  };
+}
+
+test("POST /api/proposals rejects missing required proposal fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, {
+      coverLetter: "I can help"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals rejects non-positive bid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, validProposal({ bidAmount: 0 }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals preserves server-generated ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, validProposal({ id: "prp_attacker" }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.notEqual(payload.data.id, "prp_attacker");
+    assert.equal(payload.data.bidAmount, 250);
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.freelancerId, "usr_freelancer");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(10).max(4000),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1).max(100),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
﻿## Summary
- add a focused proposal creation schema for required proposal fields
- return a structured `400` for invalid proposal payloads
- keep proposal ids server-owned by assigning the generated `prp_*` id after accepted payload fields
- add route coverage for missing fields, invalid bid amounts, and caller-supplied id overrides

## Why
`POST /api/proposals` previously forwarded `req.body` directly to `createProposal()`, and the service spread caller payloads after the generated id. That allowed incomplete proposal records and caller-controlled proposal identifiers.

## Validation
- `node --test .\src\tests\*.js`

Fixes #4428
Related #4423
/claim #743
