### PR TITLE
fix: expose importable db package entrypoint

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/db/src/index.js
+++ b/packages/db/src/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";


### PR DESCRIPTION
## Summary

Closes #2775.

This PR makes @freelanceflow/db directly importable by workspace consumers. It adds explicit package metadata (type, main, types, and exports) plus a JavaScript runtime entrypoint that re-exports Prisma Client while preserving the existing TypeScript source for types.

## Validation

- Ran direct Node import of @freelanceflow/db and confirmed it prints PrismaClient exported.
- Ran npm run build -w apps/web; the Next.js build and TypeScript step completed successfully.

/claim #2775