### PR TITLE
fix: restrict auth registration and refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,15 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const payload = registerSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, payload.error.issues[0]?.message ?? "Invalid registration payload", 400);
+  }
+
+  const result = await registerUser(payload.data);
   return ok(res, result, 201);
 }
 
@@ -22,6 +27,16 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const payload = refreshSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, payload.error.issues[0]?.message ?? "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(payload.data.token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,13 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+
+  return {
+    token: signAccessToken({
+      sub: decoded.sub,
+      role: decoded.role
+    })
+  };
 }

--- a/apps/api/src/tests/auth-security.test.js
+++ b/apps/api/src/tests/auth-security.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/auth/register rejects admin self-registration", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "admin-attempt@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /client|freelancer/);
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/auth/refresh requires a token", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/auth/refresh forwards token identity into the refreshed token", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const token = signAccessToken({ sub: "usr_freelancer", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token })
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_freelancer");
+    assert.equal(decoded.role, "freelancer");
+  } finally {
+    await close(server);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,14 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
+});
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
 });


### PR DESCRIPTION
## Summary

Closes #4860.
Related: #1823 and parent bounty #743.

This PR tightens the auth flow in two places:

- Self-registration no longer accepts `role: "admin"`; only `client` and `freelancer` can be selected by public registration.
- `POST /api/auth/refresh` now requires a submitted token, verifies it, and issues a refreshed token that preserves the submitted identity and role.

Invalid or missing refresh tokens now return explicit 400/401 responses instead of silently refreshing a hard-coded user.

## Validation

- Added coverage for rejecting admin self-registration.
- Added coverage for missing refresh token input.
- Added coverage that a valid submitted token is forwarded and preserved in the refreshed token.
- Ran `node --test "src/tests/*.test.js"` from `apps/api`; all API tests pass with 4 passing tests and 0 failures.

/claim #4860