### PR TITLE
Add build script and tsconfig to @freelanceflow/ui package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit"
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Fixes #5104

Running `npm run build -w packages/ui` failed with `Missing script: "build"` because the `@freelanceflow/ui` package had no `build` script and no `tsconfig.json`.

## What changed

- **`packages/ui/package.json`** — added `"build": "tsc --noEmit"` script
- **`packages/ui/tsconfig.json`** — minimal TypeScript config matching project conventions (ES2022 target, react-jsx, noEmit)

## How to test

```bash
npm install
npm run build -w packages/ui
```

The command should now succeed and type-check the shared Button and Card components.