### PR TITLE
fix(api): require authentication for payment endpoint

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
+
+paymentRoutes.use(authMiddleware);
 
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
Closes #4578

## Problem

`POST /api/payments` is mounted without authentication. Unauthenticated callers can trigger payment creation.

## Fix

Add `authMiddleware` to `paymentRoutes`:

```js
paymentRoutes.use(authMiddleware);
```

Same pattern as `adminRoutes.js`.