### PR TITLE
Require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/requireAdmin.js
+++ b/apps/api/src/middleware/requireAdmin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/requireAdmin.test.js
+++ b/apps/api/src/tests/requireAdmin.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { requireAdmin } from "../middleware/requireAdmin.js";
+
+function createMockResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("requireAdmin rejects missing authenticated user", () => {
+  const res = createMockResponse();
+
+  requireAdmin({}, res, assert.fail);
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireAdmin rejects non-admin users", () => {
+  const res = createMockResponse();
+
+  requireAdmin({ user: { sub: "usr_1", role: "client" } }, res, assert.fail);
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireAdmin allows admin users", () => {
+  const res = createMockResponse();
+  let called = false;
+
+  requireAdmin({ user: { sub: "usr_admin", role: "admin" } }, res, () => {
+    called = true;
+  });
+
+  assert.equal(called, true);
+  assert.equal(res.statusCode, undefined);
+  assert.equal(res.body, undefined);
+});


### PR DESCRIPTION
## Summary
- add requireAdmin middleware for role checks
- apply it after authMiddleware on admin routes
- add regression tests for missing user, non-admin user, and admin user

## Validation
- node --test src/tests/*.test.js

Closes #4770