### PR TITLE
Return defensive user list snapshots

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/user-service.test.js
+++ b/apps/api/src/tests/user-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers returns a defensive snapshot", async () => {
+  const created = await createUser({ email: "user@example.com" });
+  const listed = await listUsers();
+
+  listed.push({ id: "usr_injected", email: "injected@example.com" });
+
+  const listedAgain = await listUsers();
+
+  assert.ok(listedAgain.some((user) => user.id === created.id));
+  assert.equal(
+    listedAgain.some((user) => user.id === "usr_injected"),
+    false,
+  );
+});


### PR DESCRIPTION
/claim #743

Fixes #4842

## Summary
- return a defensive snapshot from `listUsers()` instead of exposing the module-level array
- add a regression test proving mutations to a returned list do not corrupt stored users

## Verification
- `node --test apps\api\src\tests\user-service.test.js`
- `git diff --check`