### PR TITLE
Require authentication before handling uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function uploadBody() {
+  const body = new FormData();
+  body.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+  return body;
+}
+
+test("POST /api/uploads rejects unauthenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/uploads accepts authenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_uploader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: uploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- apply `authMiddleware` to `POST /api/uploads` before `upload.single("file")`
- reject unauthenticated multipart uploads with the existing `401 Unauthorized` response
- preserve authenticated upload behavior and the existing success payload
- add focused upload route regression tests

## Tests
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/uploadRoutes.test.js`

/claim #743
Closes #5116
