### PR TITLE
Accept bearer auth scheme case-insensitively

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const bearerMatch = typeof authHeader === "string" ? authHeader.match(/^bearer\s+(.+)$/i) : null;
+
+  if (!bearerMatch) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(bearerMatch[1].trim());
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth middleware accepts Bearer scheme case-insensitively", async () => {
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+
+  await withServer(async (baseUrl) => {
+    for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+      const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+        headers: { authorization: `${scheme} ${token}` }
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(payload.success, true);
+    }
+  });
+});
+
+test("auth middleware still rejects non-Bearer authorization schemes", async () => {
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Basic ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #5020.

## Summary
- Parse the Authorization auth scheme case-insensitively while still requiring Bearer tokens.
- Keep non-Bearer authorization schemes rejected with 401.
- Add protected-route regression coverage for `Bearer`, `bearer`, and `BEARER`.
- Make the API test script explicitly target test files so `npm test` runs on this Node/Windows setup.
- Rebased the branch onto current GitHub `main` (`0a1d1f`) so the PR is aligned with the latest leaderboard/main branch state.

## Validation
- `npm test -w apps/api` -> 3 passed.
- `git diff --check origin/main...HEAD` -> passed locally before the final GitHub-main ref refresh.

## Scope
Auth middleware scheme parsing and focused tests only. No token signing, role validation, route authorization policy, payment, upload, webhook, payout, secrets, or unrelated API behavior changed.