### PR TITLE
Add accessible labels to job detail links

### DIFF
--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -10,7 +10,9 @@ export default function JobsPage() {
           <article className="card" key={job.id}>
             <h3>{job.title}</h3>
             <p>{job.budget}</p>
-            <Link href={`/jobs/${job.id}`}>View details</Link>
+            <Link href={`/jobs/${job.id}`} aria-label={`View details for ${job.title}`}>
+              View details
+            </Link>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add job-specific aria-label text to each job details link
- keep the visible "View details" label unchanged while giving assistive technologies unique link names

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/jobs/page.tsx

/claim #743

Closes #5230
