### PR TITLE
fix: enforce unique registration emails

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,11 +1,18 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error.status === 409) {
+      return fail(res, error.message, 409);
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,34 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsersByEmail = new Map();
+
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}
+
+function duplicateEmailError(email) {
+  const error = new Error(`User with email ${email} already exists`);
+  error.status = 409;
+  return error;
+}
+
 export async function registerUser(payload) {
+  const email = normalizeEmail(payload.email);
+  if (registeredUsersByEmail.has(email)) {
+    throw duplicateEmailError(email);
+  }
+
   // TODO: persist new user via Prisma
-  return {
+  const user = {
     id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    email,
+    role: payload.role
+  };
+  registeredUsersByEmail.set(email, user);
+
+  return {
+    ...user,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser rejects a duplicate email address", async () => {
+  await registerUser({
+    email: "duplicate@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  await assert.rejects(
+    () =>
+      registerUser({
+        email: "duplicate@example.com",
+        password: "password123",
+        role: "freelancer"
+      }),
+    (error) => {
+      assert.equal(error.status, 409);
+      assert.match(error.message, /already exists/);
+      return true;
+    }
+  );
+});
+
+test("registerUser treats email addresses case-insensitively", async () => {
+  await registerUser({
+    email: "case-sensitive@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  await assert.rejects(
+    () =>
+      registerUser({
+        email: "CASE-SENSITIVE@example.com",
+        password: "password123",
+        role: "client"
+      }),
+    { status: 409 }
+  );
+});


### PR DESCRIPTION
/claim #743

Closes #4772

## Summary
- Track registered users by normalized email in `authService.registerUser()` so duplicate addresses cannot be registered repeatedly.
- Return `409 Conflict` for duplicate registration attempts, including case-insensitive duplicates.
- Store only the temporary account identity fields needed for uniqueness and reuse the generated user id as the JWT subject.
- Add service-level regression coverage for duplicate and case-insensitive email registrations.

## Demo
- GIF: https://tmpfiles.org/dl/wLwZ6c1uT5wy/auth-email-uniqueness-demo.gif

## Validation
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/authRegistration.test.js`
- `node --test apps/api/src/tests/authRegistration.test.js` could not be completed in this local workspace because API dependencies are not installed (`ERR_MODULE_NOT_FOUND: jsonwebtoken`).