### PR TITLE
fix: require admin role for admin metrics endpoint

### DIFF
--- a/apps/api/src/middleware/adminGuard.js
+++ b/apps/api/src/middleware/adminGuard.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function adminGuard(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+  next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminGuard } from "../middleware/adminGuard.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", adminGuard, metrics);


### PR DESCRIPTION
## Summary

Fixes #4893

`/api/admin/metrics` currently uses `authMiddleware` which only verifies a valid JWT token. Any authenticated client or freelancer can reach admin metrics because the role is never checked.

## What changed

- Added `apps/api/src/middleware/adminGuard.js` - a focused middleware that checks `req.user.role === "admin"` and returns 403 Forbidden for non-admin users
- Applied `adminGuard` to the metrics route in `adminRoutes.js`

## How to test

1. Start the API server
2. Register a regular user and get a token
3. Use that token to access admin metrics - Expected: 403 Forbidden
4. Repeat with an admin-role token - Expected: 200 with metrics data

Parent bounty: #743
