### PR TITLE
fix: validate oauth callback parameters

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+
+const supportedOAuthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,18 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = req.params.provider;
+  if (!supportedOAuthProviders.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
+  const code = typeof req.query.code === "string" ? req.query.code.trim() : "";
+  if (!code) {
+    return fail(res, "OAuth code is required", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauth-callback.test.js
+++ b/apps/api/src/tests/oauth-callback.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getCallback(baseUrl, path) {
+  const response = await fetch(`${baseUrl}${path}`);
+  return { response, payload: await response.json() };
+}
+
+test("OAuth callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getCallback(baseUrl, "/api/auth/oauth/not-real/callback?code=abc");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Unsupported OAuth provider" });
+  });
+});
+
+test("OAuth callback requires a code", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getCallback(baseUrl, "/api/auth/oauth/github/callback");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth code is required" });
+  });
+});
+
+test("OAuth callback rejects blank codes", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getCallback(baseUrl, "/api/auth/oauth/github/callback?code=%20%20");
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "OAuth code is required" });
+  });
+});
+
+test("OAuth callback accepts supported providers with codes", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getCallback(baseUrl, "/api/auth/oauth/github/callback?code=abc123");
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: { provider: "github", status: "callback-received" }
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- reject unsupported OAuth callback providers with `400 Bad Request`
- require a non-empty `code` query parameter for supported providers
- keep valid supported provider callbacks returning the existing success payload
- add route coverage for unsupported provider, missing code, blank code, and valid callback behavior

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/oauth-callback.test.js`
- `git diff --check`

Closes #4505