### PR TITLE
Keep message creation fields server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps id and sentAt server-owned", async () => {
+  const message = await sendMessage({
+    id: "caller-controlled",
+    sentAt: "2000-01-01T00:00:00.000Z",
+    fromUserId: "usr_123",
+    toUserId: "usr_456",
+    body: "Hello from the marketplace"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "caller-controlled");
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(message.sentAt).toISOString());
+  assert.equal(message.fromUserId, "usr_123");
+  assert.equal(message.toUserId, "usr_456");
+  assert.equal(message.body, "Hello from the marketplace");
+});


### PR DESCRIPTION
## Summary
- Keep message creation `id` server-owned even when the request payload includes an `id` field.
- Preserve the existing server-owned `sentAt` behavior and add regression coverage for it.
- Preserve normal message payload fields such as `fromUserId`, `toUserId`, and `body`.

## Validation
- `node --check apps\api\src\services\messageService.js`
- `node --check apps\api\src\tests\messageService.test.js`
- `node --test apps\api\src\tests\messageService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5188
