### PR TITLE
Return JSON for unknown API routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,10 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use("/api", (req, res) => {
+    return fail(res, "Not found", 404);
+  });
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/api-not-found.test.js
+++ b/apps/api/src/tests/api-not-found.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown API routes return structured JSON 404 responses", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  });
+});
+
+test("existing non-API routes keep their current behavior", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
Refs #4322

/claim #743

## Summary

- Add an /api catch-all after the registered API routes.
- Return the existing structured error envelope for unknown API paths.
- Preserve existing route behavior such as GET /health.
- Update the API test script so route-level regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- GET /api/does-not-exist returns 404 JSON: { success: false, message: "Not found" }.
- GET /health keeps the existing 200 payload.