### PR TITLE
Return defensive message creation snapshot

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -7,5 +7,5 @@ export async function listMessages() {
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return { ...message };
 }

--- a/apps/api/src/tests/messageCreateSnapshot.test.js
+++ b/apps/api/src/tests/messageCreateSnapshot.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage, listMessages } from "../services/messageService.js";
+
+test("sendMessage returns a defensive snapshot", async () => {
+  const created = await sendMessage({
+    senderId: "sender_snapshot",
+    recipientId: "recipient_snapshot",
+    body: "Original message"
+  });
+
+  created.body = "Mutated message";
+  created.senderId = "mutated_sender";
+
+  const messages = await listMessages();
+
+  assert.equal(messages.some((message) => message.body === "Mutated message"), false);
+  assert.equal(messages.some((message) => message.senderId === "mutated_sender"), false);
+  assert.equal(messages.some((message) => message.body === "Original message"), true);
+});


### PR DESCRIPTION
## Summary
- return a cloned message object from sendMessage so callers cannot mutate the stored in-memory message through the returned reference
- add a regression test that mutates the returned message and verifies listMessages still returns the original stored values

## Validation
- node --check apps/api/src/services/messageService.js
- node --check apps/api/src/tests/messageCreateSnapshot.test.js
- node --test apps/api/src/tests/messageCreateSnapshot.test.js
- git diff --check -- apps/api/src/services/messageService.js apps/api/src/tests/messageCreateSnapshot.test.js

/claim #743

Closes #5218
