### PR TITLE
Preserve notification server-owned fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationServerOwnedFields.test.js
+++ b/apps/api/src/tests/notificationServerOwnedFields.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("createNotification keeps id and read state server-owned", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    userId: "usr_123",
+    title: "Proposal update",
+    body: "You have a new proposal.",
+    read: true
+  });
+  const storedNotification = (await listNotifications()).find(
+    (candidate) => candidate.userId === notification.userId && candidate.title === notification.title
+  );
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_attacker");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.title, "Proposal update");
+  assert.equal(storedNotification?.id, notification.id);
+  assert.equal(storedNotification?.read, false);
+});


### PR DESCRIPTION
Refs #4740

/claim #743

## Summary

- Preserve server-generated notification ids when creating notifications.
- Preserve the initial unread state by forcing read: false on creation.
- Ignore caller-supplied id and read values while keeping normal notification payload fields.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered case:

- createNotification returns and stores a server-generated ntf_* id with read: false even when callers submit id and read fields.

Closes #4740
