### PR TITLE
Add clear contract poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Clear Contract
+
+The client writes the border lines,
+The maker reads them into light;
+A scope that names its turns and signs,
+Can guide the work from wrong to right.
+
+The proof arrives with numbered care,
+Each change can show the trail it made;
+Reviewers meet the record there,
+And weigh the craft before it is paid.
+
+No promise hides in drifting chat,
+No milestone fades behind the door;
+The ledger knows the where and what,
+And asks for neither less nor more.
+
+When escrow holds the agreed-upon rate,
+The worker builds without a doubt;
+The buyer sees the finished state,
+And fair release can travel out.
+
+So FreelanceFlow keeps trust in tune,
+With scope, review, and payout clear;
+A signed-off task beneath the moon,
+Becomes good work that all can hear.


### PR DESCRIPTION
/claim #76

Adds a root-level `POEM.md` with an original five-stanza rhymed poem for FreelanceFlow.

Creative note: "Clear Contract" frames scope, proof, review, escrow, and payout as accountable work promises moving through the marketplace.

Validation:
- Root `POEM.md` added
- 5 stanzas, original and project-specific
- `git diff --check` passed
