### PR TITLE
Return defensive list copies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-services.test.js
+++ b/apps/api/src/tests/list-services.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createUser, listUsers } from "../services/userService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+async function assertDefensiveListCopy({ create, list, payload }) {
+  await create(payload);
+
+  const firstResult = await list();
+  const originalLength = firstResult.length;
+  firstResult.push({ id: "injected" });
+
+  const secondResult = await list();
+  assert.equal(secondResult.length, originalLength);
+  assert.equal(secondResult.some((item) => item.id === "injected"), false);
+  assert.notEqual(firstResult, secondResult);
+}
+
+test("job lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Job" }
+  });
+});
+
+test("user lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "user@example.com" }
+  });
+});
+
+test("proposal lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_1" }
+  });
+});
+
+test("notification lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_1", text: "Hello" }
+  });
+});
+
+test("review lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: createReview,
+    list: listReviews,
+    payload: { jobId: "job_1", rating: 5 }
+  });
+});
+
+test("message lists return defensive array copies", async () => {
+  await assertDefensiveListCopy({
+    create: sendMessage,
+    list: listMessages,
+    payload: { from: "usr_1", to: "usr_2", text: "Hi" }
+  });
+});


### PR DESCRIPTION
Refs #3713

/claim #743

## Summary

- Return new arrays from list service methods instead of exposing internal in-memory arrays.
- Cover jobs, users, proposals, notifications, reviews, and messages.
- Preserve the existing created record objects and list contents.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 7, pass 7, fail 0.

Covered cases:

- Mutating a returned list does not mutate the next list response for each affected service.
- Each list call returns a distinct array instance.