### PR TITLE
Return 404 for unknown freelancer profiles

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((item) => item.username === params.username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p>{freelancer.skills.join(" · ")}</p>
+      <p>{freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary
- look up the requested freelancer username in the mock freelancers dataset
- return notFound() for unknown usernames instead of rendering a valid-looking placeholder page
- render the matched freelancer username, skills, and rate for valid profiles

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/freelancers/[username]/page.tsx

/claim #743

Closes #5237
