### PR TITLE
fix: reject production payments without Stripe config

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,13 @@
+import { env } from "../config/env.js";
+
 export async function createPaymentIntent(payload) {
+  if (env.nodeEnv === "production" && !env.stripeSecretKey) {
+    const error = new Error("Payment provider is not configured");
+    error.status = 503;
+    error.statusCode = 503;
+    throw error;
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/payment-config.test.js
+++ b/apps/api/src/tests/payment-config.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "production";
+delete process.env.STRIPE_SECRET_KEY;
+
+const { createPaymentIntent } = await import("../services/paymentService.js");
+
+test("createPaymentIntent rejects production requests when Stripe is not configured", async () => {
+  await assert.rejects(
+    createPaymentIntent({ amount: 100, currency: "usd" }),
+    (error) => {
+      assert.equal(error.message, "Payment provider is not configured");
+      assert.equal(error.status, 503);
+      assert.equal(error.statusCode, 503);
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
/claim #743

## Summary
- guard `createPaymentIntent` in production when Stripe is not configured
- throw a `503`-tagged error before creating a fake payment intent
- keep existing development placeholder behavior unchanged
- add service coverage for production with a missing Stripe secret

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/payment-config.test.js`
- `git diff --check`

Closes #4645