### PR TITLE
fix(api): preserve server-owned user fields

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id, isVerified, ...userFields } = payload;
+  const user = { ...userFields, id: `usr_${Date.now()}`, isVerified: false };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-service-fields.test.js
+++ b/apps/api/src/tests/user-service-fields.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users preserves server-owned id and verification status", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        email: "new@example.com",
+        fullName: "New User",
+        isVerified: true,
+      }),
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.isVerified, false);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve server-owned `id` during `POST /api/users` creation
- default new API-created users to `isVerified: false`, ignoring caller-provided verification state
- add focused API regression coverage for spoofed `id` and pre-verified payloads

Fixes #5097
/claim #743

## Verification
- `node --test src/tests/user-service-fields.test.js`
- `node --test src/tests/health.test.js`
- `node --test src/tests/*.js`

Note: the repository's existing `npm test` command fails under this local Node v25/Windows environment because `node --test src/tests` treats the test directory as a file path. I did not change that script because it is unrelated to this scoped fix.