### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  const role = payload.role === "freelancer" ? "freelancer" : "client";
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role })
   };
 }
 

--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const validEmail = "user@example.com";
+const validPassword = "correct horse battery staple";
+
+test("registerSchema rejects admin role self-assignment", () => {
+  assert.throws(
+    () => registerSchema.parse({
+      email: validEmail,
+      password: validPassword,
+      role: "admin"
+    }),
+    /Invalid enum value/
+  );
+});
+
+test("registerSchema still accepts public registration roles", () => {
+  assert.equal(
+    registerSchema.parse({
+      email: validEmail,
+      password: validPassword,
+      role: "freelancer"
+    }).role,
+    "freelancer"
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #1737

## Summary
- remove `admin` from the public registration role enum
- defensively normalize registration roles in `registerUser()` so only `client` and `freelancer` can be self-selected
- add validator coverage for rejected admin self-assignment and accepted public roles
- fix the API package test script so the existing Node test suite runs via a file glob

## Verification
- `npm test --workspace apps/api`
- 3 tests passed

## Notes
This keeps admin assignment out of the public registration path. Admin promotion should be handled by a trusted internal/admin-only path, not by user-supplied registration payloads.