### PR TITLE
Reject inverted job budget ranges in job validation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a reliable API service",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development",
+  skills: ["node"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema allows partial budget updates with only one field", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const ensureBudgetRange = (data, context) => {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+};
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(ensureBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(ensureBudgetRange);


### PR DESCRIPTION
## Summary

- reject job payloads where `budgetMax` is lower than `budgetMin`
- keep partial job updates valid when only one budget field is provided
- add focused validator coverage and make the API test script run test files explicitly

## Tests

- `npm.cmd test -w apps/api`

Closes #4562