### PR TITLE
Forward native props from shared Button

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, type = "button", style, ...props }: ButtonProps) {
   return (
     <button
+      type={type}
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- type the shared Button with native React button attributes
- default Button to type="button" so it does not accidentally submit forms
- forward remaining native props and merge caller-provided style with the existing base style

## Validation
- node_modules/.bin/tsc.cmd --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --esModuleInterop --skipLibCheck --noEmit packages/ui/src/Button.tsx
- git diff --check -- packages/ui/src/Button.tsx

/claim #743

Closes #5222
