### PR TITLE
fix(api): validate proposal creation payload with Zod

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  rate: z.number().positive(),
+  message: z.string().min(10)
+});


### PR DESCRIPTION
Closes #4586

Adds `createProposalSchema` (Zod) in `validators/proposal.js` and applies it in `proposalController.postProposal`, matching the pattern used by `jobController`.