### PR TITLE
Return defensive job list snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/tests/jobListService.test.js
+++ b/apps/api/src/tests/jobListService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("listJobs returns defensive snapshots", async () => {
+  await createJob({
+    title: "Snapshot job",
+    description: "A job used to verify defensive list snapshots",
+    budgetMin: 100,
+    budgetMax: 300,
+    categoryId: "qa",
+    skills: ["Testing"]
+  });
+
+  const firstList = await listJobs();
+  firstList.push({ id: "injected", title: "Injected job" });
+  firstList[0].title = "Mutated job";
+
+  const secondList = await listJobs();
+
+  assert.equal(secondList.some((job) => job.id === "injected"), false);
+  assert.equal(secondList.some((job) => job.title === "Mutated job"), false);
+  assert.equal(secondList.some((job) => job.title === "Snapshot job"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listJobs()` return cloned job records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored jobs by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\jobService.js`
- `node --check apps\api\src\tests\jobListService.test.js`
- `node --test apps\api\src\tests\jobListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5192
