### PR TITLE
Require registered credentials for login

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,11 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+
+  if (!result) {
+    return fail(res, "Invalid credentials", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,37 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = [];
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password,
+    role: payload.role
+  };
+  registeredUsers.push(user);
+
+  return {
+    id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const user = registeredUsers.find((candidate) => candidate.email === payload.email);
+
+  if (!user || user.password !== payload.password) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, payload) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("POST /api/auth/login rejects unknown users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: `missing-${Date.now()}@example.com`,
+      password: "validpass123"
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid credentials"
+    });
+  });
+});
+
+test("POST /api/auth/login rejects mismatched passwords", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `auth-${Date.now()}@example.com`;
+
+    await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password: "correctpass123",
+      role: "client"
+    });
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "wrongpass123"
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid credentials"
+    });
+  });
+});
+
+test("POST /api/auth/login issues tokens for registered credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `auth-success-${Date.now()}@example.com`;
+
+    const registration = await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password: "correctpass123",
+      role: "freelancer"
+    });
+
+    assert.equal(registration.response.status, 201);
+    assert.equal(registration.payload.data.email, email);
+    assert.equal(registration.payload.data.role, "freelancer");
+    assert.equal("password" in registration.payload.data, false);
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "correctpass123"
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, email);
+    assert.equal(typeof payload.data.token, "string");
+    assert.equal("password" in payload.data, false);
+  });
+});


### PR DESCRIPTION
Fixes #4554

/claim #743

## What changed
- Store demo registration credentials in the auth service so login can verify known users
- Return a structured 401 response for unknown emails or mismatched passwords
- Preserve password-free registration and login response payloads
- Add focused auth route regression coverage for unknown-user, wrong-password, and successful registered-user login paths

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/auth.test.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/auth.test.js`
- `git diff --check`