### PR TITLE
fix(auth): generate user id once to prevent token/user id mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authRegister.test.js
+++ b/apps/api/src/tests/authRegister.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+// Decode JWT without verifying signature (we only need the payload)
+function decodeToken(token) {
+  const [, payloadB64] = token.split(".");
+  return JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+}
+
+// ─── registerUser returns consistent id and token sub ────────
+
+test("registerUser: token sub matches returned id", async () => {
+  const result = await registerUser({ email: "test@example.com", role: "client" });
+
+  assert.ok(result.id, "result should have an id");
+  assert.ok(result.token, "result should have a token");
+
+  const decoded = decodeToken(result.token);
+  assert.equal(decoded.sub, result.id, "JWT sub must equal the returned user id");
+});
+
+test("registerUser: id and token sub use the same generated value", async () => {
+  const result = await registerUser({ email: "a@b.com", role: "freelancer" });
+  const decoded = decodeToken(result.token);
+
+  // Both should reference the same usr_<timestamp> id
+  assert.ok(result.id.startsWith("usr_"), "id should start with usr_");
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, "freelancer");
+});
+
+test("registerUser: each call generates a consistent id (sub always matches)", async () => {
+  const r1 = await registerUser({ email: "a@b.com", role: "client" });
+  const r2 = await registerUser({ email: "c@d.com", role: "client" });
+
+  // Both calls independently produce valid, self-consistent results
+  const d1 = decodeToken(r1.token);
+  const d2 = decodeToken(r2.token);
+  assert.equal(d1.sub, r1.id, "first call: sub matches id");
+  assert.equal(d2.sub, r2.id, "second call: sub matches id");
+  assert.ok(r1.id.startsWith("usr_"), "id format");
+});
+
+test("registerUser: response shape is unchanged", async () => {
+  const result = await registerUser({ email: "x@y.com", role: "client" });
+
+  assert.deepEqual(Object.keys(result).sort(), ["email", "id", "role", "token"]);
+  assert.equal(result.email, "x@y.com");
+  assert.equal(result.role, "client");
+});


### PR DESCRIPTION
## Summary

Fixes #4675 (references #4674 / parent #743).

`authService.registerUser()` called `Date.now()` independently for the returned `id` and the JWT `sub` claim. When those calls spanned different milliseconds, the issued token identified a different user than the API response — breaking all downstream auth that trusts `req.user.sub`.

## What changed

**`apps/api/src/services/authService.js`** — generate the user id once and reuse it for both the response `id` and the JWT `sub`:

```js
const id = `usr_${Date.now()}`;
return { id, ..., token: signAccessToken({ sub: id, role: payload.role }) };
```

## Tests

**`apps/api/src/tests/authRegister.test.js`** — 4 new tests:

| Test | Verifies |
|------|----------|
| token sub matches returned id | core invariant: `decoded.sub === result.id` |
| id and token sub use the same value | role passthrough + id format |
| each call generates consistent id | regression: both registrations self-consistent |
| response shape unchanged | API contract preserved |

**Full suite: 25/25 passing.**

## How to verify

```bash
cd apps/api && node --test src/tests/authRegister.test.js
```

/claim #4675