### PR TITLE
fix: validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,10 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid proposal", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/proposals rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postProposal(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/proposals rejects non-positive rates", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postProposal(baseUrl, {
+      jobId: "job_1",
+      rate: 0,
+      message: "I can help"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/proposals accepts valid proposals", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postProposal(baseUrl, {
+      jobId: "job_1",
+      rate: 120,
+      message: "I can help"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.rate, 120);
+    assert.equal(payload.data.message, "I can help");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  rate: z.number().positive(),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for proposal creation payloads
- reject invalid `POST /api/proposals` bodies with `400 Bad Request` before the service runs
- pass only validated `jobId`, `rate`, and `message` fields to `createProposal`
- add route coverage for empty payload rejection, non-positive rate rejection, and valid proposal creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/proposal-validation.test.js`
- `git diff --check`

Closes #4629