### PR TITLE
fix: resolve mock freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,36 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "../../../lib/mock";
+
+interface FreelancerProfile {
+  username: string;
+  skills: string[];
+  rate: string;
+}
+
+export default async function FreelancerProfilePage({
+  params
+}: {
+  params: Promise<{ username: string }>
+}) {
+  const { username } = await params;
+  const freelancer: FreelancerProfile | undefined = freelancers.find(
+    (f) => f.username === username
+  );
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>The profile <strong>{username}</strong> does not exist.</p>
+        <p><a href="/freelancers/search">Browse all freelancers</a></p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

The freelancer profile page now looks up profiles from mock data. Known usernames (maya-dev, jordan-ux) render skills and rate. Unknown usernames show a not-found fallback.

## Changes
- `apps/web/app/freelancers/[username]/page.tsx`: Import mock data, async params for Next.js 16, conditional rendering

Closes #5128