### PR TITLE
Reject admin role during public registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema defaults public registrations to client role", () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(payload.role, "client");
+});
+
+test("registerSchema accepts freelancer public registrations", () => {
+  const payload = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(payload.role, "freelancer");
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const result = registerSchema.safeParse({
+    email: "admin@example.com",
+    password: "password123",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- remove admin from the public registration role enum
- keep omitted role defaulting to client and allow freelancer
- add focused auth validator regression tests

## Validation
- node --test src/tests/*.test.js

Closes #4766