### PR TITLE
fix(ui): point package entrypoint to compiled dist instead of TS source

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  }
 }


### PR DESCRIPTION
## Fix: @freelanceflow/ui package entrypoint should be directly importable

Closes #2781

### Problem
The `@freelanceflow/ui` package declared `"main": "src/index.ts"` in package.json, pointing to TypeScript source instead of compiled JavaScript. This caused `import('@freelanceflow/ui')` to fail for any Node/ESM consumer because:
1. TypeScript files are not valid runtime JavaScript modules
2. No build/transpilation step runs at import time

### Solution
Updated `packages/ui/package.json` to expose the pre-compiled JavaScript entrypoint:

| Field | Before | After |
|-------|--------|-------|
| `main` | `src/index.ts` | `dist/index.js` |
| `types` | *(missing)* | `dist/index.d.ts` |
| `exports` | *(missing)* | `{ ".": { "types", "import", "require" } }` |

### Acceptance Criteria (from issue)

| Criterion | Status |
|-----------|--------|
| Package is directly importable via `import()` (ESM) | ✅ Verified — `Button` and `Card` exported |
| Package is directly importable via `require()` (CJS) | ✅ Verified — `Button` and `Card` exported |
| TypeScript declarations preserved for TS consumers | ✅ `types` field points to `dist/index.d.ts` |
| No source `.ts` files exposed as entrypoint | ✅ `main` now points to `dist/index.js` |
| Existing compiled dist files used (no rebuild needed) | ✅ All 6 dist files confirmed present |

### Verification
```
$ node -e "const ui = require('@freelanceflow/ui'); console.log(Object.keys(ui));"
[ 'Button', 'Card' ]

$ node --input-type=module -e "import('@freelanceflow/ui').then(ui => console.log(Object.keys(ui)));"
[ 'Button', 'Card' ]
```
