### PR TITLE
Persist job skill requirements in Prisma schema

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test tests/*.test.js"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Job {
   client        User        @relation("ClientJobs", fields: [clientId], references: [id])
   categoryId    String
   category      Category    @relation(fields: [categoryId], references: [id])
+  skills        Skill[]
   proposals     Proposal[]
   payments      Payment[]
   createdAt     DateTime    @default(now())
@@ -114,6 +115,7 @@ model Skill {
   id            String      @id @default(cuid())
   name          String      @unique
   users         User[]
+  jobs          Job[]
 }
 
 model Notification {

--- a/packages/db/tests/schema-audit.test.js
+++ b/packages/db/tests/schema-audit.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = readFileSync(join(__dirname, "../prisma/schema.prisma"), "utf8");
+
+function modelBlock(modelName) {
+  const match = schema.match(new RegExp(`model ${modelName} \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `Expected ${modelName} model to exist`);
+  return match[1];
+}
+
+test("Job and Skill models keep a bidirectional skills relation", () => {
+  assert.match(modelBlock("Job"), /\n\s+skills\s+Skill\[\]/);
+  assert.match(modelBlock("Skill"), /\n\s+jobs\s+Job\[\]/);
+});


### PR DESCRIPTION
## Summary
- add a bidirectional Job.skills / Skill.jobs Prisma relation so accepted job skill requirements have a persisted representation
- add a db schema audit test for the job-skill relation
- enable the packages/db node:test script with ESM support

## Validation
- npm run test -w packages/db
- DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow npx prisma@5.17.0 validate --schema packages/db/prisma/schema.prisma
- git diff --check

Closes #5296
/claim #743