### PR TITLE
fix(api): add 50kb size limit to express.json() body parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "50kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
## Summary

`express.json()` was called without a `limit` option, allowing clients to POST arbitrarily large JSON payloads. The server parses the entire body in memory before any application logic runs — a large payload can exhaust heap space and cause a denial of service.

## Fix

Pass `{ limit: "50kb" }` to `express.json()`. Express will reject oversized requests with HTTP 413 Payload Too Large before they reach any controller.

Closes #4653

/attempt #743