### PR TITLE
Omit submitted passwords from user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload ?? {};
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users does not persist or return submitted passwords", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `password-redaction-${Date.now()}@example.com`;
+    const createResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Password Redaction",
+        email,
+        password: "super-secret-password"
+      })
+    });
+
+    const created = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(created.success, true);
+    assert.equal(created.data.email, email);
+    assert.equal("password" in created.data, false);
+
+    const listResponse = await fetch(`${baseUrl}/api/users`);
+    const listed = await listResponse.json();
+    const storedUser = listed.data.find((user) => user.email === email);
+
+    assert.equal(listResponse.status, 200);
+    assert.ok(storedUser);
+    assert.equal("password" in storedUser, false);
+  });
+});


### PR DESCRIPTION
## Summary

- Removed `password` from user payloads before persisting or returning created users.
- Added route-level regression coverage for `POST /api/users` followed by `GET /api/users`.

Closes #4540
References #743

## Verification

- `node --test apps/api/src/tests/users.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/users.test.js`