### PR TITLE
Protect server-generated ids in proposal and review creation

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/proposalReviewIdOverride.test.js
+++ b/apps/api/src/tests/proposalReviewIdOverride.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+
+describe("createProposal - server-owned id", () => {
+  it("should ignore caller-supplied id", async () => {
+    const result = await createProposal({
+      id: "prp_malicious",
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can do this"
+    });
+
+    expect(result.id).toMatch(/^prp_\d+$/);
+    expect(result.id).not.toBe("prp_malicious");
+    expect(result.jobId).toBe("job_123");
+  });
+});
+
+describe("createReview - server-owned id", () => {
+  it("should ignore caller-supplied id", async () => {
+    const result = await createReview({
+      id: "rev_malicious",
+      jobId: "job_123",
+      rating: 5,
+      comment: "Great work"
+    });
+
+    expect(result.id).toMatch(/^rev_\d+$/);
+    expect(result.id).not.toBe("rev_malicious");
+    expect(result.rating).toBe(5);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #5203

Both `createProposal()` and `createReview()` spread payload after the server-generated id, letting callers override it.

## Fix

Reversed spread order in both services so server id always wins.

## Test

Added `proposalReviewIdOverride.test.js` with separate test cases for both proposal and review id protection.