### PR TITLE
fix: reject upload requests without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(app, callback) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects multipart requests without a file", async () => {
+  await withServer(createApp(), async (baseUrl) => {
+    const form = new FormData();
+    form.set("description", "metadata without an attached file");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads keeps successful responses for requests with a file", async () => {
+  await withServer(createApp(), async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Rejects `POST /api/uploads` requests that do not include the multipart `file` field with a clear `400` response.
- Keeps `201` success responses reserved for requests that actually include `req.file`.
- Adds route-level regression coverage for both missing-file rejection and successful file upload.

## Verification
- `node --check apps/api/src/controllers/uploadController.js`
- `node --check apps/api/src/tests/upload.test.js`
- `node --test apps/api/src/tests/*.js` -> 3 passed
- `git diff --check`

Note: the existing workspace script `npm test -w apps/api` still fails on current Node because it runs `node --test src/tests` against a directory path. The explicit test-file glob above passes and covers this change.

Closes #5162

/claim #5162
