### PR TITLE
Require JWT secret in production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,21 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+function readJwtSecret() {
+  if (process.env.JWT_SECRET) {
+    return process.env.JWT_SECRET;
+  }
+
+  if (nodeEnv === "production") {
+    throw new Error("JWT_SECRET is required in production");
+  }
+
+  return "development-secret";
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: readJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+function importEnvWith(overrides) {
+  const script = "await import('./src/config/env.js');";
+  return spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ...overrides
+    },
+    encoding: "utf8"
+  });
+}
+
+test("production env requires JWT_SECRET", () => {
+  const result = importEnvWith({
+    NODE_ENV: "production",
+    JWT_SECRET: ""
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET is required in production/);
+});
+
+test("production env accepts an explicit JWT_SECRET", () => {
+  const result = importEnvWith({
+    NODE_ENV: "production",
+    JWT_SECRET: "prod-secret"
+  });
+
+  assert.equal(result.status, 0);
+});
+
+test("development env keeps the fallback JWT secret", () => {
+  const result = importEnvWith({
+    NODE_ENV: "development",
+    JWT_SECRET: ""
+  });
+
+  assert.equal(result.status, 0);
+});


### PR DESCRIPTION
Refs #4050

/claim #743

## Summary

- Keep the development JWT secret fallback for local development.
- Require JWT_SECRET to be explicitly set when NODE_ENV is production.
- Throw a clear startup configuration error instead of silently using development-secret in production.
- Update the API test script so config regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- Production without JWT_SECRET fails configuration import.
- Production with JWT_SECRET succeeds.
- Development without JWT_SECRET keeps the existing fallback behavior.