### PR TITLE
fix: validate refresh token before minting replacements (#5243)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,13 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  // Fix #5243: Pass token from request body to refreshToken service
+  const { token } = req.body;
+  try {
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch (err) {
+    const status = err.statusCode || 500;
+    return fail(res, err.message, status);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,19 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  // Fix #5243: Validate supplied token before minting replacements
+  if (!token) {
+    const err = new Error("Missing refresh token");
+    err.statusCode = 400;
+    throw err;
+  }
+  try {
+    const decoded = verifyAccessToken(token);
+    return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
+  } catch {
+    const err = new Error("Invalid refresh token");
+    err.statusCode = 401;
+    throw err;
+  }
 }

--- a/apps/api/src/tests/refreshToken.test.js
+++ b/apps/api/src/tests/refreshToken.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { signAccessToken } from "../utils/jwt.js";
+import { refreshToken } from "../services/authService.js";
+
+test("refreshToken: rejects missing token", async () => {
+  await assert.rejects(
+    async () => refreshToken(undefined),
+    (err) => {
+      assert.equal(err.message, "Missing refresh token");
+      assert.equal(err.statusCode, 400);
+      return true;
+    }
+  );
+});
+
+test("refreshToken: rejects null token", async () => {
+  await assert.rejects(
+    async () => refreshToken(null),
+    (err) => {
+      assert.equal(err.message, "Missing refresh token");
+      return true;
+    }
+  );
+});
+
+test("refreshToken: rejects empty string token", async () => {
+  await assert.rejects(
+    async () => refreshToken(""),
+    (err) => {
+      assert.equal(err.message, "Missing refresh token");
+      return true;
+    }
+  );
+});
+
+test("refreshToken: rejects invalid token", async () => {
+  await assert.rejects(
+    async () => refreshToken("invalid-token"),
+    (err) => {
+      assert.equal(err.message, "Invalid refresh token");
+      assert.equal(err.statusCode, 401);
+      return true;
+    }
+  );
+});
+
+test("refreshToken: accepts valid token and returns new token", async () => {
+  const originalToken = signAccessToken({ sub: "usr_123", role: "client" });
+  const result = await refreshToken(originalToken);
+  
+  assert.ok(result.token);
+  // Verify the new token has the same sub and role
+  const { verifyAccessToken } = await import("../utils/jwt.js");
+  const decoded = verifyAccessToken(result.token);
+  assert.equal(decoded.sub, "usr_123");
+  assert.equal(decoded.role, "client");
+});


### PR DESCRIPTION
## Summary

Fixes #5243: The refresh endpoint now validates the supplied token before issuing a replacement access token.

## Problem

POST /api/auth/refresh ignored the request body and called refreshToken() without validating any supplied token. An unauthenticated caller could mint a fresh access token without presenting any credential.

## Fix

- refreshToken(token) now requires a token parameter
- Returns 400 if token is missing/null/empty
- Returns 401 if token is invalid (fails JWT verification)
- On success, issues a new token with the same sub and role from the validated token
- Controller catches errors and returns appropriate status codes

## Test Coverage

- apps/api/src/tests/refreshToken.test.js - 5 tests:
  - Missing token results in 400
  - Null token results in 400
  - Empty string token results in 400
  - Invalid token results in 401
  - Valid token returns new token with same sub and role

## Verification

cd apps/api && node --test src/tests