### PR TITLE
Add visible keyboard focus styles

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,11 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid #8fd3ff;
+  outline-offset: 3px;
+}
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }


### PR DESCRIPTION
## Summary
- add global focus-visible styles for links and buttons
- use a high-contrast outline with offset so keyboard focus remains visible on dark cards and backgrounds

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/globals.css

/claim #743

Closes #5228
