### PR TITLE
Add original settlement weather poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Settlement Weather
+
+At dawn the brief arrives as pressure,
+a clean front moving over open work.
+Scope pins the clouds to names and numbers,
+and every promise learns where not to drift.
+
+By noon the proof begins to gather:
+screens, commits, traces, notes in line.
+Reviewers read the wind for thunder,
+then mark the sky with pass or fix.
+
+At dusk the escrow lamps turn amber,
+waiting on the final merge report.
+A payout is not weather made of hope;
+it is rain that falls when evidence holds.
+
+At night the market cools and listens.
+Reputation keeps its careful barometer.
+Tomorrow someone posts another storm,
+and trust again becomes the forecast.


### PR DESCRIPTION
/claim #76

## Summary
- Adds root-level `POEM.md` with an original four-stanza poem written for the FreelanceFlow bounty project.
- Creative decision: I used a weather-report structure so scope, proof, review, and payout read like observable public signals rather than generic marketplace slogans.

## Validation
- `POEM.md` exists at the project root.
- Minimum stanza count exceeded: 4 stanzas.
- `git diff --check` passed.

## Demo
- Static Markdown preview is available directly in this PR diff via `POEM.md`.