### PR TITLE
Add receipt window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# Receipt Window
+
+A brief arrives with measured lines,
+the budget clear, the deadline bright;
+FreelanceFlow keeps the promise framed
+before the first commit takes light.
+
+The proposal answers point by point,
+with scope made plain and risks in view;
+no hidden work, no drifting guess,
+just names for what the hands will do.
+
+The proof is pushed in tested steps,
+each check a small receipt of care;
+reviewers read the trail it leaves
+and find the moving parts still there.
+
+When merge turns green, the ledger wakes,
+milestones settle into pay;
+accepted work becomes a record
+that both sides trust the following day.
+
+So build the market out of proof:
+clear asks, clean code, a fair reply;
+where every payout has a path,
+and every promise shows its why.


### PR DESCRIPTION
Refs #76

/claim #76

## Summary
- Add an original root-level `POEM.md` written specifically for FreelanceFlow.
- The poem has five stanzas and follows the requested root-file placement.

## Creative note
I used a receipt-window structure so scope, proof, review, merge, and payout read like accountable marketplace checkpoints.

## Validation
- `python3 - <<'PY' ...` stanza check returned `stanzas_including_title=6` and `poem_stanzas=5`.
- `git diff --check` passed.

No payout address, token, cookie, seed phrase, or API key is included.