### PR TITLE
fix(api): block admin self-assignment during public registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return next(error);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    return next(error);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -21,7 +29,11 @@ export async function oauthCallback(req, res) {
   });
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export async function refresh(req, res, next) {
+  try {
+    const result = await refreshToken();
+    return ok(res, result);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message
+      }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/auth/register rejects admin self-assignment", async () => {
+  const server = await startServer();
+  try {
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "eve@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("POST /api/auth/register still allows public roles", async () => {
+  const server = await startServer();
+  try {
+    const { port } = server.address();
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+  } finally {
+    await stopServer(server);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

## Summary

Fixes a privilege-escalation bug in public registration where a new user could submit `role: "admin"` and self-assign admin privileges during signup.

## Problem

Public registration should only allow end-user roles. Before this change, the request body accepted an admin role value, which made the registration path too permissive.

## Fix

- restrict public registration roles to `client` and `freelancer`
- reject `admin` in the registration payload
- return a clear validation error instead of creating an invalid privileged user

## Validation

- added regression coverage for admin self-assignment rejection
- confirmed public roles still register successfully
- focused test command used:

```bash
node --test --test-reporter spec apps/api/src/tests/auth.test.js apps/api/src/tests/health.test.js
```

Result at preparation time: `3 pass / 0 fail`

## Related

- Closes `#4723`
- Related bounty thread: `#743`
