### PR TITLE
fix: omit submitted passwords from user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser does not store submitted passwords", async () => {
+  const created = await createUser({
+    email: "alice@example.com",
+    name: "Alice",
+    password: "super-secret"
+  });
+  const users = await listUsers();
+  const stored = users.find((user) => user.id === created.id);
+
+  assert.equal(created.email, "alice@example.com");
+  assert.equal(created.name, "Alice");
+  assert.equal(Object.hasOwn(created, "password"), false);
+  assert.equal(Object.hasOwn(stored, "password"), false);
+});


### PR DESCRIPTION
/claim #743

## Summary
- Omit submitted `password` fields before creating in-memory user records.
- Prevent both `POST /api/users` responses and later `GET /api/users` listings from exposing password material.
- Add a focused service test for the password omission behavior.

## Verification
- Ran a focused Node smoke check that creates a user with `password: "secret"` and verifies neither the returned user nor the stored user has a `password` property.

Closes #4786