### PR TITLE
Return defensive user creation snapshot

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -7,5 +7,5 @@ export async function listUsers() {
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  return { ...user };
 }

--- a/apps/api/src/tests/userCreateSnapshot.test.js
+++ b/apps/api/src/tests/userCreateSnapshot.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser returns a defensive snapshot", async () => {
+  const created = await createUser({
+    email: "returned-user@example.com",
+    name: "Returned User",
+    role: "client"
+  });
+
+  created.email = "mutated@example.com";
+  created.name = "Mutated User";
+
+  const users = await listUsers();
+
+  assert.equal(users.some((user) => user.email === "mutated@example.com"), false);
+  assert.equal(users.some((user) => user.name === "Mutated User"), false);
+  assert.equal(users.some((user) => user.email === "returned-user@example.com"), true);
+});


### PR DESCRIPTION
## Summary
- Make `createUser()` return a cloned user object instead of the stored object reference.
- Add regression coverage proving callers cannot corrupt stored users by mutating the creation response.

## Validation
- `node --check apps\api\src\services\userService.js`
- `node --check apps\api\src\tests\userCreateSnapshot.test.js`
- `node --test apps\api\src\tests\userCreateSnapshot.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5208
