### PR TITLE
fix: add workspace build commands for ui and db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,6 +2,7 @@
   "name": "@freelanceflow/db",
   "private": true,
   "scripts": {
+    "build": "prisma generate --schema prisma/schema.prisma",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit -p tsconfig.json"
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["react"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Fixes #5077 Fixes #5082

/claim #743

## What changed
- Added a build script to packages/db that runs prisma generate against the local schema
- Added a build script + tsconfig to packages/ui so the package can be typechecked directly

## Validation
- npm run build -w packages/db
- npm run build -w packages/ui