### PR TITLE
fix: redact credential fields from user listings

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,12 @@
 const users = [];
 
+function toPublicUser(user) {
+  const { password, passwordHash, accessToken, refreshToken, ...publicUser } = user;
+  return publicUser;
+}
+
 export async function listUsers() {
-  return users;
+  return users.map(toPublicUser);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/user-service.test.js
+++ b/apps/api/src/tests/user-service.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers redacts password and credential fields", async () => {
+  const email = `redacted-${Date.now()}@example.com`;
+
+  await createUser({
+    email,
+    role: "client",
+    password: "plain-secret",
+    passwordHash: "hashed-secret",
+    accessToken: "access-token",
+    refreshToken: "refresh-token"
+  });
+
+  const listedUsers = await listUsers();
+  const listedUser = listedUsers.find((user) => user.email === email);
+
+  assert.ok(listedUser);
+  assert.equal(listedUser.role, "client");
+  assert.equal(listedUser.password, undefined);
+  assert.equal(listedUser.passwordHash, undefined);
+  assert.equal(listedUser.accessToken, undefined);
+  assert.equal(listedUser.refreshToken, undefined);
+});


### PR DESCRIPTION
/claim #743

## Summary
- redact `password` and credential-like fields from `listUsers()` responses
- return public user snapshots without changing user creation behavior
- add focused service coverage to prevent password, passwordHash, accessToken, and refreshToken leaks

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/user-service.test.js`
- `git diff --check`

Closes #4616
