### PR TITLE
Validate payment intent payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, payload) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/payments rejects invalid payment amounts", async () => {
+  await withServer(async (baseUrl) => {
+    for (const amount of [undefined, "100", 0, -1, Number.POSITIVE_INFINITY]) {
+      const requestPayload = amount === undefined ? {} : { amount };
+      const { response, payload } = await postPayment(baseUrl, requestPayload);
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid payment payload"
+      });
+    }
+  });
+});
+
+test("POST /api/payments rejects unsupported currencies", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, {
+      amount: 125,
+      currency: "eur"
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments creates a payment intent with default USD currency", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postPayment(baseUrl, { amount: 125 });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().finite().positive(),
+  currency: z.enum(["usd"]).default("usd")
+});


### PR DESCRIPTION
## Summary
- add a focused schema for payment intent creation
- reject missing, non-numeric, zero, negative, and non-finite amounts with `400`
- reject unsupported currencies with `400`
- preserve the existing default `usd` currency and `201` success shape for valid requests
- add route regression tests for invalid and valid payment payloads

## Tests
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentRoutes.test.js`

/claim #743
Closes #5120
