### PR TITLE
Reject duplicate proposals

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { fail, ok } from "../utils/response.js";
+import { createProposal, DuplicateProposalError, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    return ok(res, await createProposal(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateProposalError) {
+      return fail(res, error.message, 409);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,10 +1,25 @@
 const proposals = [];
 
+export class DuplicateProposalError extends Error {
+  constructor() {
+    super("Freelancer already submitted a proposal for this job");
+    this.name = "DuplicateProposalError";
+  }
+}
+
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
+  const duplicate = proposals.some(
+    (proposal) => proposal.jobId === payload?.jobId && proposal.freelancerId === payload?.freelancerId
+  );
+
+  if (duplicate) {
+    throw new DuplicateProposalError();
+  }
+
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
   return proposal;

--- a/apps/api/src/tests/proposalDuplicate.test.js
+++ b/apps/api/src/tests/proposalDuplicate.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import {
+  createProposal,
+  DuplicateProposalError,
+  listProposals
+} from "../services/proposalService.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function proposalPayload(overrides = {}) {
+  return {
+    jobId: "job_duplicate_service",
+    freelancerId: "freelancer_duplicate_service",
+    coverLetter: "I can handle this project.",
+    bidAmount: 200,
+    ...overrides
+  };
+}
+
+test("createProposal rejects duplicate proposals for the same job and freelancer", async () => {
+  const listLengthBefore = (await listProposals()).length;
+
+  await createProposal(proposalPayload());
+  await assert.rejects(() => createProposal(proposalPayload()), DuplicateProposalError);
+  assert.equal((await listProposals()).length, listLengthBefore + 1);
+});
+
+test("createProposal preserves proposals for different jobs or freelancers", async () => {
+  const listLengthBefore = (await listProposals()).length;
+
+  await createProposal(
+    proposalPayload({
+      jobId: "job_distinct_a",
+      freelancerId: "freelancer_distinct"
+    })
+  );
+  await createProposal(
+    proposalPayload({
+      jobId: "job_distinct_b",
+      freelancerId: "freelancer_distinct"
+    })
+  );
+  await createProposal(
+    proposalPayload({
+      jobId: "job_distinct_a",
+      freelancerId: "freelancer_other"
+    })
+  );
+
+  assert.equal((await listProposals()).length, listLengthBefore + 3);
+});
+
+test("POST /api/proposals returns 409 for duplicate proposals", async () => {
+  const listLengthBefore = (await listProposals()).length;
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+  const payload = proposalPayload({
+    jobId: "job_duplicate_route",
+    freelancerId: "freelancer_duplicate_route"
+  });
+
+  try {
+    const firstResponse = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const secondResponse = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const secondPayload = await secondResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondPayload, {
+      success: false,
+      message: "Freelancer already submitted a proposal for this job"
+    });
+    assert.equal((await listProposals()).length, listLengthBefore + 1);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
Refs #4079

/claim #743

## Summary

- Reject duplicate proposal submissions with the same jobId and freelancerId.
- Map duplicate proposal errors to HTTP 409 in POST /api/proposals.
- Preserve normal proposal creation for different jobs or different freelancers.
- Update the API test script so route and service regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- createProposal rejects duplicate job/freelancer pairs.
- Different jobs or freelancers remain valid.
- POST /api/proposals returns 409 for duplicates and stores only one proposal.