### PR TITLE
Add server-owned proposal status

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,18 @@
 const proposals = [];
+export const PROPOSAL_STATUS = Object.freeze({
+  pending: "PENDING"
+});
 
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = {
+    ...(payload ?? {}),
+    id: `prp_${Date.now()}`,
+    status: PROPOSAL_STATUS.pending
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, PROPOSAL_STATUS } from "../services/proposalService.js";
+
+test("createProposal assigns a server-owned pending status", async () => {
+  const proposal = await createProposal({
+    coverLetter: "I can help with this project.",
+    bidAmount: 500,
+    estDuration: "2 weeks",
+    jobId: "job_123",
+    freelancerId: "usr_456",
+    status: "ACCEPTED"
+  });
+
+  assert.equal(proposal.status, PROPOSAL_STATUS.pending);
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_456");
+});

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,6 +21,13 @@ enum JobStatus {
   CANCELLED
 }
 
+enum ProposalStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+  WITHDRAWN
+}
+
 model User {
   id             String      @id @default(cuid())
   email          String      @unique
@@ -59,15 +66,16 @@ model Job {
 }
 
 model Proposal {
-  id            String      @id @default(cuid())
+  id            String         @id @default(cuid())
   coverLetter   String
   bidAmount     Float
   estDuration   String
+  status        ProposalStatus @default(PENDING)
   jobId         String
-  job           Job         @relation(fields: [jobId], references: [id])
+  job           Job            @relation(fields: [jobId], references: [id])
   freelancerId  String
-  freelancer    User        @relation(fields: [freelancerId], references: [id])
-  createdAt     DateTime    @default(now())
+  freelancer    User           @relation(fields: [freelancerId], references: [id])
+  createdAt     DateTime       @default(now())
 }
 
 model Payment {


### PR DESCRIPTION
Closes #4463

/claim #743

## Summary
- Adds a Prisma `ProposalStatus` enum with `PENDING` as the default state for new proposals.
- Makes the in-memory `createProposal` service assign a server-owned `PENDING` status after spreading caller payloads, so request bodies cannot pre-accept/reject a proposal.
- Adds a focused node:test regression check for status override protection.

## Validation
- `node --check apps\api\src\services\proposalService.js`
- `node --check apps\api\src\tests\proposalService.test.js`
- `node --test apps\api\src\tests\proposalService.test.js apps\api\src\tests\health.test.js`
- `$env:DATABASE_URL='postgresql://user:pass@localhost:5432/freelanceflow'; npx prisma validate --schema packages\db\prisma\schema.prisma`
- `git diff --check`