### PR TITLE
Use list semantics for primary navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -12,12 +12,25 @@ const links = [
 
 export function Navigation() {
   return (
-    <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
-      {links.map(([href, label]) => (
-        <Link key={href} href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
-          {label}
-        </Link>
-      ))}
+    <nav aria-label="Primary navigation">
+      <ul
+        style={{
+          display: "flex",
+          gap: 12,
+          flexWrap: "wrap",
+          listStyle: "none",
+          margin: "0 0 20px",
+          padding: 0
+        }}
+      >
+        {links.map(([href, label]) => (
+          <li key={href}>
+            <Link href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ul>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- label the primary navigation region
- render navigation links as a ul/li list for clearer assistive-technology structure
- preserve the existing flex layout and spacing

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/components/Navigation.tsx

/claim #743

Closes #5226
