### PR TITLE
Add accessible labels to freelancer profile links

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -11,7 +11,12 @@ export default function FreelancerSearchPage() {
             <h3>{freelancer.username}</h3>
             <p>{freelancer.skills.join(" · ")}</p>
             <p>{freelancer.rate}</p>
-            <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
+            <Link
+              href={`/freelancers/${freelancer.username}`}
+              aria-label={`Open profile for ${freelancer.username}`}
+            >
+              Open profile
+            </Link>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add freelancer-specific aria-label text to each profile link
- keep the visible "Open profile" label unchanged while giving assistive technologies unique link names

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/freelancers/search/page.tsx

/claim #743

Closes #5232
