### PR TITLE
fix(api): require authentication for upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
+
+uploadRoutes.use(authMiddleware);
 
 uploadRoutes.post("/", upload.single("file"), uploadFile);


### PR DESCRIPTION
Closes #4582

`POST /api/uploads` allows unauthenticated file uploads. Add `authMiddleware` before the multer handler.