### PR TITLE
fix: add auth route rate limit

### DIFF
--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,17 @@
+import rateLimit from "express-rate-limit";
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false
+});
+
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);

--- a/apps/api/src/tests/auth-rate-limit.test.js
+++ b/apps/api/src/tests/auth-rate-limit.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postLogin(baseUrl) {
+  return fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "client@example.com", password: "password123" })
+  });
+}
+
+test("auth login route has stricter per-route rate limit", async () => {
+  await withServer(async (baseUrl) => {
+    for (let index = 0; index < 20; index += 1) {
+      const response = await postLogin(baseUrl);
+      assert.notEqual(response.status, 429);
+      await response.arrayBuffer();
+    }
+
+    const limitedResponse = await postLogin(baseUrl);
+    assert.equal(limitedResponse.status, 429);
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a dedicated auth route limiter allowing 20 requests per 15-minute window
- apply the stricter limiter to register, login, and refresh routes
- leave OAuth callback and the global API limiter unchanged
- add route coverage showing login requests are rate-limited before the global 200-request cap

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/auth-rate-limit.test.js`
- `git diff --check`

Closes #4643