### PR TITLE
Return defensive snapshots from in-memory services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return snapshotRecords(jobs);
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = snapshotRecord({ id: `job_${Date.now()}`, status: "open", ...payload });
   jobs.push(job);
-  return job;
+  return snapshotRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return snapshotRecords(messages);
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = snapshotRecord({ id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() });
   messages.push(message);
-  return message;
+  return snapshotRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return snapshotRecords(notifications);
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = snapshotRecord({ id: `ntf_${Date.now()}`, read: false, ...payload });
   notifications.push(notification);
-  return notification;
+  return snapshotRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return snapshotRecords(proposals);
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = snapshotRecord({ id: `prp_${Date.now()}`, ...payload });
   proposals.push(proposal);
-  return proposal;
+  return snapshotRecord(proposal);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return snapshotRecords(reviews);
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = snapshotRecord({ id: `rev_${Date.now()}`, ...payload });
   reviews.push(review);
-  return review;
+  return snapshotRecord(review);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,13 @@
+import { snapshotRecord, snapshotRecords } from "../utils/snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return snapshotRecords(users);
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = snapshotRecord({ id: `usr_${Date.now()}`, ...payload });
   users.push(user);
-  return user;
+  return snapshotRecord(user);
 }

--- a/apps/api/src/tests/serviceSnapshots.test.js
+++ b/apps/api/src/tests/serviceSnapshots.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const services = [
+  {
+    name: "jobs",
+    create: createJob,
+    list: listJobs,
+    payload: () => ({
+      title: "Snapshot job",
+      description: "A job used to verify service snapshots",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "cat_snapshot",
+      skills: ["initial"]
+    }),
+    listField: "skills"
+  },
+  {
+    name: "messages",
+    create: sendMessage,
+    list: listMessages,
+    payload: () => ({ recipientId: "usr_target", body: "Snapshot message", tags: ["initial"] }),
+    listField: "tags"
+  },
+  {
+    name: "notifications",
+    create: createNotification,
+    list: listNotifications,
+    payload: () => ({ userId: "usr_target", title: "Snapshot notification", tags: ["initial"] }),
+    listField: "tags"
+  },
+  {
+    name: "proposals",
+    create: createProposal,
+    list: listProposals,
+    payload: () => ({ jobId: "job_target", coverLetter: "Snapshot proposal", tags: ["initial"] }),
+    listField: "tags"
+  },
+  {
+    name: "reviews",
+    create: createReview,
+    list: listReviews,
+    payload: () => ({ subjectId: "usr_target", rating: 5, tags: ["initial"] }),
+    listField: "tags"
+  },
+  {
+    name: "users",
+    create: createUser,
+    list: listUsers,
+    payload: () => ({ email: "snapshot@example.com", name: "Snapshot User", tags: ["initial"] }),
+    listField: "tags"
+  }
+];
+
+for (const service of services) {
+  test(`${service.name} service returns defensive snapshots`, async () => {
+    const before = await service.list();
+    const payload = service.payload();
+    const created = await service.create(payload);
+    const field = service.listField;
+
+    payload[field].push("payload-mutation");
+    created[field].push("created-mutation");
+
+    const afterCreate = await service.list();
+    assert.equal(afterCreate.length, before.length + 1);
+
+    const listed = afterCreate.find((record) => record.id === created.id);
+    assert.deepEqual(listed[field], ["initial"]);
+
+    afterCreate.push({ id: "external-record" });
+    listed[field].push("listed-record-mutation");
+
+    const afterListMutation = await service.list();
+    const persisted = afterListMutation.find((record) => record.id === created.id);
+
+    assert.equal(afterListMutation.length, before.length + 1);
+    assert.deepEqual(persisted[field], ["initial"]);
+  });
+}

--- a/apps/api/src/utils/snapshot.js
+++ b/apps/api/src/utils/snapshot.js
@@ -1,0 +1,21 @@
+function snapshotValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(snapshotValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, snapshotValue(nestedValue)])
+    );
+  }
+
+  return value;
+}
+
+export function snapshotRecord(record) {
+  return snapshotValue(record);
+}
+
+export function snapshotRecords(records) {
+  return records.map(snapshotRecord);
+}


### PR DESCRIPTION
## Summary
- add a small snapshot helper for plain in-memory API records
- return copied arrays and record snapshots from list helpers
- store snapshots and return separate response snapshots from create helpers
- add regression coverage across jobs, messages, notifications, proposals, reviews, and users

## Tests
- `node --test apps/api/src/tests/*.test.js`

/claim #743
Closes #5114
