### PR TITLE
Load API env from local dotenv file

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,3 +1,19 @@
+function loadLocalEnvFile() {
+  if (typeof process.loadEnvFile !== "function") {
+    return;
+  }
+
+  try {
+    process.loadEnvFile();
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+loadLocalEnvFile();
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url).href;
+const keys = ["PORT", "JWT_SECRET", "STRIPE_SECRET_KEY", "DATABASE_URL"];
+
+async function importFreshEnv() {
+  return import(`${envModuleUrl}?t=${Date.now()}-${Math.random()}`);
+}
+
+function snapshotEnv() {
+  return Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const key of keys) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+}
+
+test("loads API configuration from local .env when process env is unset", async () => {
+  const cwd = process.cwd();
+  const envSnapshot = snapshotEnv();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-env-"));
+
+  try {
+    restoreEnv({});
+    fs.writeFileSync(
+      path.join(tmpDir, ".env"),
+      [
+        "PORT=4555",
+        "JWT_SECRET=file-secret",
+        "STRIPE_SECRET_KEY=sk_test_file",
+        "DATABASE_URL=postgres://file-db"
+      ].join("\n")
+    );
+
+    process.chdir(tmpDir);
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.port, 4555);
+    assert.equal(env.jwtSecret, "file-secret");
+    assert.equal(env.stripeSecretKey, "sk_test_file");
+    assert.equal(env.databaseUrl, "postgres://file-db");
+  } finally {
+    process.chdir(cwd);
+    restoreEnv(envSnapshot);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("keeps process environment values ahead of local .env values", async () => {
+  const cwd = process.cwd();
+  const envSnapshot = snapshotEnv();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-env-"));
+
+  try {
+    restoreEnv({});
+    process.env.JWT_SECRET = "process-secret";
+    fs.writeFileSync(path.join(tmpDir, ".env"), "JWT_SECRET=file-secret\n");
+
+    process.chdir(tmpDir);
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.jwtSecret, "process-secret");
+  } finally {
+    process.chdir(cwd);
+    restoreEnv(envSnapshot);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Refs #743

/claim #743

## Summary
- Load a local `.env` file during API config initialization using Node built-in `process.loadEnvFile()` when available.
- Keep already-exported process environment values authoritative over `.env` values.
- Add focused regression coverage for `.env` loading and process env precedence.

## Validation
- `node --test apps/api/src/tests/env.test.js apps/api/src/tests/health.test.js`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/env.test.js`
- `git diff --check`

## Note
`npm test -w apps/api` still fails on the existing upstream script path (`node --test src/tests` looks for a literal `src/tests` module). I kept this PR scoped to the local API env loading issue and validated the concrete test files directly.

No payout address, token, cookie, seed phrase, or API key is included.