### PR TITLE
docs: add technical poem for bounty 76

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Ode to FreelanceFlow
+
+A brief asks softly in the queue,  
+A profile answers, clear and true;  
+Across the board where contracts grow,  
+The right hands find the work they know.
+
+The API keeps a steady beat,  
+With routes and schemas, clean, discrete;  
+Each payload shaped before it flies,  
+Each promise checked before replies.
+
+The dashboard lights a careful way,  
+From posted job to funded pay;  
+And in that flow, both sides can see  
+A market built on clarity.
+
+So let the services compose,  
+Let tests mark paths where value goes;  
+A simple poem joins the plan:  
+Make freelance work more human.


### PR DESCRIPTION
## Summary
- Adds an original technical poem about FreelanceFlow to `POEM.md` in the repository root.
- Keeps the change focused on issue #76 only.

## Verification
- `wc -l POEM.md` → 21 lines
- Custom Python check → `exists True`, `stanza_count 4`, `nonempty_lines 17`
- `node --check apps/api/src/app.js` → passed
- `npm test` was also attempted on current `main`, but it fails before this change because the root script calls `node --test src/tests` while the repo contains `apps/api/src/tests/health.test.js`; no code paths were changed by this PR.

## Creative note
I chose a concise technical ode that mirrors the project structure: marketplace flow, API validation, dashboards, and human-centered freelance work.

/claim #76
Closes #76