### PR TITLE
Require finite job budgets

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Logo design",
+  description: "Create a clean logo concept.",
+  budgetMin: 0,
+  budgetMax: 250,
+  categoryId: "design",
+  skills: ["branding"]
+};
+
+test("createJobSchema accepts finite zero and positive budgets", () => {
+  const zeroBudgetResult = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 0,
+    budgetMax: 0
+  });
+  const positiveBudgetResult = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 100,
+    budgetMax: 500
+  });
+
+  assert.equal(zeroBudgetResult.success, true);
+  assert.equal(positiveBudgetResult.success, true);
+});
+
+test("createJobSchema rejects non-finite budgets", () => {
+  for (const value of [Infinity, -Infinity, Number.NaN]) {
+    assert.equal(createJobSchema.safeParse({ ...validJob, budgetMin: value }).success, false);
+    assert.equal(createJobSchema.safeParse({ ...validJob, budgetMax: value }).success, false);
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
+const budgetSchema = z.number().finite().nonnegative();
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: budgetSchema,
+  budgetMax: budgetSchema,
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
Refs #4052

/claim #743

## Summary

- Add a shared finite nonnegative budget schema for job budget fields.
- Reject Infinity, -Infinity, and NaN for both budgetMin and budgetMax.
- Preserve existing zero and positive budget behavior.
- Update the API test script so schema regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- createJobSchema accepts zero budgets.
- createJobSchema accepts positive finite budgets.
- createJobSchema rejects Infinity, -Infinity, and NaN for budgetMin and budgetMax.