### PR TITLE
fix: return service list snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/serviceSnapshots.test.js
+++ b/apps/api/src/tests/serviceSnapshots.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  {
+    name: "users",
+    create: () => createUser({ email: "snapshot-user@example.com", role: "client" }),
+    list: listUsers
+  },
+  {
+    name: "jobs",
+    create: () =>
+      createJob({
+        clientId: "usr_snapshot",
+        title: "Snapshot job",
+        description: "Prove list snapshots are defensive.",
+        budgetMin: 100,
+        budgetMax: 200,
+        skills: []
+      }),
+    list: listJobs
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ jobId: "job_snapshot", freelancerId: "usr_snapshot", amount: 150 }),
+    list: listProposals
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ senderId: "usr_a", recipientId: "usr_b", body: "snapshot" }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ userId: "usr_snapshot", message: "snapshot" }),
+    list: listNotifications
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ jobId: "job_snapshot", reviewerId: "usr_a", rating: 5, comment: "snapshot" }),
+    list: listReviews
+  }
+];
+
+for (const service of cases) {
+  test(`${service.name} list returns a defensive snapshot`, async () => {
+    const record = await service.create();
+    const firstList = await service.list();
+    const initialLength = firstList.length;
+
+    firstList.length = 0;
+    const secondList = await service.list();
+
+    assert.equal(secondList.length, initialLength);
+    assert.ok(secondList.some((item) => item.id === record.id));
+  });
+}


### PR DESCRIPTION
/claim #743

## Summary
- return shallow snapshot arrays from all six list service functions
- keep existing record objects and create/send behavior unchanged
- add regression coverage proving callers cannot clear backing stores by mutating a list response

## Verification
- `node --test apps\api\src\tests\serviceSnapshots.test.js apps\api\src\tests\health.test.js`
- `git diff --check`

Closes #4617