### PR TITLE
Run API test files explicitly

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- Update the API workspace test script to target `src/tests/*.js` directly instead of passing the `src/tests` directory path to Node's test runner.
- Keep the change scoped to `apps/api/package.json`; no runtime code or dependency changes.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); console.log('package json ok')"`
- `npm.cmd test -w apps/api` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

Note: PowerShell blocks `npm.ps1` in this environment, so I used the equivalent Windows npm entrypoint `npm.cmd`. I ran `npm ci` first to install existing lockfile dependencies; no package files were changed.

/claim #743

Closes #5180
