### PR TITLE
fix(docs): update stale Next.js version in README from 14 to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
+- `apps/web` — Next.js 16 App Router frontend
 - `apps/api` — Express.js backend with layered REST API
 - `packages/db` — Prisma schema and database package
 - `packages/ui` — Shared UI components


### PR DESCRIPTION
## Summary

The README states the frontend runs on Next.js 14, but `apps/web/package.json` declares `"next": "16.2.6"`. This causes confusion for contributors setting up the project.

## Fix

Update the README description to match the actual installed version.

Closes #4544

/attempt #743