### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API integration",
+  description: "Create a production-ready API integration.",
+  budgetMin: 100,
+  budgetMax: 250,
+  categoryId: "cat_backend",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts valid budget ranges", () => {
+  const parsed = createJobSchema.parse(validJob);
+
+  assert.equal(parsed.budgetMin, 100);
+  assert.equal(parsed.budgetMax, 250);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.deepEqual(updateJobSchema.parse({ budgetMax: 300 }), { budgetMax: 300 });
+});
+
+test("updateJobSchema rejects inverted budget ranges when both ends are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 400, budgetMax: 150 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function hasValidBudgetRange(payload) {
+  return (
+    payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMax >= payload.budgetMin
+  );
+}
+
+export const createJobSchema = jobFieldsSchema.refine(hasValidBudgetRange, {
+  path: ["budgetMax"],
+  message: "budgetMax must be greater than or equal to budgetMin"
+});
+
+export const updateJobSchema = jobFieldsSchema.partial().refine(hasValidBudgetRange, {
+  path: ["budgetMax"],
+  message: "budgetMax must be greater than or equal to budgetMin"
+});


### PR DESCRIPTION
/claim #743

Fixes #4875

## Summary
- Reject job payloads where `budgetMax` is lower than `budgetMin`.
- Preserve partial update behavior while validating budget ranges when both values are present.
- Add validator coverage for valid create ranges, inverted create ranges, partial updates, and inverted update ranges.

## Verification
- `node --test src/tests/job.test.js`
- Result: focused validator test passed.

## Demo evidence
- `createJobSchema` now rejects min 500 / max 100 with a `budgetMax` validation error.
- `updateJobSchema` still accepts `{ budgetMax: 300 }`, but rejects `{ budgetMin: 400, budgetMax: 150 }`.

## Payment fallback
- PayPal: samik4184@gmail.com
- Revolut: @standamarek
- USDC: 0x10DFE6771131BEc830A7a44D7Be45Ced0741b2b3