### PR TITLE
Return defensive message list snapshots

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/tests/messageListService.test.js
+++ b/apps/api/src/tests/messageListService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("listMessages returns defensive snapshots", async () => {
+  await sendMessage({
+    fromUserId: "usr_sender",
+    toUserId: "usr_receiver",
+    body: "Snapshot message"
+  });
+
+  const firstList = await listMessages();
+  firstList.push({ id: "injected", body: "Injected message" });
+  firstList[0].body = "Mutated message";
+
+  const secondList = await listMessages();
+
+  assert.equal(secondList.some((message) => message.id === "injected"), false);
+  assert.equal(secondList.some((message) => message.body === "Mutated message"), false);
+  assert.equal(secondList.some((message) => message.body === "Snapshot message"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listMessages()` return cloned message records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored messages by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\messageService.js`
- `node --check apps\api\src\tests\messageListService.test.js`
- `node --test apps\api\src\tests\messageListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5198
