### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,17 +2,21 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
+function asyncHandler(fn) {
+  return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+}
+
+export const register = asyncHandler(async (req, res) => {
   const payload = registerSchema.parse(req.body);
   const result = await registerUser(payload);
   return ok(res, result, 201);
-}
+});
 
-export async function login(req, res) {
+export const login = asyncHandler(async (req, res) => {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
   return ok(res, result);
-}
+});
 
 export async function oauthCallback(req, res) {
   return ok(res, {
@@ -21,7 +25,7 @@ export async function oauthCallback(req, res) {
   });
 }
 
-export async function refresh(req, res) {
+export const refresh = asyncHandler(async (req, res) => {
   const result = await refreshToken();
   return ok(res, result);
-}
+});

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors,
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+
+const JWT_SECRET = process.env.JWT_SECRET || "development-secret";
+
+test("POST /api/auth/register rejects admin role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve) => server.once("listening", resolve));
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "admin@example.com",
+      password: "securepass123",
+      role: "admin",
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  const payload = await response.json();
+  assert.equal(payload.success, false, "Should return success: false for admin role");
+  assert.ok(payload.message, "Should return an error message");
+
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/auth/register accepts client role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve) => server.once("listening", resolve));
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "client@example.com",
+      password: "securepass123",
+      role: "client",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.data.role, "client");
+
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/auth/register accepts freelancer role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve) => server.once("listening", resolve));
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "freelancer@example.com",
+      password: "securepass123",
+      role: "freelancer",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.data.role, "freelancer");
+
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("POST /api/auth/register token subject matches returned user id", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve) => server.once("listening", resolve));
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "test@example.com",
+      password: "securepass123",
+      role: "client",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  const userId = payload.data.id;
+  const token = payload.data.token;
+
+  // Decode the JWT and verify the subject matches the returned id
+  const decoded = jwt.verify(token, JWT_SECRET);
+  assert.equal(decoded.sub, userId, "Token subject must match returned user id");
+
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes admin role self-assignment vulnerability in public registration and token subject mismatch.

## Changes

1. **Validator (auth.js):** Removed  from allowed registration roles. Only  and  are now accepted.

2. **Auth service (authService.js):** Generate user ID once and reuse for both the response uid=0(root) gid=0(root) groups=0(root) and JWT  claim. Previously, two separate  calls could produce different values.

3. **Error handler (errorHandler.js):** Added Zod error handling to return proper 400 responses with validation details instead of generic 500 errors.

4. **Auth controller (authController.js):** Added async error wrapper to ensure thrown errors (including Zod validation errors) propagate to the error handler.

5. **Tests (auth.test.js):** Added 4 tests:
   - Registration rejects admin role (returns 400)
   - Registration accepts client role
   - Registration accepts freelancer role
   - Token subject matches returned user ID

## Test Results

All 5 tests pass (4 new + 1 existing health check).

Closes #5316