### PR TITLE
fix: require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/requireAdmin.js
+++ b/apps/api/src/middleware/requireAdmin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-role.test.js
+++ b/apps/api/src/tests/admin-role.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestMetrics(baseUrl, role) {
+  const token = signAccessToken({ sub: `usr_${role}`, role });
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { authorization: `Bearer ${token}` }
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("admin metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await requestMetrics(baseUrl, "admin");
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});
+
+test("admin metrics rejects non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await requestMetrics(baseUrl, "client");
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, { success: false, message: "Forbidden" });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a `requireAdmin` middleware that rejects non-admin authenticated users with `403 Forbidden`
- apply the admin role gate after `authMiddleware` for all `/api/admin` routes
- add focused route coverage for admin access and non-admin rejection

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/admin-role.test.js`
- `git diff --check`

Closes #4639
