### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,15 +1,14 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const payload = req.validatedBody;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
+  const payload = req.validatedBody;
   const result = await loginUser(payload);
   return ok(res, result);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,21 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors.map((e) => ({ path: e.path.join("."), message: e.message })),
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
-    message: "Unexpected server error"
+    message: "Unexpected server error",
   });
 }

--- a/apps/api/src/middleware/validate.js
+++ b/apps/api/src/middleware/validate.js
@@ -1,0 +1,21 @@
+/**
+ * Express middleware factory that validates req.body against a Zod schema.
+ * Returns 400 with structured errors on validation failure.
+ */
+export function validate(schema) {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      return res.status(400).json({
+        success: false,
+        message: "Validation failed",
+        errors: result.error.errors.map((e) => ({
+          path: e.path.join("."),
+          message: e.message,
+        })),
+      });
+    }
+    req.validatedBody = result.data;
+    next();
+  };
+}

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { validate } from "../middleware/validate.js";
+import { registerSchema, loginSchema } from "../validators/auth.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", validate(registerSchema), register);
+authRoutes.post("/login", validate(loginSchema), login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
 authRoutes.post("/refresh", refresh);

--- a/apps/api/src/tests/auth-register.test.js
+++ b/apps/api/src/tests/auth-register.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve) => {
+    server.once("listening", () => resolve(server));
+  });
+}
+
+async function register(server, body) {
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+test("register accepts client role", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await register(server, {
+      email: "client@test.com",
+      password: "securepass123",
+      role: "client",
+    });
+    assert.equal(status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "client");
+  } finally {
+    server.close();
+  }
+});
+
+test("register accepts freelancer role", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await register(server, {
+      email: "freelancer@test.com",
+      password: "securepass123",
+      role: "freelancer",
+    });
+    assert.equal(status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "freelancer");
+  } finally {
+    server.close();
+  }
+});
+
+test("register defaults to client role when role omitted", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await register(server, {
+      email: "default@test.com",
+      password: "securepass123",
+    });
+    assert.equal(status, 201);
+    assert.equal(body.data.role, "client");
+  } finally {
+    server.close();
+  }
+});
+
+test("register rejects admin role", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await register(server, {
+      email: "hacker@test.com",
+      password: "securepass123",
+      role: "admin",
+    });
+    assert.equal(status, 400);
+    assert.equal(body.success, false);
+  } finally {
+    server.close();
+  }
+});
+
+test("register rejects invalid role", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await register(server, {
+      email: "bad@test.com",
+      password: "securepass123",
+      role: "superadmin",
+    });
+    assert.equal(status, 400);
+    assert.equal(body.success, false);
+  } finally {
+    server.close();
+  }
+});
+
+test("register rejects invalid email", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await register(server, {
+      email: "not-an-email",
+      password: "securepass123",
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test("register rejects short password", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await register(server, {
+      email: "test@test.com",
+      password: "short",
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Problem

Public registration accepts `role: "admin"` in the request body, allowing any unauthenticated user to self-assign admin privileges and receive a JWT signed with admin role.

**Vulnerable code** (`validators/auth.js`):
```js
role: z.enum(["client", "freelancer", "admin"]).default("client")
```

## Solution

1. **Removed `"admin"` from the registration enum** — now only `client` and `freelancer` are accepted
2. **Added `validate()` middleware** — a reusable Zod validation middleware that returns structured 400 errors instead of crashing the server
3. **Improved `errorHandler`** — now properly catches `ZodError` and returns 400 with field-level error details instead of generic 500
4. **Updated routes and controllers** — auth routes use the middleware, controllers use `req.validatedBody`

## Files changed

| File | Change |
|------|--------|
| `validators/auth.js` | Removed `"admin"` from enum |
| `middleware/validate.js` | **New** — reusable Zod validation middleware |
| `middleware/errorHandler.js` | Added ZodError handling (400 with structured errors) |
| `routes/authRoutes.js` | Added `validate(registerSchema)` and `validate(loginSchema)` middleware |
| `controllers/authController.js` | Uses `req.validatedBody` instead of `parse()` |

## Tests (7 passing)

- ✔ accepts `client` role
- ✔ accepts `freelancer` role
- ✔ defaults to `client` when role omitted
- ✔ **rejects `admin` role** (400)
- ✔ rejects invalid role like `"superadmin"` (400)
- ✔ rejects invalid email (400)
- ✔ rejects short password (400)

All existing tests continue to pass.

Closes #4952