### PR TITLE
Add ledger harbor poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger Harbor
+
+At daybreak, every brief comes in like freight,
+with scope lines folded clean against the foam.
+We mark the work before we lift the crate,
+so every promise knows its weight and home.
+
+The proof is not a boast across the pier;
+it is the lamp left burning by the gate.
+A test log, link, or trace makes distance clear,
+and lets a reviewer meet the work as state.
+
+In quiet lanes where proposals queue,
+the careful hands move faster than the loud.
+They trim the noise, keep only what is true,
+and send a smaller signal through the crowd.
+
+A merge is not the thunder of a crown;
+it is a dock line tightened without strain.
+The record lands, the page can settle down,
+and future builders cross that plank again.
+
+Then payout follows, visible and plain,
+not luck, not rumor, not a favor owed.
+Just honest labor passing through the chain,
+with trust made lighter at the next upload.


### PR DESCRIPTION
Closes #76

/claim #76

## Summary

- Added an original root-level `POEM.md`.
- The poem has five stanzas and is written specifically for FreelanceFlow.

## Creative note

I used a restrained ledger-harbor form so scope, proof, review, merge, and payout read as accountable handoffs in a paid-work marketplace.

## Validation

- Root file present: `POEM.md`
- Stanza count check: `stanzas=5`
- `git diff --check`
