### PR TITLE
Preserve server-owned user ids

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userServerOwnedId.test.js
+++ b/apps/api/src/tests/userServerOwnedId.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser keeps ids server-owned", async () => {
+  const user = await createUser({
+    id: "usr_attacker",
+    email: "server-owned-id@example.com",
+    fullName: "Server Owned"
+  });
+  const storedUser = (await listUsers()).find((candidate) => candidate.email === user.email);
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.email, "server-owned-id@example.com");
+  assert.equal(user.fullName, "Server Owned");
+  assert.equal(storedUser?.id, user.id);
+});


### PR DESCRIPTION
Refs #4029

/claim #743

## Summary

- Preserve server-generated usr_* ids when creating users.
- Ignore caller-supplied id values while keeping normal user payload fields.
- Add focused service regression coverage for id override attempts.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered cases:

- createUser returns a server-generated usr_* id.
- A caller-supplied id cannot replace the stored or returned id.
- Normal email and fullName fields are preserved.