### PR TITLE
fix: preserve server-owned notification fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...safePayload } = payload;
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "attacker-controlled-id",
+    read: true,
+    userId: "usr_123",
+    message: "New proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "attacker-controlled-id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "New proposal received");
+});
+
+test("createNotification creates unread notifications for normal payloads", async () => {
+  const notification = await createNotification({
+    userId: "usr_456",
+    message: "Payment received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_456");
+  assert.equal(notification.message, "Payment received");
+});


### PR DESCRIPTION
## Summary
- prevent caller-provided `id` and `read` fields from overriding server-owned notification fields
- keep newly created notifications unread by default
- add focused tests for override attempts and normal creation
- make the API test script target test files explicitly

## Tests
- npm.cmd test

Closes #5169
Refs #743