### PR TITLE
Protect notification generated fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification uses generated id and unread defaults", async (t) => {
+  const originalNow = Date.now;
+
+  Date.now = () => 1800000000000;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+
+  const notification = await createNotification({
+    id: "ntf_spoofed",
+    read: true,
+    userId: "usr_1",
+    title: "Payment received"
+  });
+
+  assert.equal(notification.id, "ntf_1800000000000");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_1");
+  assert.equal(notification.title, "Payment received");
+});


### PR DESCRIPTION
/claim #743

Fixes #4880

## Summary
- Keep generated notification `id` authoritative over request payload fields.
- Always create new notifications as unread, even if payload includes `read: true`.
- Add service coverage for spoofed id/read payload fields.

## Verification
- `node --test src/tests/notification-service.test.js`
- Result: focused notification-service test passed.

## Demo evidence
- Payload `{ id: "ntf_spoofed", read: true }` now returns generated `ntf_1800000000000` and `read: false`.

## Payment fallback
- PayPal: samik4184@gmail.com
- Revolut: @standamarek
- USDC: 0x10DFE6771131BEc830A7a44D7Be45Ced0741b2b3