### PR TITLE
fix: validate payment creation payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid payment", 400);
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment-validation.test.js
+++ b/apps/api/src/tests/payment-validation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/payments rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: 0,
+      currency: "usd"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments accepts valid payments", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: 100,
+      currency: "usd"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 100);
+    assert.equal(payload.data.currency, "usd");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for payment creation payloads
- reject invalid `POST /api/payments` bodies with `400 Bad Request` before the payment service runs
- pass only validated `amount` and `currency` fields to `createPaymentIntent`
- add route coverage for empty payload rejection, non-positive amount rejection, and valid payment creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/payment-validation.test.js`
- `git diff --check`

Closes #4623