### PR TITLE
fix: PostCSS advisory + resolve mock data in job/freelancer pages

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,32 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "@/lib/mock";
+
+export default function FreelancerProfilePage({
+  params,
+}: {
+  params: { username: string };
+}) {
+  const profile = freelancers.find((f) => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>
+          No freelancer matches the username <strong>{params.username}</strong>.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{profile.username}</h2>
+      <p>
+        <strong>Skills:</strong> {profile.skills.join(", ")}
+      </p>
+      <p>
+        <strong>Rate:</strong> {profile.rate}
+      </p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,26 @@
+import { jobs } from "@/lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job matches the identifier <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>
+        <strong>Budget:</strong> {job.budget}
+      </p>
+      <p>
+        <strong>Job ID:</strong> {job.id}
+      </p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
+  },
+  "overrides": {
+    "postcss": ">=8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- Added `postcss >=8.5.10` override to fix GHSA-qx2v-qp2m-jg93
- Job detail page now resolves mock data by ID with fallback
- Freelancer profile now resolves mock data by username with fallback

## Testing
- Unknown job IDs show 'Job Not Found'
- Known job IDs render title and budget
- PostCSS advisory resolved in npm audit