### PR TITLE
Add initial payment intent status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "requires_payment_method"
   };
 }

--- a/apps/api/src/tests/paymentStatus.test.js
+++ b/apps/api/src/tests/paymentStatus.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments returns an initial payment intent status", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1200, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.provider, "stripe");
+    assert.equal(payload.data.status, "requires_payment_method");
+  });
+});


### PR DESCRIPTION
Fixes #4473

/claim #743

## Summary

- Add `status: "requires_payment_method"` to newly created payment intent responses.
- Preserve the existing payment intent fields and default currency behavior.
- Add focused route-level regression coverage for the initial status response.

## Validation

- `node --test apps/api/src/tests/paymentStatus.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentStatus.test.js`

## Demo evidence

The payment route regression test exercises the payment intent creation path end to end and verifies the initial `requires_payment_method` status in the HTTP response.