### PR TITLE
fix(api): use collision-resistant service ids

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,15 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createResourceId } from "../utils/id.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = createResourceId("usr");
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: createResourceId("job"), status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: createResourceId("msg"), sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: createResourceId("ntf"), read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createResourceId } from "../utils/id.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createResourceId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: createResourceId("prp") };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: createResourceId("rev") };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createResourceId } from "../utils/id.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: createResourceId("usr") };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serviceIds.test.js
+++ b/apps/api/src/tests/serviceIds.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+function assertUniquePrefixedIds(first, second, prefix) {
+  assert.match(first, new RegExp(`^${prefix}_[0-9a-f-]{36}$`));
+  assert.match(second, new RegExp(`^${prefix}_[0-9a-f-]{36}$`));
+  assert.notEqual(first, second);
+}
+
+test("service-generated ids stay unique when resources are created back-to-back", async () => {
+  const [firstUser, secondUser] = await Promise.all([
+    createUser({ email: "first@example.com", fullName: "First" }),
+    createUser({ email: "second@example.com", fullName: "Second" })
+  ]);
+  const [firstPayment, secondPayment] = await Promise.all([
+    createPaymentIntent({ amount: 10 }),
+    createPaymentIntent({ amount: 20 })
+  ]);
+
+  assertUniquePrefixedIds(firstUser.id, secondUser.id, "usr");
+  assertUniquePrefixedIds(firstPayment.paymentId, secondPayment.paymentId, "pay");
+});
+
+test("create paths keep lifecycle fields server-owned", async () => {
+  const job = await createJob({ id: "job_caller", status: "closed", title: "Build API" });
+  const message = await sendMessage({ id: "msg_caller", sentAt: "2000-01-01T00:00:00.000Z", body: "hello" });
+  const notification = await createNotification({ id: "ntf_caller", read: true, message: "hello" });
+  const proposal = await createProposal({ id: "prp_caller", coverLetter: "hello" });
+  const review = await createReview({ id: "rev_caller", rating: 5 });
+  const user = await createUser({ id: "usr_caller", email: "maya@example.com", fullName: "Maya" });
+  const payment = await createPaymentIntent({ paymentId: "pay_caller", amount: 30, provider: "caller" });
+
+  assert.match(job.id, /^job_[0-9a-f-]{36}$/);
+  assert.equal(job.status, "open");
+  assert.match(message.id, /^msg_[0-9a-f-]{36}$/);
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.match(notification.id, /^ntf_[0-9a-f-]{36}$/);
+  assert.equal(notification.read, false);
+  assert.match(proposal.id, /^prp_[0-9a-f-]{36}$/);
+  assert.match(review.id, /^rev_[0-9a-f-]{36}$/);
+  assert.match(user.id, /^usr_[0-9a-f-]{36}$/);
+  assert.match(payment.paymentId, /^pay_[0-9a-f-]{36}$/);
+  assert.equal(payment.provider, "stripe");
+});
+
+test("registration returns one generated user id and signs the same subject", async () => {
+  const user = await registerUser({
+    email: "registered@example.com",
+    role: "client"
+  });
+  const decoded = jwt.decode(user.token);
+
+  assert.match(user.id, /^usr_[0-9a-f-]{36}$/);
+  assert.equal(decoded.sub, user.id);
+  assert.equal(decoded.role, "client");
+});

--- a/apps/api/src/utils/id.js
+++ b/apps/api/src/utils/id.js
@@ -1,0 +1,5 @@
+import { randomUUID } from "node:crypto";
+
+export function createResourceId(prefix) {
+  return `${prefix}_${randomUUID()}`;
+}


### PR DESCRIPTION
/claim #743
Closes #5314

## Summary
- add a shared prefixed UUID helper for API resource ids
- replace Date.now()-based ids in API creation services
- keep service-owned lifecycle fields after payload fields so callers cannot override them
- reuse the generated registration id as the JWT subject
- add focused service regression tests for uniqueness and server-owned field override attempts

## Validation
- Local syntax checks passed with bundled Node for all changed service files, apps/api/src/utils/id.js, and apps/api/src/tests/serviceIds.test.js.
- Structural check confirmed Date.now() no longer appears in the API service files and createResourceId() is used for generated ids.
- Full npm test suite was not run in this workspace because npm is unavailable in the current runtime.