### PR TITLE
fix(validation): Restrict registration to public roles

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1, "Full name is required"),
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

This PR restricts registration to public roles only.

### Changes Made

1. **Remove admin role** - Only allow client and freelancer roles
2. **Prevent self-assignment** - Users cannot assign themselves admin role
3. **Security improvement** - Prevents privilege escalation during registration

Fixes #4718
Refs #743