### PR TITLE
fix: use shared ok() envelope for health endpoint

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { ok } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -24,7 +25,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+    return ok(res, { service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,7 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  assert.deepEqual(payload, { success: true, data: { service: "api" } });
 
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
Closes #4600

## Change
Imported `ok` from `./utils/response.js` and replaced the raw `res.status(200).json({ ok: true, service: 'api' })` call with `ok(res, { service: 'api' })` in `apps/api/src/app.js`.

Health endpoint now returns `{ success: true, data: { service: 'api' } }`, consistent with all other endpoints.

/attempt #743