### PR TITLE
Add original FreelanceFlow poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Ledger of the Clear Handoff
+
+A profile lights the first small pane,
+a name, a skill, a careful scope;
+the client brings a rough-shaped need,
+the builder answers it with hope.
+
+A proposal lands like tested code,
+plain enough for both to read:
+what will be made, what will be paid,
+and which small proofs define complete.
+
+Escrow keeps the promise still,
+not as a wall, but as a bridge;
+trust is measured, step by step,
+from milestone note to merged commit.
+
+The review arrives with human weight:
+not stars alone, but what was learned,
+where the handoff held its shape,
+and where the next clean patch should turn.
+
+Then payout leaves the final log,
+a quiet receipt, a closed request;
+FreelanceFlow keeps the path in view:
+fair work delivered, fairly blessed.


### PR DESCRIPTION
/claim #76

## Summary
- Adds an original five-stanza poem as `POEM.md` in the project root.
- Keeps the PR focused on the requested content-only bounty.

## Creative decision
I used a ledger-and-handoff theme because FreelanceFlow is about turning proposals, escrow, reviews, and payouts into visible trust between clients and freelancers.

Closes #76