### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,24 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid user payload",
+      errors: parsed.error.issues.map(({ path, message }) => ({
+        field: path.join("."),
+        message
+      }))
+    });
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects malformed user payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ arbitrary: "value" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid user payload");
+    assert.ok(payload.errors.some((error) => error.field === "email"));
+    assert.ok(payload.errors.some((error) => error.field === "fullName"));
+  });
+});
+
+test("POST /api/users creates users from validated fields only", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "maya@example.com",
+        fullName: "Maya Dev",
+        role: "freelancer",
+        arbitrary: "value"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "maya@example.com");
+    assert.equal(payload.data.fullName, "Maya Dev");
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(payload.data.arbitrary, undefined);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer", "admin"]).default("client"),
+  bio: z.string().trim().max(1000).optional()
+});


### PR DESCRIPTION
/claim #743
Closes #5312

## Summary
- add a focused Zod schema for user creation payloads
- validate POST /api/users before calling createUser()
- return HTTP 400 for malformed user payloads and strip unknown request fields before persistence
- add API regression tests for invalid payload rejection and validated-field creation

## Validation
- Local syntax checks passed with bundled Node:
  - node --check apps/api/src/controllers/userController.js
  - node --check apps/api/src/validators/user.js
  - node --check apps/api/src/tests/users.test.js
- Structural check confirmed createUser(req.body) is no longer present and createUserSchema.safeParse(req.body) is used.
- Full npm test suite was not run in this workspace because npm is unavailable in the current runtime.