### PR TITLE
fix: validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/user-validation.test.js
+++ b/apps/api/src/tests/user-validation.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/users accepts valid user payloads", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  const response = await fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: "maya@example.com",
+      name: "Maya",
+      role: "freelancer"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.email, "maya@example.com");
+  assert.equal(payload.data.name, "Maya");
+  assert.equal(payload.data.role, "freelancer");
+
+  await close(server);
+});
+
+test("POST /api/users rejects invalid emails", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  const response = await fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: "not-an-email",
+      name: "Maya"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await close(server);
+});
+
+test("POST /api/users rejects admin self-assignment", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  const response = await fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      email: "maya@example.com",
+      name: "Maya",
+      role: "admin"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await close(server);
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
## Summary

Closes #4802.
Related: #1773 and parent bounty #743.

This PR adds Zod validation to POST /api/users so malformed user records are rejected before reaching the service layer. It validates email/name and prevents requesters from self-assigning the admin role.

## Validation

Ran npm test -w apps/api; all API tests pass with 4 passing tests and 0 failures.

/claim #4802