### PR TITLE
Return 404 for unknown job details

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,17 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>{job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary
- look up the requested job detail id in the mock jobs dataset
- return notFound() for unknown job ids instead of rendering a valid-looking placeholder page
- render the matched job title and budget for valid ids

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/jobs/[id]/page.tsx

/claim #743

Closes #5235
