### PR TITLE
Require verified auth for token refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
 
 export const authRoutes = Router();
@@ -6,4 +7,4 @@ export const authRoutes = Router();
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,15 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  if (!user?.sub) {
+    throw new Error("Authenticated user required for token refresh");
+  }
+
+  return {
+    token: signAccessToken({
+      sub: user.sub,
+      role: user.role ?? "client"
+    })
+  };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: "Bearer not-a-token" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/auth/refresh preserves verified requester claims", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_42", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const refreshed = verifyAccessToken(payload.data.token);
+    assert.equal(refreshed.sub, "usr_42");
+    assert.equal(refreshed.role, "freelancer");
+  });
+});


### PR DESCRIPTION
Closes #4452

/claim #743

## Summary

- Require `authMiddleware` on `POST /api/auth/refresh`.
- Refresh tokens from the verified requester claims instead of hard-coded `usr_existing` data.
- Add route-level regression tests for missing auth, invalid bearer tokens, and claim preservation.

## Validation

- `node --test apps/api/src/tests/auth-refresh.test.js` -> 3 passed
- `node --test apps/api/src/tests/*.js` -> 4 passed
- `node --check apps/api/src/routes/authRoutes.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/auth-refresh.test.js`
- `git diff --check`

Note: `npm test -w apps/api` could not run in this shell because `npm` is not installed on PATH, so I ran the API test files directly with Node's test runner.
