### PR TITLE
fix: normalize payment currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }


### PR DESCRIPTION
/claim #743

## Summary
- Normalize payment currency values to lowercase inside `createPaymentIntent`.
- Keeps the default fallback as `usd`.
- Leaves controller and route code unchanged, matching the issue scope.

## Verification
- Ran a focused Node smoke test against the updated service logic:
  - `createPaymentIntent({ amount: 100, currency: "USD" })` returns `currency: "usd"`
  - `createPaymentIntent({ amount: 100 })` keeps the fallback `currency: "usd"`

Closes #4778