### PR TITLE
fix: enforce admin role check on admin routes

### DIFF
--- a/apps/api/src/middleware/requireAdmin.js
+++ b/apps/api/src/middleware/requireAdmin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Closes #4639

## Change
- Created `apps/api/src/middleware/requireAdmin.js` that checks `req.user?.role === 'admin'` and returns `403 Forbidden` via `fail()` otherwise
- Updated `apps/api/src/routes/adminRoutes.js` to apply `requireAdmin` after `authMiddleware`

/attempt #743