### PR TITLE
feat: add actionable settings overview

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,103 @@
-export default function SettingsPage() {
+const profileSettings = [
+  { label: "Display name", value: "Maya Chen" },
+  { label: "Public role", value: "Freelancer" },
+  { label: "Profile visibility", value: "Public" }
+];
+
+const notificationSettings = [
+  { label: "Proposal updates", value: "Email + in-app" },
+  { label: "Message alerts", value: "In-app only" },
+  { label: "Weekly digest", value: "Enabled" }
+];
+
+const securitySettings = [
+  { label: "Password", value: "Updated 18 days ago", status: "Healthy" },
+  { label: "Two-factor auth", value: "Not enabled", status: "Recommended" },
+  { label: "Active sessions", value: "2 devices", status: "Review" }
+];
+
+const payoutSettings = [
+  { label: "Default payout rail", value: "USDC on Solana" },
+  { label: "Invoice currency", value: "USD" },
+  { label: "Auto-withdraw", value: "Manual approval" }
+];
+
+function SettingsGroup({
+  title,
+  description,
+  action,
+  rows
+}: {
+  title: string;
+  description: string;
+  action: string;
+  rows: Array<{ label: string; value: string; status?: string }>;
+}) {
   return (
     <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "flex-start" }}>
+        <div>
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+        <button>{action}</button>
+      </div>
+      <div style={{ display: "grid", gap: "0.75rem", marginTop: "1rem" }}>
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: "1rem",
+              borderTop: "1px solid #e5e7eb",
+              paddingTop: "0.75rem"
+            }}
+          >
+            <span>{row.label}</span>
+            <strong>{row.status ? `${row.value} - ${row.status}` : row.value}</strong>
+          </div>
+        ))}
+      </div>
     </section>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <div style={{ display: "grid", gap: "1rem" }}>
+      <section className="card">
+        <h2>Settings</h2>
+        <p>Review account defaults, notification routing, security posture, and payout preferences.</p>
+      </section>
+
+      <SettingsGroup
+        title="Account and profile"
+        description="Controls how your public profile appears to clients and collaborators."
+        action="Edit profile"
+        rows={profileSettings}
+      />
+
+      <SettingsGroup
+        title="Notifications"
+        description="Keeps high-signal workflow updates visible without overloading email."
+        action="Tune alerts"
+        rows={notificationSettings}
+      />
+
+      <SettingsGroup
+        title="Security"
+        description="Highlights session and authentication settings that need attention."
+        action="Review access"
+        rows={securitySettings}
+      />
+
+      <SettingsGroup
+        title="Billing and payouts"
+        description="Shows the default money movement settings used for invoices and withdrawals."
+        action="Manage payouts"
+        rows={payoutSettings}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #4820.
Related: #2822 and parent bounty #743.

This PR replaces the placeholder /settings page with a static, scannable account controls overview using mock data only. It adds dedicated sections for account/profile, notifications, security, and billing/payout preferences, with status-oriented rows and visible next-action controls.

The implementation stays scoped to the web settings route and does not change backend/API behavior.

## Validation

- Ran `npm run build -w apps/web`; the Next.js build and TypeScript step completed successfully.

/claim #4820