### PR TITLE
Return defensive review list snapshots

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/tests/reviewListService.test.js
+++ b/apps/api/src/tests/reviewListService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("listReviews returns defensive snapshots", async () => {
+  await createReview({
+    jobId: "job_snapshot",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 4,
+    comment: "Snapshot review"
+  });
+
+  const firstList = await listReviews();
+  firstList.push({ id: "injected", comment: "Injected review" });
+  firstList[0].comment = "Mutated review";
+
+  const secondList = await listReviews();
+
+  assert.equal(secondList.some((review) => review.id === "injected"), false);
+  assert.equal(secondList.some((review) => review.comment === "Mutated review"), false);
+  assert.equal(secondList.some((review) => review.comment === "Snapshot review"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listReviews()` return cloned review records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored reviews by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\reviewService.js`
- `node --check apps\api\src\tests\reviewListService.test.js`
- `node --test apps\api\src\tests\reviewListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5196
