### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +11,21 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(
+  (job) => job.budgetMax >= job.budgetMin,
+  {
+    message: budgetRangeMessage,
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = jobSchema.partial().refine(
+  (job) =>
+    job.budgetMin === undefined ||
+    job.budgetMax === undefined ||
+    job.budgetMax >= job.budgetMin,
+  {
+    message: budgetRangeMessage,
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
/claim #743

## Summary
- add a cross-field budget range check to `createJobSchema`
- reject job creation payloads where `budgetMax < budgetMin`
- keep partial job updates usable while applying the same range check when both fields are present

## Verification
- `node --input-type=module -e "import assert from 'node:assert/strict'; import { createJobSchema, updateJobSchema } from './apps/api/src/validators/job.js'; const valid = { title: 'Build API', description: 'Build a useful API', budgetMin: 100, budgetMax: 500, categoryId: 'cat_1', skills: ['node'] }; assert.equal(createJobSchema.parse(valid).budgetMax, 500); const result = createJobSchema.safeParse({ ...valid, budgetMin: 500, budgetMax: 100 }); assert.equal(result.success, false); assert.equal(result.error.issues[0].path.join('.'), 'budgetMax'); assert.match(result.error.issues[0].message, /budgetMax/); assert.equal(updateJobSchema.safeParse({ title: 'Only title' }).success, true); assert.equal(updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 100 }).success, false);"`
- `node --test apps/api/src/tests/health.test.js`
- `git diff --check`

Closes #4605