### PR TITLE
Normalize payment intent currency values

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,18 @@
+function normalizeCurrency(currency) {
+  if (typeof currency !== "string") {
+    return "usd";
+  }
+
+  const normalized = currency.trim().toLowerCase();
+  return normalized || "usd";
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function postPayment(body) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    });
+
+    return { response, payload: await response.json() };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("payment creation defaults missing currency to usd", async () => {
+  const { response, payload } = await postPayment({ amount: 1200 });
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.currency, "usd");
+});
+
+test("payment creation normalizes string currency", async () => {
+  const { response, payload } = await postPayment({ amount: 1200, currency: " USD " });
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.currency, "usd");
+});
+
+test("payment creation defaults blank currency to usd", async () => {
+  const { response, payload } = await postPayment({ amount: 1200, currency: "  " });
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.currency, "usd");
+});
+
+test("payment creation defaults non-string currency to usd", async () => {
+  const { response, payload } = await postPayment({ amount: 1200, currency: ["eur"] });
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- normalize payment intent currency strings by trimming and lowercasing them
- keep missing, blank, or non-string currency values falling back to `usd`
- add route-level regression tests for default, mixed-case/whitespace, blank, and non-string currency inputs

## Why
`createPaymentIntent()` previously echoed `payload.currency` exactly as submitted. Whitespace-padded or mixed-case values could produce non-canonical intent data such as `" USD "` even though payment providers expect normalized currency codes.

Fixes #4516
Related #4512
Related #4471
Related #743

/claim #743

## Validation
- `node --test .\src\tests\*.js` from `apps/api` -> 5 pass, 0 fail
- `git diff --check`
