### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
+function normalizeCurrency(currency) {
+  return typeof currency === "string" ? currency.trim().toLowerCase() : "usd";
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments defaults missing currency to usd", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1200 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments normalizes submitted currency codes", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1200, currency: " USD " })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
Fixes #4471

/claim #743

## Summary

- Normalize submitted payment currency codes by trimming whitespace and lowercasing them before returning the payment intent response.
- Keep the existing missing-currency behavior defaulting to `usd`.
- Add focused route-level regression tests for omitted currency and mixed-case/whitespace currency input.

## Validation

- `node --test apps/api/src/tests/payment.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/payment.test.js`

## Demo evidence

The payment route regression test exercises both default currency behavior and the `" USD "` normalization path end to end through the HTTP API.