### PR TITLE
Return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { fail } from "../utils/response.js";
+
+function isMalformedJsonError(err) {
+  return err instanceof SyntaxError && err.status === 400 && err.type === "entity.parse.failed";
+}
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (isMalformedJsonError(err)) {
+    return fail(res, "Malformed JSON body", 400);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return a 400 response", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Malformed JSON body" });
+  });
+});


### PR DESCRIPTION
Refs #4753

/claim #743

## Summary

- Detect malformed JSON parser errors in the API error handler.
- Return a clean 400 response with a stable client-facing message.
- Keep unexpected server errors on the existing 500 path.
- Update the API test script so route regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered case:

- POST /api/jobs with invalid JSON and `Content-Type: application/json` returns `400` with `{ success: false, message: "Malformed JSON body" }`.

Closes #4753
