### PR TITLE
Keep proposal creation id server-owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps id server-owned", async () => {
+  const proposal = await createProposal({
+    id: "caller-controlled",
+    jobId: "job_123",
+    freelancerId: "usr_456",
+    coverLetter: "I can build this workflow.",
+    bidAmount: 1200
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "caller-controlled");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_456");
+  assert.equal(proposal.bidAmount, 1200);
+});


### PR DESCRIPTION
## Summary
- Keep proposal creation `id` server-owned even when the request payload includes an `id` field.
- Preserve normal proposal payload fields such as `jobId`, `freelancerId`, `coverLetter`, and `bidAmount`.
- Add a focused service regression test.

## Validation
- `node --check apps\api\src\services\proposalService.js`
- `node --check apps\api\src\tests\proposalService.test.js`
- `node --test apps\api\src\tests\proposalService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5184
