### PR TITLE
Add skip link to page content

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2,5 +2,24 @@
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  transform: translateY(-150%);
+  background: #f2f5ff;
+  color: #0b1020;
+  border: 2px solid #8bb4ff;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  z-index: 1000;
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+#main-content:focus {
+  outline: 2px solid #8bb4ff;
+  outline-offset: 6px;
+}
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,10 +10,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <a className="skip-link" href="#main-content">Skip to main content</a>
         <main>
           <h1>FreelanceFlow</h1>
           <Navigation />
-          {children}
+          <div id="main-content" tabIndex={-1}>
+            {children}
+          </div>
         </main>
       </body>
     </html>


### PR DESCRIPTION
## Summary

- add a visible-on-focus skip link before the repeated layout content
- target a focusable page-content wrapper after the shared navigation
- add focus styling for the page-content target

Closes #5283
/claim #743

## Validation

- `git diff --check`
- Runtime tests were not run because this clone does not have `node_modules` installed and this environment has Node but no `npm`/`pnpm`/`yarn` available.
