### PR TITLE
fix: handle zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: err.errors[0]?.message ?? "Invalid request payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError, z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: 200,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+test("Zod validation errors return 400 response", () => {
+  const schema = z.object({
+    email: z.string().email()
+  });
+  let error;
+
+  try {
+    schema.parse({ email: "notanemail" });
+  } catch (err) {
+    error = err;
+  }
+
+  assert.ok(error instanceof ZodError);
+  const response = createResponse();
+  errorHandler(error, {}, response, assert.fail);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.payload, {
+    success: false,
+    message: "Invalid email"
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- return `400 Bad Request` for `ZodError` validation failures in the API error handler
- include the first Zod validation message in the shared `{ success: false, message }` response shape
- keep unknown errors on the existing generic `500 Unexpected server error` path

## Verification
- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\errorHandler.test.js`
- `git diff --check`

Closes #4635