### PR TITLE
Require auth for user and search routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
+searchRoutes.use(authMiddleware);
 searchRoutes.get("/", search);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/auth-routes.test.js
+++ b/apps/api/src/tests/auth-routes.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertRequest) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertRequest(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/users requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/search requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});


### PR DESCRIPTION
﻿/claim #743

Closes #4658.

## Summary
- apply the existing bearer-token `authMiddleware` to `/api/users`
- apply the same guard to `/api/search`
- add focused route tests proving both endpoints return the shared 401 response without credentials
- update the API test script so it executes the checked-in `*.test.js` files consistently

## Verification
- `npm test -w apps/api`
- `git diff --check`

## Demo / Evidence
- Demo evidence comment: https://github.com/SecureBananaLabs/bug-bounty/pull/4659#issuecomment-4629111468

