### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,21 @@
+function normalizeCurrency(currency) {
+  if (currency == null) {
+    return "usd";
+  }
+
+  if (typeof currency === "string") {
+    return currency.trim().toLowerCase() || "usd";
+  }
+
+  return currency;
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function postPayment(port, body) {
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("POST /api/payments defaults missing currency to usd", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const { response, payload } = await postPayment(port, { amount: 1200 });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/payments normalizes string currency codes", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const { response, payload } = await postPayment(port, {
+      amount: 1200,
+      currency: " USD "
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
﻿## Summary
- Normalize payment intent currency strings by trimming whitespace and lowercasing before returning the intent response.
- Preserve the existing default of `usd` when a payment request omits currency.
- Add focused route-level coverage for default currency and mixed-case/whitespace input.

## Validation
- `node --check apps\api\src\services\paymentService.js`
- `node --check apps\api\src\tests\payment.test.js`
- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\payment.test.js` -> 3 passed
- `git diff --check` -> no whitespace errors; CRLF conversion warnings only

## Note
- `npm run test -w apps/api` still fails on this Windows/Node 24 environment because the package script runs `node --test src/tests`, which Node resolves as a module path instead of discovering the directory. The explicit test-file command above validates the affected API tests.

Fixes #4512

/claim #743