### PR TITLE
fix(upload): Reject empty file uploads with 400 response

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided. Please include a file in the request.", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Summary

This PR fixes the upload endpoint to properly reject requests without files.

### Changes Made

1. **Reject missing file** - Return 400 Bad Request when no file is provided
2. **Descriptive error** - Include helpful error message
3. **Proper success** - Only return 201 when file actually exists

Fixes #4680
Refs #743