### PR TITLE
fix: validate user creation and protect auth refresh

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,3 +1,4 @@
+import { createUserSchema } from "../validators/user.js";
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
 
@@ -5,6 +6,11 @@ export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
-export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+export async function postUser(req, res, next) {
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, ...tokenParts] = authHeader?.trim().split(/\s+/) ?? [];
+  if (!scheme || scheme.toLowerCase() !== "bearer" || tokenParts.length === 0) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(tokenParts.join(" "));
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,26 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  if (err instanceof ZodError || err?.name === "ZodError" || Array.isArray(err?.issues)) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.issues ?? err.errors ?? []
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  const userId = `usr_${Date.now()}`;
   // TODO: persist new user via Prisma
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 
@@ -18,6 +19,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const userId = `usr_${Date.now()}`;
+  const user = { id: userId, ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/auth-user.test.js
+++ b/apps/api/src/tests/auth-user.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function decodeJwtPayload(token) {
+  const payload = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+  const padded = payload.padEnd(Math.ceil(payload.length / 4) * 4, "=");
+  return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+}
+
+test("user creation validates payloads and keeps server-owned ids", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const emptyResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  assert.equal(emptyResponse.status, 400);
+
+  const badIdResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      id: "usr_client_controlled",
+      email: "jane@example.com",
+      fullName: "Jane Doe",
+      role: "client"
+    })
+  });
+  assert.equal(badIdResponse.status, 400);
+
+  const validResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "jane@example.com",
+      fullName: "Jane Doe",
+      role: "client"
+    })
+  });
+  const validPayload = await validResponse.json();
+
+  assert.equal(validResponse.status, 201);
+  assert.equal(validPayload.data.email, "jane@example.com");
+  assert.match(validPayload.data.id, /^usr_/);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("auth refresh requires auth and preserves the requester subject", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const unauthenticated = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST"
+  });
+  assert.equal(unauthenticated.status, 401);
+
+  const token = signAccessToken({ sub: "usr_abc123", role: "freelancer" });
+  for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `${scheme} ${token}` }
+    });
+    const payload = await response.json();
+    const decoded = decodeJwtPayload(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(decoded.sub, "usr_abc123");
+    assert.equal(decoded.role, "freelancer");
+  }
+
+  const invalidScheme = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { Authorization: `Token ${token}` }
+  });
+  assert.equal(invalidScheme.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+}).strict();


### PR DESCRIPTION
Fixes #5007 Fixes #4954 Fixes #5022

/claim #743

## What changed
- Added a strict user creation schema requiring email and fullName and rejecting client-controlled ids
- Preserved server-generated user ids in createUser()
- Protected /api/auth/refresh with auth middleware and refreshes tokens for the authenticated subject
- Made Bearer parsing case-insensitive while still rejecting non-Bearer schemes
- Added route-level tests for user creation and auth refresh behavior

## Validation
- node --test apps/api/src/tests/auth-user.test.js
- node --check apps/api/src/controllers/userController.js
- node --check apps/api/src/validators/user.js
- node --check apps/api/src/middleware/auth.js
- node --check apps/api/src/middleware/errorHandler.js
- node --check apps/api/src/controllers/authController.js
- node --check apps/api/src/routes/authRoutes.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/services/userService.js