### PR TITLE
fix: normalize payment currency to lowercase

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }


### PR DESCRIPTION
Fixes #4624

/claim #743

## What changed
- createPaymentIntent now lowercases the currency value before processing

## Validation
- node --check src/services/paymentService.js