### PR TITLE
fix: reject upload requests without a file instead of returning 201

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in upload request", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Summary

Fixes #4901

`uploadFile` was returning HTTP 201 with `{ status: "no-file" }` when no file was attached to the multipart request. A 201 status code signals successful resource creation, which is misleading when nothing was actually uploaded.

## What changed

- Added an early guard in `uploadController.js` that returns **400 Bad Request** with a clear message when `req.file` is missing
- The success path now only runs when a file is actually present
- Removed the conditional status field — successful uploads now always return `"uploaded"`

## How to test

1. Start the API server
2. Send a POST to `/api/uploads` **without** a file attached:
   ```bash
   curl -X POST http://localhost:3000/api/uploads
   # Expected: 400 { success: false, message: "No file provided in upload request" }
   ```
3. Send a POST with a file:
   ```bash
   curl -F file=@test.txt http://localhost:3000/api/uploads
   # Expected: 201 { success: true, data: { filename: "test.txt", status: "uploaded" } }
   ```

Parent bounty: #743