### PR TITLE
fix: validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,10 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid message", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message-validation.test.js
+++ b/apps/api/src/tests/message-validation.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/messages rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postMessage(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/messages accepts valid messages", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postMessage(baseUrl, {
+      to: "usr_1",
+      text: "Hello"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.to, "usr_1");
+    assert.equal(payload.data.text, "Hello");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  to: z.string().min(1),
+  text: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for message creation payloads
- reject invalid `POST /api/messages` bodies with `400 Bad Request` before the service runs
- pass only validated `to` and `text` fields to `sendMessage`
- add route coverage for empty payload rejection and valid message creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/message-validation.test.js`
- `git diff --check`

Closes #4630
