### PR TITLE
fix: return 400 for zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload",
+      issues: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/zod-error-handling.test.js
+++ b/apps/api/src/tests/zod-error-handling.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      resolve({
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        server
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("Zod validation errors return 400 instead of unexpected server errors", async () => {
+  const { baseUrl, server } = await listen(createApp());
+
+  try {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Job",
+        description: "too short",
+        budgetMin: -1,
+        budgetMax: 100,
+        categoryId: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request payload");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.length > 0);
+  } finally {
+    await close(server);
+  }
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,3 @@
+export function asyncHandler(handler) {
+  return (req, res, next) => Promise.resolve(handler(req, res, next)).catch(next);
+}


### PR DESCRIPTION
## Summary

Closes #5036.
Related: #5027 and parent bounty #743.

This PR makes Zod validation failures return request-level 400 responses instead of falling through as unexpected server errors.

It also adds a small async route wrapper for the Express 4 routes that call `.parse(...)`, so rejected async controllers reach the central error middleware before the Zod-specific response is returned.

## Validation

- Added route coverage proving an invalid `POST /api/jobs` payload returns 400.
- Verified the response keeps `success: false`, identifies the payload as invalid, and includes validation issues.
- Ran `node --test "src/tests/*.test.js"` from `apps/api`; all API tests pass with 2 passing tests and 0 failures.

/claim #5036