### PR TITLE
Handle Zod validation errors in API error handler

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: err.errors[0]?.message ?? "Invalid request payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createMockResponse({ headersSent = false } = {}) {
+  return {
+    headersSent,
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 for Zod validation errors", () => {
+  const schema = z.object({ email: z.string().email() });
+  const error = schema.safeParse({ email: "not-an-email" }).error;
+  const res = createMockResponse();
+
+  errorHandler(error, {}, res, assert.fail);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Invalid email"
+  });
+});
+
+test("errorHandler returns 500 for generic errors", () => {
+  const res = createMockResponse();
+  const originalError = console.error;
+  console.error = () => {};
+
+  try {
+    errorHandler(new Error("database unavailable"), {}, res, assert.fail);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});
+
+test("errorHandler delegates when headers were already sent", () => {
+  const error = new Error("stream failed");
+  const res = createMockResponse({ headersSent: true });
+
+  errorHandler(error, {}, res, (receivedError) => {
+    assert.equal(receivedError, error);
+  });
+
+  assert.equal(res.statusCode, undefined);
+  assert.equal(res.body, undefined);
+});


### PR DESCRIPTION
## Summary
- detect ZodError before the generic API error handler branch
- return a 400 validation response with success: false and the first validation message
- add focused regression tests for Zod errors, generic errors, headers-sent delegation, and make the API test script target test files

## Validation
- npm test -w apps/api

Closes #4763