### PR TITLE
Reject invalid payment intent amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { PaymentValidationError, createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentValidationError) {
+      return fail(res, error.message, 400);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,21 @@
+export class PaymentValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PaymentValidationError";
+  }
+}
+
 export async function createPaymentIntent(payload) {
+  const amount = Number(payload.amount);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new PaymentValidationError("Payment amount must be a positive number");
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/payment-amount-service.test.js
+++ b/apps/api/src/tests/payment-amount-service.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, PaymentValidationError } from "../services/paymentService.js";
+
+test("createPaymentIntent accepts positive numeric amounts", async () => {
+  const intent = await createPaymentIntent({ amount: "25", currency: "usd" });
+
+  assert.equal(intent.amount, 25);
+});
+
+test("createPaymentIntent rejects zero amounts", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0, currency: "usd" }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "Payment amount must be a positive number",
+  );
+});
+
+test("createPaymentIntent rejects negative amounts", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: -5, currency: "usd" }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "Payment amount must be a positive number",
+  );
+});
+
+test("createPaymentIntent rejects non-numeric amounts", async () => {
+  await assert.rejects(
+    () => createPaymentIntent({ amount: "not-a-number", currency: "usd" }),
+    (error) =>
+      error instanceof PaymentValidationError &&
+      error.message === "Payment amount must be a positive number",
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4828

## Summary
- validate payment intent amounts before creating a Stripe-style response
- reject zero, negative, missing, and non-numeric amounts through a clear payment validation error
- return `400` from the payment controller for invalid payment amounts
- add focused payment service regression coverage

## Verification
- `node --test apps/api/src/tests/payment-amount-service.test.js`
- `git diff --check`