### PR TITLE
fix: validate payment creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1)
+});


### PR DESCRIPTION
Closes #4623

## Change
- Created `apps/api/src/validators/payment.js` with a Zod schema requiring `amount` (positive number) and `currency` (non-empty string)
- Updated `paymentController.createPayment` to validate with `createPaymentSchema.safeParse()` before calling the service; invalid payloads return `400`

/attempt #743