### PR TITLE
Add Zod validation for review creation

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0].message, 400);
+  }
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/review-validation.test.js
+++ b/apps/api/src/tests/review-validation.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/reviews with rating 999 returns 400", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "usr_1",
+      revieweeId: "usr_2",
+      comment: "Great work",
+      rating: 999,
+    }),
+  });
+  assert.equal(res.status, 400);
+
+  const body = await res.json();
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/reviews with valid payload returns 201", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "usr_1",
+      revieweeId: "usr_2",
+      comment: "Great work",
+      rating: 5,
+    }),
+  });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.equal(body.success, true);
+
+  await close(server);
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1),
+  comment: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+});


### PR DESCRIPTION
## Problem

`POST /api/reviews` stores `req.body` directly without validating fields. Payloads with ratings like `999`, missing user IDs, or empty comments are accepted.

## Fix

Added a Zod schema (`validators/review.js`) that requires:
- `reviewerId` — non-empty string
- `revieweeId` — non-empty string
- `comment` — non-empty string
- `rating` — integer between 1 and 5

The controller validates with `safeParse` and returns 400 for invalid payloads.

## Tests

```
node --test apps/api/src/tests/review-validation.test.js
✔ POST /api/reviews with rating 999 returns 400
✔ POST /api/reviews with valid payload returns 201
```

Closes #5057