### PR TITLE
Protect server-owned job id and status from caller override

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobIdStatusOverride.test.js
+++ b/apps/api/src/tests/jobIdStatusOverride.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { createJob } from "../services/jobService.js";
+
+describe("createJob - server-owned id and status", () => {
+  it("should ignore caller-supplied id and status, use server values", async () => {
+    const result = await createJob({
+      id: "job_malicious",
+      status: "completed",
+      title: "Build a website",
+      description: "Need a landing page",
+      budgetMin: 500,
+      budgetMax: 1000
+    });
+
+    expect(result.id).toMatch(/^job_\d+$/);
+    expect(result.id).not.toBe("job_malicious");
+    expect(result.status).toBe("open");
+    expect(result.title).toBe("Build a website");
+    expect(result.budgetMin).toBe(500);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #5202

`createJob()` was spreading payload after `id` and `status`, allowing callers to override both the server-generated id and the initial status.

## Fix

Reversed the spread order so server fields always win: `{ ...payload, id, status }`.

## Test

Added `jobIdStatusOverride.test.js` verifying that caller-supplied `id` and `status` are ignored.