### PR TITLE
Add billing overview page with mock data

### DIFF
--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -1,8 +1,143 @@
+const mockBalance = {
+  available: 4823.5,
+  escrowPending: 1250.0,
+  nextPayout: "2026-06-12",
+};
+
+const mockInvoices = [
+  { id: "INV-0042", client: "Acme Corp", amount: 3200, status: "Paid", date: "2026-05-28" },
+  { id: "INV-0041", client: "NovaTech", amount: 1850, status: "Pending", date: "2026-06-01" },
+  { id: "INV-0040", client: "PixelCraft", amount: 975, status: "Paid", date: "2026-05-15" },
+  { id: "INV-0039", client: "Acme Corp", amount: 2100, status: "Overdue", date: "2026-04-20" },
+];
+
+const mockPayoutMethod = {
+  type: "PayPal",
+  email: "j***@gmail.com",
+  last4: null,
+};
+
+const mockTransfers = [
+  { id: "TX-9812", amount: 3200, date: "2026-05-30", status: "Completed" },
+  { id: "TX-9805", amount: 975, date: "2026-05-18", status: "Completed" },
+  { id: "TX-9798", amount: 4100, date: "2026-05-05", status: "Completed" },
+];
+
+function StatusBadge({ status }: { status: string }) {
+  const colorMap: Record<string, string> = {
+    Paid: "#22c55e",
+    Completed: "#22c55e",
+    Pending: "#eab308",
+    Overdue: "#ef4444",
+  };
+  const bg = colorMap[status] || "#6b7280";
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        borderRadius: "9999px",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        background: `${bg}22`,
+        color: bg,
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
 export default function BillingPage() {
   return (
-    <section className="card">
+    <>
       <h2>Billing</h2>
-      <p>Invoices, payout methods, and transaction history are managed here.</p>
-    </section>
+
+      <div className="grid">
+        <section className="card">
+          <h3>Available Balance</h3>
+          <p style={{ fontSize: "1.5rem", fontWeight: 700 }}>
+            ${mockBalance.available.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+          </p>
+        </section>
+
+        <section className="card">
+          <h3>Escrow Pending</h3>
+          <p style={{ fontSize: "1.5rem", fontWeight: 700 }}>
+            ${mockBalance.escrowPending.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+          </p>
+        </section>
+
+        <section className="card">
+          <h3>Next Payout</h3>
+          <p style={{ fontSize: "1.5rem", fontWeight: 700 }}>
+            {mockBalance.nextPayout}
+          </p>
+        </section>
+      </div>
+
+      <section className="card" style={{ marginTop: "1rem" }}>
+        <h3>Recent Invoices</h3>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem" }}>
+          <thead>
+            <tr style={{ borderBottom: "1px solid #2a3765", textAlign: "left" }}>
+              <th style={{ padding: "0.5rem" }}>Invoice</th>
+              <th style={{ padding: "0.5rem" }}>Client</th>
+              <th style={{ padding: "0.5rem" }}>Amount</th>
+              <th style={{ padding: "0.5rem" }}>Date</th>
+              <th style={{ padding: "0.5rem" }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {mockInvoices.map((inv) => (
+              <tr key={inv.id} style={{ borderBottom: "1px solid #2a376533" }}>
+                <td style={{ padding: "0.5rem" }}>{inv.id}</td>
+                <td style={{ padding: "0.5rem" }}>{inv.client}</td>
+                <td style={{ padding: "0.5rem" }}>${inv.amount.toLocaleString()}</td>
+                <td style={{ padding: "0.5rem" }}>{inv.date}</td>
+                <td style={{ padding: "0.5rem" }}>
+                  <StatusBadge status={inv.status} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <div className="grid" style={{ marginTop: "1rem" }}>
+        <section className="card">
+          <h3>Payout Method</h3>
+          <p>
+            {mockPayoutMethod.type}: {mockPayoutMethod.email}
+          </p>
+        </section>
+
+        <section className="card">
+          <h3>Recent Transfers</h3>
+          <ul style={{ listStyle: "none", padding: 0 }}>
+            {mockTransfers.map((tx) => (
+              <li
+                key={tx.id}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  padding: "0.35rem 0",
+                  borderBottom: "1px solid #2a376533",
+                  fontSize: "0.875rem",
+                }}
+              >
+                <span>
+                  {tx.id} — {tx.date}
+                </span>
+                <span style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                  ${tx.amount.toLocaleString()}
+                  <StatusBadge status={tx.status} />
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #5098

The `/billing` route had a single placeholder card with the text "Invoices, payout methods, and transaction history are managed here." This PR replaces it with a static billing dashboard using mock data.

## What changed

- **`apps/web/app/billing/page.tsx`** — renders a scannable billing overview with:
  - Available balance card
  - Escrow pending amount card
  - Next payout date card
  - Recent invoices table with status badges (Paid / Pending / Overdue)
  - Payout method section (PayPal mock)
  - Recent transfer activity list

## How to test

1. `cd apps/web && npm run dev`
2. Navigate to `/billing`
3. Verify all sections render: balance cards, invoice table, payout method, transfers

No backend or API changes — mock data only, scoped to the billing page component.

## Screenshots (conceptual layout)

Top row: 3 cards (Available Balance | Escrow Pending | Next Payout)
Middle: Invoice table with colored status badges
Bottom row: Payout Method | Recent Transfers