### PR TITLE
fix(search): Add input validation and length limit to search query

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,23 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+
+  // Reject non-string input (e.g., repeated q parameters result in array)
+  if (q !== undefined && typeof q !== "string") {
+    return fail(res, "Query parameter 'q' must be a string", 400);
+  }
+
+  // Trim and use empty string as default
+  const query = (q ?? "").trim();
+
+  // Enforce length limit
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query parameter 'q' must not exceed ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }


### PR DESCRIPTION
## Summary

This PR fixes the search endpoint input validation issue (#4673).

### Changes Made

1. **Input type validation** - Reject non-string q parameters
2. **Whitespace trimming** - Trim leading/trailing whitespace
3. **Length limit** - Enforce 200 character maximum
4. **Error responses** - Return 400 Bad Request

Fixes #4673
Refs #743