### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,16 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: parsed.error.issues
+    });
+  }
+
+  return ok(res, await globalSearch(parsed.data.q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search accepts a valid query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20developer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "developer");
+  });
+});
+
+test("GET /api/search rejects missing query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.issues[0].path[0], "q");
+  });
+});
+
+test("GET /api/search rejects overlong query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(121)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.issues[0].path[0], "q");
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().min(1).max(120)
+});


### PR DESCRIPTION
Refs #2833, #1781, #1777

/claim #743

## Summary

- Add a Zod schema for /api/search query validation.
- Require q to be a non-empty trimmed string with a 120-character maximum.
- Return 400 Validation failed for missing or overlong search queries.
- Fix the API test script so Node discovers the .test.js files reliably.
- Add regression coverage for valid, missing, and overlong search queries.

## Validation

npm test

Result: tests 4, pass 4, fail 0.