### PR TITLE
fix: reject inverted budget range in job creation schema

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
+
+export const updateJobSchema = baseJobSchema.partial();


### PR DESCRIPTION
Closes #4605

## Change
Refactored `apps/api/src/validators/job.js` to split the base shape from the cross-field refinement:
- `createJobSchema` now includes a `.refine()` check that rejects payloads where `budgetMax < budgetMin`
- `updateJobSchema` remains a partial of the base shape (unaffected by the refinement)

/attempt #743