### PR TITLE
fix(notifications): Preserve server-owned id and read state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,15 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Extract server-owned fields from payload to prevent override
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload;
+  
+  const notification = { 
+    id: `ntf_${Date.now()}`, 
+    read: false, 
+    ...safePayload 
+  };
+  
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Summary

This PR fixes notification creation to prevent caller override of server-owned fields.

### Changes Made

1. **Extract ignored fields** - Destructure id and read from payload
2. **Use safe payload** - Only spread remaining fields
3. **Server-owned id** - Always generate new id
4. **Initial read state** - Always start with read: false

Fixes #4710
Refs #743