### PR TITLE
Encode freelancer usernames in profile links

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -11,7 +11,9 @@ export default function FreelancerSearchPage() {
             <h3>{freelancer.username}</h3>
             <p>{freelancer.skills.join(" · ")}</p>
             <p>{freelancer.rate}</p>
-            <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
+            <Link href={`/freelancers/${encodeURIComponent(freelancer.username)}`}>
+              Open profile
+            </Link>
           </article>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- encode the dynamic freelancer username path segment when building profile links
- keep the existing visible link text and freelancer data unchanged

## Validation
- cmd /c npm run build -w apps/web
- git diff --check -- apps/web/app/freelancers/search/page.tsx

/claim #743

Closes #5241
