### PR TITLE
Reject self reviews

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,6 +5,10 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
+  if (payload?.reviewerId === payload?.revieweeId) {
+    throw new RangeError("Review reviewer and reviewee must be different users");
+  }
+
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;

--- a/apps/api/src/tests/reviewSelfReview.test.js
+++ b/apps/api/src/tests/reviewSelfReview.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+const validReview = {
+  reviewerId: "usr_reviewer",
+  revieweeId: "usr_reviewee",
+  rating: 5,
+  comment: "Great collaboration."
+};
+
+test("createReview preserves reviews between different users", async () => {
+  const review = await createReview(validReview);
+
+  assert.equal(review.reviewerId, validReview.reviewerId);
+  assert.equal(review.revieweeId, validReview.revieweeId);
+  assert.notEqual(review.reviewerId, review.revieweeId);
+});
+
+test("createReview rejects self-review payloads without storing them", async () => {
+  const listLengthBefore = (await listReviews()).length;
+
+  await assert.rejects(
+    () =>
+      createReview({
+        ...validReview,
+        reviewerId: "usr_same",
+        revieweeId: "usr_same"
+      }),
+    /Review reviewer and reviewee must be different users/
+  );
+  assert.equal((await listReviews()).length, listLengthBefore);
+});


### PR DESCRIPTION
Refs #3750

/claim #743

## Summary

- Reject review payloads where reviewerId and revieweeId are the same user.
- Preserve valid reviews where the reviewer and reviewee are different users.
- Add focused service-level regression coverage.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- createReview preserves a valid different-user review.
- createReview rejects self-review payloads without storing them.