### PR TITLE
fix: add admin RBAC and user creation validation

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -6,5 +6,14 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const { email, name } = req.body || {};
+
+  if (!email || typeof email !== "string" || !email.includes("@")) {
+    return res.status(400).json({
+      success: false,
+      message: "A valid email is required to create a user."
+    });
+  }
+
+  return ok(res, await createUser({ email, name }), 201);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary
Added `requireAdmin` middleware checking `req.user.role`, applied to admin routes. Added email validation to `POST /api/users`.

## Testing
- Admin routes now reject non-admin tokens with 403
- User creation rejects empty/missing email with 400
- Existing valid requests continue to work