### PR TITLE
Return defensive message list snapshots

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("listMessages returns a defensive snapshot", async () => {
+  const created = await sendMessage({ conversationId: "conv_1", body: "hello" });
+  const listed = await listMessages();
+
+  listed.push({ id: "msg_injected", conversationId: "conv_2" });
+
+  const listedAgain = await listMessages();
+
+  assert.ok(listedAgain.some((message) => message.id === created.id));
+  assert.equal(
+    listedAgain.some((message) => message.id === "msg_injected"),
+    false,
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4838

## Summary
- return a defensive snapshot from `listMessages()` instead of exposing the module-level array
- add a regression test proving mutations to a returned list do not corrupt stored messages

## Verification
- `node --test apps\api\src\tests\message-service.test.js`
- `git diff --check`