### PR TITLE
fix: reject empty upload submissions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required.", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/uploads rejects multipart requests without a file", async () => {
+  const { baseUrl, server } = await listen(createApp());
+  const form = new FormData();
+  form.append("description", "empty upload");
+
+  const response = await fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "File is required."
+  });
+
+  await close(server);
+});
+
+test("POST /api/uploads accepts multipart requests with a file", async () => {
+  const { baseUrl, server } = await listen(createApp());
+  const form = new FormData();
+  form.append("file", new Blob(["hello"]), "hello.txt");
+
+  const response = await fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(payload, {
+    success: true,
+    data: {
+      filename: "hello.txt",
+      status: "uploaded"
+    }
+  });
+
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Closes #4800.
Related: #2850 and parent bounty #743.

This PR rejects empty multipart upload submissions instead of treating them as successful uploads. Missing-file requests now return a clear 400 response, while valid file uploads still return 201 with the uploaded filename.

## Validation

Ran npm test -w apps/api; all API tests pass with 3 passing tests and 0 failures.

/claim #4800