### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("job creation rejects inverted budget ranges", () => {
+  const valid = createJobSchema.parse({
+    title: "Build landing page",
+    description: "Need a landing page for the new product launch",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "cat_1",
+    skills: ["react"]
+  });
+
+  assert.equal(valid.budgetMin, 100);
+  assert.equal(valid.budgetMax, 250);
+  assert.throws(() => createJobSchema.parse({
+    title: "Build landing page",
+    description: "Need a landing page for the new product launch",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "cat_1",
+    skills: ["react"]
+  }));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+const budgetRangeCheck = (data, ctx) => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined && data.budgetMax < data.budgetMin) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+};
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
@@ -7,6 +17,13 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).superRefine(budgetRangeCheck);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).optional()
+}).superRefine(budgetRangeCheck);


### PR DESCRIPTION
Fixes #4888

/claim #743

## What changed
- Added a Zod superRefine check so budgetMax must be >= budgetMin
- Added regression coverage for valid and inverted ranges

## Validation
- node --test apps/api/src/tests/job.test.js
- node --check apps/api/src/validators/job.js