### PR TITLE
Require Stripe configuration for production payments

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { createPaymentIntent, PaymentConfigurationError } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentConfigurationError) {
+      return fail(res, error.message, 503);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,17 @@
+import { env } from "../config/env.js";
+
+export class PaymentConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentConfigurationError";
+  }
+}
+
 export async function createPaymentIntent(payload) {
+  if (env.nodeEnv === "production" && !env.stripeSecretKey) {
+    throw new PaymentConfigurationError("Stripe is not configured");
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/paymentConfig.test.js
+++ b/apps/api/src/tests/paymentConfig.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments fails in production without Stripe configuration", async () => {
+  const previousNodeEnv = env.nodeEnv;
+  const previousStripeSecretKey = env.stripeSecretKey;
+  env.nodeEnv = "production";
+  env.stripeSecretKey = "";
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount: 5000, currency: "usd" })
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Stripe is not configured"
+      });
+    });
+  } finally {
+    env.nodeEnv = previousNodeEnv;
+    env.stripeSecretKey = previousStripeSecretKey;
+  }
+});


### PR DESCRIPTION
Closes #4549

/claim #743

## Summary
- Add a production-only guard so payment creation fails when `STRIPE_SECRET_KEY` is not configured.
- Map missing payment provider configuration to a structured `503` response instead of returning a fake successful Stripe payment.
- Add focused API regression coverage for the production missing-config path.

## Demo
The focused test exercises the behavior directly: with `env.nodeEnv = "production"` and an empty `env.stripeSecretKey`, `POST /api/payments` now returns `503` with `{ success: false, message: "Stripe is not configured" }` instead of a successful payment object.

## Validation
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentConfig.test.js`
- `node --test apps/api/src/tests/paymentConfig.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentConfig.test.js`
- `git -c core.fsmonitor=false diff --check`