### PR TITLE
fix(web): Resolve freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,24 @@
+import { freelancers } from "@/lib/mock";
+import { notFound } from "next/navigation";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find(f => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username: <strong>{params.username}</strong></p>
+        <p>Please check the username and try again.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

This PR fixes the freelancer profile page to display actual mock data instead of placeholder text.

### Changes Made

1. **Import mock data** - Import freelancers array from mock.ts
2. **Lookup by username** - Find freelancer matching the URL param
3. **Display real data** - Show skills and rate for known usernames
4. **Not-found fallback** - Clear message for unknown usernames

Fixes #4695
Refs #743