### PR TITLE
fix: reject inverted job budget ranges (resolves #2853)

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a REST API",
+  description: "Create a full REST API with authentication and CRUD",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "tech",
+  skills: ["nodejs", "typescript"],
+};
+
+// --- createJobSchema ---
+
+test("createJobSchema: accepts valid job with budgetMax >= budgetMin", () => {
+  const result = createJobSchema.safeParse(validJob);
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema: accepts equal budgetMin and budgetMax", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 500, budgetMax: 500 });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema: rejects inverted budget range (budgetMax < budgetMin)", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 1000, budgetMax: 500 });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.message.includes("budgetMax")));
+});
+
+test("createJobSchema: rejects when budgetMax is zero but budgetMin is positive", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 100, budgetMax: 0 });
+  assert.equal(result.success, false);
+});
+
+test("createJobSchema: rejects missing required fields", () => {
+  const result = createJobSchema.safeParse({ title: "Hi" });
+  assert.equal(result.success, false);
+});
+
+// --- updateJobSchema ---
+
+test("updateJobSchema: accepts partial update with only title", () => {
+  const result = updateJobSchema.safeParse({ title: "Updated title" });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema: accepts valid budget range in partial update", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 100, budgetMax: 200 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema: rejects inverted budget range when both fields present", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 100 });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.message.includes("budgetMax")));
+});
+
+test("updateJobSchema: allows only budgetMin without budgetMax (no comparison needed)", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 200 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema: allows only budgetMax without budgetMin (no comparison needed)", () => {
+  const result = updateJobSchema.safeParse({ budgetMax: 800 });
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,31 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: z.array(z.string().min(1)).default([]),
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
+
+export const updateJobSchema = jobBaseSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #2853 — `createJobSchema` now rejects payloads where `budgetMax < budgetMin`.

## Changes

- **`apps/api/src/validators/job.js`**: Extracted base schema, added Zod `.refine()` to both `createJobSchema` and `updateJobSchema` to validate budget range order.
- **`apps/api/src/tests/jobValidator.test.js`**: Added 10 tests covering valid ranges, equal budgets, inverted ranges, and partial update scenarios.

## How it works

- `createJobSchema`: Always requires `budgetMax >= budgetMin` (fails hard on inverted ranges).
- `updateJobSchema`: Only validates range order when **both** `budgetMin` and `budgetMax` are present in the partial update. If only one is provided, no comparison is needed (allows incremental updates).

## Tests

All 11 tests pass (1 existing health test + 10 new validator tests):
- ✅ Accepts valid ranges (budgetMax > budgetMin)
- ✅ Accepts equal ranges (budgetMax == budgetMin)  
- ✅ Rejects inverted ranges (budgetMax < budgetMin)
- ✅ Rejects budgetMax=0 with positive budgetMin
- ✅ Partial updates: only validates when both fields present
- ✅ Partial updates: allows single-field updates without comparison

```
git -C . diff main...ranukita/fdfde6 --stat
 apps/api/src/tests/jobValidator.test.js | 68 +++++++++++++++++++++++++++
 apps/api/src/validators/job.js          | 25 ++++++++++--
 2 files changed, 90 insertions(+), 3 deletions(-)
```