### PR TITLE
Return defensive review creation snapshot

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -7,5 +7,5 @@ export async function listReviews() {
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return { ...review };
 }

--- a/apps/api/src/tests/reviewCreateSnapshot.test.js
+++ b/apps/api/src/tests/reviewCreateSnapshot.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("createReview returns a defensive snapshot", async () => {
+  const created = await createReview({
+    jobId: "job_snapshot",
+    reviewerId: "client_snapshot",
+    revieweeId: "freelancer_snapshot",
+    rating: 5,
+    comment: "Original review"
+  });
+
+  created.rating = 1;
+  created.comment = "Mutated review";
+
+  const reviews = await listReviews();
+
+  assert.equal(reviews.some((review) => review.rating === 1), false);
+  assert.equal(reviews.some((review) => review.comment === "Mutated review"), false);
+  assert.equal(reviews.some((review) => review.comment === "Original review"), true);
+});


### PR DESCRIPTION
## Summary
- return a cloned review object from createReview so callers cannot mutate the stored in-memory review through the returned reference
- add a regression test that mutates the returned review and verifies listReviews still returns the original stored values

## Validation
- node --check apps/api/src/services/reviewService.js
- node --check apps/api/src/tests/reviewCreateSnapshot.test.js
- node --test apps/api/src/tests/reviewCreateSnapshot.test.js
- git diff --check -- apps/api/src/services/reviewService.js apps/api/src/tests/reviewCreateSnapshot.test.js

/claim #743

Closes #5216
