### PR TITLE
[Anicca] fix: require fullName in registration (Closes #2770)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,13 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues, 422);
+  }
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -4,6 +4,7 @@ export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return { server, port };
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/auth/register rejects missing fullName", async () => {
+  const { server, port } = await startServer();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "user@example.com",
+      password: "password123"
+    })
+  });
+
+  assert.equal(response.status, 422, "Should reject with 422 when fullName is absent");
+
+  await stopServer(server);
+});
+
+test("POST /api/auth/register rejects empty fullName", async () => {
+  const { server, port } = await startServer();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fullName: "",
+      email: "user@example.com",
+      password: "password123"
+    })
+  });
+
+  assert.equal(response.status, 422, "Should reject with 422 when fullName is empty");
+
+  await stopServer(server);
+});
+
+test("POST /api/auth/register includes fullName in response", async () => {
+  const { server, port } = await startServer();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fullName: "Alice Smith",
+      email: "alice@example.com",
+      password: "password123"
+    })
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.fullName, "Alice Smith");
+
+  await stopServer(server);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Problem

Issue #2770: The Prisma `User` model requires `fullName`, but the registration schema only accepted `email`, `password`, and `role`. `registerUser()` also omitted `fullName` from the returned user payload.

## Changes

**`apps/api/src/validators/auth.js`**
- Added `fullName: z.string().min(1)` to `registerSchema`

**`apps/api/src/services/authService.js`**
- Included `fullName: payload.fullName` in the returned user object

**`apps/api/src/controllers/authController.js`**
- Switched from `parse()` to `safeParse()` so validation failures return HTTP 422 instead of an unhandled error

**`apps/api/src/tests/auth.test.js`** (new)
- Test: rejects missing `fullName` → 422
- Test: rejects empty `fullName` → 422
- Test: accepts valid payload → 201 with `fullName` in response data

## Test Results

```
✔ POST /api/auth/register rejects missing fullName (34ms)
✔ POST /api/auth/register rejects empty fullName (3ms)
✔ POST /api/auth/register includes fullName in response (3ms)
tests 3, pass 3, fail 0
```

Closes #2770