### PR TITLE
Keep job creation fields server-owned

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps id and initial status server-owned", async () => {
+  const job = await createJob({
+    id: "caller-controlled",
+    status: "closed",
+    title: "Build a checkout flow",
+    description: "Implement a guided checkout flow for clients",
+    budgetMin: 1000,
+    budgetMax: 2500,
+    categoryId: "web",
+    skills: ["Next.js"]
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "caller-controlled");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build a checkout flow");
+  assert.deepEqual(job.skills, ["Next.js"]);
+});


### PR DESCRIPTION
## Summary
- Keep job creation `id` and initial `status: open` server-owned even when the request payload includes those fields.
- Preserve normal job payload fields such as title, description, budget, category, and skills.
- Add a focused regression test.

## Validation
- `node --check apps\api\src\services\jobService.js`
- `node --check apps\api\src\tests\jobService.test.js`
- `node --test apps\api\src\tests\jobService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5178