### PR TITLE
Return defensive proposal list snapshots

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposalListService.test.js
+++ b/apps/api/src/tests/proposalListService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("listProposals returns defensive snapshots", async () => {
+  await createProposal({
+    jobId: "job_snapshot",
+    freelancerId: "usr_snapshot",
+    coverLetter: "Snapshot proposal",
+    bidAmount: 450
+  });
+
+  const firstList = await listProposals();
+  firstList.push({ id: "injected", coverLetter: "Injected proposal" });
+  firstList[0].coverLetter = "Mutated proposal";
+
+  const secondList = await listProposals();
+
+  assert.equal(secondList.some((proposal) => proposal.id === "injected"), false);
+  assert.equal(secondList.some((proposal) => proposal.coverLetter === "Mutated proposal"), false);
+  assert.equal(secondList.some((proposal) => proposal.coverLetter === "Snapshot proposal"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listProposals()` return cloned proposal records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored proposals by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\proposalService.js`
- `node --check apps\api\src\tests\proposalListService.test.js`
- `node --test apps\api\src\tests\proposalListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5194
