### PR TITLE
Require production DATABASE_URL

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+function readOptionalValue(value) {
+  return value?.trim() ?? "";
+}
+
+export function resolveEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const databaseUrl = readOptionalValue(source.DATABASE_URL);
+
+  if (nodeEnv === "production" && !databaseUrl) {
+    throw new Error("DATABASE_URL is required in production");
+  }
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret: source.JWT_SECRET ?? "development-secret",
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl
+  };
+}
+
+export const env = resolveEnv();

--- a/apps/api/src/tests/envConfig.test.js
+++ b/apps/api/src/tests/envConfig.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveEnv } from "../config/env.js";
+
+test("resolveEnv requires DATABASE_URL in production", () => {
+  assert.throws(
+    () => resolveEnv({ NODE_ENV: "production", DATABASE_URL: "   " }),
+    /DATABASE_URL is required in production/
+  );
+});
+
+test("resolveEnv keeps development DATABASE_URL optional", () => {
+  const env = resolveEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.databaseUrl, "");
+  assert.equal(env.port, 4000);
+});
+
+test("resolveEnv accepts production DATABASE_URL", () => {
+  const env = resolveEnv({
+    NODE_ENV: "production",
+    DATABASE_URL: "postgresql://user:pass@example.com:5432/app"
+  });
+
+  assert.equal(env.databaseUrl, "postgresql://user:pass@example.com:5432/app");
+});


### PR DESCRIPTION
Refs #4749

/claim #743

## Summary

- Centralize API environment resolution in a testable `resolveEnv()` helper.
- Fail fast in production when `DATABASE_URL` is missing or blank.
- Keep the existing development defaults for local work.
- Update the API test script so config regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- Production env resolution throws when `DATABASE_URL` is missing or blank.
- Development env resolution still allows a missing database URL.
- Production env resolution accepts a configured database URL.

Closes #4749
