### PR TITLE
fix(api): validate message payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { sendMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  to: z.string().min(1),
+  text: z.string().min(1)
+});


### PR DESCRIPTION
Closes #4588

Adds `sendMessageSchema` in `validators/message.js` requiring `to` and `text` fields, then applies it in `messageController.postMessage`.