### PR TITLE
fix: parse bearer auth scheme case-insensitively

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, token] = authHeader?.split(/\s+/, 2) ?? [];
+
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth-bearer.test.js
+++ b/apps/api/src/tests/auth-bearer.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("protected routes accept Bearer auth scheme case-insensitively", async () => {
+  const token = signAccessToken({ sub: "usr_case_test", role: "admin" });
+
+  await withServer(async (baseUrl) => {
+    for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+      const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+        headers: { Authorization: `${scheme} ${token}` }
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(payload.success, true);
+    }
+  });
+});
+
+test("protected routes still reject non-Bearer auth schemes", async () => {
+  const token = signAccessToken({ sub: "usr_case_test", role: "admin" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Basic ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Parse the Authorization scheme case-insensitively while still requiring the Bearer scheme.
- Preserve JWT verification for the extracted token.
- Add regression coverage for `Bearer`, `bearer`, `BEARER`, and non-Bearer rejection.

## Validation
- `node --test apps/api/src/tests/*.test.js`

Fixes #5022
Refs #5020