### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,12 +1,18 @@
 import { ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
+import { fail } from "../utils/response.js";
 
 export async function getJobs(req, res) {
   return ok(res, await listJobs());
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid job payload", 400);
+  }
+
+  const payload = result.data;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      title: "Build bounty board",
+      description: "Create a small job board for payouts",
+      budgetMin: 100,
+      budgetMax: 50,
+      categoryId: "cat_1",
+      skills: ["api"]
+    })
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.match(payload.message, /budgetMin/i);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/jobs accepts valid job payloads", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      title: "Build bounty board",
+      description: "Create a small job board for payouts",
+      budgetMin: 50,
+      budgetMax: 100,
+      categoryId: "cat_1",
+      skills: ["api"]
+    })
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.budgetMin, 50);
+  assert.equal(payload.data.budgetMax, 100);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine((job) => job.budgetMin <= job.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMin"]
+});
+
+export const updateJobSchema = jobBaseSchema.partial();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Fixes #3663\n\n/claim #743\n\n## What changed\n- Added a refinement to reject jobs where budgetMin > budgetMax\n- Added a route-level regression test for the 400 response\n- Kept the update schema based on the unrefined base schema so partial updates still work\n\n## Validation\n- node --test src/tests/health.test.js src/tests/job.test.js\n- node --check src/controllers/jobController.js\n- node --check src/validators/job.js