### PR TITLE
fix: reject inverted budget ranges in createJobSchema

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,23 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax > data.budgetMin,
+  {
+    message: "budgetMax must be greater than budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax > data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than budgetMin when both are provided",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Summary

Adds zod `.refine()` to ensure `budgetMax > budgetMin` on job creation and on partial updates when both fields are present.

## Changes
- `apps/api/src/validators/job.js`: Added `.refine()` to both `createJobSchema` and `updateJobSchema`

Closes #5124