### PR TITLE
fix: validate oauth callback inputs

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, oauthCallbackSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +15,17 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
-  return ok(res, {
+  const payload = oauthCallbackSchema.safeParse({
     provider: req.params.provider,
+    code: req.query.code
+  });
+
+  if (!payload.success) {
+    return fail(res, payload.error.issues[0]?.message ?? "Invalid OAuth callback", 400);
+  }
+
+  return ok(res, {
+    provider: payload.data.provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauth-callback.test.js
+++ b/apps/api/src/tests/oauth-callback.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported providers", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/unknown/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  } finally {
+    await close(server);
+  }
+});
+
+test("GET /api/auth/oauth/:provider/callback requires an authorization code", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  } finally {
+    await close(server);
+  }
+});
+
+test("GET /api/auth/oauth/:provider/callback accepts supported provider with code", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.provider, "github");
+    assert.equal(payload.data.status, "callback-received");
+  } finally {
+    await close(server);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,8 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const oauthCallbackSchema = z.object({
+  provider: z.enum(["github", "google"]),
+  code: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #5029.
Related: #4855 and parent bounty #743.

This PR validates OAuth callback inputs before returning a successful callback response:

- Unsupported providers now return 400.
- Missing or empty authorization codes now return 400.
- Supported providers with a code keep the existing `callback-received` response.

The provider allow-list is centralized in the auth validator so additional OAuth providers can be added deliberately later.

## Validation

- Added route coverage for unsupported providers.
- Added route coverage for missing authorization code.
- Added route coverage for a supported provider with a valid code.
- Ran `node --test "src/tests/*.test.js"` from `apps/api`; all API tests pass with 4 passing tests and 0 failures.

/claim #5029