### PR TITLE
Declare React dependency in UI package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "dependencies": {
+        "react": "19.2.0"
+      }
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "dependencies": {
+    "react": "19.2.0"
+  }
 }


### PR DESCRIPTION
/claim #743

Fixes #4523

## Summary
- Add `react` as an explicit dependency of the `@freelanceflow/ui` workspace package.
- Keep the version aligned with `apps/web` (`19.2.0`).
- Refresh the root lockfile workspace metadata for `packages/ui`.

## Validation
- Not run locally by this publisher.
- This is a focused package metadata change only.