### PR TITLE
Expose ui runtime entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,17 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test \"src/tests/**/*.test.js\""
+  }
 }

--- a/packages/ui/src/Button.d.ts
+++ b/packages/ui/src/Button.d.ts
@@ -1,0 +1,3 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Button(props: { children: ReactNode }): ReactElement;

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,20 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+module.exports = { Button };

--- a/packages/ui/src/Card.d.ts
+++ b/packages/ui/src/Card.d.ts
@@ -1,0 +1,3 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Card(props: { title: string; children: ReactNode }): ReactElement;

--- a/packages/ui/src/Card.js
+++ b/packages/ui/src/Card.js
@@ -1,0 +1,12 @@
+const React = require("react");
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Card };

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,0 +1,2 @@
+export * from "./Button";
+export * from "./Card";

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,4 @@
+const { Button } = require("./Button.js");
+const { Card } = require("./Card.js");
+
+module.exports = { Button, Card };

--- a/packages/ui/src/tests/entrypoint.test.js
+++ b/packages/ui/src/tests/entrypoint.test.js
@@ -1,0 +1,11 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/ui exposes a runtime package entrypoint", () => {
+  const ui = require("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+  assert.equal(ui.Button({ children: "Save" }).type, "button");
+  assert.equal(ui.Card({ title: "Project", children: "Details" }).type, "section");
+});


### PR DESCRIPTION
Refs #3736

/claim #743

## Summary

- Add explicit main, types, and exports metadata for @freelanceflow/ui.
- Add runtime JavaScript entrypoints for the package, Button, and Card exports.
- Add TypeScript declaration entrypoints matching the existing component API.
- Add a focused workspace import test for the package name.

## Validation

npm run test -w packages/ui

Result: tests 1, pass 1, fail 0.

Covered case:

- require("@freelanceflow/ui") resolves through the workspace package entrypoint and exposes Button and Card runtime exports.