### PR TITLE
fix: add authMiddleware to review routes

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
+reviewRoutes.use(authMiddleware);
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);


### PR DESCRIPTION
Closes #4598

## Change
Added `authMiddleware` import and `reviewRoutes.use(authMiddleware)` to `apps/api/src/routes/reviewRoutes.js`.

`GET /api/reviews` and `POST /api/reviews` now require a valid Bearer token, consistent with all other non-admin routes.

/attempt #743