### PR TITLE
fix: preserve server-owned id and isVerified in createUser

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,3 +1,4 @@
+import { createUserSchema } from "../validators/user.js";
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
 
@@ -5,6 +6,11 @@ export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
-export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+export async function postUser(req, res, next) {
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,14 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const userId = `usr_${Date.now()}`;
+  const user = {
+    id: userId,
+    email: payload.email,
+    fullName: payload.fullName,
+    role: payload.role,
+    isVerified: false
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-ownership.test.js
+++ b/apps/api/src/tests/user-ownership.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser preserves server-owned id and defaults isVerified to false", async () => {
+  const user = await createUser({
+    email: "jane@example.com",
+    fullName: "Jane Doe",
+    role: "client"
+  });
+
+  assert.match(user.id, /^usr_/);
+  assert.equal(user.email, "jane@example.com");
+  assert.equal(user.isVerified, false);
+});


### PR DESCRIPTION
Fixes #5108

/claim #743

## What changed
- createUser now assigns a server-generated id and isVerified: false
- Caller-supplied id and isVerified values are ignored
- Added regression test for server-owned fields

## Validation
- node --test apps/api/src/tests/user-ownership.test.js
- node --check apps/api/src/services/userService.js