### PR TITLE
Validate OAuth callback provider and code

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,16 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOauthProviders = new Set(["github", "google"]);
+
+function getSingleQueryValue(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +25,18 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = req.params.provider;
+  if (!supportedOauthProviders.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
+  const code = getSingleQueryValue(req.query.code);
+  if (!code) {
+    return fail(res, "OAuth code is required", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/not-real/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Unsupported OAuth provider" });
+  });
+});
+
+test("OAuth callback requires a code for supported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth code is required" });
+  });
+});
+
+test("OAuth callback rejects blank codes", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/google/callback?code=%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth code is required" });
+  });
+});
+
+test("OAuth callback accepts supported providers with a code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: { provider: "github", status: "callback-received" }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- reject unsupported OAuth callback providers with a structured `400`
- require a non-empty `code` query parameter for supported providers
- keep valid GitHub/Google callback requests returning the existing success payload
- add route-level regression tests for unsupported provider, missing code, blank code, and valid callback behavior

## Why
`GET /api/auth/oauth/:provider/callback` previously accepted arbitrary provider names and successful callbacks without an OAuth authorization code, which made malformed OAuth requests indistinguishable from valid callback handoffs.

Fixes #4505
Related #4469
Related #743

/claim #743

## Validation
- `node --test .\src\tests\*.js` from `apps/api` -> 5 pass, 0 fail
- `git diff --check`