### PR TITLE
fix: add 1mb body size limit to json parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,12 +15,14 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const JSON_BODY_LIMIT = "1mb";
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: JSON_BODY_LIMIT }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
## Summary

Fixes #4897

`express.json()` was mounted without an explicit request body size limit, meaning a client could send an arbitrarily large JSON payload and it would be fully buffered in memory before any route handler or validation runs. This is a low-effort denial-of-service path against every JSON endpoint.

## What changed

Added a `1mb` limit to the `express.json()` middleware in `app.js`:

```js
app.use(express.json({ limit: "1mb" }));
```

When the payload exceeds 1mb, Express will reject it with a **413 Payload Too Large** error before any route handler runs.

## How to test

1. Start the API server
2. Send a JSON body larger than 1mb:
   ```bash
   python3 -c "import json; print(json.dumps({data: x * 1100000}))" | \
     curl -X POST http://localhost:3000/api/auth/register \
       -H "Content-Type: application/json" \
       -d @-
   # Expected: 413 Payload Too Large
   ```
3. Send a normal-sized JSON body and confirm it still works fine.

Parent bounty: #743