### PR TITLE
Return defensive proposal list snapshots

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposal-service.test.js
+++ b/apps/api/src/tests/proposal-service.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("listProposals returns a defensive snapshot", async () => {
+  const created = await createProposal({ jobId: "job_1", coverLetter: "Proposal" });
+  const listed = await listProposals();
+
+  listed.push({ id: "prp_injected", jobId: "job_2" });
+
+  const listedAgain = await listProposals();
+
+  assert.ok(listedAgain.some((proposal) => proposal.id === created.id));
+  assert.equal(listedAgain.some((proposal) => proposal.id === "prp_injected"), false);
+});


### PR DESCRIPTION
/claim #743

Fixes #4833

## Summary
- make `listProposals()` return a defensive snapshot instead of the backing array
- prevent callers from mutating the in-memory proposal store through a returned list
- add focused service regression coverage

## Verification
- `node --test apps/api/src/tests/proposal-service.test.js`
- `git diff --check`