### PR TITLE
fix: keep registered user id consistent

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser uses the same generated id for response id and token subject", async () => {
+  const user = await registerUser({
+    email: "client@example.com",
+    role: "client"
+  });
+
+  const decoded = jwt.decode(user.token);
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.equal(decoded.sub, user.id);
+  assert.equal(decoded.role, "client");
+});


### PR DESCRIPTION
## Summary
- Generate the registered user id once in `registerUser()` and reuse it for the response id and JWT subject.
- Add a focused service test that decodes the issued token and verifies `sub` matches the returned user id.

Closes #5204
/claim #5204

## Verification
- `node --test apps/api/src/tests/authService.test.js` — passed
- `node --test apps/api/src/tests/*.js` — passed
- `git diff --check` — passed
- Added-line security scan — 0 findings
- Independent reviewer — passed (no security concerns or logic errors)

## Note
- `npm test -w apps/api` currently fails on this environment because the existing script runs `node --test src/tests`, which Node 24 treats as a module path instead of expanding test files. The explicit `apps/api/src/tests/*.js` command above verifies both the existing health test and the new auth service test.