### PR TITLE
fix: validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,10 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid notification", 400);
+  }
+
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/tests/notification-validation.test.js
+++ b/apps/api/src/tests/notification-validation.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postNotification(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/notifications rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postNotification(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/notifications accepts valid notifications", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postNotification(baseUrl, {
+      userId: "usr_1",
+      type: "message",
+      message: "New message received"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.type, "message");
+    assert.equal(payload.data.message, "New message received");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  type: z.string().min(1),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for notification creation payloads
- reject invalid `POST /api/notifications` bodies with `400 Bad Request` before the service runs
- pass only validated `userId`, `type`, and `message` fields to `createNotification`
- add route coverage for empty payload rejection and valid notification creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notification-validation.test.js`
- `git diff --check`

Closes #4633