### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a conversion-focused landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["copywriting"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.ok(
+    result.error.issues.some(
+      (issue) =>
+        issue.path.join(".") === "budgetMax" &&
+        issue.message === "budgetMax must be greater than or equal to budgetMin"
+    )
+  );
+});
+
+test("updateJobSchema rejects inverted budget ranges when both values are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 250,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job schemas accept ordered budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 100, budgetMax: 100 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const validateBudgetRange = (data, ctx) => {
+  if (
+    typeof data.budgetMin === "number" &&
+    typeof data.budgetMax === "number" &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+};
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Fixes #2853.\n\nSummary:\n- Adds shared budget range validation for createJobSchema and updateJobSchema.\n- Rejects inverted ranges when both budgetMin and budgetMax are provided.\n- Adds focused node:test coverage for create, update, and valid/equal range behavior.\n\nVerification:\n- node --test apps/api/src/tests/jobValidator.test.js