### PR TITLE
fix: keep registration token subject aligned with user id

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-service.test.js
+++ b/apps/api/src/tests/auth-service.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token with the returned user id", async () => {
+  const result = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
## Summary

Closes #2768.

This PR fixes a subtle registration consistency bug where `registerUser()` generated the returned user id and JWT `sub` claim from two separate `Date.now()` calls. If those calls crossed a millisecond boundary, the API could return one user id while issuing a token for another subject.

The fix generates the user id once, reuses it in the response, and signs the access token with that same id.

## Validation

- Added focused service coverage that registers a user, verifies the JWT, and asserts `decoded.sub === result.id`.
- Ran `npm test -w apps/api`; all API tests pass with 2 passing tests and 0 failures.

/claim #2768