### PR TITLE
fix: resolve job detail mock data by route id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,25 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((candidate) => candidate.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job exists for <strong>{params.id}</strong>.</p>
+        <Link href="/jobs">Back to jobs</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <Link href="/jobs">Back to jobs</Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Closes #4801.
Related: #2790 and parent bounty #743.

This PR updates the job detail route so it resolves the dynamic route id against the mock job data instead of rendering the id as placeholder text.

Known ids now show the matching mock job title and budget, while unknown ids show a clear fallback and link back to the job list.

## Validation

Ran npm run build -w apps/web; the Next.js build and TypeScript step completed successfully.

/claim #4801