### PR TITLE
Require fullName during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/registerFullName.test.js
+++ b/apps/api/src/tests/registerFullName.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+test("registration requires a full name", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "correct-horse"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registration rejects a blank full name", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "correct-horse",
+    fullName: "   "
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerUser returns the submitted full name", async () => {
+  const user = await registerUser({
+    email: "client@example.com",
+    password: "correct-horse",
+    fullName: "Ada Lovelace",
+    role: "client"
+  });
+
+  assert.equal(user.fullName, "Ada Lovelace");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().trim().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
Refs #4776

/claim #743

## Summary
- Require a non-blank `fullName` in registration payload validation.
- Return the submitted `fullName` from `registerUser` so the registration response matches the user data contract.
- Add focused validator/service regression coverage.
- Update the API test script so test files are discovered reliably by Node.

## Validation
`npm test`

Result: tests 4, pass 4, fail 0.

Closes #4776
