### PR TITLE
fix: validate proposal creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  rate: z.number().positive(),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
Closes #4629

## Change
- Created `apps/api/src/validators/proposal.js` with a Zod schema requiring `jobId` (string), `rate` (positive number), and `message` (string)
- Updated `proposalController.postProposal` to validate with `createProposalSchema.safeParse()`; invalid payloads return `400`

/attempt #743