### PR TITLE
Preserve unread notification defaults

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps new notifications unread", async () => {
+  const notification = await createNotification({
+    userId: "usr_1",
+    title: "New proposal",
+    read: true
+  });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.equal(notification.userId, "usr_1");
+  assert.equal(notification.title, "New proposal");
+  assert.equal(notification.read, false);
+});


### PR DESCRIPTION
Refs #4397

/claim #743

## Summary

- Preserve service-owned notification fields by applying payload fields first.
- Ensure newly created notifications always keep read: false, even when callers submit read: true.
- Add focused service-level regression coverage for the unread default.
- Update the API test script so the regression test is discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.