### PR TITLE
fix: resolve freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,26 @@
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((candidate) => candidate.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer exists for <strong>{params.username}</strong>.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
+      <Link href="/freelancers/search">Back to freelancer search</Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Closes #2849.

This PR updates the freelancer profile route so it resolves the dynamic username against the mock freelancer data instead of rendering placeholder text.

Known usernames now show useful profile context including rate and skills, while unknown usernames show a clear not-found fallback and a link back to freelancer search.

## Validation

Ran npm run build -w apps/web; the Next.js build and TypeScript step completed successfully.

/claim #2849