### PR TITLE
Prevent public admin role registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return next(error);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    return next(error);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  const target = new URL(url);
+  const requestBody = JSON.stringify(body);
+
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method: "POST",
+      agent: false,
+      headers: {
+        "content-length": Buffer.byteLength(requestBody),
+        "content-type": "application/json"
+      }
+    }, (response) => {
+      let responseBody = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        responseBody += chunk;
+      });
+      response.on("end", () => {
+        resolve({
+          status: response.statusCode,
+          json: () => JSON.parse(responseBody)
+        });
+      });
+    });
+
+    request.on("error", reject);
+    request.end(requestBody);
+  });
+}
+
+test("POST /api/auth/register defaults new users to client role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const payload = response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+    assert.match(payload.data.token, /^[\w-]+\.[\w-]+\.[\w-]+$/);
+  });
+});
+
+test("POST /api/auth/register rejects public admin role escalation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request payload");
+    assert.equal(payload.issues[0].path, "role");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Refs #743, #2832, #1755

/claim #743

## Summary

- Prevent public registration from accepting role: admin.
- Route auth validation failures through the API error handler so invalid payloads return 400 instead of hanging.
- Add regression tests for normal client registration and rejected admin role self-registration.
- Update the API test script so npm test discovers the test files reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Manual endpoint check: clientStatus 201, clientRole client, adminStatus 400, adminMessage Invalid request payload, adminIssuePath role.