### PR TITLE
fix: add server-owned createdAt to payment intents

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const createdAt = new Date().toISOString();
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
+    createdAt,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("payment intent includes server-owned createdAt timestamp", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => 1710000000000;
+
+  try {
+    const result = await createPaymentIntent({ amount: 250, currency: "usd" });
+
+    assert.match(result.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.equal(result.provider, "stripe");
+    assert.equal(result.currency, "usd");
+    assert.equal(result.amount, 250);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Fixes #5032

/claim #743

## What changed
- createPaymentIntent now returns a server-generated createdAt timestamp
- Added regression test for timestamp presence and shape

## Validation
- node --test apps/api/src/tests/payment.test.js
- node --check apps/api/src/services/paymentService.js