### PR TITLE
fix: preserve user server-owned fields

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id, isVerified, ...profile } = payload ?? {};
+  const user = { ...profile, id: `usr_${Date.now()}`, isVerified: false };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users preserves server-owned id and verification status", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        email: "security@example.com",
+        name: "Security Reviewer",
+        isVerified: true
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.isVerified, false);
+    assert.equal(payload.data.email, "security@example.com");
+    assert.equal(payload.data.name, "Security Reviewer");
+  });
+});


### PR DESCRIPTION
/claim #5108

## Summary
- Ensure `createUser()` preserves server-owned `id` and `isVerified` fields.
- Ignore caller-supplied `id` and `isVerified` while preserving ordinary profile fields.
- Add an HTTP regression test for `POST /api/users` proving spoofed values are not returned.

## Verification
- From `apps/api`: `node --test "src/tests/*.test.js"`
- `git diff --check`
