### PR TITLE
Add actionable settings overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,6 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.status-chip { display: inline-block; margin: 0 0 0.5rem; padding: 0.25rem 0.5rem; border: 1px solid #3f5f9e; border-radius: 999px; color: #bfdbfe; font-size: 0.85rem; }
+.action-button { border: 1px solid #60a5fa; border-radius: 8px; background: #1d4ed8; color: #f8fafc; cursor: pointer; font: inherit; padding: 0.55rem 0.8rem; }
+.action-button:hover { background: #2563eb; }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,47 @@
+const settingsSections = [
+  {
+    title: "Account / Profile",
+    status: "Public profile",
+    detail: "Maya Chen is visible to clients with portfolio links and verified skills enabled.",
+    action: "Edit profile"
+  },
+  {
+    title: "Notifications",
+    status: "Digest on",
+    detail: "Email alerts are enabled for proposals, milestones, direct messages, and payout updates.",
+    action: "Manage alerts"
+  },
+  {
+    title: "Security",
+    status: "2FA ready",
+    detail: "Password login is active and two-factor authentication is ready to be configured.",
+    action: "Review security"
+  },
+  {
+    title: "Billing / Payout",
+    status: "Default saved",
+    detail: "Client billing uses the saved card, while freelancer payouts are set to weekly bank transfer.",
+    action: "Update billing"
+  }
+];
+
 export default function SettingsPage() {
   return (
-    <section className="card">
+    <section>
       <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+      <p>Account preferences, profile visibility, notification, security, and payout defaults.</p>
+      <div className="grid">
+        {settingsSections.map((section) => (
+          <article className="card" key={section.title}>
+            <p className="status-chip">
+              {section.status}
+            </p>
+            <h3>{section.title}</h3>
+            <p>{section.detail}</p>
+            <button className="action-button" type="button">{section.action}</button>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Fixes #4977

/claim #743

## Summary
- replace the placeholder `/settings` route with a static settings overview
- add account/profile, notification, security, and billing/payout preference sections
- include status chips and next-action controls using mock data only
- add small shared styles for the chips and action buttons

## Tests
- `npx tsc --noEmit --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target ES2022 --lib dom,dom.iterable,esnext --esModuleInterop --allowSyntheticDefaultImports --strict false app/settings/page.tsx`