### PR TITLE
[agent] Add notifications alert feed

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,66 @@
+const notifications = [
+  {
+    category: "Proposal",
+    message: "Maya Chen submitted a revised milestone estimate.",
+    time: "8 min ago",
+    status: "Unread",
+    action: "Review estimate",
+    urgent: true
+  },
+  {
+    category: "Message",
+    message: "Jordan Lee replied in the onboarding flow thread.",
+    time: "42 min ago",
+    status: "Unread",
+    action: "Open thread",
+    urgent: true
+  },
+  {
+    category: "Billing",
+    message: "Invoice FF-1042 was marked as paid.",
+    time: "Yesterday",
+    status: "Resolved",
+    action: "View receipt",
+    urgent: false
+  }
+];
+
 export default function NotificationsPage() {
+  const unreadCount = notifications.filter((item) => item.status === "Unread").length;
+  const actionCount = notifications.filter((item) => item.urgent).length;
+
   return (
-    <section className="card">
+    <section>
       <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
+
+      <div className="grid">
+        <article className="card">
+          <h3>Unread</h3>
+          <p>{unreadCount} updates need attention</p>
+        </article>
+        <article className="card">
+          <h3>Action Needed</h3>
+          <p>{actionCount} items have next steps</p>
+        </article>
+        <article className="card">
+          <h3>Latest Alert</h3>
+          <p>{notifications[0].time}</p>
+        </article>
+      </div>
+
+      <section className="card">
+        <h3>Alert Feed</h3>
+        {notifications.map((notification) => (
+          <article key={`${notification.category}-${notification.message}`} className="card">
+            <h4>{notification.category}</h4>
+            <p>{notification.message}</p>
+            <p>
+              <strong>{notification.status}</strong> · {notification.time}
+            </p>
+            <button type="button">{notification.action}</button>
+          </article>
+        ))}
+      </section>
     </section>
   );
 }

--- a/demos/notifications-alert-feed-demo.svg
+++ b/demos/notifications-alert-feed-demo.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="960" height="540" fill="#0b1020"/>
+  <text x="56" y="72" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="34" font-weight="700">Notifications</text>
+  <rect x="56" y="104" width="248" height="96" rx="8" fill="#151c35" stroke="#2a3765"/>
+  <rect x="332" y="104" width="248" height="96" rx="8" fill="#151c35" stroke="#2a3765"/>
+  <rect x="608" y="104" width="248" height="96" rx="8" fill="#151c35" stroke="#2a3765"/>
+  <text x="80" y="146" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="20">Unread</text>
+  <text x="80" y="176" fill="#facc15" font-family="Arial, sans-serif" font-size="18">2 updates need attention</text>
+  <text x="356" y="146" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="20">Action Needed</text>
+  <text x="356" y="176" fill="#93c5fd" font-family="Arial, sans-serif" font-size="18">2 items have next steps</text>
+  <text x="632" y="146" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="20">Latest Alert</text>
+  <text x="632" y="176" fill="#86efac" font-family="Arial, sans-serif" font-size="18">8 min ago</text>
+  <rect x="56" y="232" width="848" height="252" rx="8" fill="#151c35" stroke="#2a3765"/>
+  <text x="80" y="274" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="22" font-weight="700">Alert Feed</text>
+  <text x="80" y="320" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="18">Proposal</text>
+  <text x="190" y="320" fill="#e5e7eb" font-family="Arial, sans-serif" font-size="17">Maya Chen submitted a revised milestone estimate.</text>
+  <text x="80" y="350" fill="#facc15" font-family="Arial, sans-serif" font-size="16">Unread · 8 min ago · Review estimate</text>
+  <text x="80" y="404" fill="#f2f5ff" font-family="Arial, sans-serif" font-size="18">Message</text>
+  <text x="190" y="404" fill="#e5e7eb" font-family="Arial, sans-serif" font-size="17">Jordan Lee replied in the onboarding flow thread.</text>
+  <text x="80" y="434" fill="#facc15" font-family="Arial, sans-serif" font-size="16">Unread · 42 min ago · Open thread</text>
+</svg>


### PR DESCRIPTION
## Summary
Replaces the placeholder `/notifications` page with a static, actionable notification center for proposal, message, and billing alerts.

Closes #4487

/claim #743

## Changes
- Add representative notification data with category, message, timestamp, status, and next action.
- Add summary cards for unread updates, action-needed items, and latest alert recency.
- Add an alert feed with per-notification action buttons.
- Add a small demo artifact for bounty review.

## Demo
- https://raw.githubusercontent.com/AxisIV/bug-bounty/axisiv/notifications-alert-feed-4487/demos/notifications-alert-feed-demo.svg

## Validation
- `npm run build -w apps/web`
- `git diff --check`