### PR TITLE
Require auth for payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/payment-auth.test.js
+++ b/apps/api/src/tests/payment-auth.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, payload, headers = { "Content-Type": "application/json" }) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/payments rejects anonymous payment creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 100,
+      currency: "usd"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/payments allows authenticated payment creation", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await postPayment(
+      baseUrl,
+      {
+        amount: 100,
+        currency: "usd"
+      },
+      {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      }
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.paymentId, /^pay_/);
+    assert.equal(payload.data.amount, 100);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
﻿## Summary
- protect `POST /api/payments` with the existing bearer auth middleware
- add route coverage proving anonymous payment creation returns `401`
- add route coverage proving authenticated requests still reach the existing payment controller

## Why
Payment intent creation is a user/session-bound workflow. The payment route previously mounted `createPayment` directly, so anonymous callers could create payment intents without a bearer token.

## Validation
- `node --test .\src\tests\*.js`

Fixes #4430
Related #4407
/claim #743
