### PR TITLE
Keep registration token subject aligned

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-service.test.js
+++ b/apps/api/src/tests/auth-service.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async (t) => {
+  const originalNow = Date.now;
+  let now = 1790000000000;
+
+  Date.now = () => now++;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+
+  const user = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const claims = verifyAccessToken(user.token);
+
+  assert.equal(user.id, "usr_1790000000000");
+  assert.equal(claims.sub, user.id);
+  assert.equal(claims.role, "client");
+});


### PR DESCRIPTION
/claim #743

Fixes #4878

## Summary
- Generate the registration user id once.
- Sign the access token `sub` with the same id returned in the response.
- Add a deterministic regression test that forces `Date.now()` to advance between calls.

## Verification
- `node --test src/tests/auth-service.test.js`
- Result: focused auth-service test passed.

## Demo evidence
- Before this fix, advancing `Date.now()` between calls makes the returned `id` differ from the JWT `sub`.
- After this fix, the returned `id` and token `sub` both equal `usr_1790000000000`.

## Payment fallback
- PayPal: samik4184@gmail.com
- Revolut: @standamarek
- USDC: 0x10DFE6771131BEc830A7a44D7Be45Ced0741b2b3