### PR TITLE
fix: add createdAt timestamp to payment intents

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,12 @@
 export async function createPaymentIntent(payload) {
+  const createdAt = new Date().toISOString();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    createdAt
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent includes a server-owned createdAt timestamp", async () => {
+  const before = Date.now();
+  const intent = await createPaymentIntent({ amount: 250, currency: "usd" });
+  const after = Date.now();
+
+  assert.equal(intent.amount, 250);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+  assert.match(intent.createdAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+  const createdAtTime = Date.parse(intent.createdAt);
+  assert.ok(Number.isFinite(createdAtTime));
+  assert.ok(createdAtTime >= before);
+  assert.ok(createdAtTime <= after);
+});


### PR DESCRIPTION
## Summary
- Add a server-owned `createdAt` ISO timestamp to `createPaymentIntent()` responses.
- Add a focused service regression test that verifies the timestamp is generated by the server and falls within the call window.

## Verification
- `node --test apps/api/src/tests/paymentService.test.js` — pass
- `node --test apps/api/src/tests/*.js` — pass
- `git diff --check` — pass

/claim #5032