### PR TITLE
fix: guard payment intent creation when Stripe is not configured in production

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,11 @@
+import { env } from "../config/env.js";
+
 export async function createPaymentIntent(payload) {
+  if (!env.stripeSecretKey && env.nodeEnv === "production") {
+    const err = new Error("Payment processing is not configured");
+    err.status = 503;
+    throw err;
+  }
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,


### PR DESCRIPTION
Closes #4645

## Change
Updated `apps/api/src/services/paymentService.js`:
- Imported `env` from config
- Added guard: if `stripeSecretKey` is empty and `nodeEnv === 'production'`, throws a `503`-tagged error to prevent fake payment records from being created

/attempt #743