### PR TITLE
fix(web): move Navigation landmark outside main element

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <Navigation />
         <main>
           <h1>FreelanceFlow</h1>
-          <Navigation />
           {children}
         </main>
       </body>


### PR DESCRIPTION
## Summary

In `apps/web/app/layout.tsx` the `<Navigation>` component (which renders a `<nav>` element) is nested inside `<main>`. This violates the ARIA landmark hierarchy — navigation landmarks should be siblings of `<main>`, not descendants of it. Screen readers and accessibility tools rely on this structure to provide correct landmark navigation.

## Fix

Move `<Navigation />` above `<main>` so the landmark hierarchy is:

```
body
├── nav (Navigation)
└── main
    └── {page content}
```

Closes #4547

/attempt #743