### PR TITLE
Validate message payloads and protect server-owned fields

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map((i) => i.message).join("; "), 400);
+  }
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -4,8 +4,13 @@ export async function listMessages() {
   return messages;
 }
 
-export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+export async function sendMessage({ text, recipientId }) {
+  const message = {
+    id: `msg_${Date.now()}`,
+    text,
+    ...(recipientId ? { recipientId } : {}),
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-validation.test.js
+++ b/apps/api/src/tests/message-validation.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/messages with valid text returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "hello world" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.equal(body.data.text, "hello world");
+  assert.ok(body.data.id.startsWith("msg_"));
+  assert.ok(body.data.sentAt);
+
+  server.close();
+});
+
+test("POST /api/messages rejects missing text", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+
+  assert.equal(res.status, 400);
+
+  server.close();
+});
+
+test("POST /api/messages rejects empty text", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "" })
+  });
+
+  assert.equal(res.status, 400);
+
+  server.close();
+});
+
+test("caller-supplied id is ignored", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "test", id: "hacked_id" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.ok(body.data.id.startsWith("msg_"));
+  assert.notEqual(body.data.id, "hacked_id");
+
+  server.close();
+});
+
+test("caller-supplied sentAt is ignored", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: "test", sentAt: "1999-01-01T00:00:00.000Z" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 201);
+  assert.notEqual(body.data.sentAt, "1999-01-01T00:00:00.000Z");
+
+  server.close();
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  text: z.string().min(1, "Message text is required"),
+  recipientId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Problem

`POST /api/messages` forwards `req.body` directly into `sendMessage()`, which spreads the full payload into the message object. This means:

1. Callers can overwrite the server-generated `id` (`msg_*`) by passing their own
2. Callers can set `sentAt` to any value
3. Empty or incomplete payloads are accepted without validation

## Fix

Three-layer fix:

**Validator** (`validators/message.js`): Zod schema requiring `text` to be a non-empty string, with optional `recipientId`.

**Controller** (`controllers/messageController.js`): Uses `safeParse` before passing validated data to the service. Returns 400 with error details on invalid input.

**Service** (`services/messageService.js`): Destructures only the validated fields (`text`, `recipientId`) from the payload. The server-owned `id` and `sentAt` are never exposed to caller input.

## Testing

```bash
node --test src/tests/message-validation.test.js
```

All 5 tests pass:
- Valid message returns 201 with correct fields
- Missing text returns 400
- Empty text returns 400
- Caller-supplied `id` is ignored
- Caller-supplied `sentAt` is ignored

Fixes #4443