### PR TITLE
fix: prevent admin self assignment

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { registerSchema } from "../validators/auth.js";
+
+test("register schema defaults to client role", () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(payload.role, "client");
+});
+
+test("register schema accepts public roles", () => {
+  const payload = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(payload.role, "freelancer");
+});
+
+test("register schema rejects admin role self-assignment", () => {
+  assert.throws(
+    () =>
+      registerSchema.parse({
+        email: "admin@example.com",
+        password: "password123",
+        role: "admin"
+      }),
+    ZodError
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

## Summary
- restrict public registration roles to `client` and `freelancer`
- preserve the existing default `client` role behavior
- add regression coverage proving `admin` self-assignment is rejected

## Verification
- `node --test apps\api\src\tests\health.test.js apps\api\src\tests\authValidator.test.js`
- `git diff --check`

Closes #4723