### PR TITLE
Prevent client-supplied IDs from overwriting server-generated ones

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/server-owned-ids.test.js
+++ b/apps/api/src/tests/server-owned-ids.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/users ignores client-supplied id", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "test@test.com", password: "password123", id: "usr_attacker" }),
+  });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.match(body.data.id, /^usr_\d+$/);
+  assert.notEqual(body.data.id, "usr_attacker");
+
+  await close(server);
+});
+
+test("POST /api/proposals ignores client-supplied id", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: "prp_attacker", jobId: "j1", freelancerId: "f1", bidAmount: 50, coverLetter: "test" }),
+  });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.match(body.data.id, /^prp_\d+$/);
+  assert.notEqual(body.data.id, "prp_attacker");
+
+  await close(server);
+});
+
+test("POST /api/reviews ignores client-supplied id", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: "rev_attacker", reviewerId: "r1", revieweeId: "e1", comment: "nice", rating: 4 }),
+  });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.match(body.data.id, /^rev_\d+$/);
+  assert.notEqual(body.data.id, "rev_attacker");
+
+  await close(server);
+});


### PR DESCRIPTION
## Problem

`userService.createUser`, `proposalService.createProposal`, and `reviewService.createReview` build records as `{ id: generatedId, ...payload }`. If a client sends an `id` field, the spread overwrites the server-generated ID, allowing ID spoofing or collisions.

## Fix

Reversed the spread order in all three services to `{ ...payload, id: generatedId }` so the generated ID always wins over any client-supplied value.

## Tests

```
node --test apps/api/src/tests/server-owned-ids.test.js
✔ POST /api/users ignores client-supplied id
✔ POST /api/proposals ignores client-supplied id
✔ POST /api/reviews ignores client-supplied id
```

Closes #5062