### PR TITLE
fix(api): reject empty upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "A file upload is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploads.test.js
+++ b/apps/api/src/tests/uploads.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/uploads rejects missing file payloads", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: new FormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "A file upload is required"
+    });
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("POST /api/uploads still accepts actual file uploads", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const form = new FormData();
+    form.set("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary

Rejects upload requests that omit the multipart `file` field so the API no longer reports a successful upload when no file was actually received.

## Problem

`POST /api/uploads` returned `201` and `success: true` even when the request did not include a file. That makes the route look successful to clients despite no upload happening.

## Fix

- return `400` when `req.file` is missing
- reserve success responses for real uploads only
- add regression coverage for the missing-file path

## Validation

- confirmed missing-file requests now fail with `400`
- confirmed normal upload requests still succeed
- focused test command used:

```bash
node --test --test-reporter spec apps/api/src/tests/uploads.test.js apps/api/src/tests/health.test.js
```

Result at preparation time: `3 pass / 0 fail`

## Related

- Closes `#5162`
- Mirrors original issue `#4680`
- Related bounty thread: `#743`
