### PR TITLE
Return JSON from API rate limiter

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,32 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("shared API rate limiter returns JSON error payloads", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    let response;
+
+    for (let i = 0; i < 201; i += 1) {
+      response = await fetch(`http://127.0.0.1:${port}/api/search`);
+    }
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.equal(response.headers.get("content-type").includes("application/json"), true);
+    assert.deepEqual(payload, { success: false, message: "Too many requests" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- configure the shared API limiter to use the project JSON error envelope for 429 responses
- preserve the existing rate-limit window, quota, and header configuration
- add regression coverage for the 429 JSON response body and content type

## Validation
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/health.test.js`
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #5157
Parent bounty: #743