### PR TITLE
fix: require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job-auth.test.js
+++ b/apps/api/src/tests/job-auth.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+const validJob = {
+  title: "Frontend polish",
+  description: "Improve dashboard responsiveness and empty states.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "web",
+  skills: ["react", "css"]
+};
+
+test("POST /api/jobs rejects unauthenticated job creation", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/jobs accepts authenticated job creation", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJob.title);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #4854.
Related: #1783 and parent bounty #743.

This PR protects `POST /api/jobs` with the existing API auth middleware so unauthenticated users can no longer create job listings.

The public `GET /api/jobs` route remains unchanged, while job creation now requires a valid bearer access token.

## Validation

- Added route coverage for unauthenticated job creation returning 401.
- Added route coverage for authenticated job creation returning 201 with a valid signed access token.
- Ran `node --test "src/tests/*.test.js"` from `apps/api`; all API tests pass with 3 passing tests and 0 failures.

/claim #4854