### PR TITLE
Cap auth password length

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+const validEmail = "worker@example.com";
+const maxPassword = "a".repeat(128);
+const tooLongPassword = "a".repeat(129);
+
+test("auth validators accept 128-character passwords", () => {
+  const registerResult = registerSchema.safeParse({
+    email: validEmail,
+    password: maxPassword,
+    role: "client"
+  });
+  const loginResult = loginSchema.safeParse({
+    email: validEmail,
+    password: maxPassword
+  });
+
+  assert.equal(registerResult.success, true);
+  assert.equal(loginResult.success, true);
+});
+
+test("auth validators reject passwords longer than 128 characters", () => {
+  const registerResult = registerSchema.safeParse({
+    email: validEmail,
+    password: tooLongPassword,
+    role: "client"
+  });
+  const loginResult = loginSchema.safeParse({
+    email: validEmail,
+    password: tooLongPassword
+  });
+
+  assert.equal(registerResult.success, false);
+  assert.equal(loginResult.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+const passwordSchema = z.string().min(8).max(128);
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
Refs #3740

/claim #743

## Summary

- Add a shared auth password schema with the existing 8-character minimum and a 128-character maximum.
- Apply the max length to both registration and login validators.
- Add focused validator regression tests for 128-character accepted passwords and 129-character rejected passwords.
- Update the API test script so validator regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- registerSchema accepts a 128-character password.
- loginSchema accepts a 128-character password.
- registerSchema rejects a 129-character password.
- loginSchema rejects a 129-character password.