### PR TITLE
Fix uploadFile returning 201 when no file is uploaded

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,5 +15,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "supertest": "^7.2.2"
   }
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({ success: false, message: "No file uploaded" });
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert";
+import request from "supertest";
+import { createApp } from "../app.js";
+
+const app = createApp();
+
+test("POST /api/uploads should return 400 when no file is provided", async () => {
+  const response = await request(app).post("/api/uploads");
+  assert.strictEqual(response.status, 400);
+  assert.strictEqual(response.body.success, false);
+  assert.strictEqual(response.body.message, "No file uploaded");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Fixes #4901
/claim #743

This PR adds validation to \uploadFile\ so that requests without an attached file receive a 400 client error instead of successfully responding with a 201. Regression tests are included.