### PR TITLE
fix(upload): return 400 when no file is attached (Closes #4601)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Fixes #4601

## What changed
`uploadController.uploadFile` now returns `HTTP 400` with `{ success: false, message: "No file provided" }` when no file is attached, instead of incorrectly returning `HTTP 201`.

## Why
An upload endpoint must not return a success status when the client sent no file. The previous behaviour misled clients and violated REST semantics.

## How to verify
1. Send `POST /api/uploads` with a valid auth token but no `multipart/form-data` file field.
2. **Before**: Response `HTTP 201` with `{ success: true, data: { filename: null, status: "no-file" } }`
3. **After**: Response `HTTP 400` with `{ success: false, message: "No file provided" }`

## Scope
Only `apps/api/src/controllers/uploadController.js` modified. Multer config, routes, and other controllers untouched.

/attempt #743
