### PR TITLE
Align registration token subject with returned user id

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registerTokenSubject.test.js
+++ b/apps/api/src/tests/registerTokenSubject.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the returned user id as the token subject", async () => {
+  const result = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
Fixes #4987

/claim #743

## Summary
- generate the registration user id once in `registerUser`
- return that same id in the response and sign it as the JWT `sub` claim
- add focused service coverage that decodes the token and verifies `sub === result.id`
- update the API test script so `npm test` discovers the test files on current Node

## Tests
- `npm test`