### PR TITLE
fix(api): validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a focused marketing landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "frontend",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMax must be greater than or equal to budgetMin"
+  );
+});
+
+test("createJobSchema accepts equal and ascending budget ranges", () => {
+  assert.equal(
+    createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 500,
+      budgetMax: 500
+    }).success,
+    true
+  );
+
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+});
+
+test("updateJobSchema validates budget range only when both bounds are provided", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,22 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const budgetRangeIsValid = (payload) =>
+  payload.budgetMin === undefined ||
+  payload.budgetMax === undefined ||
+  payload.budgetMax >= payload.budgetMin;
+
+const budgetRangeValidation = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = jobSchema.refine(
+  budgetRangeIsValid,
+  budgetRangeValidation
+);
+
+export const updateJobSchema = jobSchema.partial().refine(
+  budgetRangeIsValid,
+  budgetRangeValidation
+);


### PR DESCRIPTION
Fixes #4683

/claim #743

## Summary
- Add a shared cross-field budget range rule for job payloads.
- Reject `budgetMax < budgetMin` on the `budgetMax` path with a clear validation message.
- Preserve partial update behavior unless both budget bounds are present.
- Add focused validator tests for inverted, equal, ascending, and partial budget payloads.

## Validation
- `node --test apps/api/src/tests/*.test.js`

## Demo
The regression test now exercises the invalid range directly: `budgetMin: 500` with `budgetMax: 100` fails validation on `budgetMax`, while equal/ascending ranges and partial update payloads still pass.
