### PR TITLE
fix(auth): Protect refresh endpoint with auth middleware

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }


### PR DESCRIPTION
## Summary

This PR fixes the auth refresh endpoint to properly authenticate users.

### Changes Made

1. **Add auth middleware** - Protect refresh route with bearer token verification
2. **Use authenticated user** - Pass req.user to refreshToken service
3. **Sign with correct subject** - Refreshed token uses actual user sub and role

### Files Changed

- `apps/api/src/routes/authRoutes.js` - Add authMiddleware to refresh route
- `apps/api/src/controllers/authController.js` - Pass req.user to refreshToken
- `apps/api/src/services/authService.js` - Accept and use user payload

Fixes #4684
Refs #743