### PR TITLE
fix: validate and normalize search query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q;
+  if (Array.isArray(raw)) {
+    return fail(res, "Query parameter 'q' must be a single string", 400);
+  }
+  const q = typeof raw === "string" ? raw.trim().slice(0, 200) : "";
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Closes #4603

## Change
Updated `apps/api/src/controllers/searchController.js` to:
- Return `400` if `req.query.q` is an array (multiple values)
- Trim the string and cap it at 200 characters before passing to the service

/attempt #743