### PR TITLE
Return defensive job list snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/tests/job-service.test.js
+++ b/apps/api/src/tests/job-service.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("listJobs returns a defensive snapshot", async () => {
+  const created = await createJob({ title: "Defensive copy check" });
+  const listed = await listJobs();
+
+  listed.push({ id: "job_injected", title: "Injected" });
+
+  const listedAgain = await listJobs();
+
+  assert.ok(listedAgain.some((job) => job.id === created.id));
+  assert.equal(listedAgain.some((job) => job.id === "job_injected"), false);
+});


### PR DESCRIPTION
/claim #743

Fixes #4831

## Summary
- make `listJobs()` return a defensive snapshot instead of the backing array
- prevent callers from mutating the in-memory job store through a returned list
- add focused service regression coverage

## Verification
- `node --test apps/api/src/tests/job-service.test.js`
- `git diff --check`