### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: result.error.issues
+    });
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createProposal } from "../services/proposalService.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.deepEqual(payload.issues.map((issue) => issue.path[0]).sort(), [
+      "bidAmount",
+      "coverLetter",
+      "freelancerId",
+      "jobId"
+    ]);
+  });
+});
+
+test("POST /api/proposals rejects negative bid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        bidAmount: -1,
+        coverLetter: "I can do this."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.issues[0].path[0], "bidAmount");
+  });
+});
+
+test("POST /api/proposals ignores caller-supplied ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "prp_attacker",
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        bidAmount: 100,
+        coverLetter: "I can do this."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.notEqual(payload.data.id, "prp_attacker");
+    assert.equal(payload.data.bidAmount, 100);
+  });
+});
+
+test("createProposal keeps generated ids server-owned", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker",
+    jobId: "job_1",
+    freelancerId: "usr_1",
+    bidAmount: 100,
+    coverLetter: "I can do this."
+  });
+
+  assert.match(proposal.id, /^prp_/);
+  assert.notEqual(proposal.id, "prp_attacker");
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  bidAmount: z.number().nonnegative(),
+  coverLetter: z.string().min(1)
+});


### PR DESCRIPTION
Closes #6182

/claim #743

## Summary

- Add a focused Zod validator for proposal creation payloads.
- Reject missing required proposal fields and negative bid amounts with `400 Validation failed`.
- Preserve server-generated `prp_*` ids even when callers supply an `id`.
- Add route and service regression coverage for invalid payloads, invalid bid amounts, and id override attempts.
- Update the API test script so the regression tests are discovered reliably.

## Validation

```bash
npm test
```

Result:

```text
tests 5
pass 5
fail 0
```

Covered cases:

- Missing proposal fields return `400`.
- Negative `bidAmount` returns `400`.
- Caller-supplied `id` is ignored by the route.
- `createProposal()` keeps generated ids server-owned at the service layer.
