### PR TITLE
Add current page state to primary navigation

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,4 +3,5 @@ body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; co
 a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+.nav-link[aria-current="page"] { background: #20304f; border-color: #9bb7ff; color: #ffffff; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 const links = [
   ["/", "Home"],
@@ -11,13 +14,25 @@ const links = [
 ];
 
 export function Navigation() {
+  const pathname = usePathname();
+
   return (
-    <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
-      {links.map(([href, label]) => (
-        <Link key={href} href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
-          {label}
-        </Link>
-      ))}
+    <nav aria-label="Primary navigation" style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
+      {links.map(([href, label]) => {
+        const isCurrent = href === "/" ? pathname === href : pathname === href || pathname.startsWith(`${href}/`);
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={isCurrent ? "page" : undefined}
+            className="card nav-link"
+            style={{ padding: "0.5rem 0.8rem" }}
+          >
+            {label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary

- mark the active primary navigation link with `aria-current="page"`
- add a named primary navigation landmark
- add a visible active state tied to the `aria-current` attribute

Closes #5278
/claim #743

## Validation

- `git diff --check`
- `env PATH=/private/tmp/npm-shim:/usr/bin:/bin:/usr/sbin:/sbin ../../node_modules/.bin/tsc --noEmit --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --esModuleInterop --skipLibCheck components/Navigation.tsx`
- `next build --webpack` compiled successfully, then stopped at the existing unrelated Next 16 dynamic-route `params` typing issue in `app/freelancers/[username]/page.tsx`, which is already covered by #2005/#4460 and PRs #2006/#4461.
