### PR TITLE
Fix case-sensitive Bearer auth parsing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const token = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+
+  if (!token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(t) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const { port } = server.address();
+  return `http://127.0.0.1:${port}`;
+}
+
+test("admin metrics accepts Bearer scheme case-insensitively", async (t) => {
+  const baseUrl = await withServer(t);
+  const token = signAccessToken({ sub: "usr_test" });
+
+  for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `${scheme} ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  }
+});
+
+test("admin metrics rejects non-bearer auth schemes", async (t) => {
+  const baseUrl = await withServer(t);
+  const token = signAccessToken({ sub: "usr_test" });
+
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Basic ${token}` }
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+});

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -4,7 +4,7 @@ import { createApp } from "../app.js";
 
 test("GET /health returns ok payload", async () => {
   const app = createApp();
-  const server = app.listen(0);
+  const server = app.listen(0, "127.0.0.1");
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);


### PR DESCRIPTION
/claim #743

Fixes #4865

## Summary
- Accept `Authorization` Bearer schemes case-insensitively in API auth middleware.
- Continue rejecting missing tokens and non-bearer schemes before JWT verification.
- Update API test script to target test files and add auth coverage for `Bearer`, `bearer`, `BEARER`, and `Basic`.

## Verification
- `npm test -w apps/api`
- Result: 3 tests passed.

## Demo evidence
- With a valid JWT, `/api/admin/metrics` returns 200 for `Bearer`, `bearer`, and `BEARER`.
- With `Basic`, `/api/admin/metrics` returns 401 Unauthorized.

## Payment fallback
- PayPal: samik4184@gmail.com
- Revolut: @standamarek
- USDC: 0x10DFE6771131BEc830A7a44D7Be45Ced0741b2b3