### PR TITLE
fix(api): return 400 for Zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: err.issues[0]?.message ?? "Invalid request payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse(headersSent = false) {
+  return {
+    body: undefined,
+    headersSent,
+    statusCode: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 with the first Zod validation message", () => {
+  const schema = z.object({
+    email: z.string().email("email must be valid")
+  });
+  const result = schema.safeParse({ email: "not-an-email" });
+  const res = createResponse();
+  let forwardedError;
+
+  assert.equal(result.success, false);
+
+  errorHandler(result.error, {}, res, (err) => {
+    forwardedError = err;
+  });
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "email must be valid"
+  });
+  assert.equal(forwardedError, undefined);
+});
+
+test("errorHandler keeps generic errors as 500 responses", () => {
+  const res = createResponse();
+  const originalError = console.error;
+
+  console.error = () => {};
+  try {
+    errorHandler(new Error("database unavailable"), {}, res, () => {});
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});
+
+test("errorHandler forwards errors after headers have been sent", () => {
+  const err = new Error("stream failed");
+  const res = createResponse(true);
+  let forwardedError;
+
+  errorHandler(err, {}, res, (nextErr) => {
+    forwardedError = nextErr;
+  });
+
+  assert.equal(forwardedError, err);
+  assert.equal(res.statusCode, undefined);
+  assert.equal(res.body, undefined);
+});


### PR DESCRIPTION
Fixes #4677

/claim #743

## Summary
- Detect `ZodError` in the shared API error handler before the generic 500 path.
- Return `400` with the first validation message using the existing `{ success: false, message }` JSON shape.
- Add focused middleware regression tests for Zod validation errors, generic errors, and already-sent headers.

## Validation
- `node --test apps/api/src/tests/*.test.js`

## Demo
The regression test exercises the failed path directly: a Zod email validation failure now returns `400` with `email must be valid`, while generic errors still return the existing `500` response.
