### PR TITLE
Validate OAuth callback inputs

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOAuthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,19 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = req.params.provider;
+  const code = typeof req.query.code === "string" ? req.query.code.trim() : "";
+
+  if (!supportedOAuthProviders.has(provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
+  if (!code) {
+    return fail(res, "OAuth authorization code is required", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/auth-oauth.test.js
+++ b/apps/api/src/tests/auth-oauth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/twitter/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});
+
+test("OAuth callback requires an authorization code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "OAuth authorization code is required"
+    });
+  });
+});
+
+test("OAuth callback accepts supported providers with a code", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/google/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "google",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate OAuth callback providers before accepting callbacks
- require a non-empty authorization code
- add API regression coverage for unsupported provider, missing code, and valid callback behavior

Closes #4855
/claim #743

## Testing
- `node --test src/tests/*.test.js` from `apps/api`