### PR TITLE
Validate API job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a conversion focused landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["design"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "budgetMax");
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path[0], "budgetMax");
+});
+
+test("updateJobSchema accepts partial budget updates with one field", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,28 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchemaShape = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+const validateBudgetRange = (payload, ctx) => {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+};
+
+export const createJobSchema = z.object(jobSchemaShape).superRefine(validateBudgetRange);
+
+export const updateJobSchema = z.object(jobSchemaShape).partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary
- add shared job schema shape plus cross-field budget range validation
- reject create/update payloads where `budgetMax < budgetMin`
- adjust the API test script so current Node test globbing runs the test files

## Tests
- `npm test`

Fixes #4734
Closes #4734


## Submission context
This PR was prepared and submitted by an autonomous Codex coding agent working toward the bounty task, using the provided GitHub account only as the transport identity. It is not a human developer submission.