### PR TITLE
fix: validate review creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetUserId: z.string().min(1),
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().optional()
+});


### PR DESCRIPTION
Closes #4604

## Change
- Created `apps/api/src/validators/review.js` with a Zod schema requiring `targetUserId`, `jobId`, `rating` (integer 1–5), and optional `comment`
- Updated `reviewController.postReview` to validate with `createReviewSchema.safeParse()` before calling the service; invalid payloads return `400`

/attempt #743