### PR TITLE
fix(api): require authentication for notification endpoints

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
+
+notificationRoutes.use(authMiddleware);
 
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
Closes #4580

`/api/notifications` (GET and POST) lacks authentication. Add `authMiddleware` same as `adminRoutes`.