### PR TITLE
fix: restrict CORS to allowlisted origins via CORS_ORIGIN env var

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,15 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim())
+  : false;
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: allowedOrigins }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Closes #4641

## Change
Updated `apps/api/src/app.js`:
- Added `allowedOrigins` that reads from `process.env.CORS_ORIGIN` (comma-separated list); falls back to `false` (deny all cross-origin) when not set
- Changed `cors()` to `cors({ origin: allowedOrigins })`

/attempt #743