### PR TITLE
fix: parse Bearer scheme case-insensitively in authMiddleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,7 +3,7 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !/^bearer /i.test(authHeader)) {
     return fail(res, "Unauthorized", 401);
   }
 


### PR DESCRIPTION
Closes #4599

## Change
Replaced `authHeader?.startsWith("Bearer ")` with `!authHeader || !/^bearer /i.test(authHeader)` in `apps/api/src/middleware/auth.js`.

Valid tokens sent with `bearer`, `BEARER`, or `Bearer` schemes are now accepted correctly per RFC 7235.

/attempt #743