### PR TITLE
Preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client-controlled-id",
+    read: true,
+    type: "message",
+    message: "New proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "client-controlled-id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.type, "message");
+  assert.equal(notification.message, "New proposal received");
+});
+
+test("createNotification keeps normal payload fields", async () => {
+  const notification = await createNotification({
+    type: "job",
+    message: "Job was updated"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.type, "job");
+  assert.equal(notification.message, "Job was updated");
+});


### PR DESCRIPTION
/claim #743

## Summary
- Preserve server-owned notification ids by applying the caller payload before generating the `ntf_...` id.
- Force every newly created notification to start with `read: false`, even if the request body includes `read: true`.
- Add focused service regression coverage for override attempts and normal notification creation.

## Validation
- `node --test apps/api/src/tests/notification-service.test.js` -> 2 passed
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/tests/notification-service.test.js`
- `git diff --check` -> passed with Windows LF/CRLF warning only

Note: `node --test apps/api/src/tests/*.test.js` is blocked in this clean checkout by missing installed dependency `cors` for the existing health test import path. The focused notification service test above passes without requiring unrelated app dependencies.

## Demo / Evidence
- Scoped bug: #4247
- Parent bounty: #743

Closes #4247
Refs #743

Payment details can be provided privately after maintainer acceptance.