### PR TITLE
fix: return 400 when no file is attached to upload request

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,8 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
-  return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
-  }, 201);
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+  return ok(res, { filename: req.file.originalname, status: "uploaded" }, 201);
 }


### PR DESCRIPTION
Closes #4601

## Change
Updated `apps/api/src/controllers/uploadController.js` to check `req.file` before responding. When no file is present, the controller now returns `fail(res, 'No file provided', 400)` instead of `201 Created`.

/attempt #743