### PR TITLE
Require authentication for notifications

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationRoutes.test.js
+++ b/apps/api/src/tests/notificationRoutes.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications rejects requests without bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/notifications rejects requests without bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "usr_1", message: "Account update" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("notification routes allow requests with valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_reader", role: "client" });
+    const createResponse = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ userId: "usr_reader", message: "Account update" })
+    });
+    const createPayload = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.success, true);
+    assert.equal(createPayload.data.userId, "usr_reader");
+    assert.equal(createPayload.data.message, "Account update");
+    assert.equal(createPayload.data.read, false);
+
+    const listResponse = await fetch(`${baseUrl}/api/notifications`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const listPayload = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listPayload.success, true);
+    assert.equal(listPayload.data.length, 1);
+    assert.equal(listPayload.data[0].message, "Account update");
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #5133

I put the notification routes behind the existing bearer auth middleware. Before this, callers without a token could read the notification list or create a notification.

The tests cover unauthenticated GET/POST rejection and the regular authenticated create/list flow.

Tested with:
node --test apps/api/src/tests/health.test.js apps/api/src/tests/notificationRoutes.test.js