### PR TITLE
Reject unsupported payment currency codes

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { PaymentValidationError, createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,25 @@
+const SUPPORTED_CURRENCIES = new Set(["usd", "eur", "gbp"]);
+
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+  }
+}
+
 export async function createPaymentIntent(payload) {
+  const rawCurrency = payload.currency ?? "usd";
+  const currency = String(rawCurrency).trim().toLowerCase();
+
+  if (!SUPPORTED_CURRENCIES.has(currency)) {
+    throw new PaymentValidationError(`Unsupported payment currency: ${rawCurrency}`);
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-service.test.js
+++ b/apps/api/src/tests/payment-service.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, PaymentValidationError } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const intent = await createPaymentIntent({ amount: 25 });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent normalizes supported currency codes", async () => {
+  const intent = await createPaymentIntent({ amount: 25, currency: "EUR" });
+
+  assert.equal(intent.currency, "eur");
+});
+
+test("createPaymentIntent rejects unsupported currency codes", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 25, currency: "DOGE" }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "Unsupported payment currency: DOGE",
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4825

## Summary
- add a payment currency allowlist for Stripe-style payment intents
- default missing currency to `usd` and normalize supported mixed-case currency input
- return a clear `400` validation response when the payment controller receives an unsupported currency
- add focused payment service regression coverage

## Verification
- `node --test apps/api/src/tests/payment-service.test.js`
- `git diff --check`