### PR TITLE
fix: apply stricter per-route rate limit to auth endpoints

### DIFF
--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,8 +1,17 @@
+import rateLimit from "express-rate-limit";
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
 
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false
+});
+
 export const authRoutes = Router();
 
+authRoutes.use(authLimiter);
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);


### PR DESCRIPTION
Closes #4643

## Change
Updated `apps/api/src/routes/authRoutes.js`:
- Added a dedicated `authLimiter` (20 requests per 15-minute window, vs the global 200)
- Applied it via `authRoutes.use(authLimiter)` before all auth route handlers

/attempt #743