### PR TITLE
Return defensive notification creation snapshot

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -7,5 +7,5 @@ export async function listNotifications() {
 export async function createNotification(payload) {
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
-  return notification;
+  return { ...notification };
 }

--- a/apps/api/src/tests/notificationCreateSnapshot.test.js
+++ b/apps/api/src/tests/notificationCreateSnapshot.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createNotification,
+  listNotifications
+} from "../services/notificationService.js";
+
+test("createNotification returns a defensive snapshot", async () => {
+  const created = await createNotification({
+    userId: "user_snapshot",
+    message: "Original notification"
+  });
+
+  created.message = "Mutated notification";
+  created.userId = "mutated_user";
+
+  const notifications = await listNotifications();
+
+  assert.equal(
+    notifications.some((notification) => notification.message === "Mutated notification"),
+    false
+  );
+  assert.equal(
+    notifications.some((notification) => notification.userId === "mutated_user"),
+    false
+  );
+  assert.equal(
+    notifications.some((notification) => notification.message === "Original notification"),
+    true
+  );
+});


### PR DESCRIPTION
## Summary
- return a cloned notification object from createNotification so callers cannot mutate the stored in-memory notification through the returned reference
- add a regression test that mutates the returned notification and verifies listNotifications still returns the original stored values

## Validation
- node --check apps/api/src/services/notificationService.js
- node --check apps/api/src/tests/notificationCreateSnapshot.test.js
- node --test apps/api/src/tests/notificationCreateSnapshot.test.js
- git diff --check -- apps/api/src/services/notificationService.js apps/api/src/tests/notificationCreateSnapshot.test.js

/claim #743

Closes #5220
