### PR TITLE
[JARVIS] Solve issue #1426: fix: prevent admin role self-assignment

### DIFF
--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { userRole } from '../db/schema';
+
+export const loginSchema = z.object({
+  email: z.string().email({
+    message: 'Please enter a valid email address',
+  }),
+  password: z.string().min(1, {
+    message: 'Password is required',
+  }),
+});
+
+export const registerSchema = z.object({
+  email: z.string().email({
+    message: 'Please enter a valid email address',
+  }),
+  password: z.string().min(8, {
+    message: 'Password must be at least 8 characters long',
+  }),
+  name: z.string().min(2, {
+    message: 'Name must be at least 2 characters long',
+  }),
+  role: z.enum(userRole.enumValues).refine((role) => role !== 'admin', {
+    message: 'Cannot assign admin role to yourself.',
+  }),
+});
+
+export const requestPasswordResetSchema = z.object({
+  email: z.string().email({
+    message: 'Please enter a valid email address',
+  }),
+});
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, {
+      message: 'Password must be at least 8 characters long',
+    }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });


### PR DESCRIPTION
Automated solution generated by JARVIS Mark XL.

**Issue:** https://github.com/SecureBananaLabs/bug-bounty/issues/1426

Implement role restriction in registerSchema to prevent admin self-assignment, matching expected behavior.