### PR TITLE
fix: validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,10 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid review", 400);
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/review-validation.test.js
+++ b/apps/api/src/tests/review-validation.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/reviews rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postReview(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/reviews rejects ratings outside 1 to 5", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postReview(baseUrl, {
+      targetUserId: "usr_1",
+      jobId: "job_1",
+      rating: 999
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/reviews accepts valid reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postReview(baseUrl, {
+      targetUserId: "usr_1",
+      jobId: "job_1",
+      rating: 5,
+      comment: "Great work"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.targetUserId, "usr_1");
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great work");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetUserId: z.string().min(1),
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().optional()
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for review creation payloads
- reject invalid `POST /api/reviews` bodies with `400 Bad Request` before the service runs
- enforce required `targetUserId`, `jobId`, and integer `rating` in the 1-5 range, with optional `comment`
- add route coverage for empty payload rejection, invalid rating rejection, and valid review creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/review-validation.test.js`
- `git diff --check`

Closes #4604