### PR TITLE
Return matching records from global search

### DIFF
--- a/apps/api/src/services/searchService.js
+++ b/apps/api/src/services/searchService.js
@@ -1,9 +1,39 @@
+import { listJobs } from "./jobService.js";
+import { listUsers } from "./userService.js";
+
+function includesQuery(value, query) {
+  return String(value ?? "").toLowerCase().includes(query);
+}
+
+function sanitizeUser(user) {
+  const { password, ...safeUser } = user;
+  return safeUser;
+}
+
 export async function globalSearch(query) {
-  // TODO: use PostgreSQL full-text search + ranking.
+  const normalizedQuery = String(query ?? "").trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return {
+      query: "",
+      users: [],
+      jobs: [],
+      freelancers: []
+    };
+  }
+
+  const [users, jobs] = await Promise.all([listUsers(), listJobs()]);
+
   return {
-    query,
-    users: [],
-    jobs: [],
+    query: normalizedQuery,
+    users: users
+      .filter((user) =>
+        [user.email, user.name, user.username, user.role].some((value) => includesQuery(value, normalizedQuery))
+      )
+      .map(sanitizeUser),
+    jobs: jobs.filter((job) =>
+      [job.title, job.description, job.categoryId, job.status].some((value) => includesQuery(value, normalizedQuery))
+    ),
     freelancers: []
   };
 }

--- a/apps/api/src/tests/searchService.test.js
+++ b/apps/api/src/tests/searchService.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+import { globalSearch } from "../services/searchService.js";
+import { createUser } from "../services/userService.js";
+
+test("globalSearch returns matching users and jobs without sensitive user fields", async () => {
+  await createUser({
+    email: "maya@example.com",
+    name: "Maya Support",
+    password: "super-secret",
+    role: "freelancer"
+  });
+  await createJob({
+    title: "Build an AI support workflow",
+    description: "Automate customer support tickets",
+    budgetMin: 500,
+    budgetMax: 1200,
+    categoryId: "automation"
+  });
+
+  const result = await globalSearch(" SUPPORT ");
+
+  assert.equal(result.query, "support");
+  assert.equal(result.users.length, 1);
+  assert.equal(result.users[0].email, "maya@example.com");
+  assert.equal(Object.hasOwn(result.users[0], "password"), false);
+  assert.equal(result.jobs.length, 1);
+  assert.equal(result.jobs[0].title, "Build an AI support workflow");
+  assert.deepEqual(result.freelancers, []);
+});
+
+test("globalSearch returns empty result groups for blank queries", async () => {
+  const result = await globalSearch("   ");
+
+  assert.deepEqual(result, {
+    query: "",
+    users: [],
+    jobs: [],
+    freelancers: []
+  });
+});


### PR DESCRIPTION
## Summary
- Make `globalSearch` search the existing in-memory user and job services instead of always returning empty groups.
- Normalize and trim the query before matching.
- Keep blank queries empty and avoid leaking user `password` fields in search results.
- Add focused service tests for matching records and blank queries.

## Validation
- `node --check apps\api\src\services\searchService.js`
- `node --check apps\api\src\tests\searchService.test.js`
- `node --test apps\api\src\tests\searchService.test.js` -> 2 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5176