### PR TITLE
fix: validate message payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { sendMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = sendMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  to: z.string().min(1),
+  text: z.string().min(1)
+});


### PR DESCRIPTION
Closes #4630

## Change
- Created `apps/api/src/validators/message.js` with a Zod schema requiring `to` (string) and `text` (string)
- Updated `messageController.postMessage` to validate with `sendMessageSchema.safeParse()`; invalid payloads return `400`

/attempt #743