### PR TITLE
Preserve payment job ids

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -2,6 +2,7 @@ export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
+    jobId: payload.jobId,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/payment-job-id.test.js
+++ b/apps/api/src/tests/payment-job-id.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("payment intents preserve submitted job ids", async () => {
+  const payment = await createPaymentIntent({
+    jobId: "job_123",
+    amount: 120,
+    currency: "usd"
+  });
+
+  assert.match(payment.paymentId, /^pay_/);
+  assert.equal(payment.jobId, "job_123");
+  assert.equal(payment.amount, 120);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+});


### PR DESCRIPTION
Refs #3726

/claim #743

## Summary

- Preserve submitted jobId values on created payment intents.
- Keep the existing generated payment id, amount, currency, and provider fields unchanged.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered case:

- createPaymentIntent keeps the submitted jobId while preserving the existing payment response fields.