### PR TITLE
Return defensive job creation snapshot

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -7,5 +7,5 @@ export async function listJobs() {
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);
-  return job;
+  return { ...job };
 }

--- a/apps/api/src/tests/jobCreateSnapshot.test.js
+++ b/apps/api/src/tests/jobCreateSnapshot.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob returns a defensive snapshot", async () => {
+  const created = await createJob({
+    title: "Returned job",
+    description: "A job used to verify returned snapshots",
+    budgetMin: 200,
+    budgetMax: 500,
+    categoryId: "qa",
+    skills: ["Testing"]
+  });
+
+  created.title = "Mutated job";
+  created.status = "closed";
+
+  const jobs = await listJobs();
+
+  assert.equal(jobs.some((job) => job.title === "Mutated job"), false);
+  assert.equal(jobs.some((job) => job.status === "closed"), false);
+  assert.equal(jobs.some((job) => job.title === "Returned job"), true);
+});


### PR DESCRIPTION
## Summary
- Make `createJob()` return a cloned job object instead of the stored object reference.
- Add regression coverage proving callers cannot corrupt stored jobs by mutating the creation response.

## Validation
- `node --check apps\api\src\services\jobService.js`
- `node --check apps\api\src\tests\jobCreateSnapshot.test.js`
- `node --test apps\api\src\tests\jobCreateSnapshot.test.js` -> 1 passed
- `git diff --check` -> passed with Windows LF/CRLF working-copy warnings only

/claim #743

Closes #5211
