### PR TITLE
fix(search): validate and normalize query parameter (Closes #4603)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+
+  if (Array.isArray(q)) {
+    return fail(res, "Query parameter q must be a single string, not an array.", 400);
+  }
+
+  const trimmed = String(q).trim().slice(0, 200);
+  return ok(res, await globalSearch(trimmed));
 }


### PR DESCRIPTION
## Fixes #4603

## What changed
`searchController.search` now validates `req.query.q` before passing it to the service:
- If `q` is an array (`?q=a&q=b`), returns `HTTP 400`
- Trims and caps `q` to 200 characters

## Why
Express parses duplicate query params as arrays. Passing an array to `globalSearch()` produced `[object Object]`-style output. Also, arbitrarily long query strings reached the service unmodified.

## How to verify
1. `GET /api/search?q=hello&q=world` → `HTTP 400`
2. `GET /api/search?q=+[very long string]` → trimmed to 200 chars

## Scope
Only `apps/api/src/controllers/searchController.js` modified.

/attempt #743
