### PR TITLE
fix: validate notification payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message, 400);
+  }
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  type: z.string().min(1),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
Closes #4633

## Change
- Created `apps/api/src/validators/notification.js` with a Zod schema requiring `userId`, `type`, and `message` (all non-empty strings)
- Updated `notificationController.postNotification` to validate with `createNotificationSchema.safeParse()`; invalid payloads return `400`

/attempt #743