### PR TITLE
Align registration token subject with returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const originalNow = Date.now;
+  Date.now = (() => {
+    const values = [123456, 789012];
+    return () => values.shift() ?? 789012;
+  })();
+
+  try {
+    const result = await registerUser({
+      email: "new.client@example.com",
+      password: "correct-horse-battery-staple",
+      role: "client"
+    });
+    const claims = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_123456");
+    assert.equal(claims.sub, result.id);
+    assert.equal(claims.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- generate a single server-owned user id during registration
- sign the registration access token with that same id as the JWT `sub`
- add regression coverage proving the returned id and verified token subject stay aligned

## Claim
/claim #743

Closes #4495

## Verification
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/auth.test.js`
- `git diff --check`
- `node --test apps/api/src/tests/*.test.js`