### PR TITLE
Use server-owned payment prices

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,27 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: result.error.issues
+    });
+  }
+
+  try {
+    return ok(res, await createPaymentIntent(result.data.priceId), 201);
+  } catch (error) {
+    if (error.code === "PRICE_NOT_FOUND") {
+      return res.status(400).json({
+        success: false,
+        message: "Unknown price id"
+      });
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,23 @@
-export async function createPaymentIntent(payload) {
+export const priceCatalog = {
+  "starter": { amount: 2500, currency: "usd" },
+  "pro": { amount: 7500, currency: "usd" },
+  "enterprise": { amount: 20000, currency: "usd" }
+};
+
+export async function createPaymentIntent(priceId) {
+  const price = priceCatalog[priceId];
+  if (!price) {
+    const error = new Error("Unknown price id");
+    error.code = "PRICE_NOT_FOUND";
+    throw error;
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    priceId,
+    amount: price.amount,
+    currency: price.currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-price.test.js
+++ b/apps/api/src/tests/payment-price.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects amount-only payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.issues[0].path[0], "priceId");
+  });
+});
+
+test("POST /api/payments rejects unknown price ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ priceId: "discounted" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unknown price id");
+  });
+});
+
+test("POST /api/payments ignores caller-supplied monetary fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        priceId: "pro",
+        amount: 1,
+        currency: "eur"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.priceId, "pro");
+    assert.equal(payload.data.amount, 7500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  priceId: z.string().min(1)
+});


### PR DESCRIPTION
Refs #4421

/claim #743

## Summary

- Add a focused payment request validator that requires a priceId.
- Resolve payment amount and currency from a server-owned price catalog.
- Reject amount-only payloads with 400 Validation failed.
- Reject unknown price ids with 400 Unknown price id.
- Ignore caller-supplied monetary fields when creating payment intents.
- Update the API test script so the regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.