### PR TITLE
Sign login tokens with actual role

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -12,9 +12,11 @@ export async function registerUser(payload) {
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const role = payload.role ?? "client";
+
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role })
   };
 }
 

--- a/apps/api/src/tests/authLoginRole.test.js
+++ b/apps/api/src/tests/authLoginRole.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("loginUser signs tokens with the login payload role", async () => {
+  for (const role of ["client", "freelancer", "admin"]) {
+    const result = await loginUser({
+      email: `${role}@example.com`,
+      password: "password123",
+      role
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, role);
+  }
+});
+
+test("loginUser defaults to client role when no role is available", async () => {
+  const result = await loginUser({
+    email: "client-default@example.com",
+    password: "password123"
+  });
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.role, "client");
+});


### PR DESCRIPTION
Refs #4739

/claim #743

## Summary

- Sign login access tokens with the login payload role instead of always using client.
- Preserve the client default when no role is available in the mock login payload.
- Add focused service regression tests that verify client, freelancer, and admin roles in decoded tokens.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 3, pass 3, fail 0.

Covered cases:

- loginUser signs client, freelancer, and admin tokens with the requested role.
- loginUser defaults to client when no role is provided.

Closes #4739
