### PR TITLE
Use shared success envelope for health route

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { ok } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -24,7 +25,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+    return ok(res, { service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -12,13 +12,19 @@ test("GET /health returns ok payload", async () => {
   });
 
   const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: { service: "api" }
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
 });


### PR DESCRIPTION
Closes #4520
/claim #743

## Summary
- route GET /health through the shared ok() response helper
- align the health regression with the standard API success envelope
- keep server cleanup reliable if the focused test fails in the future

## Validation
- node --test apps/api/src/tests/health.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/app.js
- node --check apps/api/src/tests/health.test.js
- git diff --check

Note: root npm test currently fails on the upstream apps/api package script because it targets src/tests as a directory; this PR leaves that separate package-script issue out of scope.