### PR TITLE
fix(api): require authentication for user endpoints

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getUsers, postUser } from "../controllers/userController.js";
 
 export const userRoutes = Router();
+
+userRoutes.use(authMiddleware);
 
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
Closes the issue above.

Add `authMiddleware` to `userRoutes` to prevent unauthenticated user enumeration.