### PR TITLE
Return defensive notification list snapshots

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((notification) => ({ ...notification }));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/notificationListService.test.js
+++ b/apps/api/src/tests/notificationListService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("listNotifications returns defensive snapshots", async () => {
+  await createNotification({
+    userId: "usr_snapshot",
+    message: "Snapshot notification",
+    type: "proposal"
+  });
+
+  const firstList = await listNotifications();
+  firstList.push({ id: "injected", message: "Injected notification" });
+  firstList[0].message = "Mutated notification";
+
+  const secondList = await listNotifications();
+
+  assert.equal(secondList.some((notification) => notification.id === "injected"), false);
+  assert.equal(secondList.some((notification) => notification.message === "Mutated notification"), false);
+  assert.equal(secondList.some((notification) => notification.message === "Snapshot notification"), true);
+});


### PR DESCRIPTION
## Summary
- Make `listNotifications()` return cloned notification records instead of the mutable backing store.
- Add regression coverage proving callers cannot corrupt the stored notifications by mutating the returned array or returned objects.

## Validation
- `node --check apps\api\src\services\notificationService.js`
- `node --check apps\api\src\tests\notificationListService.test.js`
- `node --test apps\api\src\tests\notificationListService.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5200
