### PR TITLE
Fix mismatched user id between registration response and JWT subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registerUserIdMismatch.test.js
+++ b/apps/api/src/tests/registerUserIdMismatch.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { registerUser } from "../services/authService.js";
+
+describe("registerUser - consistent id in response and JWT", () => {
+  it("should use the same id in the returned object and JWT subject", async () => {
+    const result = await registerUser({
+      email: "test@example.com",
+      password: "secret1234",
+      role: "client"
+    });
+
+    expect(result.id).toMatch(/^usr_\d+$/);
+    expect(result.token).toBeDefined();
+
+    // Decode JWT without verifying (just check the sub claim matches)
+    const [, payload] = result.token.split(".");
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf-8")
+    );
+
+    expect(decoded.sub).toBe(result.id);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #5204

`registerUser()` called `Date.now()` twice — once for the returned user `id` and once for the JWT `sub` claim. Since these are separate calls, they produce different timestamps, so the JWT subject never matches the actual user id. Any downstream code validating token subject against user id would fail.

## Fix

Generate the id once and reuse it in both the response object and the JWT payload.

## Test

Added `registerUserIdMismatch.test.js` that decodes the JWT and verifies the `sub` claim matches the returned `id`.