### PR TITLE
fix: accept case-insensitive bearer auth scheme

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,15 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const token = bearerMatch?.[1]?.trim();
+
+  if (!token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+async function runAuthHeader(header) {
+  const req = { headers: { authorization: header } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { req, res, nextCalled };
+}
+
+test("authMiddleware accepts case-insensitive bearer schemes", async () => {
+  const token = signAccessToken({ sub: "user_1" });
+
+  for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+    const { req, nextCalled } = await runAuthHeader(`${scheme} ${token}`);
+
+    assert.equal(nextCalled, true);
+    assert.equal(req.user.sub, "user_1");
+  }
+});
+
+test("authMiddleware rejects missing, blank, and malformed authorization headers", async () => {
+  for (const header of [undefined, "Bearer ", "bearer    ", "Basic token"]) {
+    const { res, nextCalled } = await runAuthHeader(header);
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.payload, { success: false, message: "Unauthorized" });
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary
- Parse the Bearer auth scheme case-insensitively in `authMiddleware`.
- Keep missing, blank, and malformed authorization headers rejected with `401 Unauthorized`.
- Add focused `node:test` coverage for canonical, lowercase, uppercase, and malformed Authorization headers.

## Verification
- Ran a focused smoke check for the Bearer parsing expression:
  - `Bearer abc`, `bearer abc`, and `BEARER abc` produce token `abc`
  - missing, blank, and `Basic abc` headers do not produce a token

Closes #4782