### PR TITLE
fix: reject inverted job budget ranges in job validation

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,5 +1,4 @@
 import { ok } from "../utils/response.js";
-import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
 export async function getJobs(req, res) {
@@ -7,6 +6,6 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const payload = req.validatedBody;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,21 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors.map((e) => ({ path: e.path.join("."), message: e.message })),
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
-    message: "Unexpected server error"
+    message: "Unexpected server error",
   });
 }

--- a/apps/api/src/middleware/validate.js
+++ b/apps/api/src/middleware/validate.js
@@ -1,0 +1,21 @@
+/**
+ * Express middleware factory that validates req.body against a Zod schema.
+ * Returns 400 with structured errors on validation failure.
+ */
+export function validate(schema) {
+  return (req, res, next) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      return res.status(400).json({
+        success: false,
+        message: "Validation failed",
+        errors: result.error.errors.map((e) => ({
+          path: e.path.join("."),
+          message: e.message,
+        })),
+      });
+    }
+    req.validatedBody = result.data;
+    next();
+  };
+}

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { validate } from "../middleware/validate.js";
+import { createJobSchema } from "../validators/job.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", validate(createJobSchema), postJob);

--- a/apps/api/src/tests/job-budget.test.js
+++ b/apps/api/src/tests/job-budget.test.js
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve) => {
+    server.once("listening", () => resolve(server));
+  });
+}
+
+const VALID_JOB = {
+  title: "Build a website",
+  description: "Need a professional website built",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web-dev",
+  skills: ["javascript"],
+};
+
+async function postJob(server, body) {
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+test("post job with valid budget range succeeds", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await postJob(server, VALID_JOB);
+    assert.equal(status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.budgetMin, 100);
+    assert.equal(body.data.budgetMax, 500);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with equal min and max succeeds", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await postJob(server, {
+      ...VALID_JOB,
+      budgetMin: 250,
+      budgetMax: 250,
+    });
+    assert.equal(status, 201);
+    assert.equal(body.success, true);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with zero budget succeeds", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await postJob(server, {
+      ...VALID_JOB,
+      budgetMin: 0,
+      budgetMax: 0,
+    });
+    assert.equal(status, 201);
+    assert.equal(body.success, true);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with inverted budget range is rejected", async () => {
+  const server = await startServer();
+  try {
+    const { status, body } = await postJob(server, {
+      ...VALID_JOB,
+      budgetMin: 500,
+      budgetMax: 100,
+    });
+    assert.equal(status, 400);
+    assert.equal(body.success, false);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with negative budgetMin is rejected", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await postJob(server, {
+      ...VALID_JOB,
+      budgetMin: -50,
+      budgetMax: 200,
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with negative budgetMax is rejected", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await postJob(server, {
+      ...VALID_JOB,
+      budgetMin: 100,
+      budgetMax: -10,
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job missing title is rejected", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await postJob(server, {
+      description: "Some description here please",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "web-dev",
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test("post job with short title is rejected", async () => {
+  const server = await startServer();
+  try {
+    const { status } = await postJob(server, {
+      ...VALID_JOB,
+      title: "Hi",
+    });
+    assert.equal(status, 400);
+  } finally {
+    server.close();
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: z.array(z.string().min(1)).default([]),
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
+
+export const updateJobSchema = jobBaseSchema.partial();


### PR DESCRIPTION
## Problem

`createJobSchema` accepts payloads where `budgetMax < budgetMin`, creating invalid job records (e.g., $500-100 range). This breaks client-side filtering, sorting, and display.

**Vulnerable code** (`validators/job.js`):
```js
budgetMin: z.number().nonnegative(),
budgetMax: z.number().nonnegative(),
// No check that budgetMax >= budgetMin
```

## Solution

1. **Added Zod `.refine()`** to `createJobSchema` ensuring `budgetMax >= budgetMin`
2. **Extracted `jobBaseSchema`** — the base object schema is shared between `createJobSchema` (with refine) and `updateJobSchema` (partial)
3. **Added `validate()` middleware** to job POST route for proper 400 responses
4. **Updated `jobController`** to use `req.validatedBody`

## Files changed

| File | Change |
|------|--------|
| `validators/job.js` | Added `.refine()` budget validation, extracted base schema |
| `middleware/validate.js` | **New** — reusable Zod validation middleware |
| `middleware/errorHandler.js` | Added ZodError handling (400 with structured errors) |
| `routes/jobRoutes.js` | Added `validate(createJobSchema)` middleware |
| `controllers/jobController.js` | Uses `req.validatedBody` instead of `parse()` |

## Tests (8 passing)

- ✔ valid budget range ($100-$500) succeeds
- ✔ equal min/max ($250-$250) succeeds
- ✔ zero budget ($0-$0) succeeds
- ✔ **inverted range ($500-$100) rejected** (400)
- ✔ negative budgetMin rejected (400)
- ✔ negative budgetMax rejected (400)
- ✔ missing title rejected (400)
- ✔ short title rejected (400)

All existing tests continue to pass.

Closes #4953