### PR TITLE
Harden API auth and payment validation

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,13 @@
+const jwtSecret = process.env.JWT_SECRET ?? "";
+
+if (process.env.NODE_ENV === "production" && !jwtSecret) {
+  throw new Error("JWT_SECRET is required in production");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,26 +2,29 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
+export function register(req, res, next) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  return Promise.resolve(registerUser(payload))
+    .then((result) => ok(res, result, 201))
+    .catch(next);
 }
 
-export async function login(req, res) {
+export function login(req, res, next) {
   const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  return Promise.resolve(loginUser(payload))
+    .then((result) => ok(res, result))
+    .catch(next);
 }
 
-export async function oauthCallback(req, res) {
+export function oauthCallback(req, res) {
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"
   });
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export function refresh(req, res, next) {
+  return Promise.resolve(refreshToken())
+    .then((result) => ok(res, result))
+    .catch(next);
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export function createPayment(req, res, next) {
+  const payload = createPaymentSchema.parse(req.body);
+  return Promise.resolve(createPaymentIntent(payload))
+    .then((result) => ok(res, result, 201))
+    .catch(next);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/api-hardening.test.js
+++ b/apps/api/src/tests/api-hardening.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("public registration rejects admin role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "admin@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});
+
+test("payment endpoint rejects missing amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});
+
+test("payment endpoint accepts validated payment payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1250, currency: " GBP " })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 1250);
+    assert.equal(payload.data.currency, "GBP");
+  });
+});
+
+test("production config requires explicit JWT_SECRET", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  try {
+    await assert.rejects(
+      () => import(`../config/env.js?missing-secret=${Date.now()}`),
+      /JWT_SECRET is required in production/
+    );
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().trim().min(3).max(10).optional()
+});


### PR DESCRIPTION
## Summary
- remove the hardcoded JWT secret fallback and require `JWT_SECRET` in production
- prevent public registration from requesting the `admin` role
- validate payment creation payloads before calling the payment service
- return structured 400 responses for schema validation failures

## Creator-owned issues
- Resolves #4498
- Resolves #4499
- Resolves #4500

## Validation
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test apps/api/src/tests/*.test.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/config/env.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/controllers/authController.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/controllers/paymentController.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/middleware/errorHandler.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/validators/payment.js`
- `/Users/minorstep/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/tests/api-hardening.test.js`
- `git diff --cached --check`

/claim #743