### PR TITLE
Require Stripe config for production payments

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+import { env } from "../config/env.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  if (env.nodeEnv === "production" && !env.stripeSecretKey.trim()) {
+    return fail(res, "Payment provider is not configured", 503);
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects production requests without Stripe configuration", async () => {
+  const originalNodeEnv = env.nodeEnv;
+  const originalStripeSecretKey = env.stripeSecretKey;
+
+  env.nodeEnv = "production";
+  env.stripeSecretKey = "";
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount: 2500, currency: "usd" })
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 503);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Payment provider is not configured"
+      });
+    });
+  } finally {
+    env.nodeEnv = originalNodeEnv;
+    env.stripeSecretKey = originalStripeSecretKey;
+  }
+});


### PR DESCRIPTION
Fixes #4551

/claim #743

## What changed
- Reject production payment creation with a structured 503 JSON response when `STRIPE_SECRET_KEY` is not configured
- Keep development and test placeholder payment behavior unchanged
- Add a focused route-level regression test for the missing production Stripe configuration case

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/payment.test.js`
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/tests/payment.test.js`
- `git diff --check`