### PR TITLE
[agent] Keep new notifications unread

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, ...payload, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications keeps new notifications unread", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_123",
+        type: "proposal",
+        message: "New proposal received",
+        read: true
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_123");
+    assert.equal(payload.data.message, "New proposal received");
+    assert.equal(payload.data.read, false);
+  });
+});

--- a/demos/notification-unread-state-demo.svg
+++ b/demos/notification-unread-state-demo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0f172a"/>
+  <rect x="48" y="44" width="864" height="452" rx="10" fill="#111827" stroke="#334155"/>
+  <circle cx="76" cy="72" r="7" fill="#ef4444"/>
+  <circle cx="100" cy="72" r="7" fill="#f59e0b"/>
+  <circle cx="124" cy="72" r="7" fill="#22c55e"/>
+  <text x="56" y="120" fill="#93c5fd" font-family="Consolas, monospace" font-size="22">POST /api/notifications</text>
+  <text x="56" y="164" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">{ "userId": "usr_123", "message": "New proposal received", "read": true }</text>
+  <text x="56" y="220" fill="#34d399" font-family="Consolas, monospace" font-size="22">201 Created</text>
+  <text x="56" y="264" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">{</text>
+  <text x="82" y="300" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">"success": true,</text>
+  <text x="82" y="336" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">"data": {</text>
+  <text x="108" y="372" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">"id": "ntf_...",</text>
+  <text x="108" y="408" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">"message": "New proposal received",</text>
+  <text x="108" y="444" fill="#facc15" font-family="Consolas, monospace" font-size="19">"read": false</text>
+  <text x="82" y="480" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">}</text>
+  <text x="56" y="516" fill="#e5e7eb" font-family="Consolas, monospace" font-size="19">}</text>
+</svg>


### PR DESCRIPTION
## Summary
Fixes notification creation so the initial unread state stays server-owned. A request body with `read: true` can no longer create an already-read notification.

Closes #4479

/claim #743

## Changes
- Move `read: false` after the request payload in `createNotification`.
- Add a focused route-level regression test for `POST /api/notifications` with `read: true` in the payload.
- Add a small demo artifact showing the API response preserves `read: false`.

## Demo
- https://raw.githubusercontent.com/AxisIV/bug-bounty/axisiv/notification-unread-state-4479/demos/notification-unread-state-demo.svg

## Validation
- `node --test apps/api/src/tests/notification.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/tests/notification.test.js`
- `git diff --check`