### PR TITLE
fix(api): add stricter auth rate limit

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,21 @@
 import rateLimit from "express-rate-limit";
 
+const fifteenMinutes = 15 * 60 * 1000;
+
 export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
+  windowMs: fifteenMinutes,
   limit: 200,
   standardHeaders: "draft-7",
   legacyHeaders: false
+});
+
+export const authLimiter = rateLimit({
+  windowMs: fifteenMinutes,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: {
+    success: false,
+    error: "Too many authentication attempts, please try again later."
+  }
 });

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
 authRoutes.post("/refresh", refresh);

--- a/apps/api/src/tests/auth-rate-limit.test.js
+++ b/apps/api/src/tests/auth-rate-limit.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("auth endpoints have a stricter rate limit than general API routes", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  try {
+    let lastResponse;
+
+    for (let index = 0; index < 21; index += 1) {
+      lastResponse = await fetch(`${baseUrl}/api/auth/login`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "tester@example.com", password: "correct-horse-battery-staple" })
+      });
+    }
+
+    assert.equal(lastResponse.status, 429);
+    const payload = await lastResponse.json();
+    assert.deepEqual(payload, {
+      success: false,
+      error: "Too many authentication attempts, please try again later."
+    });
+
+    const healthResponse = await fetch(`${baseUrl}/health`);
+    assert.equal(healthResponse.status, 200);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Add a stricter 20-request/15-minute limiter for `POST /api/auth/login` and `POST /api/auth/register`
- Keep the existing 200-request general API limiter for non-auth routes
- Add route-level regression coverage proving auth attempts receive `429` while general routes still respond

## Verification
- `npm test -w apps/api` currently fails because the existing script runs `node --test src/tests`, which Node 22 treats as a missing directory module.
- `node --test apps/api/src/tests/*.test.js` passes (2 tests).
- `git diff --check` passes.
- Added-line security scan found 0 findings.
- Independent code review passed with no security concerns or logic errors.

Closes #4643
/claim #4643