### PR TITLE
Keep user creation id server-owned

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps id server-owned", async () => {
+  const user = await createUser({
+    id: "caller-controlled",
+    email: "client@example.com",
+    name: "Client Example",
+    role: "client"
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "caller-controlled");
+  assert.equal(user.email, "client@example.com");
+  assert.equal(user.name, "Client Example");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
## Summary
- Keep user creation `id` server-owned even when the request payload includes an `id` field.
- Preserve normal user payload fields such as `email`, `name`, and `role`.
- Add a focused service regression test.

## Validation
- `node --check apps\api\src\services\userService.js`
- `node --check apps\api\src\tests\userService.test.js`
- `node --test apps\api\src\tests\userService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5182
