### PR TITLE
fix: reject duplicate email addresses on user registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,11 +1,18 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err.status === 409) {
+      return fail(res, err.message, 409);
+    }
+    throw err;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,26 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const users = [];
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
+  const duplicate = users.find((u) => u.email === payload.email);
+  if (duplicate) {
+    const err = new Error("Email address is already registered");
+    err.status = 409;
+    throw err;
+  }
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: payload.role
+  };
+  users.push(user);
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 


### PR DESCRIPTION
Closes #4647

## Change
- `authService.registerUser`: checks for an existing user with the same email before creating; throws a `409`-tagged error on duplicate
- `authController.register`: wraps the service call in try/catch; returns `fail(res, err.message, 409)` on a 409 error

/attempt #743