### PR TITLE
Return JSON 405 for unsupported API methods

### DIFF
--- a/apps/api/src/middleware/methodNotAllowed.js
+++ b/apps/api/src/middleware/methodNotAllowed.js
@@ -1,0 +1,10 @@
+import { fail } from "../utils/response.js";
+
+export function methodNotAllowed(allowedMethods) {
+  const allowHeader = allowedMethods.join(", ");
+
+  return (req, res) => {
+    res.set("Allow", allowHeader);
+    return fail(res, "Method not allowed", 405);
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,11 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.route("/metrics")
+  .get(metrics)
+  .all(methodNotAllowed(["GET"]));

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,21 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.route("/register")
+  .post(register)
+  .all(methodNotAllowed(["POST"]));
+
+authRoutes.route("/login")
+  .post(login)
+  .all(methodNotAllowed(["POST"]));
+
+authRoutes.route("/oauth/:provider/callback")
+  .get(oauthCallback)
+  .all(methodNotAllowed(["GET"]));
+
+authRoutes.route("/refresh")
+  .post(refresh)
+  .all(methodNotAllowed(["POST"]));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.route("/")
+  .get(getJobs)
+  .post(postJob)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.route("/")
+  .get(getMessages)
+  .post(postMessage)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.route("/")
+  .get(getNotifications)
+  .post(postNotification)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.route("/")
+  .post(createPayment)
+  .all(methodNotAllowed(["POST"]));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.route("/")
+  .get(getProposals)
+  .post(postProposal)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.route("/")
+  .get(getReviews)
+  .post(postReview)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.route("/")
+  .get(search)
+  .all(methodNotAllowed(["GET"]));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.route("/")
+  .post(upload.single("file"), uploadFile)
+  .all(methodNotAllowed(["POST"]));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.route("/")
+  .get(getUsers)
+  .post(postUser)
+  .all(methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/tests/methodNotAllowed.test.js
+++ b/apps/api/src/tests/methodNotAllowed.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("known API collection routes return JSON 405 for unsupported methods", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, { method: "PUT" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET, POST");
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Method not allowed"
+    });
+  });
+});
+
+test("supported methods on known API routes keep their current behavior", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { success: true, data: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable methodNotAllowed middleware that returns the existing JSON error shape with HTTP 405
- attach explicit method handling to known API collection routes and auth/admin endpoints
- add coverage proving unsupported methods on known API paths return JSON 405 while supported methods still work

## Bounty
/claim #743
Closes #5270

## Validation
- node --test apps/api/src/tests/*.js
- node --check apps/api/src/middleware/methodNotAllowed.js && for f in apps/api/src/routes/*.js apps/api/src/tests/methodNotAllowed.test.js; do node --check "$f" || exit 1; done
- git diff --check