### PR TITLE
fix(payment): resolve payment amount server-side via jobId lookup

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,17 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { ZodError } from "zod";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    const payload = createPaymentSchema.parse(req.body);
+    const result = await createPaymentIntent(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, error.errors, 400);
+    }
+    return next(error);
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,16 @@
+import { listJobs } from "./jobService.js";
+
 export async function createPaymentIntent(payload) {
+  const jobs = await listJobs();
+  const job = jobs.find((j) => j.id === payload.jobId);
+  if (!job) {
+    throw new Error("Job not found");
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount: job.budgetMax,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Payment API", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const jobUrl = `http://127.0.0.1:${port}/api/jobs`;
+  const paymentUrl = `http://127.0.0.1:${port}/api/payments`;
+
+  await t.test("POST /api/payments resolves payment amount server-side based on jobId", async () => {
+    // 1. Create a job first
+    const jobPayload = {
+      title: "Develop high-performance REST API backend",
+      description: "Looking for an expert to build and optimize Express REST APIs with TypeScript.",
+      budgetMin: 500,
+      budgetMax: 750,
+      categoryId: "cat_backend",
+      skills: ["Node.js", "Express", "Zod"]
+    };
+
+    const jobResponse = await fetch(jobUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(jobPayload)
+    });
+
+    const jobData = await jobResponse.json();
+    assert.equal(jobResponse.status, 201);
+    const createdJobId = jobData.data.id;
+
+    // 2. Create a payment intent using the jobId and check that the amount is set by the server
+    const paymentPayload = {
+      jobId: createdJobId,
+      currency: "usd"
+    };
+
+    const paymentResponse = await fetch(paymentUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(paymentPayload)
+    });
+
+    const paymentData = await paymentResponse.json();
+
+    assert.equal(paymentResponse.status, 201);
+    assert.ok(paymentData.data.paymentId.startsWith("pay_"));
+    // The amount MUST equal job's budgetMax (750) rather than being specified by the client
+    assert.equal(paymentData.data.amount, 750);
+    assert.equal(paymentData.data.currency, "usd");
+  });
+
+  await t.test("POST /api/payments rejects unknown jobId", async () => {
+    const paymentPayload = {
+      jobId: "job_does_not_exist",
+      currency: "usd"
+    };
+
+    const paymentResponse = await fetch(paymentUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(paymentPayload)
+    });
+
+    assert.equal(paymentResponse.status, 500);
+  });
+
+  await t.test("POST /api/payments rejects missing jobId in payload", async () => {
+    const paymentPayload = {
+      currency: "usd"
+    };
+
+    const paymentResponse = await fetch(paymentUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(paymentPayload)
+    });
+
+    assert.equal(paymentResponse.status, 400);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  jobId: z.string().min(1),
+  currency: z.string().min(1).default("usd")
+});


### PR DESCRIPTION
This PR fixes the critical security vulnerability where the payment amount was controlled on the client-side.

### Changes:
1. Created \pps/api/src/validators/payment.js\ with a Zod schema to validate payment payload inputs, requiring a valid \jobId\ and optional \currency\.
2. Modified \pps/api/src/controllers/paymentController.js\ to parse request body with \createPaymentSchema\ and handle validation errors cleanly, returning a structured \400\ status.
3. Modified \pps/api/src/services/paymentService.js\ to resolve the payment \mount\ on the server-side by fetching the corresponding job from the database via \jobId\ and using the job's \udgetMax\ instead of trusting the user-supplied input.
4. Created \pps/api/src/tests/payment.test.js\ to cover valid payment processing (checking that amount is resolved correctly), rejecting unknown \jobId\ values (500), and rejecting payloads missing \jobId\ (400).

/claim #743
Closes #4434