### PR TITLE
Prevent duplicate job proposals

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,18 @@
-import { ok } from "../utils/response.js";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { fail, ok } from "../utils/response.js";
+import { createProposal, DuplicateProposalError, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    return ok(res, await createProposal(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateProposalError) {
+      return fail(res, "Freelancer already submitted a proposal for this job", 409);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,10 +1,28 @@
 const proposals = [];
 
+export class DuplicateProposalError extends Error {
+  constructor(jobId, freelancerId) {
+    super(`Freelancer ${freelancerId} already submitted a proposal for job ${jobId}`);
+    this.name = "DuplicateProposalError";
+    this.statusCode = 409;
+  }
+}
+
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
+  if (payload?.jobId && payload?.freelancerId) {
+    const duplicate = proposals.some(
+      (proposal) => proposal.jobId === payload.jobId && proposal.freelancerId === payload.freelancerId
+    );
+
+    if (duplicate) {
+      throw new DuplicateProposalError(payload.jobId, payload.freelancerId);
+    }
+  }
+
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
   return proposal;

--- a/apps/api/src/tests/proposalDuplicates.test.js
+++ b/apps/api/src/tests/proposalDuplicates.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { postProposal } from "../controllers/proposalController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("postProposal rejects duplicate proposals for the same freelancer and job", async () => {
+  const suffix = `${Date.now()}_${Math.random()}`;
+  const request = {
+    body: {
+      coverLetter: "I can help with this implementation.",
+      bidAmount: 750,
+      estDuration: "1 week",
+      jobId: `job_${suffix}`,
+      freelancerId: `usr_${suffix}`
+    }
+  };
+
+  const firstResponse = createResponse();
+  await postProposal(request, firstResponse);
+
+  const duplicateResponse = createResponse();
+  await postProposal(request, duplicateResponse);
+
+  assert.equal(firstResponse.statusCode, 201);
+  assert.equal(duplicateResponse.statusCode, 409);
+  assert.deepEqual(duplicateResponse.body, {
+    success: false,
+    message: "Freelancer already submitted a proposal for this job"
+  });
+});

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -68,6 +68,8 @@ model Proposal {
   freelancerId  String
   freelancer    User        @relation(fields: [freelancerId], references: [id])
   createdAt     DateTime    @default(now())
+
+  @@unique([jobId, freelancerId])
 }
 
 model Payment {


### PR DESCRIPTION
Closes #4465

/claim #743

## Summary
- Adds a Prisma uniqueness constraint so one freelancer can only have one proposal per job.
- Adds a `DuplicateProposalError` from the in-memory proposal service when a duplicate `(jobId, freelancerId)` pair is submitted.
- Maps that duplicate proposal case to a 409 Conflict JSON response in the proposal controller.
- Adds a focused regression test for the duplicate-submission path.

## Validation
- `node --check apps\api\src\services\proposalService.js`
- `node --check apps\api\src\controllers\proposalController.js`
- `node --check apps\api\src\tests\proposalDuplicates.test.js`
- `node --test apps\api\src\tests\proposalDuplicates.test.js apps\api\src\tests\health.test.js`
- `$env:DATABASE_URL='postgresql://user:pass@localhost:5432/freelanceflow'; npx prisma validate --schema packages\db\prisma\schema.prisma`
- `git diff --check`