### PR TITLE
fix: require fullName in registration validation

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,8 +5,9 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role }),
   };
 }
 
@@ -14,7 +15,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "client" }),
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /register rejects missing fullName", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "test@example.com",
+      password: "password123",
+      role: "client",
+    }),
+  });
+
+  assert.equal(response.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /register rejects whitespace-only fullName", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fullName: "   ",
+      email: "test@example.com",
+      password: "password123",
+      role: "client",
+    }),
+  });
+
+  assert.equal(response.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /register accepts valid payload with fullName", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fullName: "Test User",
+      email: "test@example.com",
+      password: "password123",
+      role: "client",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+
+  assert.equal(payload.data.email, "test@example.com");
+  assert.equal(payload.data.fullName, "Test User");
+  assert.equal(payload.data.role, "client");
+  assert.ok(payload.data.token);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,13 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1, "fullName is required").max(255),
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer", "admin"]).default("client"),
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8),
 });


### PR DESCRIPTION
Closes #2770

## Problem
The Prisma `User` model requires `fullName`, but the registration schema only accepted `email`, `password`, and `role`. `registerUser()` also omitted `fullName` from the returned user payload. When the auth flow wires to Prisma, registration payloads accepted by the API are missing a required user field.

## Fix
- **Validator**: Added `fullName: z.string().trim().min(1, "fullName is required").max(255)` to `registerSchema`
- **Service**: Included `fullName: payload.fullName` in `registerUser()` response
- **Tests**: 
  - Missing `fullName` → 400
  - Whitespace-only `fullName` → 400
  - Valid payload → 201 with `fullName` preserved in response

## Security Notes
- `.trim()` uses JavaScript's `String.prototype.trim()` which strips the full Unicode whitespace set (including U+3000, U+FEFF), safe against Unicode bypass
- `.max(255)` prevents oversized name attacks
- Prisma ORM uses parameterized queries — no SQL injection vector through this field
- `JSON.stringify()` does not escape `<>` but this is a downstream concern for SSR consumers, not an API vulnerability

## Files Changed
- `apps/api/src/validators/auth.js` — added fullName validation
- `apps/api/src/services/authService.js` — included fullName in response
- `apps/api/src/tests/auth.test.js` — new test coverage