### PR TITLE
Fix job detail route mock lookup

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,36 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+  const job = jobs.find((item) => item.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job listing exists for <strong>{id}</strong>.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <h3>Project context</h3>
+      <ul>
+        {job.deliverables.map((deliverable) => (
+          <li key={deliverable}>{deliverable}</li>
+        ))}
+      </ul>
+      <Link href="/jobs">Back to job listings</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,25 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create an embeddable support widget that answers common customer questions with AI-assisted responses.",
+    deliverables: ["Embeddable web widget", "Knowledge-base prompt flow", "Basic analytics events"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Move an existing REST API onto a Node.js service while preserving the current public contract.",
+    deliverables: ["Node.js API implementation", "Migration checklist", "Regression test coverage"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Design user onboarding screens that help new SaaS teams invite members and complete setup.",
+    deliverables: ["Onboarding flow wireframes", "Empty-state copy", "Responsive handoff notes"]
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
Closes #4437

/claim #743

## Summary

- Resolve `/jobs/[id]` against `apps/web/lib/mock.ts` instead of rendering the raw route id.
- Render the selected mock job title, budget, summary, and project context for known ids.
- Show a clear fallback for unknown job ids with a link back to job listings.

## Demo video

![Job detail route demo](https://github.com/henryle1/bug-bounty/releases/download/job-detail-route-demo-4437/job-detail-route-demo.gif)

https://github.com/henryle1/bug-bounty/releases/download/job-detail-route-demo-4437/job-detail-route-demo.gif

## Validation

- `npm run build -w apps/web`
- Browser check: `/jobs` -> click `/jobs/job-101`
- Browser check: `/jobs/missing-job`
- Mobile viewport check at `390x844`
- Console check: no relevant `error` or `warn` logs
