### PR TITLE
Avoid exposing submitted user passwords

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...publicPayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...publicPayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userPassword.test.js
+++ b/apps/api/src/tests/userPassword.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users does not persist submitted passwords", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const createResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "redacted@example.com",
+        password: "do-not-return-this",
+        role: "client"
+      })
+    });
+    const created = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(created.success, true);
+    assert.equal(created.data.email, "redacted@example.com");
+    assert.equal(created.data.role, "client");
+    assert.equal("password" in created.data, false);
+
+    const listResponse = await fetch(`http://127.0.0.1:${port}/api/users`);
+    const listed = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listed.success, true);
+    assert.equal(listed.data.at(-1).email, "redacted@example.com");
+    assert.equal("password" in listed.data.at(-1), false);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- omit submitted `password` values from created user records
- prevent `GET /api/users` from exposing passwords submitted through `POST /api/users`
- add route-level regression coverage for create-then-list behavior

## Claim
/claim #743

Closes #4514

## Verification
- `node --check apps/api/src/services/userService.js`
- `node --check apps/api/src/tests/userPassword.test.js`
- `git diff --check`
- `node --test apps/api/src/tests/*.test.js`