### PR TITLE
[JARVIS] Solve issue #1737: fix: prevent admin role self-assignment

### DIFF
--- a/apps/api/src/users/dto/create-user.dto.ts
+++ b/apps/api/src/users/dto/create-user.dto.ts
@@ -1,0 +1,32 @@
+import { Role } from '@prisma/client';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotIn,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  email: string;
+
+  @MinLength(8)
+  password?: string;
+
+  @IsString()
+  @IsOptional()
+  firstName?: string;
+
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @IsEnum(Role)
+  @IsNotIn([Role.ADMIN], {
+    message: 'Admin role cannot be assigned during registration.',
+  })
+  @IsOptional()
+  role?: Role;
+}


### PR DESCRIPTION
Automated solution generated by JARVIS Mark XL.

**Issue:** https://github.com/SecureBananaLabs/bug-bounty/issues/1737

Implement registration role restriction to prevent admin self-assignment as a security fix.