### PR TITLE
Require production Stripe configuration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { createPaymentIntent, PaymentConfigurationError } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentConfigurationError) {
+      return fail(res, error.message, 503);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,25 @@
-export async function createPaymentIntent(payload) {
+import { env } from "../config/env.js";
+
+export class PaymentConfigurationError extends Error {
+  constructor(message = "Stripe is not configured") {
+    super(message);
+    this.name = "PaymentConfigurationError";
+  }
+}
+
+function requiresStripeConfiguration(config) {
+  return config.nodeEnv === "production";
+}
+
+function hasStripeSecret(config) {
+  return Boolean(config.stripeSecretKey?.trim());
+}
+
+export async function createPaymentIntent(payload, config = env) {
+  if (requiresStripeConfiguration(config) && !hasStripeSecret(config)) {
+    throw new PaymentConfigurationError();
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,

--- a/apps/api/src/tests/paymentStripeConfig.test.js
+++ b/apps/api/src/tests/paymentStripeConfig.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, PaymentConfigurationError } from "../services/paymentService.js";
+
+test("createPaymentIntent rejects missing Stripe config in production", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 2500, currency: "usd" }, { nodeEnv: "production", stripeSecretKey: "" }),
+    PaymentConfigurationError
+  );
+});
+
+test("createPaymentIntent keeps development stub behavior", async () => {
+  const paymentIntent = await createPaymentIntent(
+    { amount: 2500, currency: "usd" },
+    { nodeEnv: "development", stripeSecretKey: "" }
+  );
+
+  assert.match(paymentIntent.paymentId, /^pay_\d+$/);
+  assert.equal(paymentIntent.amount, 2500);
+  assert.equal(paymentIntent.currency, "usd");
+  assert.equal(paymentIntent.provider, "stripe");
+});
+
+test("createPaymentIntent accepts configured production Stripe secret", async () => {
+  const paymentIntent = await createPaymentIntent(
+    { amount: 2500 },
+    { nodeEnv: "production", stripeSecretKey: "sk_live_configured" }
+  );
+
+  assert.match(paymentIntent.paymentId, /^pay_\d+$/);
+  assert.equal(paymentIntent.currency, "usd");
+});


### PR DESCRIPTION
Refs #4756

/claim #743

## Summary

- Guard payment intent creation in production when Stripe is not configured.
- Return a clear 503 response from the payment route for the missing Stripe configuration path.
- Preserve the existing local development stub behavior.
- Update the API test script so service regression tests are discovered reliably.

## Validation

npm test

Result: tests 4, pass 4, fail 0.

Covered cases:

- Production payment creation rejects a missing or blank Stripe secret.
- Development payment creation keeps the existing stub behavior.
- Production payment creation accepts a configured Stripe secret.

Closes #4756
