### PR TITLE
fix(api): require authentication for job endpoints

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
+
+jobRoutes.use(authMiddleware);
 
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);


### PR DESCRIPTION
Closes #4575

## Problem

`/api/jobs` (GET and POST) is mounted without authentication.
Unauthenticated callers can list all jobs or create jobs without any identity check.

## Fix

Add `authMiddleware` to `jobRoutes`:

```js
jobRoutes.use(authMiddleware);
```

Same pattern as `adminRoutes.js`.