### PR TITLE
fix(auth): keep registered token subject aligned with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Summary
- Generate the registered user id once in `registerUser`
- Reuse that id for both the API response and the JWT `sub` claim

## Validation
- Static check: `Date.now()` is now called once in `apps/api/src/services/authService.js`
- Static check: both `id` and token `sub` reference the same `userId`
- Could not run `npm test` locally because npm is not available in this environment; WindowsApps `node.exe` is present but cannot be executed due Access denied.

Closes #4674