### PR TITLE
[agent] Normalize repeated search query values

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+function normalizeSearchQuery(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.find((item) => typeof item === "string") ?? "";
+  }
+
+  return "";
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  return ok(res, await globalSearch(normalizeSearchQuery(req.query.q)));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search uses the first repeated q value", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design&q=backend`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "design");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});

--- a/demos/search-query-normalization-demo.svg
+++ b/demos/search-query-normalization-demo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#101820"/>
+  <rect x="48" y="48" width="864" height="444" rx="10" fill="#16232e" stroke="#3b5266"/>
+  <text x="64" y="104" fill="#7dd3fc" font-family="Consolas, monospace" font-size="22">GET /api/search?q=design&amp;q=backend</text>
+  <text x="64" y="160" fill="#34d399" font-family="Consolas, monospace" font-size="22">200 OK</text>
+  <text x="64" y="212" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">{</text>
+  <text x="92" y="252" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">"success": true,</text>
+  <text x="92" y="292" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">"data": {</text>
+  <text x="120" y="332" fill="#facc15" font-family="Consolas, monospace" font-size="20">"query": "design",</text>
+  <text x="120" y="372" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">"users": [],</text>
+  <text x="120" y="412" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">"jobs": [],</text>
+  <text x="120" y="452" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">"freelancers": []</text>
+  <text x="92" y="492" fill="#e5e7eb" font-family="Consolas, monospace" font-size="20">}</text>
+</svg>


### PR DESCRIPTION
## Summary
Normalizes repeated `q` query parameters before calling `globalSearch`, so `/api/search` always reports a single query string instead of leaking Express' repeated-parameter array shape into the API response.

Closes #4481

/claim #743

## Changes
- Add a small search query normalization helper in the search controller.
- Preserve missing/string query behavior and use the first string when `q` is repeated.
- Add a focused route-level regression test for `GET /api/search?q=design&q=backend`.
- Add a small demo artifact showing the normalized response.

## Demo
- https://raw.githubusercontent.com/AxisIV/bug-bounty/axisiv/search-query-normalization-4481/demos/search-query-normalization-demo.svg

## Validation
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --check apps/api/src/controllers/searchController.js`
- `node --check apps/api/src/tests/search.test.js`
- `git diff --check`