### PR TITLE
Return defensive snapshots from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListIsSnapshot({ create, list, payload, idPrefix }) {
+  const initialLength = (await list()).length;
+  const created = await create(payload);
+
+  assert.match(created.id, new RegExp(`^${idPrefix}_`));
+
+  const snapshot = await list();
+  assert.equal(snapshot.length, initialLength + 1);
+
+  snapshot.length = 0;
+
+  const afterMutation = await list();
+  assert.equal(afterMutation.length, initialLength + 1);
+  assert.equal(afterMutation.at(-1).id, created.id);
+}
+
+test("list services return defensive array snapshots", async () => {
+  await assertListIsSnapshot({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "snapshot-user@example.com", role: "client" },
+    idPrefix: "usr"
+  });
+
+  await assertListIsSnapshot({
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Snapshot job", description: "Verify list snapshots" },
+    idPrefix: "job"
+  });
+
+  await assertListIsSnapshot({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_snapshot", userId: "usr_snapshot" },
+    idPrefix: "prp"
+  });
+
+  await assertListIsSnapshot({
+    create: createReview,
+    list: listReviews,
+    payload: { reviewerId: "usr_a", revieweeId: "usr_b", rating: 5 },
+    idPrefix: "rev"
+  });
+
+  await assertListIsSnapshot({
+    create: sendMessage,
+    list: listMessages,
+    payload: { senderId: "usr_a", recipientId: "usr_b", content: "hello" },
+    idPrefix: "msg"
+  });
+
+  await assertListIsSnapshot({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_a", type: "proposal", message: "new proposal" },
+    idPrefix: "ntf"
+  });
+});


### PR DESCRIPTION
Closes #4524
/claim #743

## Summary
- return shallow array snapshots from API service list functions
- preserve existing record objects and response shape
- add focused regression coverage proving callers cannot mutate backing stores through list responses

## Validation
- node --test apps/api/src/tests/listServices.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/tests/listServices.test.js
- node --check apps/api/src/services/jobService.js
- node --check apps/api/src/services/messageService.js
- node --check apps/api/src/services/notificationService.js
- node --check apps/api/src/services/proposalService.js
- node --check apps/api/src/services/reviewService.js
- node --check apps/api/src/services/userService.js
- git diff --check
- git diff --cached --check