### PR TITLE
Redact production error logs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,5 +1,13 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  if (process.env.NODE_ENV === "production") {
+    console.error("Unhandled API error:", {
+      name: err?.name || "Error",
+      statusCode: err?.statusCode || err?.status || 500
+    });
+  } else {
+    console.error("Unhandled API error:", err);
+  }
+
   if (res.headersSent) {
     return next(err);
   }

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+async function withConsoleErrorSpy(fn) {
+  const originalConsoleError = console.error;
+  const calls = [];
+  console.error = (...args) => calls.push(args);
+
+  try {
+    await fn(calls);
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
+test("production error logging avoids raw error serialization", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  const error = new Error("secret-token-value");
+  const res = createResponse();
+
+  try {
+    await withConsoleErrorSpy(async (calls) => {
+      errorHandler(error, {}, res, () => {});
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0][0], "Unhandled API error:");
+      assert.notEqual(calls[0][1], error);
+      assert.deepEqual(calls[0][1], { name: "Error", statusCode: 500 });
+      assert.equal(JSON.stringify(calls[0]).includes("secret-token-value"), false);
+      assert.equal(JSON.stringify(calls[0]).includes("at "), false);
+      assert.equal(res.statusCode, 500);
+      assert.deepEqual(res.payload, {
+        success: false,
+        message: "Unexpected server error"
+      });
+    });
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});
+
+test("non-production error logging keeps the raw error for debugging", async () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+  const error = new Error("local debug detail");
+  const res = createResponse();
+
+  try {
+    await withConsoleErrorSpy(async (calls) => {
+      errorHandler(error, {}, res, () => {});
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0][0], "Unhandled API error:");
+      assert.equal(calls[0][1], error);
+      assert.equal(res.statusCode, 500);
+      assert.deepEqual(res.payload, {
+        success: false,
+        message: "Unexpected server error"
+      });
+    });
+  } finally {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});


### PR DESCRIPTION
Refs #4061

/claim #743

## Summary

- Redact production error logging so raw error objects, messages, and stacks are not serialized.
- Preserve raw error logging in non-production environments for local debugging.
- Keep the existing generic 500 response shape unchanged.
- Update the API test script so error-handler regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- Production logs minimal structured metadata without raw error details.
- Development logs keep the raw error object.
- The generic 500 response shape stays unchanged.