### PR TITLE
fix: add Zod input validation to payment, message, proposal, notification controllers

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { sendMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,6 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  to: z.string().min(1),
+  content: z.string().min(1)
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  type: z.string().min(1),
+  message: z.string().min(1)
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(2).max(5).default("usd")
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().nonnegative()
+});


### PR DESCRIPTION
Fixes #4623 Fixes #4630 Fixes #4629 Fixes #4633

/claim #743

## What changed
- Added Zod schemas for payment, message, proposal, and notification
- Each write controller now calls schema.parse(req.body) before passing to the service
- Read endpoints remain untouched

## Validation
- node --check on all new validators and updated controllers