### PR TITLE
fix: enforce admin role check on metrics endpoint

### DIFF
--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,10 @@
+import { fail } from "../utils/response.js";
 import { ok } from "../utils/response.js";
 import { getAdminMetrics } from "../services/adminService.js";
 
 export async function metrics(req, res) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
   return ok(res, await getAdminMetrics());
 }


### PR DESCRIPTION
Fixes #4639

/claim #743

## What changed
- adminController.metrics now checks req.user.role === "admin" before returning data
- Returns 403 Forbidden for non-admin authenticated users

## Validation
- node --check src/controllers/adminController.js