### PR TITLE
Return JSON rate limit errors

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests, please try again later.", 429)
 });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("rate limited API requests return structured JSON errors", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const url = `http://127.0.0.1:${port}/api/users`;
+
+    for (let i = 0; i < 200; i += 1) {
+      const response = await fetch(url);
+      assert.notEqual(response.status, 429);
+    }
+
+    const response = await fetch(url);
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many requests, please try again later."
+    });
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
﻿## Summary
- Configure the shared API rate limiter to return the existing structured JSON error shape for 429 responses.
- Add a focused regression test that exhausts the API quota and verifies the 429 status, JSON content type, and payload.

## Validation
- `node --check apps\api\src\middleware\rateLimit.js`
- `node --check apps\api\src\tests\rateLimit.test.js`
- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\rateLimit.test.js` -> 2 passed
- `git diff --check` -> no whitespace errors; CRLF conversion warnings only

## Note
- `npm run test -w apps/api` still fails on this Windows/Node 24 environment because the package script runs `node --test src/tests`, which Node resolves as a module path instead of discovering the directory. The explicit test-file command above validates the affected API tests.

Fixes #4507

/claim #743