### PR TITLE
Validate proposal estimated duration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +6,13 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
+  if (
+    req.body?.estimatedDuration === undefined ||
+    req.body?.estimatedDuration === null ||
+    req.body?.estimatedDuration === ""
+  ) {
+    return fail(res, "estimatedDuration is required", 400);
+  }
+
   return ok(res, await createProposal(req.body), 201);
 }

--- a/apps/api/src/tests/proposal-routes.test.js
+++ b/apps/api/src/tests/proposal-routes.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const beforeResponse = await fetch(`${baseUrl}/api/proposals`);
+    const beforePayload = await beforeResponse.json();
+
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_123",
+        freelancerId: "usr_456",
+        coverLetter: "I can deliver this milestone this week.",
+        priceUsd: 500
+      })
+    });
+    const payload = await response.json();
+
+    const afterResponse = await fetch(`${baseUrl}/api/proposals`);
+    const afterPayload = await afterResponse.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "estimatedDuration is required"
+    });
+    assert.equal(afterPayload.data.length, beforePayload.data.length);
+  });
+});
+
+test("POST /api/proposals accepts payloads with estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_123",
+        freelancerId: "usr_456",
+        coverLetter: "I can deliver this milestone this week.",
+        priceUsd: 500,
+        estimatedDuration: "5 business days"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.estimatedDuration, "5 business days");
+    assert.match(payload.data.id, /^prp_/);
+  });
+});


### PR DESCRIPTION
﻿/claim #743

Closes #4830.

Summary:
- Rejects proposal creation requests that omit `estimatedDuration` before calling the service layer.
- Returns a clear 400 response: `estimatedDuration is required`.
- Adds focused route coverage for invalid and valid proposal creation payloads.
- Updates the API test script to run test files directly so the workspace test command executes on Windows/Node 24.

Validation:
- `git diff --check`
- `npm.cmd test -w apps/api` passed: 3 tests
- `node --test apps/api/src/tests/proposal-routes.test.js` passed: 2 tests

Demo / Evidence:
- Scoped issue evidence posted at #4830: https://github.com/SecureBananaLabs/bug-bounty/issues/4830#issuecomment-4632618664

Bounty request: #743 scoped bug-bounty claim if accepted. Payment details can be provided privately after acceptance.
