### PR TITLE
Return defensive snapshots from service list functions

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/serviceSnapshots.test.js
+++ b/apps/api/src/tests/serviceSnapshots.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListSnapshot({ create, list, payload }) {
+  const before = await list();
+  await create(payload);
+
+  const snapshot = await list();
+  assert.equal(snapshot.length, before.length + 1);
+
+  snapshot.length = 0;
+
+  const afterMutation = await list();
+  assert.equal(afterMutation.length, before.length + 1);
+}
+
+test("user lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "snapshot-user@example.com", role: "client" }
+  });
+});
+
+test("job lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: createJob,
+    list: listJobs,
+    payload: {
+      title: "Snapshot job",
+      description: "Verify list snapshots cannot mutate backing arrays",
+      budgetMin: 10,
+      budgetMax: 25,
+      categoryId: "cat_test",
+      skills: ["testing"]
+    }
+  });
+});
+
+test("proposal lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_snapshot", freelancerId: "usr_snapshot", coverLetter: "Ready to help" }
+  });
+});
+
+test("review lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: createReview,
+    list: listReviews,
+    payload: { jobId: "job_snapshot", freelancerId: "usr_snapshot", rating: 5, comment: "Great work" }
+  });
+});
+
+test("message lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: sendMessage,
+    list: listMessages,
+    payload: { threadId: "thr_snapshot", body: "Hello" }
+  });
+});
+
+test("notification lists are defensive array snapshots", async () => {
+  await assertListSnapshot({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_snapshot", type: "proposal", message: "New update" }
+  });
+});


### PR DESCRIPTION
## Summary
- return shallow array snapshots from API service list functions
- keep record objects and response shapes unchanged
- add focused service regression coverage proving list response mutation cannot corrupt backing stores

## Why
The in-memory service list functions returned their module-level arrays directly. An in-process caller could mutate the returned array and silently corrupt later reads from the service backing store.

Fixes #4530
Related #4524
Related #743

/claim #743

## Validation
- `node --test .\src\tests\*.js` from `apps/api` -> 7 pass, 0 fail
- `git diff --check`
