### PR TITLE
fix: preserve notification server-owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client_id",
+    userId: "usr_1",
+    type: "message",
+    message: "New message",
+    read: true
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "client_id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_1");
+  assert.equal(notification.type, "message");
+  assert.equal(notification.message, "New message");
+});


### PR DESCRIPTION
/claim #743

## Summary
- preserve service-owned notification fields after applying client payload data
- prevent callers from overriding generated `id` and default unread `read: false`
- add service coverage proving client-supplied `id` and `read` cannot override server-owned values

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notification-service.test.js`
- `git diff --check`

Closes #4602