### PR TITLE
Return defensive proposal creation snapshot

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -7,5 +7,5 @@ export async function listProposals() {
 export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }

--- a/apps/api/src/tests/proposalCreateSnapshot.test.js
+++ b/apps/api/src/tests/proposalCreateSnapshot.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal returns a defensive snapshot", async () => {
+  const created = await createProposal({
+    jobId: "job_snapshot",
+    freelancerId: "user_snapshot",
+    coverLetter: "Original cover letter"
+  });
+
+  created.coverLetter = "Mutated cover letter";
+
+  const proposals = await listProposals();
+
+  assert.equal(
+    proposals.some((proposal) => proposal.coverLetter === "Mutated cover letter"),
+    false
+  );
+  assert.equal(
+    proposals.some((proposal) => proposal.coverLetter === "Original cover letter"),
+    true
+  );
+});


### PR DESCRIPTION
## Summary
- return a cloned proposal object from createProposal so callers cannot mutate the stored in-memory proposal through the returned reference
- add a regression test that mutates the returned proposal and verifies listProposals still returns the original stored value

## Validation
- node --check apps/api/src/services/proposalService.js
- node --check apps/api/src/tests/proposalCreateSnapshot.test.js
- node --test apps/api/src/tests/proposalCreateSnapshot.test.js
- git diff --check

/claim #743

Closes #5214
