### PR TITLE
Assign server-owned review timestamps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}`, createdAt: new Date().toISOString() };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-created-at.test.js
+++ b/apps/api/src/tests/review-created-at.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("review creation assigns server-owned createdAt timestamps", async () => {
+  const callerCreatedAt = "2000-01-01T00:00:00.000Z";
+
+  const review = await createReview({
+    jobId: "job_1",
+    freelancerId: "usr_1",
+    rating: 5,
+    text: "Great work",
+    createdAt: callerCreatedAt
+  });
+
+  assert.match(review.id, /^rev_/);
+  assert.notEqual(review.createdAt, callerCreatedAt);
+  assert.doesNotThrow(() => new Date(review.createdAt).toISOString());
+});


### PR DESCRIPTION
Refs #3730

/claim #743

## Summary

- Assign review createdAt timestamps on the server when reviews are created.
- Apply server-owned id and createdAt after caller payload fields so submitted values cannot override them.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered case:

- createReview ignores a caller-supplied createdAt value and returns a valid server timestamp.