### PR TITLE
Add payment intent createdAt timestamp

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    createdAt: new Date().toISOString()
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent includes a server-owned createdAt timestamp", async () => {
+  const before = Date.now();
+  const intent = await createPaymentIntent({ amount: 250, currency: "usd" });
+  const after = Date.now();
+
+  const createdAt = Date.parse(intent.createdAt);
+
+  assert.equal(intent.amount, 250);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+  assert.ok(Number.isFinite(createdAt));
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= after);
+});
+
+test("createPaymentIntent does not trust caller-provided createdAt", async () => {
+  const callerCreatedAt = "2000-01-01T00:00:00.000Z";
+  const intent = await createPaymentIntent({
+    amount: 250,
+    currency: "usd",
+    createdAt: callerCreatedAt
+  });
+
+  assert.notEqual(intent.createdAt, callerCreatedAt);
+  assert.ok(Number.isFinite(Date.parse(intent.createdAt)));
+});


### PR DESCRIPTION
/claim #743

Scoped issue: #5032
Closes #5032

## Summary
- Add a server-owned `createdAt` ISO timestamp to `createPaymentIntent()` responses.
- Ignore any caller-provided `createdAt` value by always generating the timestamp inside the payment service.
- Add focused service tests for timestamp creation and server ownership.
- Update the API workspace test script so current Node discovers `src/tests/*.test.js` files reliably.
- Rebased the branch onto current GitHub `main` (`0a1d1f`) so the PR is aligned with the latest leaderboard/main branch state.

## Validation
- `npm test -w apps/api` -> 3 passed.
- `node --test apps\api\src\tests\paymentService.test.js` -> 2 passed.
- `node --test apps\api\src\tests\*.test.js` -> 3 passed.
- `git diff --check origin/main...HEAD` -> passed locally before the final GitHub-main ref refresh.

## Scope
Payment service response shape, focused tests, and API test discovery only. No payment route authentication, controller behavior, amount validation, currency normalization, provider integration, webhook, payout, secrets, or unrelated routing behavior changed.