### PR TITLE
Reject duplicate user emails

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
-import { createUser, listUsers } from "../services/userService.js";
+import { fail, ok } from "../utils/response.js";
+import { createUser, DuplicateUserEmailError, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  try {
+    return ok(res, await createUser(req.body), 201);
+  } catch (error) {
+    if (error instanceof DuplicateUserEmailError) {
+      return fail(res, error.message, 409);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,10 +1,21 @@
 const users = [];
 
+export class DuplicateUserEmailError extends Error {
+  constructor() {
+    super("User email already exists");
+    this.name = "DuplicateUserEmailError";
+  }
+}
+
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
+  if (users.some((user) => user.email === payload?.email)) {
+    throw new DuplicateUserEmailError();
+  }
+
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
   return user;

--- a/apps/api/src/tests/userDuplicateEmail.test.js
+++ b/apps/api/src/tests/userDuplicateEmail.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createUser, DuplicateUserEmailError, listUsers } from "../services/userService.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("createUser rejects duplicate email addresses without storing another user", async () => {
+  const listLengthBefore = (await listUsers()).length;
+
+  await createUser({ email: "duplicate-service@example.com", fullName: "Alex One" });
+  await assert.rejects(
+    () => createUser({ email: "duplicate-service@example.com", fullName: "Alex Two" }),
+    DuplicateUserEmailError
+  );
+  assert.equal((await listUsers()).length, listLengthBefore + 1);
+});
+
+test("POST /api/users returns 409 for duplicate email addresses", async () => {
+  const listLengthBefore = (await listUsers()).length;
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  try {
+    const firstResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "duplicate-route@example.com",
+        fullName: "Alex One"
+      })
+    });
+    const secondResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "duplicate-route@example.com",
+        fullName: "Alex Two"
+      })
+    });
+    const secondPayload = await secondResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondPayload, {
+      success: false,
+      message: "User email already exists"
+    });
+    assert.equal((await listUsers()).length, listLengthBefore + 1);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
Refs #4077

/claim #743

## Summary

- Add a focused duplicate-email guard in the in-memory user service.
- Map duplicate user email errors to HTTP 409 in POST /api/users.
- Preserve normal user creation for first-time email addresses.
- Update the API test script so route and service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- createUser rejects a second user with the same email without storing it.
- POST /api/users returns 409 for duplicate email addresses.
- The stored user count only increases for the first accepted user.