### PR TITLE
Isolate API rate limiter per app instance

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,7 +21,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(createApiLimiter());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export function createApiLimiter() {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    standardHeaders: "draft-7",
+    legacyHeaders: false
+  });
+}

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,49 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+function serverUrl(server, path) {
+  const { port } = server.address();
+  return `http://127.0.0.1:${port}${path}`;
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("createApp instances do not share API rate-limit counters", async () => {
+  const firstServer = await startServer();
+
+  try {
+    for (let i = 0; i < 200; i += 1) {
+      const response = await fetch(serverUrl(firstServer, "/api/search"));
+      assert.notEqual(response.status, 429);
+    }
+  } finally {
+    await closeServer(firstServer);
+  }
+
+  const secondServer = await startServer();
+
+  try {
+    const response = await fetch(serverUrl(secondServer, "/api/search"));
+
+    assert.equal(response.status, 200);
+  } finally {
+    await closeServer(secondServer);
+  }
+});


### PR DESCRIPTION
## Summary
- replace the module-level API limiter singleton with a per-app limiter factory
- keep the existing API limiter window, request limit, and header settings unchanged
- add regression coverage proving separate `createApp()` instances do not share rate-limit counters

## Validation
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/health.test.js`
- `PATH="/Users/jiahuiwu/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js`
- `git diff --check`

/claim #743
Closes #5159
Parent bounty: #743