### PR TITLE
Require production JWT secret

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,23 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+function resolveJwtSecret() {
+  const jwtSecret = process.env.JWT_SECRET;
+
+  if (typeof jwtSecret === "string" && jwtSecret.trim().length > 0) {
+    return jwtSecret;
+  }
+
+  if (nodeEnv === "production") {
+    throw new Error("JWT_SECRET is required in production");
+  }
+
+  return "development-secret";
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalJwtSecret = process.env.JWT_SECRET;
+let importCounter = 0;
+
+function setEnvValue(name, value) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+async function withEnv(overrides, callback) {
+  setEnvValue("NODE_ENV", overrides.NODE_ENV);
+  setEnvValue("JWT_SECRET", overrides.JWT_SECRET);
+
+  try {
+    return await callback();
+  } finally {
+    setEnvValue("NODE_ENV", originalNodeEnv);
+    setEnvValue("JWT_SECRET", originalJwtSecret);
+  }
+}
+
+async function importFreshEnv() {
+  importCounter += 1;
+  return import(`../config/env.js?test=${importCounter}`);
+}
+
+test("non-production config uses local JWT fallback when secret is missing", async () => {
+  await withEnv({ NODE_ENV: "development", JWT_SECRET: undefined }, async () => {
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.jwtSecret, "development-secret");
+  });
+});
+
+test("production config rejects missing JWT secret", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: undefined }, async () => {
+    await assert.rejects(importFreshEnv, /JWT_SECRET is required in production/);
+  });
+});
+
+test("production config rejects blank JWT secret", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: "   " }, async () => {
+    await assert.rejects(importFreshEnv, /JWT_SECRET is required in production/);
+  });
+});
+
+test("production config preserves provided JWT secret", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret-value" }, async () => {
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.jwtSecret, "prod-secret-value");
+  });
+});


### PR DESCRIPTION
﻿/claim #743

Closes #4849.

## Summary
- Fail fast when `NODE_ENV=production` is missing a usable `JWT_SECRET`.
- Keep the existing local fallback for non-production environments.
- Preserve provided production secrets without trimming or rewriting them.
- Add focused config tests for local fallback, missing production secret, blank production secret, and provided production secret.
- Update the API test script to run the concrete test files.

## Validation
- `git diff --check`
- `npm.cmd test -w apps/api` passed 5/5
- `node --test apps/api/src/tests/*.test.js` passed 5/5

## Demo / Evidence
- Scoped issue evidence posted at #4849: https://github.com/SecureBananaLabs/bug-bounty/issues/4849#issuecomment-4633022344

Bounty request: #743 scoped bug-bounty claim if accepted. Payment details can be provided privately after acceptance.
