### PR TITLE
fix: restrict upload file types and enforce 10 MB size limit

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,25 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(Object.assign(new Error("Unsupported file type"), { status: 400 }), false);
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
Closes #4637

## Change
Updated multer configuration in `apps/api/src/routes/uploadRoutes.js`:
- Added `limits: { fileSize: 10 * 1024 * 1024 }` (10 MB cap)
- Added `fileFilter` that rejects any MIME type not in the allowlist (`image/jpeg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`)

/attempt #743