### PR TITLE
fix: reject uploads missing file field

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "A file field is required for uploads", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/uploads rejects requests without a file field", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const { port } = server.address();
+    const form = new FormData();
+    form.append("description", "missing file regression case");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "A file field is required for uploads"
+    });
+  } finally {
+    await close(server);
+  }
+});
+
+test("POST /api/uploads accepts multipart requests with a file field", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const { port } = server.address();
+    const form = new FormData();
+    form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Rejects `POST /api/uploads` requests that do not include the multipart `file` field with a 400 response.
- Keeps successful upload responses reserved for requests that include `req.file`.
- Adds route-level regression coverage for both missing-file and successful upload cases.

## Verification
- `node --test apps/api/src/tests/*.test.js` ✅
- `git diff --check` ✅
- Added-line security scan: 0 findings ✅
- Independent reviewer: passed ✅

Note: `npm test -w apps/api` currently fails because the existing script runs `node --test src/tests`, which Node 22 treats as a module path rather than expanding the test directory. The explicit test glob above passes and includes the existing health test plus the new upload regression tests.

Closes #5162
/attempt #743
