### PR TITLE
Fix @freelanceflow/ui workspace package entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "peerDependencies": {
+        "react": ">=18"
+      }
     }
   }
 }

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export interface ButtonProps {
+  children: ReactNode;
+}
+
+export declare function Button(props: ButtonProps): JSX.Element;
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export declare function Card(props: CardProps): JSX.Element;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,34 @@
+"use strict";
+
+function Button({ children }) {
+  const React = require("react");
+
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  const React = require("react");
+
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+exports.Button = Button;
+exports.Card = Card;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/import.test.mjs"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }

--- a/packages/ui/test/import.test.mjs
+++ b/packages/ui/test/import.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("@freelanceflow/ui can be imported through the workspace package name", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});


### PR DESCRIPTION
Closes #4784

## Summary

- Adds a real JavaScript entrypoint for `@freelanceflow/ui`.
- Adds package `types` and `exports` metadata for the workspace package.
- Adds a focused import test for `@freelanceflow/ui`.

## Validation

- `npm run test -w @freelanceflow/ui`
- `node --input-type=module -e "import { Button, Card } from '@freelanceflow/ui'; console.log(typeof Button, typeof Card)"`
