### PR TITLE
Implement full admin operations panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,100 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  getAdminMetrics,
+  listAdminUsers,
+  listAuditLog,
+  listDisputes,
+  listFlaggedJobs,
+  moderateJob,
+  ruleDispute,
+  updatePlatformControl,
+  updateUserStatus
+} from "../services/adminService.js";
 
-export async function metrics(req, res) {
+function adminId(req) {
+  return req.user?.sub ?? req.user?.id ?? "admin";
+}
+
+function handleAdminError(res, error) {
+  const message = error instanceof Error ? error.message : "Admin action failed";
+  const status = message.includes("not found") ? 404 : 400;
+  return fail(res, message, status);
+}
+
+export async function metrics(_req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function setUserStatus(req, res) {
+  try {
+    return ok(
+      res,
+      await updateUserStatus(adminId(req), req.params.userId, req.body?.status)
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function moderationQueue(req, res) {
+  return ok(res, await listFlaggedJobs(req.query));
+}
+
+export async function moderateListing(req, res) {
+  try {
+    return ok(
+      res,
+      await moderateJob(
+        adminId(req),
+        req.params.jobId,
+        req.body?.action,
+        req.body?.reason
+      )
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function disputeQueue(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function resolveDispute(req, res) {
+  try {
+    return ok(
+      res,
+      await ruleDispute(
+        adminId(req),
+        req.params.disputeId,
+        req.body?.ruling,
+        req.body?.note
+      )
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function platformControl(req, res) {
+  try {
+    return ok(
+      res,
+      await updatePlatformControl(
+        adminId(req),
+        req.params.key,
+        req.body?.enabled
+      )
+    );
+  } catch (error) {
+    return handleAdminError(res, error);
+  }
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await listAuditLog(req.query));
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,26 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import {
+  auditLog,
+  disputeQueue,
+  metrics,
+  moderateListing,
+  moderationQueue,
+  platformControl,
+  resolveDispute,
+  setUserStatus,
+  users
+} from "../controllers/adminController.js";
+import { adminMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminMiddleware);
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.patch("/users/:userId/status", setUserStatus);
+adminRoutes.get("/moderation/jobs", moderationQueue);
+adminRoutes.post("/moderation/jobs/:jobId", moderateListing);
+adminRoutes.get("/disputes", disputeQueue);
+adminRoutes.post("/disputes/:disputeId/ruling", resolveDispute);
+adminRoutes.patch("/controls/:key", platformControl);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,266 @@
-export async function getAdminMetrics() {
+const users = [
+  {
+    id: "usr_001",
+    name: "Avery Client",
+    email: "avery@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-05-01",
+    trustScore: 92,
+    activeJobs: ["job_001", "job_003"],
+    disputeHistory: ["dsp_001"]
+  },
+  {
+    id: "usr_002",
+    name: "Morgan Freelancer",
+    email: "morgan@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-05-04",
+    trustScore: 84,
+    activeJobs: ["job_002"],
+    disputeHistory: []
+  },
+  {
+    id: "usr_003",
+    name: "Casey Review",
+    email: "casey@example.com",
+    role: "freelancer",
+    status: "suspended",
+    joinedAt: "2026-05-12",
+    trustScore: 46,
+    activeJobs: [],
+    disputeHistory: ["dsp_001", "dsp_002"]
+  }
+];
+
+const flaggedJobs = [
+  {
+    id: "job_001",
+    title: "Build checkout flow",
+    clientId: "usr_001",
+    status: "flagged",
+    reason: "Payment terms mention off-platform settlement",
+    severity: "high",
+    reportedAt: "2026-06-05T11:30:00.000Z"
+  },
+  {
+    id: "job_004",
+    title: "Scrape competitor leads",
+    clientId: "usr_001",
+    status: "escalated",
+    reason: "Potential policy violation",
+    severity: "medium",
+    reportedAt: "2026-06-06T09:20:00.000Z"
+  }
+];
+
+const disputes = [
+  {
+    id: "dsp_001",
+    jobId: "job_001",
+    clientId: "usr_001",
+    freelancerId: "usr_003",
+    status: "open",
+    amount: 850,
+    thread: [
+      "Client says milestone was incomplete.",
+      "Freelancer uploaded deployment evidence.",
+      "Escrow hold is active pending admin ruling."
+    ],
+    evidence: ["deployment-log.txt", "milestone-brief.pdf"]
+  },
+  {
+    id: "dsp_002",
+    jobId: "job_002",
+    clientId: "usr_001",
+    freelancerId: "usr_002",
+    status: "under_review",
+    amount: 320,
+    thread: ["Scope expansion disputed after final handoff."],
+    evidence: ["handoff-screenshot.png"]
+  }
+];
+
+const platformControls = {
+  registrationsEnabled: true,
+  jobPostingEnabled: true
+};
+
+const auditLog = [
+  {
+    id: "aud_001",
+    adminId: "system",
+    action: "admin_panel_seeded",
+    targetType: "platform",
+    targetId: "platform",
+    details: "Initial admin queue snapshot loaded",
+    createdAt: "2026-06-01T00:00:00.000Z"
+  }
+];
+
+function paginate(items, page = 1, pageSize = 20) {
+  const currentPage = Math.max(1, Number(page) || 1);
+  const size = Math.min(100, Math.max(1, Number(pageSize) || 20));
+  const start = (currentPage - 1) * size;
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    items: items.slice(start, start + size),
+    page: currentPage,
+    pageSize: size,
+    total: items.length
   };
+}
+
+function writeAudit(adminId, action, targetType, targetId, details) {
+  const entry = {
+    id: `aud_${String(auditLog.length + 1).padStart(3, "0")}`,
+    adminId,
+    action,
+    targetType,
+    targetId,
+    details,
+    createdAt: new Date().toISOString()
+  };
+  auditLog.unshift(entry);
+  return entry;
+}
+
+function requireKnownUser(userId) {
+  const user = users.find((item) => item.id === userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user;
+}
+
+function requireKnownJob(jobId) {
+  const job = flaggedJobs.find((item) => item.id === jobId);
+  if (!job) {
+    throw new Error("Flagged job not found");
+  }
+  return job;
+}
+
+function requireKnownDispute(disputeId) {
+  const dispute = disputes.find((item) => item.id === disputeId);
+  if (!dispute) {
+    throw new Error("Dispute not found");
+  }
+  return dispute;
+}
+
+export async function getAdminMetrics() {
+  const activeJobs = users.reduce((count, user) => count + user.activeJobs.length, 0);
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = flaggedJobs.filter((job) => job.status !== "approved").length;
+  const trustBands = users.reduce(
+    (bands, user) => {
+      if (user.trustScore >= 80) bands.high += 1;
+      else if (user.trustScore >= 60) bands.medium += 1;
+      else bands.low += 1;
+      return bands;
+    },
+    { high: 0, medium: 0, low: 0 }
+  );
+
+  return {
+    totalUsers: users.length,
+    activeJobs,
+    openDisputes,
+    flaggedListings,
+    revenueCurrentPeriod: 128900,
+    trustScoreDistribution: trustBands,
+    controls: platformControls
+  };
+}
+
+export async function listAdminUsers(filters = {}) {
+  const { role, status, search, joinedAfter, joinedBefore, page, pageSize } = filters;
+  let result = [...users];
+  if (role) result = result.filter((user) => user.role === role);
+  if (status) result = result.filter((user) => user.status === status);
+  if (joinedAfter) result = result.filter((user) => user.joinedAt >= joinedAfter);
+  if (joinedBefore) result = result.filter((user) => user.joinedAt <= joinedBefore);
+  if (search) {
+    const needle = search.toLowerCase();
+    result = result.filter(
+      (user) =>
+        user.name.toLowerCase().includes(needle) ||
+        user.email.toLowerCase().includes(needle)
+    );
+  }
+  return paginate(result, page, pageSize);
+}
+
+export async function updateUserStatus(adminId, userId, status) {
+  if (!["active", "suspended", "banned"].includes(status)) {
+    throw new Error("Invalid user status");
+  }
+  const user = requireKnownUser(userId);
+  user.status = status;
+  const audit = writeAudit(adminId, `user_${status}`, "user", userId, `User status set to ${status}`);
+  return { user, audit };
+}
+
+export async function listFlaggedJobs(filters = {}) {
+  const { status, severity, page, pageSize } = filters;
+  let result = [...flaggedJobs];
+  if (status) result = result.filter((job) => job.status === status);
+  if (severity) result = result.filter((job) => job.severity === severity);
+  return paginate(result, page, pageSize);
+}
+
+export async function moderateJob(adminId, jobId, action, reason = "") {
+  if (!["approve", "reject", "escalate"].includes(action)) {
+    throw new Error("Invalid moderation action");
+  }
+  const job = requireKnownJob(jobId);
+  job.status = action === "approve" ? "approved" : action === "reject" ? "rejected" : "escalated";
+  job.notification = action === "reject" ? `Listing rejected: ${reason || "Policy review"}` : null;
+  const audit = writeAudit(adminId, `listing_${action}`, "job", jobId, reason || "No reason provided");
+  return { job, audit };
+}
+
+export async function listDisputes(filters = {}) {
+  const { status, page, pageSize } = filters;
+  let result = [...disputes];
+  if (status) result = result.filter((dispute) => dispute.status === status);
+  return paginate(result, page, pageSize);
+}
+
+export async function ruleDispute(adminId, disputeId, ruling, note = "") {
+  if (!["client", "freelancer", "escalate"].includes(ruling)) {
+    throw new Error("Invalid dispute ruling");
+  }
+  const dispute = requireKnownDispute(disputeId);
+  dispute.status = ruling === "escalate" ? "under_review" : "resolved";
+  dispute.ruling = ruling;
+  dispute.notification = `Dispute ${dispute.id} updated: ${ruling}`;
+  const audit = writeAudit(adminId, "dispute_ruling", "dispute", disputeId, note || ruling);
+  return { dispute, audit };
+}
+
+export async function updatePlatformControl(adminId, key, enabled) {
+  if (!["registrationsEnabled", "jobPostingEnabled"].includes(key)) {
+    throw new Error("Invalid platform control");
+  }
+  platformControls[key] = Boolean(enabled);
+  const audit = writeAudit(
+    adminId,
+    "platform_control_updated",
+    "platform",
+    key,
+    `${key} set to ${platformControls[key]}`
+  );
+  return { controls: platformControls, audit };
+}
+
+export async function listAuditLog(filters = {}) {
+  const { adminId, action, from, to, page, pageSize } = filters;
+  let result = [...auditLog];
+  if (adminId) result = result.filter((entry) => entry.adminId === adminId);
+  if (action) result = result.filter((entry) => entry.action === action);
+  if (from) result = result.filter((entry) => entry.createdAt >= from);
+  if (to) result = result.filter((entry) => entry.createdAt <= to);
+  return paginate(result, page, pageSize);
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function adminHeaders() {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: "admin_001", role: "admin" })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+function userHeaders() {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: "usr_001", role: "client" })}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject non-admin users server-side", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: userHeaders()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Forbidden");
+  });
+});
+
+test("admin metrics and users endpoint return paginated operations data", async () => {
+  await withServer(async (baseUrl) => {
+    const metrics = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: adminHeaders()
+    });
+    const metricsPayload = await metrics.json();
+
+    assert.equal(metrics.status, 200);
+    assert.equal(metricsPayload.data.totalUsers, 3);
+    assert.equal(metricsPayload.data.openDisputes, 2);
+    assert.equal(metricsPayload.data.flaggedListings, 2);
+
+    const users = await fetch(`${baseUrl}/api/admin/users?role=freelancer&pageSize=1`, {
+      headers: adminHeaders()
+    });
+    const usersPayload = await users.json();
+
+    assert.equal(users.status, 200);
+    assert.equal(usersPayload.data.total, 2);
+    assert.equal(usersPayload.data.items.length, 1);
+    assert.equal(usersPayload.data.items[0].role, "freelancer");
+  });
+});
+
+test("admin user actions and moderation actions create audit entries", async () => {
+  await withServer(async (baseUrl) => {
+    const userAction = await fetch(`${baseUrl}/api/admin/users/usr_002/status`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ status: "suspended" })
+    });
+    const userPayload = await userAction.json();
+    assert.equal(userAction.status, 200);
+    assert.equal(userPayload.data.user.status, "suspended");
+    assert.equal(userPayload.data.audit.action, "user_suspended");
+
+    const moderationAction = await fetch(`${baseUrl}/api/admin/moderation/jobs/job_001`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({
+        action: "reject",
+        reason: "Off-platform payment terms"
+      })
+    });
+    const moderationPayload = await moderationAction.json();
+    assert.equal(moderationAction.status, 200);
+    assert.equal(moderationPayload.data.job.status, "rejected");
+    assert.match(moderationPayload.data.job.notification, /Off-platform/);
+
+    const audit = await fetch(`${baseUrl}/api/admin/audit-log?pageSize=10`, {
+      headers: adminHeaders()
+    });
+    const auditPayload = await audit.json();
+    const actions = auditPayload.data.items.map((entry) => entry.action);
+    assert.ok(actions.includes("user_suspended"));
+    assert.ok(actions.includes("listing_reject"));
+  });
+});
+
+test("admin can rule disputes and update platform controls", async () => {
+  await withServer(async (baseUrl) => {
+    const dispute = await fetch(`${baseUrl}/api/admin/disputes/dsp_001/ruling`, {
+      method: "POST",
+      headers: adminHeaders(),
+      body: JSON.stringify({ ruling: "freelancer", note: "Evidence accepted" })
+    });
+    const disputePayload = await dispute.json();
+    assert.equal(dispute.status, 200);
+    assert.equal(disputePayload.data.dispute.status, "resolved");
+    assert.equal(disputePayload.data.dispute.ruling, "freelancer");
+
+    const control = await fetch(`${baseUrl}/api/admin/controls/jobPostingEnabled`, {
+      method: "PATCH",
+      headers: adminHeaders(),
+      body: JSON.stringify({ enabled: false })
+    });
+    const controlPayload = await control.json();
+    assert.equal(control.status, 200);
+    assert.equal(controlPayload.data.controls.jobPostingEnabled, false);
+    assert.equal(controlPayload.data.audit.action, "platform_control_updated");
+  });
+});

--- a/apps/api/src/utils/adminTokenHelper.js
+++ b/apps/api/src/utils/adminTokenHelper.js
@@ -1,0 +1,3 @@
+import { signAccessToken } from "./jwt.js";
+
+console.log(signAccessToken({ sub: "admin_demo", role: "admin" }));

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,360 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ApiEnvelope<T> = { success: boolean; data: T; message?: string };
+
+type Metrics = {
+  totalUsers: number;
+  activeJobs: number;
+  openDisputes: number;
+  flaggedListings: number;
+  revenueCurrentPeriod: number;
+  trustScoreDistribution: { high: number; medium: number; low: number };
+  controls: { registrationsEnabled: boolean; jobPostingEnabled: boolean };
+};
+
+type PageResult<T> = { items: T[]; page: number; pageSize: number; total: number };
+
+type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  joinedAt: string;
+  trustScore: number;
+  activeJobs: string[];
+  disputeHistory: string[];
+};
+
+type FlaggedJob = {
+  id: string;
+  title: string;
+  status: string;
+  reason: string;
+  severity: string;
+  reportedAt: string;
+  notification?: string | null;
+};
+
+type Dispute = {
+  id: string;
+  jobId: string;
+  status: string;
+  amount: number;
+  thread: string[];
+  evidence: string[];
+  ruling?: string;
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  details: string;
+  createdAt: string;
+};
+
+const token =
+  typeof window === "undefined" ? "" : window.localStorage.getItem("access_token") || "";
+
+async function adminApi<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`/api/admin${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {})
+    }
+  });
+  const payload = (await response.json()) as ApiEnvelope<T>;
+  if (!response.ok || !payload.success) {
+    throw new Error(payload.message || "Admin request failed");
+  }
+  return payload.data;
+}
+
+function StatusBadge({ value }: { value: string }) {
+  return <span className={`badge badge-${value.replace("_", "-")}`}>{value}</span>;
+}
+
 export default function AdminPanelPage() {
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [users, setUsers] = useState<PageResult<AdminUser> | null>(null);
+  const [jobs, setJobs] = useState<PageResult<FlaggedJob> | null>(null);
+  const [disputes, setDisputes] = useState<PageResult<Dispute> | null>(null);
+  const [audit, setAudit] = useState<PageResult<AuditEntry> | null>(null);
+  const [role, setRole] = useState("");
+  const [status, setStatus] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const needsAuth = useMemo(() => !token, []);
+
+  async function load() {
+    if (needsAuth) {
+      setError("403: admin access requires a valid admin token.");
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const query = new URLSearchParams();
+      if (role) query.set("role", role);
+      if (status) query.set("status", status);
+      query.set("pageSize", "20");
+      const [metricData, userData, jobData, disputeData, auditData] = await Promise.all([
+        adminApi<Metrics>("/metrics"),
+        adminApi<PageResult<AdminUser>>(`/users?${query.toString()}`),
+        adminApi<PageResult<FlaggedJob>>("/moderation/jobs?pageSize=20"),
+        adminApi<PageResult<Dispute>>("/disputes?pageSize=20"),
+        adminApi<PageResult<AuditEntry>>("/audit-log?pageSize=20")
+      ]);
+      setMetrics(metricData);
+      setUsers(userData);
+      setJobs(jobData);
+      setDisputes(disputeData);
+      setAudit(auditData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load admin data");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function updateUser(userId: string, nextStatus: string) {
+    await adminApi(`/users/${userId}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: nextStatus })
+    });
+    await load();
+  }
+
+  async function moderateJob(jobId: string, action: string) {
+    const reason = action === "reject" ? "Rejected after admin review" : "Reviewed by admin";
+    await adminApi(`/moderation/jobs/${jobId}`, {
+      method: "POST",
+      body: JSON.stringify({ action, reason })
+    });
+    await load();
+  }
+
+  async function ruleDispute(disputeId: string, ruling: string) {
+    await adminApi(`/disputes/${disputeId}/ruling`, {
+      method: "POST",
+      body: JSON.stringify({ ruling, note: "Admin ruling submitted from operations panel" })
+    });
+    await load();
+  }
+
+  async function toggleControl(key: keyof Metrics["controls"], enabled: boolean) {
+    const confirmed = window.confirm(`Confirm platform control change: ${key} = ${enabled}`);
+    if (!confirmed) return;
+    await adminApi(`/controls/${key}`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled })
+    });
+    await load();
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
   return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+    <section className="admin-shell" aria-label="Admin operations panel">
+      <div className="admin-header">
+        <div>
+          <p className="eyebrow">Operations</p>
+          <h1>Admin Panel</h1>
+        </div>
+        <button type="button" onClick={load} disabled={loading} aria-label="Refresh admin data">
+          {loading ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      {error ? <div className="notice error">{error}</div> : null}
+      {loading ? <div className="notice">Loading admin data...</div> : null}
+
+      {metrics ? (
+        <div className="metric-grid" aria-label="Trust and platform metrics">
+          {[
+            ["Total Users", metrics.totalUsers],
+            ["Active Jobs", metrics.activeJobs],
+            ["Open Disputes", metrics.openDisputes],
+            ["Flagged Listings", metrics.flaggedListings],
+            ["Revenue", `$${metrics.revenueCurrentPeriod.toLocaleString()}`]
+          ].map(([label, value]) => (
+            <article className="metric-card" key={label}>
+              <span>{label}</span>
+              <strong>{value}</strong>
+            </article>
+          ))}
+          <article className="metric-card">
+            <span>Trust Scores</span>
+            <strong>
+              {metrics.trustScoreDistribution.high}/{metrics.trustScoreDistribution.medium}/
+              {metrics.trustScoreDistribution.low}
+            </strong>
+          </article>
+        </div>
+      ) : null}
+
+      <div className="admin-section">
+        <div className="section-title">
+          <h2>User Management</h2>
+          <div className="filters">
+            <select aria-label="Filter users by role" value={role} onChange={(event) => setRole(event.target.value)}>
+              <option value="">All roles</option>
+              <option value="client">Clients</option>
+              <option value="freelancer">Freelancers</option>
+            </select>
+            <select aria-label="Filter users by status" value={status} onChange={(event) => setStatus(event.target.value)}>
+              <option value="">All statuses</option>
+              <option value="active">Active</option>
+              <option value="suspended">Suspended</option>
+              <option value="banned">Banned</option>
+            </select>
+            <button type="button" onClick={load}>Apply</button>
+          </div>
+        </div>
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>User</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Trust</th>
+                <th>Activity</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users?.items.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <strong>{user.name}</strong>
+                    <span>{user.email}</span>
+                  </td>
+                  <td>{user.role}</td>
+                  <td><StatusBadge value={user.status} /></td>
+                  <td>{user.trustScore}</td>
+                  <td>{user.activeJobs.length} jobs, {user.disputeHistory.length} disputes</td>
+                  <td>
+                    <button type="button" onClick={() => updateUser(user.id, "suspended")}>Suspend</button>
+                    <button type="button" onClick={() => updateUser(user.id, "active")}>Reinstate</button>
+                    <button type="button" onClick={() => updateUser(user.id, "banned")}>Ban</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="admin-grid">
+        <section className="admin-section">
+          <h2>Job Moderation</h2>
+          {jobs?.items.length ? (
+            jobs.items.map((job) => (
+              <article className="queue-card" key={job.id}>
+                <div>
+                  <strong>{job.title}</strong>
+                  <p>{job.reason}</p>
+                  <StatusBadge value={job.status} />
+                </div>
+                <div>
+                  <button type="button" onClick={() => moderateJob(job.id, "approve")}>Approve</button>
+                  <button type="button" onClick={() => moderateJob(job.id, "reject")}>Reject</button>
+                  <button type="button" onClick={() => moderateJob(job.id, "escalate")}>Escalate</button>
+                </div>
+              </article>
+            ))
+          ) : <p>No flagged listings.</p>}
+        </section>
+
+        <section className="admin-section">
+          <h2>Dispute Resolution</h2>
+          {disputes?.items.length ? (
+            disputes.items.map((dispute) => (
+              <article className="queue-card" key={dispute.id}>
+                <div>
+                  <strong>{dispute.id} · ${dispute.amount}</strong>
+                  <p>{dispute.thread.join(" ")}</p>
+                  <p>Evidence: {dispute.evidence.join(", ")}</p>
+                  <StatusBadge value={dispute.status} />
+                </div>
+                <div>
+                  <button type="button" onClick={() => ruleDispute(dispute.id, "client")}>Client</button>
+                  <button type="button" onClick={() => ruleDispute(dispute.id, "freelancer")}>Freelancer</button>
+                  <button type="button" onClick={() => ruleDispute(dispute.id, "escalate")}>Escalate</button>
+                </div>
+              </article>
+            ))
+          ) : <p>No open disputes.</p>}
+        </section>
+      </div>
+
+      {metrics ? (
+        <section className="admin-section">
+          <h2>Platform Controls</h2>
+          <div className="control-row">
+            <span>New registrations</span>
+            <button
+              type="button"
+              aria-label="Toggle new user registrations"
+              onClick={() => toggleControl("registrationsEnabled", !metrics.controls.registrationsEnabled)}
+            >
+              {metrics.controls.registrationsEnabled ? "Enabled" : "Disabled"}
+            </button>
+          </div>
+          <div className="control-row">
+            <span>New job postings</span>
+            <button
+              type="button"
+              aria-label="Toggle new job postings"
+              onClick={() => toggleControl("jobPostingEnabled", !metrics.controls.jobPostingEnabled)}
+            >
+              {metrics.controls.jobPostingEnabled ? "Enabled" : "Disabled"}
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="admin-section">
+        <h2>Audit Log</h2>
+        {audit?.items.length ? (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Admin</th>
+                  <th>Action</th>
+                  <th>Target</th>
+                  <th>Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {audit.items.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.createdAt}</td>
+                    <td>{entry.adminId}</td>
+                    <td>{entry.action}</td>
+                    <td>{entry.targetType}:{entry.targetId}</td>
+                    <td>{entry.details}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : <p>No audit entries found.</p>}
+      </section>
     </section>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,84 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+button, select {
+  border: 1px solid #40528d;
+  background: #1d2850;
+  color: #f2f5ff;
+  border-radius: 8px;
+  padding: 0.45rem 0.7rem;
+}
+
+button:hover, select:hover { background: #26356a; }
+button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.admin-shell { max-width: 1180px; margin: 0 auto; }
+.admin-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.admin-header h1 { margin: 0; font-size: 2rem; }
+.eyebrow { margin: 0 0 0.35rem; color: #96a5dc; text-transform: uppercase; font-size: 0.8rem; letter-spacing: 0.08em; }
+.notice { background: #172146; border: 1px solid #40528d; border-radius: 8px; padding: 0.8rem; margin-bottom: 1rem; }
+.notice.error { border-color: #b94b5b; color: #ffd7dc; }
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+}
+.metric-card, .admin-section, .queue-card {
+  background: #151c35;
+  border: 1px solid #2a3765;
+  border-radius: 10px;
+}
+.metric-card { padding: 0.9rem; }
+.metric-card span { display: block; color: #aab6e9; font-size: 0.85rem; }
+.metric-card strong { display: block; margin-top: 0.35rem; font-size: 1.35rem; }
+.admin-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1rem; }
+.admin-section { padding: 1rem; margin-bottom: 1rem; }
+.section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.filters { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; min-width: 680px; }
+th, td { border-bottom: 1px solid #2a3765; padding: 0.7rem; text-align: left; vertical-align: top; }
+td span { display: block; color: #aab6e9; font-size: 0.85rem; margin-top: 0.2rem; }
+td button { margin: 0 0.25rem 0.25rem 0; }
+.badge {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  background: #2a3765;
+  color: #dbe4ff;
+  font-size: 0.78rem;
+}
+.badge-active, .badge-approved, .badge-resolved { background: #145a48; color: #c9ffee; }
+.badge-suspended, .badge-flagged, .badge-under-review { background: #735a16; color: #fff3c4; }
+.badge-banned, .badge-rejected, .badge-open { background: #743143; color: #ffd8e1; }
+.badge-escalated { background: #42327a; color: #e4dcff; }
+.queue-card {
+  padding: 0.85rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.queue-card p { color: #c3ccf5; margin: 0.35rem 0; }
+.control-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid #2a3765;
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://127.0.0.1:4000/api/:path*"
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary

Implements the admin panel requested in #29.

/claim #29

## What changed

- Replaced the placeholder `/admin` page with a functional admin operations dashboard.
- Added server-side admin authorization for every `/api/admin/*` route.
- Added paginated/filterable admin user management.
- Added suspend, reinstate, and ban user actions.
- Added flagged listing moderation with approve, reject, and escalate actions.
- Added dispute queue with thread/evidence visibility and ruling actions.
- Added trust/platform metrics and control toggles.
- Added append-only audit events for admin actions.
- Added audit log viewing.
- Added local `/api/*` rewrite for demoing the web app against the Express API.

## Verification

- `npm run test -w apps/api`
  - 5 tests passed.
  - Covers non-admin 403, metrics/users, user status action, moderation action, audit entries, dispute ruling, platform control updates, and health check.
- `npm run build -w apps/web`
  - Next.js production build passed.

## Demo evidence

Local screenshots and smoke evidence were captured before submission:

- `admin-dashboard-full.png`
- `admin-dashboard-action-audit.png`
- `admin-dashboard-smoke.txt`

Fixes #29
