### PR TITLE
Add Zod validation for proposal creation

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0].message, 400);
+  }
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/proposals with negative bidAmount returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jobId: "job_1",
+      freelancerId: "usr_1",
+      bidAmount: -50,
+      coverLetter: "I can do this",
+    }),
+  });
+  assert.equal(res.status, 400);
+
+  const body = await res.json();
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/proposals with valid payload returns 201", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jobId: "job_1",
+      freelancerId: "usr_1",
+      bidAmount: 100,
+      coverLetter: "I can do this",
+    }),
+  });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.equal(body.success, true);
+
+  await close(server);
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  bidAmount: z.number().positive(),
+  coverLetter: z.string().min(1),
+});


### PR DESCRIPTION
## Problem

`POST /api/proposals` stores `req.body` directly without validating required fields. Negative bid amounts like `bidAmount: -50` are accepted.

## Fix

Added a Zod schema (`validators/proposal.js`) that requires:
- `jobId` — non-empty string
- `freelancerId` — non-empty string
- `bidAmount` — positive number
- `coverLetter` — non-empty string

The controller now validates with `safeParse` and returns 400 for invalid payloads.

## Tests

```
node --test apps/api/src/tests/proposal-validation.test.js
✔ POST /api/proposals with negative bidAmount returns 400
✔ POST /api/proposals with valid payload returns 201
```

Closes #5059