### PR TITLE
Handle API startup failures explicitly

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,13 +1,35 @@
 import { connectDb } from "./config/db.js";
 import { env } from "./config/env.js";
 import { createApp } from "./app.js";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-async function bootstrap() {
-  await connectDb();
-  const app = createApp();
-  app.listen(env.port, () => {
-    console.log(`API listening on http://localhost:${env.port}`);
+export async function bootstrap({
+  connect = connectDb,
+  createApplication = createApp,
+  port = env.port,
+  logger = console
+} = {}) {
+  await connect();
+
+  const app = createApplication();
+  return new Promise((resolveServer, reject) => {
+    const server = app.listen(port, () => {
+      logger.log(`API listening on http://localhost:${port}`);
+      resolveServer(server);
+    });
+
+    server.once("error", reject);
   });
 }
 
-bootstrap();
+function isEntrypoint() {
+  return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isEntrypoint()) {
+  bootstrap().catch((error) => {
+    console.error("API startup failed", error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/api/src/tests/server.test.js
+++ b/apps/api/src/tests/server.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("server module exports bootstrap without auto-starting", async () => {
+  const module = await import(`../server.js?import-test=${Date.now()}`);
+
+  assert.equal(typeof module.bootstrap, "function");
+});
+
+test("bootstrap starts the app with injectable dependencies", async () => {
+  const { bootstrap } = await import(`../server.js?start-test=${Date.now()}`);
+  const server = await bootstrap({
+    connect: async () => ({ connected: true }),
+    createApplication: createApp,
+    port: 0,
+    logger: { log() {} }
+  });
+
+  assert.ok(server.address().port > 0);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("bootstrap surfaces startup dependency failures", async () => {
+  const { bootstrap } = await import(`../server.js?failure-test=${Date.now()}`);
+
+  await assert.rejects(
+    () =>
+      bootstrap({
+        connect: async () => {
+          throw new Error("database unavailable");
+        },
+        createApplication: createApp,
+        port: 0,
+        logger: { log() {} }
+      }),
+    /database unavailable/
+  );
+});


### PR DESCRIPTION
## Summary
- export a testable `bootstrap()` helper from the API server entrypoint
- keep importing `server.js` side-effect free by only auto-starting when the file is executed directly
- catch entrypoint startup failures, log a clear error, and set a non-zero exit code
- add regression coverage for import safety, injectable startup, and startup dependency failures

## Why
`server.js` previously called `bootstrap()` at module load time without a rejection handler. A failed `connectDb()` or listener startup could surface as an unhandled rejection, and tests could not import the entrypoint without starting the API listener.

Fixes #4502
Related #4456
Related #743

/claim #743

## Validation
- `node --test .\src\tests\*.js` from `apps/api` -> 4 pass, 0 fail
- `git diff --check`