### PR TITLE
fix: preserve notification server owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id, read, ...safePayload } = payload;
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-creation.test.js
+++ b/apps/api/src/tests/notification-creation.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/notifications preserves server-owned id and read state", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "client_supplied",
+        read: true,
+        userId: "usr_123",
+        title: "Proposal accepted",
+        body: "Your proposal was accepted."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "client_supplied");
+    assert.match(payload.data.id, /^ntf_/);
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.userId, "usr_123");
+    assert.equal(payload.data.title, "Proposal accepted");
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #4866.
Related: #2762 and parent bounty #743.

This PR keeps notification creation fields owned by the server:

- Caller-supplied `id` is ignored and replaced with a generated `ntf_` id.
- Caller-supplied `read` is ignored and new notifications always start unread.
- The rest of the notification payload is still preserved.

## Validation

- Added route coverage proving a submitted `id` and `read: true` cannot override server-owned fields.
- Ran `node --test "src/tests/*.test.js"` from `apps/api`; all API tests pass with 2 passing tests and 0 failures.

/claim #4866