### PR TITLE
fix: validate user creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["client", "freelancer"])
+});


### PR DESCRIPTION
Closes #4625

## Change
- Created `apps/api/src/validators/user.js` with a Zod schema requiring `email` (valid email) and `role` (enum: `'client' | 'freelancer'`)
- Updated `userController.postUser` to validate with `createUserSchema.safeParse()` before calling the service; invalid payloads return `400`

/attempt #743