### PR TITLE
Validate OAuth provider and authorization code in callback

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+
+const SUPPORTED_PROVIDERS = ["github", "google"];
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,19 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+  const code = req.query.code;
+
+  if (!SUPPORTED_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
+
+  if (!code || code.trim() === "") {
+    return fail(res, "Missing authorization code", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauthCallback.test.js
+++ b/apps/api/src/tests/oauthCallback.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("oauth callback accepts supported provider with code", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(
+    `http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=abc123`
+  );
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(body.data.provider, "github");
+  assert.equal(body.data.status, "callback-received");
+
+  await close(server);
+});
+
+test("oauth callback rejects unsupported provider", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(
+    `http://127.0.0.1:${port}/api/auth/oauth/facebook/callback?code=abc123`
+  );
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("oauth callback rejects missing authorization code", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(
+    `http://127.0.0.1:${port}/api/auth/oauth/github/callback`
+  );
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("oauth callback rejects empty authorization code", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(
+    `http://127.0.0.1:${port}/api/auth/oauth/google/callback?code=`
+  );
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});


### PR DESCRIPTION
## What

The OAuth callback route (`GET /api/auth/oauth/:provider/callback`) was accepting any provider string and succeeding even when the authorization code was missing, making invalid requests indistinguishable from valid handoffs.

## Changes

- Added a `SUPPORTED_PROVIDERS` allowlist (`github`, `google`) in `authController.js`
- Reject unsupported providers with a 400 response and a clear message
- Require a non-empty `code` query parameter; reject with 400 when missing or blank
- Valid requests (supported provider + code) keep returning the existing callback-received response unchanged

## Testing

Added `tests/oauthCallback.test.js` with 4 test cases:
- Supported provider with valid code → 200
- Unsupported provider → 400
- Missing code param → 400
- Empty code param → 400

All pass with `node --test src/tests/oauthCallback.test.js`.

Fixes #5029