### PR TITLE
fix: prevent caller override of server-generated id in user creation (#5201)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,9 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Fix #5201: Prevent caller from overriding server-generated id
+  const { id: _ignored, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser: server-generated id cannot be overridden by caller", async () => {
+  const result = await createUser({
+    email: "test@example.com",
+    id: "malicious_user_id"
+  });
+  
+  assert.ok(result.id.startsWith("usr_"));
+  assert.notEqual(result.id, "malicious_user_id");
+});
+
+test("createUser: preserves non-id fields from payload", async () => {
+  const result = await createUser({
+    email: "owl@test.com",
+    name: "Owl Test",
+    role: "client"
+  });
+  
+  assert.equal(result.email, "owl@test.com");
+  assert.equal(result.name, "Owl Test");
+  assert.equal(result.role, "client");
+  assert.ok(result.id.startsWith("usr_"));
+});
+
+test("createUser: generates unique IDs for each call", async () => {
+  const user1 = await createUser({ email: "a@test.com" });
+  const user2 = await createUser({ email: "b@test.com" });
+  
+  assert.notEqual(user1.id, user2.id);
+});


### PR DESCRIPTION
## Summary

Fixes #5201: createUser() now prevents callers from overriding the server-generated user ID.

## Problem

createUser() spread payload after server-generated id, allowing callers to include id in the request body to override the server-generated identity.

## Fix

- Destructure and discard id from payload before spreading
- Server-generated id is always preserved

## Test Coverage

- apps/api/src/tests/userService.test.js - 3 tests:
  - User id cannot be overridden
  - Non-id fields preserved
  - Unique IDs generated for each call

## Verification

cd apps/api && node --test src/tests