### PR TITLE
Validate authenticated review creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: result.error.issues
+    });
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("POST /api/reviews rejects missing bearer auth", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        rating: 5,
+        text: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/reviews rejects missing required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.deepEqual(payload.issues.map((issue) => issue.path[0]).sort(), [
+      "freelancerId",
+      "jobId",
+      "rating",
+      "text"
+    ]);
+  });
+});
+
+test("POST /api/reviews rejects ratings outside 1-5", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        rating: 6,
+        text: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.issues[0].path[0], "rating");
+  });
+});
+
+test("POST /api/reviews creates valid authenticated reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        rating: 5,
+        text: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_/);
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.freelancerId, "usr_1");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.text, "Great work");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  text: z.string().min(1)
+});


### PR DESCRIPTION
Closes #6181

/claim #743

## Summary

- Protect `POST /api/reviews` with the existing `authMiddleware`.
- Add a focused Zod validator for review creation payloads.
- Reject missing review fields and ratings outside the 1-5 range with `400 Validation failed`.
- Preserve valid authenticated review creation as `201 Created`.
- Update the API test script so the route-level regression tests are discovered reliably.

## Validation

```bash
npm test
```

Result:

```text
tests 5
pass 5
fail 0
```

Covered cases:

- Missing bearer auth returns `401`.
- Missing required fields return `400`.
- Invalid rating returns `400`.
- Valid authenticated creation returns `201`.
