### PR TITLE
List service responses should be defensive snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listUsers, createUser } from "../services/userService.js";
+import { listJobs, createJob } from "../services/jobService.js";
+import { listProposals, createProposal } from "../services/proposalService.js";
+import { listReviews, createReview } from "../services/reviewService.js";
+import { listMessages, sendMessage } from "../services/messageService.js";
+import { listNotifications, createNotification } from "../services/notificationService.js";
+
+const cases = [
+  {
+    name: "users",
+    create: () => createUser({ email: "a@example.com" }),
+    list: listUsers,
+    mutate: (items) => items.push({ id: "evil" }),
+    expect: (items) => assert.equal(items.length, 1)
+  },
+  {
+    name: "jobs",
+    create: () => createJob({ title: "Build thing", description: "A detailed job post", budgetMin: 10, budgetMax: 20, categoryId: "cat_1", skills: [] }),
+    list: listJobs,
+    mutate: (items) => items.splice(0, items.length),
+    expect: (items) => assert.equal(items.length, 1)
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ jobId: "job_1", freelancerId: "usr_1", coverLetter: "I can do this" }),
+    list: listProposals,
+    mutate: (items) => { items.length = 0; },
+    expect: (items) => assert.equal(items.length, 1)
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ jobId: "job_1", rating: 5, comment: "great" }),
+    list: listReviews,
+    mutate: (items) => items.push({ id: "evil" }),
+    expect: (items) => assert.equal(items.length, 1)
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ threadId: "thr_1", text: "hello" }),
+    list: listMessages,
+    mutate: (items) => items.pop(),
+    expect: (items) => assert.equal(items.length, 1)
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ userId: "usr_1", title: "Ping" }),
+    list: listNotifications,
+    mutate: (items) => items.unshift({ id: "evil" }),
+    expect: (items) => assert.equal(items.length, 1)
+  }
+];
+
+test("list services return defensive snapshots", async () => {
+  for (const entry of cases) {
+    const created = await entry.create();
+    const first = await entry.list();
+
+    assert.equal(first.length, 1, `${entry.name} should have one item`);
+    assert.notEqual(first, await entry.list(), `${entry.name} should return a fresh array`);
+
+    entry.mutate(first);
+    entry.expect(await entry.list());
+    assert.deepEqual((await entry.list())[0], created, `${entry.name} backing store should stay intact`);
+  }
+});


### PR DESCRIPTION
Fixes #4530\n\n/claim #743\n\n## What changed\n- Return shallow copies from all list services so callers cannot mutate backing stores\n- Added a regression test proving mutations to returned arrays do not affect later reads\n\n## Validation\n- node --test src/tests/health.test.js src/tests/listSnapshots.test.js\n- node --check src/services/userService.js src/services/jobService.js src/services/proposalService.js src/services/reviewService.js src/services/messageService.js src/services/notificationService.js