### PR TITLE
Expose db package entrypoint

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/src/index.d.ts
+++ b/packages/db/src/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/src/index.js
+++ b/packages/db/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/src/tests/entrypoint.test.js
+++ b/packages/db/src/tests/entrypoint.test.js
@@ -1,0 +1,8 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/db exposes the workspace package entrypoint", () => {
+  const db = require("@freelanceflow/db");
+
+  assert.equal(typeof db.PrismaClient, "function");
+});


### PR DESCRIPTION
Refs #3734

/claim #743

## Summary

- Add explicit main, types, and exports metadata for @freelanceflow/db.
- Add a lightweight runtime JS entrypoint and TypeScript declaration entrypoint.
- Add a focused workspace import test for the package name.

## Validation

npm run generate -w packages/db
npm run test -w packages/db

Result: tests 1, pass 1, fail 0.

Covered case:

- require("@freelanceflow/db") resolves through the workspace package entrypoint and exposes PrismaClient.