### PR TITLE
fix: reject empty file uploads with 400 status

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in the upload request", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Summary

Returns 400 when no file is provided in upload requests. Previously returned 201 with `success: true` even for empty requests.

## Changes
- `apps/api/src/controllers/uploadController.js`: Check for `req.file` and return 400 if missing

Closes #5125