### PR TITLE
Move site navigation out of main landmark

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,8 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+.site-shell { max-width: 960px; margin: 0 auto; padding: 0 1rem; }
+.site-header { padding-top: 2rem; }
+main.site-shell { padding-bottom: 2rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,9 +10,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <main>
+        <header className="site-shell site-header">
           <h1>FreelanceFlow</h1>
           <Navigation />
+        </header>
+        <main className="site-shell">
           {children}
         </main>
       </body>


### PR DESCRIPTION
## Summary
- Moves the repeated site title and global navigation into a sibling `<header>` landmark.
- Leaves route-specific page content inside `<main>` only.
- Adds shared `.site-shell` layout styling so the header and main content keep the existing width and page padding behavior.

Fixes #4547

## Validation
- `git diff --check`
- Verified `<Navigation />` renders inside `<header className="site-shell site-header">`
- Verified `<main className="site-shell">` contains `{children}` without the global navigation
- Verified shared CSS keeps the 960px centered shell and top/bottom page padding

Note: full `npm run build -w apps/web` could not complete in this workspace because dependencies were not installed and `npm ci` did not finish within the available execution window.

/claim #743
