### PR TITLE
fix(api): require authentication for proposal endpoints

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
 
 export const proposalRoutes = Router();
+
+proposalRoutes.use(authMiddleware);
 
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/tests/proposalAuth.test.js
+++ b/apps/api/src/tests/proposalAuth.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/proposals requires authentication", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`);
+
+  assert.equal(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/proposals requires authentication", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jobId: "j1", rate: 50, message: "test" }),
+  });
+
+  assert.equal(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #4572

## Problem

`/api/proposals` (both GET and POST) is mounted without authentication.
Any caller — authenticated or not — can list all proposals or create new ones.
`/api/admin` correctly uses `authMiddleware`; proposals does not.

## Fix

Add `authMiddleware` to `proposalRoutes` the same way it is applied in `adminRoutes`:

```js
proposalRoutes.use(authMiddleware);
```

## Tests

`apps/api/src/tests/proposalAuth.test.js` — two new tests verify that
`GET /api/proposals` and `POST /api/proposals` both return `401` when called
without a bearer token.