### PR TITLE
Return 400 for async validation errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
+import { ZodError } from "zod";
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", asyncHandler(metrics));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", asyncHandler(getMessages));
+messageRoutes.post("/", asyncHandler(postMessage));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", asyncHandler(getNotifications));
+notificationRoutes.post("/", asyncHandler(postNotification));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", asyncHandler(createPayment));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", asyncHandler(getProposals));
+proposalRoutes.post("/", asyncHandler(postProposal));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", asyncHandler(getReviews));
+reviewRoutes.post("/", asyncHandler(postReview));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", asyncHandler(search));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), asyncHandler(uploadFile));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", asyncHandler(getUsers));
+userRoutes.post("/", asyncHandler(postUser));

--- a/apps/api/src/tests/asyncValidationErrors.test.js
+++ b/apps/api/src/tests/asyncValidationErrors.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("async validation errors return a 400 response", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", password: "short" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Validation failed" });
+  });
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
Refs #4760

/claim #743

## Summary

- Add a small async route wrapper so Express 4 forwards async controller rejections to the shared error middleware.
- Wire existing async API route handlers through the wrapper.
- Return `400` for Zod validation failures using the existing error response shape.
- Update the API test script so route regression tests are discovered reliably.

## Validation

npm test

Result: tests 2, pass 2, fail 0.

Covered case:

- POST /api/auth/register with an invalid email and short password returns `400` with `{ success: false, message: "Validation failed" }` instead of hanging or falling through as an internal error.

Closes #4760
