### PR TITLE
fix: enforce file type allowlist and 5mb size limit on uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,29 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "text/csv",
+];
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5mb
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter(_req, file, cb) {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Unsupported file type: ${file.mimetype}`));
+    }
+  },
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Summary

Fixes #4892

The upload route configured multer with in-memory storage but no MIME type allowlist or file-size limit. Any file type (including active content like `text/html`) could be uploaded, and arbitrarily large files would be buffered entirely in process memory.

## What changed

Updated `uploadRoutes.js` to configure multer with:

- **MIME allowlist**: jpeg, png, gif, webp, pdf, plain text, csv
- **5mb size limit**: rejects anything larger with a clear error
- **fileFilter callback**: rejects unsupported types with a descriptive error message

## How to test

1. Start the API server
2. Upload a valid file type:
   ```bash
   curl -F file=@photo.jpg http://localhost:3000/api/uploads
   # Expected: 201
   ```
3. Upload an unsupported type:
   ```bash
   echo "<script>alert(1)</script>" > evil.html
   curl -F file=@evil.html http://localhost:3000/api/uploads
   # Expected: 400 with "Unsupported file type: text/html"
   ```
4. Upload a file larger than 5mb:
   ```bash
   dd if=/dev/zero bs=1M count=6 | curl -F file=@- http://localhost:3000/api/uploads
   # Expected: rejected by multer size limit
   ```

Parent bounty: #743
