### PR TITLE
Fix auth token claim validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,20 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
+function hasUsableIdentityClaims(payload) {
+  return Boolean(
+    payload &&
+      typeof payload === "object" &&
+      !Array.isArray(payload) &&
+      typeof payload.sub === "string" &&
+      payload.sub.trim().length > 0 &&
+      typeof payload.role === "string" &&
+      allowedRoles.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +22,12 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!hasUsableIdentityClaims(payload)) {
+      return fail(res, "Invalid token claims", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth-middleware-claims.test.js
+++ b/apps/api/src/tests/auth-middleware-claims.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getAdminMetrics(baseUrl, token) {
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  return { response, payload: await response.json() };
+}
+
+test("authMiddleware accepts valid identity claims", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const { response, payload } = await getAdminMetrics(baseUrl, token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});
+
+test("authMiddleware rejects tokens missing sub", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ role: "client" });
+    const { response, payload } = await getAdminMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token claims");
+  });
+});
+
+test("authMiddleware rejects blank sub claims", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "   ", role: "client" });
+    const { response, payload } = await getAdminMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token claims");
+  });
+});
+
+test("authMiddleware rejects unsupported roles", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "owner" });
+    const { response, payload } = await getAdminMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token claims");
+  });
+});
+
+test("authMiddleware rejects non-object JWT payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const token = jwt.sign("usr_1", env.jwtSecret);
+    const { response, payload } = await getAdminMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token claims");
+  });
+});


### PR DESCRIPTION
Refs #4417

/claim #743

## Summary

- Validate decoded access-token payloads inside `authMiddleware`.
- Require a non-empty string `sub` claim.
- Require `role` to be one of the supported application roles.
- Reject verified tokens with missing, blank, unsupported, array, or non-object identity payloads.
- Preserve valid app-issued bearer tokens for protected routes.
- Update the API test script so the route-level regression tests are discovered reliably.
- Refreshed the branch onto current GitHub `main` (`0a1d1f`) so this pending claim is aligned with the latest repository state.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
tests 6
pass 6
fail 0
```

Covered cases:

- Valid identity claims can access a protected route.
- Tokens missing `sub` are rejected.
- Tokens with blank `sub` are rejected.
- Tokens with unsupported roles are rejected.
- Non-object JWT payloads are rejected.
- `GET /health` still returns the expected ok payload.

## Scope

Auth middleware identity-claim validation, focused tests, and API test discovery only. No token signing, role assignment, route authorization policy, payment, upload, webhook, payout, secrets, or unrelated API behavior changed.