### PR TITLE
Resolve job detail routes from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,22 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((item) => item.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No active job matches <strong>{id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Fixes #4967

/claim #743

## Summary
- resolve `/jobs/[id]` against `apps/web/lib/mock.ts` job data
- render the matching job title and budget for known ids
- show a clear not-found fallback for unknown job ids
- use the Next 16 async `params` shape for the dynamic route

## Tests
- `npx tsc --noEmit --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target ES2022 --lib dom,dom.iterable,esnext --esModuleInterop --allowSyntheticDefaultImports --strict false app/jobs/[id]/page.tsx lib/mock.ts`
- `npx tsc --noEmit --project tsconfig.json --pretty false` *(fails only on existing `freelancers/[username]` Next 16 params typing outside this PR)*
- `npx next build --webpack` *(compiles, then fails on this Windows host because the installed Next SWC native binding is not a valid Win32 application)*