### PR TITLE
fix: handle api startup failures

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,13 +1,29 @@
+import { pathToFileURL } from "node:url";
 import { connectDb } from "./config/db.js";
 import { env } from "./config/env.js";
 import { createApp } from "./app.js";
 
-async function bootstrap() {
-  await connectDb();
-  const app = createApp();
-  app.listen(env.port, () => {
-    console.log(`API listening on http://localhost:${env.port}`);
+export async function bootstrap({
+  connect = connectDb,
+  createServerApp = createApp,
+  port = env.port
+} = {}) {
+  await connect();
+  const app = createServerApp();
+
+  return new Promise((resolve, reject) => {
+    const server = app.listen(port, () => {
+      console.log(`API listening on http://localhost:${port}`);
+      resolve(server);
+    });
+
+    server.once("error", reject);
   });
 }
 
-bootstrap();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  bootstrap().catch((error) => {
+    console.error("Failed to start API:", error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/api/src/tests/server.test.js
+++ b/apps/api/src/tests/server.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { bootstrap } from "../server.js";
+
+test("server module exports bootstrap without starting on import", () => {
+  assert.equal(typeof bootstrap, "function");
+});
+
+test("bootstrap rejects when database startup fails", async () => {
+  await assert.rejects(
+    bootstrap({
+      connect: async () => {
+        throw new Error("database unavailable");
+      },
+      createServerApp: () => assert.fail("app should not be created after connect failure")
+    }),
+    /database unavailable/
+  );
+});
+
+test("bootstrap rejects when listener startup fails", async () => {
+  await assert.rejects(
+    bootstrap({
+      connect: async () => {},
+      createServerApp: () => ({
+        listen() {
+          const server = new EventEmitter();
+          queueMicrotask(() => server.emit("error", new Error("listen failed")));
+          return server;
+        }
+      })
+    }),
+    /listen failed/
+  );
+});


### PR DESCRIPTION
/claim #743

## Summary
- export a testable `bootstrap()` helper from the API server module
- make importing `server.js` side-effect free by only auto-starting when executed as the entrypoint
- reject bootstrap failures from database connection or listener startup, and set a non-zero exit code on entrypoint startup failure

## Verification
- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\server.test.js`
- `git diff --check`

Closes #4502