### PR TITLE
Validate OAuth callback provider and authorization code

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+
+const SUPPORTED_OAUTH_PROVIDERS = ["github", "google"];
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,19 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+  const { code } = req.query;
+
+  if (!SUPPORTED_OAUTH_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
+
+  if (!code || typeof code !== "string" || code.trim() === "") {
+    return fail(res, "Missing or blank OAuth authorization code", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauthCallback.test.js
+++ b/apps/api/src/tests/oauthCallback.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/auth/oauth/not-real/callback returns 400 for unsupported provider", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/not-real/callback?code=abc`);
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Unsupported OAuth provider"));
+
+  await new Promise((r) => server.close(r));
+});
+
+test("GET /api/auth/oauth/github/callback returns 400 when code is missing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback`);
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Missing or blank OAuth authorization code"));
+
+  await new Promise((r) => server.close(r));
+});
+
+test("GET /api/auth/oauth/github/callback returns 400 when code is blank", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=`);
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Missing or blank OAuth authorization code"));
+
+  await new Promise((r) => server.close(r));
+});
+
+test("GET /api/auth/oauth/github/callback returns 400 when code is whitespace only", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=%20%20`);
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Missing or blank OAuth authorization code"));
+
+  await new Promise((r) => server.close(r));
+});
+
+test("GET /api/auth/oauth/github/callback returns success with valid code", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=valid_code_123`);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(body.data.provider, "github");
+  assert.equal(body.data.status, "callback-received");
+
+  await new Promise((r) => server.close(r));
+});
+
+test("GET /api/auth/oauth/google/callback returns success with valid code", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/google/callback?code=google_auth_code`);
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(body.data.provider, "google");
+  assert.equal(body.data.status, "callback-received");
+
+  await new Promise((r) => server.close(r));
+});


### PR DESCRIPTION
## Summary

- Validate that the OAuth callback route only accepts supported providers (`github`, `google`).
- Require a non-empty `code` query parameter for all supported providers.
- Return `400 Bad Request` with structured JSON error for unsupported providers, missing codes, or blank codes.
- Valid requests with a supported provider and non-empty code continue returning `200 OK` with the callback payload.

## What changed

**`apps/api/src/controllers/authController.js`**:
- Added `SUPPORTED_OAUTH_PROVIDERS` allowlist (`github`, `google`).
- `oauthCallback` now checks `req.params.provider` against the allowlist and validates `req.query.code` is a non-empty string.
- Returns 400 via the existing `fail()` helper for unsupported providers or missing/blank codes.

**`apps/api/src/tests/oauthCallback.test.js`** (new):
- 6 focused API tests covering: unsupported provider, missing code, blank code, whitespace-only code, valid github callback, valid google callback.

**`apps/api/package.json`**:
- Fixed test script glob from `node --test src/tests` to `node --test "src/tests/*.test.js"` so the Node test runner discovers test files.

## Validation

```
npm test
# Result: tests 7, pass 7, fail 0
```

All 7 tests pass (1 existing health check + 6 new OAuth validation tests).

Fixes #4505
Ref #743
/claim #4505
/claim #743