### PR TITLE
Return defensive user list snapshots

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/userListService.test.js
+++ b/apps/api/src/tests/userListService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers returns defensive snapshots", async () => {
+  await createUser({
+    email: "snapshot@example.com",
+    name: "Snapshot User",
+    role: "client"
+  });
+
+  const firstList = await listUsers();
+  firstList.push({ id: "injected", email: "injected@example.com" });
+  firstList[0].email = "mutated@example.com";
+
+  const secondList = await listUsers();
+
+  assert.equal(secondList.some((user) => user.id === "injected"), false);
+  assert.equal(secondList.some((user) => user.email === "mutated@example.com"), false);
+  assert.equal(secondList.some((user) => user.email === "snapshot@example.com"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listUsers()` return cloned user records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored users by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\userService.js`
- `node --check apps\api\src\tests\userListService.test.js`
- `node --test apps\api\src\tests\userListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5190
