### PR TITLE
fix: ensure registerUser generates consistent user ID and token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Bug
`registerUser` called `Date.now()` twice, producing different values for the response `id` and token `sub`. This caused authentication inconsistencies.

## Fix
Generate the user ID once and reuse it for both the response and the JWT subject.

## Process
Per #743, this issue (#5248) was created first, then fixed.

Closes #5248