### PR TITLE
feat: add skip link for keyboard users

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2,5 +2,25 @@
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: 1rem;
+  z-index: 1000;
+  transform: translateY(-150%);
+  border: 1px solid #8fb3ff;
+  border-radius: 8px;
+  background: #f2f5ff;
+  color: #0b1020;
+  padding: 0.6rem 0.85rem;
+  font-weight: 700;
+  transition: transform 0.15s ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 3px solid #8fb3ff;
+  outline-offset: 2px;
+}
+#main-content:focus { outline: none; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,10 +10,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <a className="skip-link" href="#main-content">
+          Skip to content
+        </a>
         <main>
           <h1>FreelanceFlow</h1>
           <Navigation />
-          {children}
+          <section id="main-content" tabIndex={-1}>
+            {children}
+          </section>
         </main>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Adds a visible-on-focus skip link before the repeated site chrome.
- Wraps page-specific content in a focusable `#main-content` target after navigation.
- Keeps existing navigation and page rendering unchanged.

## Validation
- `npm.cmd run build -w apps/web`
- `git diff --cached --check`
- `git diff --check`

/claim #5321

Closes #5321