### PR TITLE
fix(api): validate token refresh requests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import jwt from "jsonwebtoken";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,18 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const parsed = refreshSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  try {
+    const result = await refreshToken(parsed.data.token);
+    return ok(res, result);
+  } catch (error) {
+    if (error instanceof jwt.JsonWebTokenError || error instanceof jwt.TokenExpiredError) {
+      return fail(res, "Invalid token", 401);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refresh } from "../controllers/authController.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+test("POST /api/auth/refresh rejects missing token", async () => {
+  const res = createResponse();
+
+  await refresh({ body: {} }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.payload, { success: false, message: "Validation failed" });
+});
+
+test("POST /api/auth/refresh rejects invalid token", async () => {
+  const res = createResponse();
+
+  await refresh({ body: { token: "not-a-jwt" } }, res);
+
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { success: false, message: "Invalid token" });
+});
+
+test("POST /api/auth/refresh signs a new token from the verified token subject and role", async () => {
+  const res = createResponse();
+  const token = signAccessToken({ sub: "usr_refreshable", role: "freelancer" });
+
+  await refresh({ body: { token } }, res);
+  const verified = verifyAccessToken(res.payload.data.token);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.success, true);
+  assert.equal(verified.sub, "usr_refreshable");
+  assert.equal(verified.role, "freelancer");
+});

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -4,7 +4,7 @@ import { createApp } from "../app.js";
 
 test("GET /health returns ok payload", async () => {
   const app = createApp();
-  const server = app.listen(0);
+  const server = app.listen(0, "127.0.0.1");
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

- Require POST /api/auth/refresh requests to include a token.
- Verify the supplied token before minting a replacement access token.
- Preserve the verified sub and role claims in the replacement token.
- Add regression coverage for missing, invalid, and valid refresh token requests.

## Validation

```sh
npm test
```

Result: 4 passing tests, 0 failures.

Closes #5243

/claim #743