### PR TITLE
fix: add ui package build command

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit"
+  },
   "main": "src/index.ts"
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
/claim #5104

## Summary
- Add a package-level `build` script for `@freelanceflow/ui`.
- Add a focused `tsconfig.json` so the UI package can typecheck its React components directly.
- Keep the change scoped to `packages/ui` build metadata/configuration.

## Verification
- `npm run build -w packages/ui`
- `npm run build -w apps/web`
- `git diff --check`
