### PR TITLE
fix: expose importable ui package entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.js"
+    }
+  }
 }

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/src/Card.js
+++ b/packages/ui/src/Card.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,2 @@
+export * from "./Button.js";
+export * from "./Card.js";


### PR DESCRIPTION
## Summary

Closes #2781.

This PR makes @freelanceflow/ui directly importable by Node/ESM consumers. It adds a JavaScript package entrypoint, explicit package exports, and runtime JS component modules while preserving the existing TypeScript source as the package types entry.

## Validation

- Ran `node -e import('@freelanceflow/ui').then(m=>console.log(Object.keys(m).sort().join(',')))` and confirmed it prints `Button,Card`.
- Ran `npm run build -w apps/web`; the Next.js build and TypeScript step completed successfully.

/claim #2781