### PR TITLE
fix(api): verify refresh token before issuing new access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,10 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { refresh_token } = req.body ?? {};
+  if (!refresh_token) {
+    return fail(res, "refresh_token is required", 400);
+  }
+  const result = await refreshToken(refresh_token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,14 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  let payload;
+  try {
+    payload = verifyAccessToken(token);
+  } catch {
+    const err = new Error("Invalid or expired refresh token");
+    err.status = 401;
+    throw err;
+  }
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }


### PR DESCRIPTION
Closes #4584

## Problem

`POST /api/auth/refresh` called `refreshToken()` with no arguments and the service always issued a hardcoded token for `usr_existing` — any caller could get a new access token without providing any credentials.

## Fix

- **Controller**: extract `refresh_token` from request body; return `400` if missing.
- **Service**: call `verifyAccessToken(token)` before signing a new access token; throw `401` if the token is invalid or expired.

## Changes

- `apps/api/src/controllers/authController.js` — passes `req.body.refresh_token` to the service
- `apps/api/src/services/authService.js` — `refreshToken(token)` verifies the token with `verifyAccessToken` before re-signing