### PR TITLE
fix: ensure notification read field cannot be overridden by client

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, ...payload, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Closes #4602

## Change
Reordered the object spread in `createNotification` in `apps/api/src/services/notificationService.js`:

Before: `{ id, read: false, ...payload }` — payload could override `read`
After:  `{ id, ...payload, read: false }` — server value always wins

/attempt #743