### PR TITLE
Reject empty upload requests

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload-controller.test.js
+++ b/apps/api/src/tests/upload-controller.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("uploadFile rejects requests without files", async () => {
+  const res = createResponse();
+
+  await uploadFile({}, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { success: false, message: "File is required" });
+});
+
+test("uploadFile returns uploaded status for a provided file", async () => {
+  const res = createResponse();
+
+  await uploadFile({ file: { originalname: "invoice.pdf" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      filename: "invoice.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #4882

## Summary
- Return `400 File is required` when upload requests do not include a file.
- Keep `201 uploaded` response only when a file exists.
- Add controller coverage for missing-file and file-present paths.

## Verification
- `node --test src/tests/upload-controller.test.js`
- Result: focused upload-controller test passed.

## Demo evidence
- Missing file now returns `{ success: false, message: "File is required" }` with HTTP 400.
- Provided file still returns filename plus `status: "uploaded"` with HTTP 201.

## Payment fallback
- PayPal: samik4184@gmail.com
- Revolut: @standamarek
- USDC: 0x10DFE6771131BEc830A7a44D7Be45Ced0741b2b3