### PR TITLE
fix: require estimated duration for proposals

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/proposals rejects payloads missing estimatedDuration", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job-101",
+        freelancerId: "usr_freelancer",
+        coverLetter: "I can deliver this project with a focused milestone plan.",
+        bidAmount: 1200
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /estimatedDuration/);
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/proposals accepts payloads with estimatedDuration", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job-101",
+        freelancerId: "usr_freelancer",
+        coverLetter: "I can deliver this project with a focused milestone plan.",
+        bidAmount: 1200,
+        estimatedDuration: "2 weeks"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.estimatedDuration, "2 weeks");
+  } finally {
+    await close(server);
+  }
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z
+    .string({ required_error: "estimatedDuration is required" })
+    .min(1, "estimatedDuration is required")
+});


### PR DESCRIPTION
## Summary

Closes #4830.
Related: #1739 and parent bounty #743.

This PR adds focused validation to POST /api/proposals so incomplete proposal records missing estimatedDuration are rejected before reaching the service layer.

Missing estimatedDuration now returns a clear 400 response, while valid proposal payloads with an estimated duration still return 201.

## Validation

- Added route coverage for missing estimatedDuration and a valid proposal payload.
- Ran `npm test -w apps/api`; all API tests pass with 3 passing tests and 0 failures.

/claim #4830