### PR TITLE
Preserve generated user ids during creation

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users preserves the generated user id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 246810;
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        email: "client@example.com",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.id, "usr_246810");
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.role, "client");
+  } finally {
+    Date.now = originalNow;
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- preserve the server-generated user id during user creation
- keep accepted request fields intact while preventing client-supplied `id` from overriding `usr_...`
- add route-level regression coverage for `POST /api/users`

## Claim
/claim #743

Closes #4510

## Verification
- `node --check apps/api/src/services/userService.js`
- `node --check apps/api/src/tests/user.test.js`
- `git diff --check`
- `node --test apps/api/src/tests/*.test.js`