### PR TITLE
fix(validation): Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,23 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin when both are provided",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Summary

This PR fixes job validation to reject inverted budget ranges.

### Changes Made

1. **Create job validation** - Add refinement to ensure budgetMax >= budgetMin
2. **Update job validation** - Add refinement for partial updates when both fields present
3. **Clear error messages** - Return descriptive error on invalid ranges

Fixes #4699
Refs #743