### PR TITLE
Fix Next 16 dynamic route params handling

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,14 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{username}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,14 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #4460
Refs #743

## Summary
- Updates both App Router dynamic pages to match Next 16 async `params` behavior.
- Awaits `params` once and renders the extracted `id` / `username` values.

## Validation
- `git diff --check` passed.
- Confirmed no remaining synchronous `params.id` / `params.username` reads under `apps/web/app`.
- Could not run `npm`/Next build in this environment because `npm` is not installed in PATH here.

## Scope
Only touches the two dynamic route pages described in #4460.