### PR TITLE
fix(api): use collision-resistant service ids

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createServiceId } from "../utils/ids.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = createServiceId("usr");
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: createServiceId("job"), status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: createServiceId("msg"), sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: createServiceId("ntf"), read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createServiceId } from "../utils/ids.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createServiceId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: createServiceId("prp") };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: createServiceId("rev") };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createServiceId } from "../utils/ids.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: createServiceId("usr") };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serviceIds.test.js
+++ b/apps/api/src/tests/serviceIds.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+function assertServiceId(value, prefix) {
+  assert.match(value, new RegExp(`^${prefix}_[0-9a-f-]{36}$`));
+}
+
+test("service ids stay unique when records are created in the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1234567890;
+
+  try {
+    const first = await createJob({
+      title: "Build API",
+      description: "Build the first API",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "engineering"
+    });
+    const second = await createJob({
+      title: "Build UI",
+      description: "Build the second UI",
+      budgetMin: 200,
+      budgetMax: 300,
+      categoryId: "design"
+    });
+
+    assertServiceId(first.id, "job");
+    assertServiceId(second.id, "job");
+    assert.notEqual(first.id, second.id);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("service-owned fields cannot be overridden by caller payloads", async () => {
+  const user = await createUser({ id: "usr_attacker", email: "a@example.com" });
+  const proposal = await createProposal({ id: "prp_attacker", jobId: "job_1" });
+  const review = await createReview({ id: "rev_attacker", rating: 5 });
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    read: true,
+    userId: "usr_1",
+    message: "Hello"
+  });
+  const message = await sendMessage({
+    id: "msg_attacker",
+    sentAt: "2000-01-01T00:00:00.000Z",
+    to: "usr_2",
+    text: "Hello"
+  });
+  const payment = await createPaymentIntent({ amount: 100, currency: "aud" });
+
+  assertServiceId(user.id, "usr");
+  assertServiceId(proposal.id, "prp");
+  assertServiceId(review.id, "rev");
+  assertServiceId(notification.id, "ntf");
+  assertServiceId(message.id, "msg");
+  assertServiceId(payment.paymentId, "pay");
+
+  assert.equal(notification.read, false);
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(payment.amount, 100);
+  assert.equal(payment.currency, "aud");
+});

--- a/apps/api/src/utils/ids.js
+++ b/apps/api/src/utils/ids.js
@@ -1,0 +1,5 @@
+import { randomUUID } from "node:crypto";
+
+export function createServiceId(prefix) {
+  return `${prefix}_${randomUUID()}`;
+}


### PR DESCRIPTION
/claim #743

Closes #4759

## Summary
- add a shared `createServiceId()` helper that preserves existing id prefixes while using `crypto.randomUUID()`
- replace `Date.now()`-based service ids across registration/user, job, message, notification, payment, proposal, and review creation paths
- keep service-owned fields authoritative by applying generated ids/status/read/sentAt after caller payload fields
- reuse the generated registration id as the JWT `sub` claim
- add focused service-level regression coverage for same-millisecond uniqueness and override attempts

## Validation
- `node --test apps/api/src/tests/serviceIds.test.js`
- `node --check apps/api/src/utils/ids.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/services/jobService.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/services/proposalService.js`
- `node --check apps/api/src/services/reviewService.js`
- `node --check apps/api/src/services/userService.js`

## Demo evidence
The new `serviceIds.test.js` freezes `Date.now()` and creates two jobs in the same millisecond, proving the generated ids remain unique. It also submits caller-controlled `id`, `read`, and `sentAt` payload fields and asserts the service-owned values win.