### PR TITLE
fix: normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-service.test.js
+++ b/apps/api/src/tests/payment-service.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes currency to lowercase", async () => {
+  const payment = await createPaymentIntent({ amount: 100, currency: "USD" });
+
+  assert.equal(payment.amount, 100);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+});
+
+test("createPaymentIntent keeps default currency lowercase", async () => {
+  const payment = await createPaymentIntent({ amount: 100 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
/claim #743

## Summary
- normalize payment intent currency codes to lowercase before storing or returning them
- keep the existing `usd` fallback behavior
- add focused service coverage for uppercase input and missing currency fallback

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/payment-service.test.js`
- `git diff --check`

Closes #4624
