### PR TITLE
Validate review rating range

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,10 +1,17 @@
 const reviews = [];
 
+function assertValidRating(rating) {
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    throw new RangeError("Review rating must be an integer from 1 to 5");
+  }
+}
+
 export async function listReviews() {
   return reviews;
 }
 
 export async function createReview(payload) {
+  assertValidRating(payload?.rating);
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+const baseReview = {
+  reviewerId: "user_reviewer",
+  revieweeId: "user_reviewee",
+  comment: "Delivered the work on time."
+};
+
+test("createReview accepts integer ratings from 1 through 5", async () => {
+  for (const rating of [1, 2, 3, 4, 5]) {
+    const review = await createReview({ ...baseReview, rating });
+
+    assert.equal(review.rating, rating);
+  }
+});
+
+test("createReview rejects ratings outside the 1-5 integer range", async () => {
+  const invalidRatings = [0, 6, -1, 3.5, "5", Number.NaN, Infinity, -Infinity, null, undefined];
+
+  for (const rating of invalidRatings) {
+    const listLengthBefore = (await listReviews()).length;
+
+    await assert.rejects(
+      () => createReview({ ...baseReview, rating }),
+      /Review rating must be an integer from 1 to 5/
+    );
+    assert.equal((await listReviews()).length, listLengthBefore);
+  }
+});


### PR DESCRIPTION
Refs #3742

/claim #743

## Summary

- Reject review ratings unless they are integers from 1 through 5.
- Prevent invalid ratings from being stored by the review service.
- Add focused service regression tests for valid boundary ratings and invalid rating values.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- createReview accepts integer ratings 1, 2, 3, 4, and 5.
- createReview rejects 0, 6, negative, decimal, string, NaN, Infinity, null, and missing ratings.
- Invalid review attempts do not mutate the stored review list.