### PR TITLE
Reject self-directed messages

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { fail, ok } from "../utils/response.js";
+import { listMessages, SelfDirectedMessageError, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    return ok(res, await sendMessage(req.body), 201);
+  } catch (error) {
+    if (error instanceof SelfDirectedMessageError) {
+      return fail(res, error.message, 400);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,10 +1,21 @@
 const messages = [];
 
+export class SelfDirectedMessageError extends Error {
+  constructor() {
+    super("Messages require distinct sender and receiver");
+    this.name = "SelfDirectedMessageError";
+  }
+}
+
 export async function listMessages() {
   return messages;
 }
 
 export async function sendMessage(payload) {
+  if (payload?.senderId === payload?.receiverId) {
+    throw new SelfDirectedMessageError();
+  }
+
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;

--- a/apps/api/src/tests/messageSelfDirected.test.js
+++ b/apps/api/src/tests/messageSelfDirected.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  listMessages,
+  SelfDirectedMessageError,
+  sendMessage
+} from "../services/messageService.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("sendMessage rejects self-directed messages without storing them", async () => {
+  const listLengthBefore = (await listMessages()).length;
+
+  await assert.rejects(
+    () =>
+      sendMessage({
+        senderId: "usr_123",
+        receiverId: "usr_123",
+        body: "hello myself"
+      }),
+    SelfDirectedMessageError
+  );
+  assert.equal((await listMessages()).length, listLengthBefore);
+});
+
+test("POST /api/messages returns 400 for self-directed messages", async () => {
+  const listLengthBefore = (await listMessages()).length;
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_123",
+        receiverId: "usr_123",
+        body: "hello myself"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Messages require distinct sender and receiver"
+    });
+    assert.equal((await listMessages()).length, listLengthBefore);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
Refs #4074

/claim #743

## Summary

- Add a focused service guard that rejects messages where senderId equals receiverId.
- Map self-directed message errors to HTTP 400 in POST /api/messages.
- Preserve storage behavior for valid messages between distinct users.
- Update the API test script so route and service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- sendMessage rejects self-directed payloads without storing them.
- POST /api/messages returns 400 for self-directed payloads.
- The stored message count does not increase on rejection.