### PR TITLE
Return 400 for Zod validation errors through async routes

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,21 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    const message = err.errors
+      .map((e) => `${e.path.join(".")}: ${e.message}`)
+      .join("; ");
+    return res.status(400).json({
+      success: false,
+      message
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/zodValidation.test.js
+++ b/apps/api/src/tests/zodValidation.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/auth/register with invalid payload returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email", password: "short" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(body.message, "should include validation error message");
+
+  await close(server);
+});
+
+test("POST /api/auth/register with missing fields returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/auth/login with invalid email returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "bad", password: "12345678" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/jobs with invalid payload returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title: "ab" })
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+
+  await close(server);
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## What

Controllers call Zod schemas with `.parse(...)`, but Express 4 doesn't catch async rejections. Invalid payloads were reaching the global error handler as unhandled exceptions and returning 500 instead of 400.

## Changes

- **errorHandler.js**: Detect `ZodError` and return HTTP 400 with field-level validation messages instead of the generic 500 response
- **asyncHandler.js**: New utility that wraps async route handlers with `Promise.resolve().catch(next)` so rejections (including ZodError) reach the central error middleware
- **authRoutes.js**: Wrap register, login, oauthCallback, refresh with `asyncHandler`
- **jobRoutes.js**: Wrap getJobs, postJob with `asyncHandler` (these also use Zod)

## Testing

Added `tests/zodValidation.test.js` with 4 test cases:
- Register with invalid email + short password → 400
- Register with empty body → 400
- Login with invalid email → 400
- Job creation with invalid payload → 400

All pass with `node --test src/tests/zodValidation.test.js`.

Fixes #5036