### PR TITLE
Preserve server-owned job fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-server-owned-fields.test.js
+++ b/apps/api/src/tests/job-server-owned-fields.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJob } from "../services/jobService.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJobPayload = {
+  title: "Build API",
+  description: "Build the backend API",
+  budgetMin: 100,
+  budgetMax: 200,
+  categoryId: "cat_1",
+  skills: ["node"]
+};
+
+test("POST /api/jobs preserves server-owned id and open status", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...validJobPayload,
+        id: "job_attacker",
+        status: "closed"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^job_/);
+    assert.notEqual(payload.data.id, "job_attacker");
+    assert.equal(payload.data.status, "open");
+  });
+});
+
+test("createJob keeps generated ids and open status server-owned", async () => {
+  const job = await createJob({
+    ...validJobPayload,
+    id: "job_attacker",
+    status: "closed"
+  });
+
+  assert.match(job.id, /^job_/);
+  assert.notEqual(job.id, "job_attacker");
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
Refs #4405

/claim #743

## Summary

- Preserve server-owned job fields by applying client payload fields first.
- Ensure new jobs always use a generated job_* id.
- Ensure new jobs always start with status: open, even when callers submit another status.
- Add route and service regression coverage for id/status override attempts.
- Update the API test script so the regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.