### PR TITLE
Remove stale Next.js version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
+- `apps/web` — Next.js App Router frontend
 - `apps/api` — Express.js backend with layered REST API
 - `packages/db` — Prisma schema and database package
 - `packages/ui` — Shared UI components


### PR DESCRIPTION
## Summary
- Removes the stale `Next.js 14` version claim from the workspace overview.
- Keeps the README aligned with `apps/web/package.json`, which currently depends on `next` `16.2.6`.

Fixes #4544

## Validation
- `git diff --check`
- Verified `README.md` now says `Next.js App Router frontend`
- Verified `apps/web/package.json` declares `next` `16.2.6`

/claim #743