### PR TITLE
fix: prevent caller override of server-generated IDs in proposal and review creation (#5203)

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,9 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  // Fix #5203: Prevent caller from overriding server-generated id
+  const { id: _ignored, ...safePayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...safePayload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,9 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  // Fix #5203: Prevent caller from overriding server-generated id
+  const { id: _ignored, ...safePayload } = payload;
+  const review = { id: `rev_${Date.now()}`, ...safePayload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/proposalReview.test.js
+++ b/apps/api/src/tests/proposalReview.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("createProposal: server-generated id cannot be overridden by caller", async () => {
+  const result = await createProposal({
+    title: "Test proposal",
+    id: "malicious_id_123",
+    jobId: "job_1"
+  });
+  
+  assert.ok(result.id.startsWith("prp_"));
+  assert.notEqual(result.id, "malicious_id_123");
+  assert.equal(result.title, "Test proposal");
+});
+
+test("createProposal: preserves non-id fields from payload", async () => {
+  const result = await createProposal({
+    title: "My proposal",
+    jobId: "job_456",
+    description: "A test"
+  });
+  
+  assert.equal(result.title, "My proposal");
+  assert.equal(result.jobId, "job_456");
+  assert.equal(result.description, "A test");
+  assert.ok(result.id.startsWith("prp_"));
+});
+
+test("createReview: server-generated id cannot be overridden by caller", async () => {
+  const result = await createReview({
+    rating: 5,
+    comment: "Great work",
+    id: "malicious_rev_id"
+  });
+  
+  assert.ok(result.id.startsWith("rev_"));
+  assert.notEqual(result.id, "malicious_rev_id");
+  assert.equal(result.rating, 5);
+});
+
+test("createReview: preserves non-id fields from payload", async () => {
+  const result = await createReview({
+    rating: 4,
+    comment: "Good",
+    jobId: "job_1"
+  });
+  
+  assert.equal(result.rating, 4);
+  assert.equal(result.comment, "Good");
+  assert.equal(result.jobId, "job_1");
+  assert.ok(result.id.startsWith("rev_"));
+});


### PR DESCRIPTION
## Summary

Fixes #5203: createProposal() and createReview() now prevent callers from overriding server-generated IDs.

## Problem

Both services spread payload after server-generated id, allowing callers to include id in the request body to override the server-generated identity.

## Fix

- Destructure and discard id from payload before spreading
- Server-generated id is always preserved

## Test Coverage

- apps/api/src/tests/proposalReview.test.js - 4 tests:
  - Proposal id cannot be overridden
  - Proposal preserves non-id fields
  - Review id cannot be overridden
  - Review preserves non-id fields

## Verification

cd apps/api && node --test src/tests