### PR TITLE
Resolve freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,27 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "../../../lib/mock";
+
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+  const freelancer = freelancers.find((profile) => profile.username === username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No freelancer profile exists for <strong>{username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p>{freelancer.skills.join(" / ")}</p>
+      <p>{freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
Refs #4206

/claim #743

## Summary

- Look up freelancer profile pages from the existing mock freelancer data by username.
- Render matching profile skills and hourly rate for known usernames such as maya-dev and jordan-ux.
- Add a clear not-found fallback for unknown freelancer usernames.
- Keep the fix scoped to the freelancer profile route.

## Validation

- npm exec -w apps/web -- tsc --noEmit
  - The touched freelancer route type-checks with Next 16 async params.
  - The command still reports the pre-existing apps/web/app/jobs/[id]/page.tsx async params issue outside this change.
- npm exec -w apps/web -- next build --webpack
  - Webpack compilation succeeded before the local Windows SWC worker exited with an environment binding error.