### PR TITLE
Keep notification creation fields server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps id and unread state server-owned", async () => {
+  const notification = await createNotification({
+    id: "caller-controlled",
+    read: true,
+    userId: "usr_123",
+    message: "New proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "caller-controlled");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "New proposal received");
+});


### PR DESCRIPTION
## Summary
- Keep notification creation `id` and initial `read: false` server-owned even when the request payload includes those fields.
- Add a focused regression test for caller-controlled notification `id` and `read` payload values.

## Validation
- `node --check apps\api\src\services\notificationService.js`
- `node --check apps\api\src\tests\notificationService.test.js`
- `node --test apps\api\src\tests\notificationService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5174