### PR TITLE
fix(api): require authentication for search endpoint

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { search } from "../controllers/searchController.js";
 
 export const searchRoutes = Router();
+
+searchRoutes.use(authMiddleware);
 
 searchRoutes.get("/", search);


### PR DESCRIPTION
Closes the issue above.

Add `authMiddleware` to `searchRoutes` to prevent unauthenticated data enumeration.