### PR TITLE
Require proposal estimated duration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposal-duration.test.js
+++ b/apps/api/src/tests/proposal-duration.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  return { response, payload: await response.json() };
+}
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can complete this safely.",
+  bidAmount: 250,
+  estDuration: "2 weeks"
+};
+
+test("proposal creation rejects missing estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const { estDuration, ...payloadWithoutDuration } = validProposal;
+    const { response, payload } = await postProposal(baseUrl, payloadWithoutDuration);
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  });
+});
+
+test("proposal creation rejects blank estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postProposal(baseUrl, {
+      ...validProposal,
+      estDuration: "   "
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  });
+});
+
+test("proposal creation preserves valid estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postProposal(baseUrl, validProposal);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.equal(payload.data.estDuration, "2 weeks");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1)
+});


### PR DESCRIPTION
Refs #4224

/claim #743

## Summary

- Add a focused proposal creation schema.
- Require jobId, freelancerId, coverLetter, positive bidAmount, and estDuration.
- Reject missing or blank estDuration with 400 Validation failed.
- Preserve valid proposal creation with estimated duration.
- Update the API test script so route-level regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- Missing estDuration is rejected.
- Blank estDuration is rejected.
- Valid estDuration is preserved on created proposals.