### PR TITLE
Let health checks bypass API rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,35 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("GET /health bypasses the shared API rate limiter", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    let limitedResponse;
+
+    for (let i = 0; i < 201; i += 1) {
+      limitedResponse = await fetch(`${baseUrl}/api/search`);
+    }
+
+    assert.equal(limitedResponse.status, 429);
+
+    const healthResponse = await fetch(`${baseUrl}/health`);
+    const healthPayload = await healthResponse.json();
+
+    assert.equal(healthResponse.status, 200);
+    assert.deepEqual(healthPayload, { ok: true, service: "api" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- register `/health` before the shared API rate limiter
- keep the existing limiter on normal `/api/*` routes
- add regression coverage showing `/api/search` can reach 429 while `/health` still returns 200

## Validation
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/health.test.js`
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #5155
Parent bounty: #743