### PR TITLE
Keep review creation id server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps id server-owned", async () => {
+  const review = await createReview({
+    id: "caller-controlled",
+    jobId: "job_123",
+    reviewerId: "usr_456",
+    revieweeId: "usr_789",
+    rating: 5,
+    comment: "Excellent delivery"
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "caller-controlled");
+  assert.equal(review.jobId, "job_123");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Excellent delivery");
+});


### PR DESCRIPTION
## Summary
- Keep review creation `id` server-owned even when the request payload includes an `id` field.
- Preserve normal review payload fields such as `jobId`, `reviewerId`, `revieweeId`, `rating`, and `comment`.
- Add a focused service regression test.

## Validation
- `node --check apps\api\src\services\reviewService.js`
- `node --check apps\api\src\tests\reviewService.test.js`
- `node --test apps\api\src\tests\reviewService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5186
