### PR TITLE
fix: prevent caller override of server-generated id and status in job creation (#5202)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,9 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  // Fix #5202: Prevent caller from overriding server-generated id and status
+  const { id: _ignored, status: _ignoredStatus, ...safePayload } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safePayload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob: server-generated id cannot be overridden by caller", async () => {
+  const result = await createJob({
+    title: "Test job",
+    id: "malicious_job_id"
+  });
+  
+  assert.ok(result.id.startsWith("job_"));
+  assert.notEqual(result.id, "malicious_job_id");
+});
+
+test("createJob: status always starts as open and cannot be overridden", async () => {
+  const result = await createJob({
+    title: "Test job",
+    status: "completed"
+  });
+  
+  assert.equal(result.status, "open");
+  assert.notEqual(result.status, "completed");
+});
+
+test("createJob: preserves non-id/status fields from payload", async () => {
+  const result = await createJob({
+    title: "Build API",
+    description: "Need a REST API",
+    budgetMin: 500,
+    budgetMax: 1000
+  });
+  
+  assert.equal(result.title, "Build API");
+  assert.equal(result.description, "Need a REST API");
+  assert.equal(result.budgetMin, 500);
+  assert.equal(result.budgetMax, 1000);
+  assert.equal(result.status, "open");
+  assert.ok(result.id.startsWith("job_"));
+});


### PR DESCRIPTION
## Summary

Fixes #5202: createJob() now prevents callers from overriding server-generated id and status.

## Problem

createJob() spread payload after server-generated id and status, allowing callers to set status: "completed" on creation or inject a custom id.

## Fix

- Destructure and discard id and status from payload before spreading
- Server-generated id and status: "open" are always preserved

## Test Coverage

- apps/api/src/tests/jobService.test.js - 3 tests:
  - Job id cannot be overridden
  - Status always starts as "open"
  - Non-id/status fields preserved

## Verification

cd apps/api && node --test src/tests