### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/job-validation.test.js
+++ b/apps/api/src/tests/job-validation.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+const validJobPayload = {
+  title: "Build an onboarding flow",
+  description: "Create a polished onboarding flow for new users.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "design",
+  skills: ["ux"]
+};
+
+test("POST /api/jobs accepts ordered budget ranges", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  const response = await fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(validJobPayload)
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.budgetMin, 100);
+  assert.equal(payload.data.budgetMax, 500);
+
+  await close(server);
+});
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  const response = await fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...validJobPayload,
+      budgetMin: 500,
+      budgetMax: 100
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.match(payload.message, /budgetMax/);
+
+  await close(server);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function budgetRangeRefinement(data, ctx) {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(budgetRangeRefinement);
+
+export const updateJobSchema = jobSchema.partial().superRefine(budgetRangeRefinement);


### PR DESCRIPTION
## Summary

Closes #2853.

This PR rejects inverted job budget ranges by validating that budgetMax is greater than or equal to budgetMin. It also makes POST /api/jobs return a clear 400 response for validation failures instead of letting schema errors reach the generic error handler.

## Validation

Ran npm test -w apps/api; all API tests pass with 3 passing tests and 0 failures.

/claim #2853