### PR TITLE
fix(notification): prevent client from overriding read field (Closes #4602)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, ...payload, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Fixes #4602

## What changed
`createNotification()` now constructs the notification object as `{ id, ...payload, read: false }` instead of `{ id, read: false, ...payload }`.

## Why
The `read` field is server-managed state. Previously, spreading `...payload` after `read: false` allowed a caller to override it by including `{ read: true }` in the request body.

## How to verify
1. `POST /api/notifications` with body `{ "userId": "u1", "type": "info", "message": "hi", "read": true }`
2. **Before**: stored notification has `read: true`
3. **After**: stored notification has `read: false` (server wins)

## Scope
Only `apps/api/src/services/notificationService.js` modified.

/attempt #743
