### PR TITLE
fix: keep server-generated resource ids authoritative

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serverGeneratedIds.test.js
+++ b/apps/api/src/tests/serverGeneratedIds.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps the server-generated id authoritative", async () => {
+  const user = await createUser({ id: "usr_attacker", email: "user@example.com" });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.email, "user@example.com");
+});
+
+test("createProposal keeps the server-generated id authoritative", async () => {
+  const proposal = await createProposal({ id: "prp_attacker", jobId: "job_1" });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "prp_attacker");
+  assert.equal(proposal.jobId, "job_1");
+});
+
+test("createReview keeps the server-generated id authoritative", async () => {
+  const review = await createReview({ id: "rev_attacker", rating: 5 });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "rev_attacker");
+  assert.equal(review.rating, 5);
+});


### PR DESCRIPTION
## Summary
- Keep server-generated IDs authoritative in user, proposal, and review creation services
- Add node:test coverage proving client-supplied IDs cannot override generated IDs

## Verification
- `git diff --check` ✅
- `node --check apps/api/src/services/userService.js` ✅
- `node --check apps/api/src/services/proposalService.js` ✅
- `node --check apps/api/src/services/reviewService.js` ✅
- `node --check apps/api/src/tests/serverGeneratedIds.test.js` ✅
- `node --test apps/api/src/tests/*.test.js` ✅ (4 tests passed)

Note: `npm test -- --test-reporter=spec` currently fails because the existing workspace script runs `node --test src/tests`, which Node 24 treats as a missing module path. The explicit test glob above passes and covers the existing health test plus the new server-generated ID tests.

Closes #5062
/claim #5062