### PR TITLE
Reject whitespace-only auth passwords

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("auth validators reject whitespace-only registration passwords", () => {
+  const result = registerSchema.safeParse({
+    email: "user@example.com",
+    password: "        "
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "password");
+  assert.equal(result.error.issues[0].message, "Password cannot be blank");
+});
+
+test("auth validators reject whitespace-only login passwords", () => {
+  const result = loginSchema.safeParse({
+    email: "user@example.com",
+    password: "        "
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "password");
+  assert.equal(result.error.issues[0].message, "Password cannot be blank");
+});
+
+test("auth validators preserve minimum password length", () => {
+  const result = registerSchema.safeParse({
+    email: "user@example.com",
+    password: "short"
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "password");
+});
+
+test("auth validators still accept non-blank valid passwords", () => {
+  const registerResult = registerSchema.safeParse({
+    email: "user@example.com",
+    password: "password123"
+  });
+  const loginResult = loginSchema.safeParse({
+    email: "user@example.com",
+    password: "password123"
+  });
+
+  assert.equal(registerResult.success, true);
+  assert.equal(registerResult.data.role, "client");
+  assert.equal(loginResult.success, true);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
+export const passwordSchema = z
+  .string()
+  .min(8)
+  .refine((value) => value.trim().length > 0, {
+    message: "Password cannot be blank"
+  });
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
Closes #6184

/claim #743

## Summary

- Add a shared auth `passwordSchema`.
- Reject whitespace-only registration and login passwords.
- Preserve the existing minimum 8-character password requirement.
- Keep valid non-blank passwords accepted.
- Update the API test script so the validator tests are discovered reliably.

## Validation

```bash
npm test
```

Result:

```text
tests 5
pass 5
fail 0
```

Covered cases:

- Whitespace-only registration passwords are rejected.
- Whitespace-only login passwords are rejected.
- Short passwords remain rejected.
- Valid non-blank passwords still pass.
