### PR TITLE
fix: validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
+import { ok, fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,10 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid user", 400);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/user-validation.test.js
+++ b/apps/api/src/tests/user-validation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/users rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postUser(baseUrl, {});
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/users rejects admin self-creation", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postUser(baseUrl, {
+      email: "admin@example.com",
+      role: "admin"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/users accepts valid client users", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postUser(baseUrl, {
+      email: "client@example.com",
+      role: "client"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.role, "client");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["client", "freelancer"])
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for user creation payloads
- reject invalid `POST /api/users` bodies with `400 Bad Request` before the service runs
- require valid `email` and restrict self-created roles to `client` or `freelancer`
- add route coverage for empty payload rejection, admin self-creation rejection, and valid client creation

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/user-validation.test.js`
- `git diff --check`

Closes #4625