### PR TITLE
Protect server-generated user id from caller override

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userIdOverride.test.js
+++ b/apps/api/src/tests/userIdOverride.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { createUser } from "../services/userService.js";
+
+describe("createUser - server-owned id", () => {
+  it("should ignore caller-supplied id and use server-generated one", async () => {
+    const result = await createUser({
+      id: "usr_malicious_override",
+      email: "test@example.com",
+      name: "Test"
+    });
+
+    expect(result.id).toMatch(/^usr_\d+$/);
+    expect(result.id).not.toBe("usr_malicious_override");
+    expect(result.email).toBe("test@example.com");
+    expect(result.name).toBe("Test");
+  });
+});


### PR DESCRIPTION
## Problem

Closes #5201

`createUser()` in `apps/api/src/services/userService.js` builds the user as `{ id: server, ...payload }`, so a caller can pass `id` in the body and overwrite the server-generated id.

## Fix

Reversed the spread order: `{ ...payload, id: server }` — server id always wins.

## Test

Added `userIdOverride.test.js` confirming that a caller-supplied `id` is ignored and the server-generated `usr_*` id is used instead.