### PR TITLE
Reject upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload-no-file.test.js
+++ b/apps/api/src/tests/upload-no-file.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/uploads without file returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+  });
+  assert.equal(res.status, 400);
+
+  const body = await res.json();
+  assert.equal(body.success, false);
+  assert.ok(body.message.toLowerCase().includes("file"));
+
+  await close(server);
+});


### PR DESCRIPTION
## Problem

`POST /api/uploads` returns `201 Created` with `status: "no-file"` when no file is included in the request. Clients can treat this as a successful upload.

## Fix

Check `req.file` in the upload controller and return `400 Bad Request` with the message "File is required" when it is missing. Valid uploads continue returning `201 Created`.

## Test

```
node --test apps/api/src/tests/upload-no-file.test.js
✔ POST /api/uploads without file returns 400
```

Closes #5055