### PR TITLE
fix: normalize payment currency to lowercase before processing

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }


### PR DESCRIPTION
Closes #4624

## Change
Updated `apps/api/src/services/paymentService.js` — `currency` is now normalized with `.toLowerCase()` before being stored: `(payload.currency ?? 'usd').toLowerCase()`.

/attempt #743