### PR TITLE
Reject non-positive payment amounts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment-amount.test.js
+++ b/apps/api/src/tests/payment-amount.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  return { response, payload: await response.json() };
+}
+
+test("payment creation rejects zero amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: 0,
+      currency: "usd"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  });
+});
+
+test("payment creation rejects negative amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: -10,
+      currency: "usd"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  });
+});
+
+test("payment creation preserves valid positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: 25,
+      currency: "nzd"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "nzd");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).optional()
+});


### PR DESCRIPTION
Refs #4253

/claim #743

## Summary

- Add payment creation payload validation for amount and currency.
- Reject zero and negative payment amounts with 400 Validation failed.
- Preserve valid positive payment creation behavior.
- Update the API test script so route-level regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- POST /api/payments rejects amount: 0.
- POST /api/payments rejects negative amounts.
- POST /api/payments preserves valid positive amounts.