### PR TITLE
Guard Prisma database connection setup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "test": "node --test src/tests"
   },
   "dependencies": {
+    "@prisma/client": "^5.17.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",

--- a/apps/api/src/config/db.js
+++ b/apps/api/src/config/db.js
@@ -1,4 +1,28 @@
-export async function connectDb() {
-  // TODO: wire Prisma client from @freelanceflow/db package
-  return { connected: true, driver: "prisma-placeholder" };
+import { PrismaClient } from "@prisma/client";
+import { env } from "./env.js";
+
+let prismaClient;
+
+export function getPrismaClient() {
+  if (!prismaClient) {
+    prismaClient = new PrismaClient();
+  }
+
+  return prismaClient;
+}
+
+export async function connectDb({ databaseUrl = env.databaseUrl, client } = {}) {
+  if (!databaseUrl) {
+    return {
+      connected: false,
+      driver: "prisma",
+      skipped: true,
+      reason: "DATABASE_URL is not configured"
+    };
+  }
+
+  const dbClient = client ?? getPrismaClient();
+  await dbClient.$connect();
+
+  return { connected: true, driver: "prisma" };
 }

--- a/apps/api/src/tests/db.test.js
+++ b/apps/api/src/tests/db.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { connectDb } from "../config/db.js";
+
+test("connectDb skips Prisma when DATABASE_URL is not configured", async () => {
+  let connectCalled = false;
+
+  const result = await connectDb({
+    databaseUrl: "",
+    client: {
+      $connect: async () => {
+        connectCalled = true;
+      }
+    }
+  });
+
+  assert.equal(connectCalled, false);
+  assert.deepEqual(result, {
+    connected: false,
+    driver: "prisma",
+    skipped: true,
+    reason: "DATABASE_URL is not configured"
+  });
+});
+
+test("connectDb connects the Prisma client when DATABASE_URL is configured", async () => {
+  const calls = [];
+
+  const result = await connectDb({
+    databaseUrl: "postgresql://user:password@localhost:5432/freelanceflow",
+    client: {
+      $connect: async () => {
+        calls.push("$connect");
+      }
+    }
+  });
+
+  assert.deepEqual(calls, ["$connect"]);
+  assert.deepEqual(result, { connected: true, driver: "prisma" });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
     "apps/api": {
       "name": "@freelanceflow/api",
       "dependencies": {
+        "@prisma/client": "^5.17.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",


### PR DESCRIPTION
## Summary

- replace the placeholder database connection status with a guarded Prisma connection path
- skip Prisma construction when `DATABASE_URL` is not configured so local/test startup does not require Postgres
- add focused regression tests for the skipped local path and configured Prisma client path

Closes #4447
/claim #743

## Validation

- `node --test apps/api/src/tests/db.test.js apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/db.js && node --check apps/api/src/tests/db.test.js && node --check apps/api/src/server.js`
- `npm run generate -w packages/db`
- `git diff --check`

Known existing issue: `npm test -w apps/api` still fails because the current package script runs `node --test src/tests`, which Node 22 treats as a module path instead of discovering concrete test files. This PR leaves that separate test-script issue untouched.