### PR TITLE
Assign proposal created timestamps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalCreatedAt.test.js
+++ b/apps/api/src/tests/proposalCreatedAt.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+const baseProposal = {
+  jobId: "job_created_at",
+  freelancerId: "freelancer_created_at",
+  coverLetter: "I can deliver this quickly.",
+  bidAmount: 300
+};
+
+test("createProposal assigns a server-generated createdAt timestamp", async () => {
+  const proposal = await createProposal(baseProposal);
+
+  assert.equal(typeof proposal.createdAt, "string");
+  assert.equal(Number.isNaN(Date.parse(proposal.createdAt)), false);
+});
+
+test("createProposal ignores caller-supplied createdAt values", async () => {
+  const callerCreatedAt = "2000-01-01T00:00:00.000Z";
+  const before = Date.now();
+  const proposal = await createProposal({
+    ...baseProposal,
+    jobId: "job_created_at_override",
+    createdAt: callerCreatedAt
+  });
+  const after = Date.now();
+  const createdAtTime = Date.parse(proposal.createdAt);
+
+  assert.notEqual(proposal.createdAt, callerCreatedAt);
+  assert.ok(createdAtTime >= before);
+  assert.ok(createdAtTime <= after);
+});


### PR DESCRIPTION
Refs #3755

/claim #743

## Summary

- Add server-generated ISO createdAt timestamps to created proposals.
- Return the createdAt timestamp with the new proposal record.
- Ignore caller-supplied createdAt values.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- createProposal assigns a valid ISO createdAt timestamp.
- createProposal ignores a caller-supplied createdAt value.