### PR TITLE
fix: require clientId in job creation schema

### DIFF
--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("job creation requires clientId", () => {
+  const parsed = createJobSchema.parse({
+    clientId: "usr_123",
+    title: "Build landing page",
+    description: "Need a landing page for the new product launch",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "cat_1",
+    skills: ["react"]
+  });
+
+  assert.equal(parsed.clientId, "usr_123");
+  assert.equal(parsed.title, "Build landing page");
+  assert.throws(() => createJobSchema.parse({
+    title: "Build landing page",
+    description: "Need a landing page for the new product launch",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "cat_1",
+    skills: ["react"]
+  }));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
+  clientId: z.string().min(1),
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),


### PR DESCRIPTION
Fixes #5066

/claim #743

## What changed
- job creation schema now requires clientId so the parsed payload matches the Prisma model
- Added regression test proving clientId is preserved and required

## Validation
- node --test apps/api/src/tests/job.test.js
- node --check apps/api/src/validators/job.js