### PR TITLE
fix: omit password field when listing users

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(({ password, ...rest }) => rest);
 }
 
 export async function createUser(payload) {


### PR DESCRIPTION
Closes #4616

## Change
Updated `apps/api/src/services/userService.js` — `listUsers()` now maps over the user array using destructuring to exclude the `password` field before returning records to callers.

/attempt #743