### PR TITLE
fix: enforce upload file type and size policy

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,33 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.too.large" || err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  if (err?.status) {
+    return res.status(err.status).json({
+      success: false,
+      message: err.message
+    });
+  }
+
+  if (err instanceof ZodError || err?.name === "ZodError" || Array.isArray(err?.issues)) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.issues ?? err.errors ?? []
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,21 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const allowedTypes = new Set(["image/jpeg", "image/png", "image/gif", "application/pdf"]);
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (!allowedTypes.has(file.mimetype)) {
+      const error = new Error("Unsupported file type");
+      error.status = 400;
+      error.code = "UNSUPPORTED_FILE_TYPE";
+      return cb(error);
+    }
+
+    return cb(null, true);
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startApp() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+test("upload endpoint rejects missing files", async () => {
+  const server = await startApp();
+  const { port } = server.address();
+
+  const form = new FormData();
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.message, "File required");
+
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});
+
+test("upload endpoint rejects unsupported types and oversized files", async () => {
+  const server = await startApp();
+  const { port } = server.address();
+
+  const badTypeForm = new FormData();
+  badTypeForm.append("file", new Blob(["<html></html>"], { type: "text/html" }), "page.html");
+  const badTypeResponse = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: badTypeForm
+  });
+  const badTypePayload = await badTypeResponse.json();
+  assert.equal(badTypeResponse.status, 400);
+  assert.equal(badTypePayload.message, "Unsupported file type");
+
+  const largeBlob = new Blob([Buffer.alloc(11 * 1024 * 1024)], { type: "image/png" });
+  const largeForm = new FormData();
+  largeForm.append("file", largeBlob, "big.png");
+  const largeResponse = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: largeForm
+  });
+  const largePayload = await largeResponse.json();
+  assert.equal(largeResponse.status, 413);
+  assert.equal(largePayload.message, "Request body too large");
+
+  await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});


### PR DESCRIPTION
Fixes #4892 Fixes #4901

/claim #743

## What changed
- Added an allowlist for upload MIME types
- Added a 10 MB multer file-size limit
- Return 400 when no file is uploaded
- Map unsupported file type and oversized upload failures to client errors
- Added regression tests for missing file, bad MIME type, and oversized uploads

## Validation
- node --test apps/api/src/tests/upload.test.js
- node --check apps/api/src/routes/uploadRoutes.js
- node --check apps/api/src/controllers/uploadController.js
- node --check apps/api/src/middleware/errorHandler.js