### PR TITLE
fix(api): require authentication for message endpoints

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
+
+messageRoutes.use(authMiddleware);
 
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);


### PR DESCRIPTION
Closes #4574

## Problem

`/api/messages` (GET and POST) is mounted without authentication.
Unauthenticated callers can list all messages or send messages as any user.

## Fix

Add `authMiddleware` to `messageRoutes`:

```js
messageRoutes.use(authMiddleware);
```

Same pattern as `adminRoutes.js`.