### PR TITLE
Return defensive notification list snapshots

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createNotification,
+  listNotifications,
+} from "../services/notificationService.js";
+
+test("listNotifications returns a defensive snapshot", async () => {
+  const created = await createNotification({ userId: "usr_1", message: "hello" });
+  const listed = await listNotifications();
+
+  listed.push({ id: "ntf_injected", userId: "usr_2" });
+
+  const listedAgain = await listNotifications();
+
+  assert.ok(
+    listedAgain.some((notification) => notification.id === created.id),
+  );
+  assert.equal(
+    listedAgain.some((notification) => notification.id === "ntf_injected"),
+    false,
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4840

## Summary
- return a defensive snapshot from `listNotifications()` instead of exposing the module-level array
- add a regression test proving mutations to a returned list do not corrupt stored notifications

## Verification
- `node --test apps\api\src\tests\notification-service.test.js`
- `git diff --check`