### PR TITLE
fix: validate and normalize search query

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+  if (Array.isArray(rawQuery)) {
+    return fail(res, "Search query must be a single value", 400);
+  }
+
+  const query = String(rawQuery).trim().slice(0, MAX_QUERY_LENGTH);
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search-query.test.js
+++ b/apps/api/src/tests/search-query.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getSearch(baseUrl, queryString) {
+  const response = await fetch(`${baseUrl}/api/search${queryString}`);
+  return { response, payload: await response.json() };
+}
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getSearch(baseUrl, "?q=hello&q=world");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Search query must be a single value" });
+  });
+});
+
+test("GET /api/search trims and caps q before searching", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = `${"a".repeat(205)}   `;
+    const { response, payload } = await getSearch(baseUrl, `?q=%20%20${longQuery}`);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query.length, 200);
+    assert.equal(payload.data.query, "a".repeat(200));
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- reject repeated `q` query parameters with `400 Bad Request`
- trim single-value search queries and cap them to 200 characters before calling `globalSearch`
- add route coverage for repeated query rejection and normalized query forwarding

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/search-query.test.js`
- `git diff --check`

Closes #4603