### PR TITLE
Normalize payment intent currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,18 @@
+function normalizeCurrency(currency) {
+  if (typeof currency !== "string") {
+    return "usd";
+  }
+
+  const normalized = currency.trim().toLowerCase();
+  return normalized || "usd";
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function createPayment(baseUrl, payload) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  const body = await response.json();
+  assert.equal(response.status, 201);
+  return body.data;
+}
+
+test("POST /api/payments normalizes payment currencies", async () => {
+  await withServer(async (baseUrl) => {
+    const defaultCurrency = await createPayment(baseUrl, { amount: 1000 });
+    const mixedCaseCurrency = await createPayment(baseUrl, {
+      amount: 1000,
+      currency: " USD "
+    });
+    const blankCurrency = await createPayment(baseUrl, {
+      amount: 1000,
+      currency: "   "
+    });
+    const nonStringCurrency = await createPayment(baseUrl, {
+      amount: 1000,
+      currency: 123
+    });
+
+    assert.equal(defaultCurrency.currency, "usd");
+    assert.equal(mixedCaseCurrency.currency, "usd");
+    assert.equal(blankCurrency.currency, "usd");
+    assert.equal(nonStringCurrency.currency, "usd");
+  });
+});


### PR DESCRIPTION
## Summary

- Added payment currency normalization before returning payment intents.
- Preserved the default `usd` behavior for missing, blank, and non-string currencies.
- Added route-level regression coverage for default, mixed-case/whitespace, blank, and non-string currency values.

Closes #4542
References #743

## Verification

- `node --test apps/api/src/tests/payments.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/payments.test.js`