### PR TITLE
Track updates for mutable Prisma records

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test tests/*.test.js"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Payment {
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }
 
 model Review {
@@ -101,6 +102,7 @@ model Message {
   receiver      User        @relation("ReceivedMessages", fields: [receiverId], references: [id])
   isRead        Boolean     @default(false)
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }
 
 model Category {
@@ -124,4 +126,5 @@ model Notification {
   body          String
   read          Boolean     @default(false)
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }

--- a/packages/db/tests/schema-audit.test.js
+++ b/packages/db/tests/schema-audit.test.js
@@ -1,0 +1,18 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const schema = readFileSync(path.join(__dirname, "../prisma/schema.prisma"), "utf8");
+
+function modelBlock(modelName) {
+  const match = schema.match(new RegExp(`model ${modelName} \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `${modelName} model should exist in Prisma schema`);
+  return match[1];
+}
+
+for (const modelName of ["Payment", "Message", "Notification"]) {
+  test(`${modelName} tracks state changes with updatedAt`, () => {
+    assert.match(modelBlock(modelName), /updatedAt\s+DateTime\s+@updatedAt/);
+  });
+}


### PR DESCRIPTION
## Summary
- Add Prisma `updatedAt @updatedAt` audit timestamps to Payment, Message, and Notification records.
- Add a DB package schema audit test that guards those mutable models.
- Add a package-local `npm run test -w packages/db` script for the DB schema check.

## Validation
- `npm run test -w packages/db`
- `env DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow npx prisma@5.17.0 validate --schema packages/db/prisma/schema.prisma`
- `git diff --check`

Closes #5294

/claim #743