### PR TITLE
Validate search query parameters

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 128;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+  if (typeof rawQuery !== "string") {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  const query = rawQuery.trim();
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query is too long", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/searchRoutes.test.js
+++ b/apps/api/src/tests/searchRoutes.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims single string query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects repeated query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a single string"
+    });
+  });
+});
+
+test("GET /api/search rejects object-shaped query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q[$ne]=x`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a single string"
+    });
+  });
+});
+
+test("GET /api/search rejects oversized query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(129)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is too long"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #5138

This tightens GET /api/search so q has to be one normal string. Before this change, repeated parameters like q=one&q=two, object-shaped values like q[$ne]=x, and very long strings all went through and came back in the response.

The route now trims a valid q, rejects arrays/objects, and rejects values over 128 characters. I added tests for the normal path and each bad input case.

Tested with:
node --test apps/api/src/tests/health.test.js apps/api/src/tests/searchRoutes.test.js