### PR TITLE
Return defensive review list snapshots

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/tests/review-service.test.js
+++ b/apps/api/src/tests/review-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("listReviews returns a defensive snapshot", async () => {
+  const created = await createReview({ proposalId: "prp_1", rating: 5 });
+  const listed = await listReviews();
+
+  listed.push({ id: "rev_injected", proposalId: "prp_2" });
+
+  const listedAgain = await listReviews();
+
+  assert.ok(listedAgain.some((review) => review.id === created.id));
+  assert.equal(
+    listedAgain.some((review) => review.id === "rev_injected"),
+    false,
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4835

## Summary
- return a defensive snapshot from `listReviews()` instead of exposing the module-level array
- add a regression test proving mutations to a returned list do not corrupt stored reviews

## Verification
- `node --test apps\api\src\tests\review-service.test.js`
- `git diff --check`