### PR TITLE
Add skip link to main content

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,9 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
+.skip-link { position: absolute; left: 1rem; top: 0; z-index: 1000; transform: translateY(-120%); background: #f2f5ff; color: #0b1020; border-radius: 0 0 8px 8px; padding: 0.75rem 1rem; font-weight: 700; transition: transform 120ms ease; }
+.skip-link:focus { transform: translateY(0); outline: 3px solid #7dd3fc; outline-offset: 2px; }
+#main-content:focus { outline: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -13,10 +13,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <a className="skip-link" href="#main-content">
           Skip to main content
         </a>
-        <main id="main-content" tabIndex={-1}>
+        <main>
           <h1>FreelanceFlow</h1>
           <Navigation />
-          {children}
+          <div id="main-content" tabIndex={-1}>
+            {children}
+          </div>
         </main>
       </body>
     </html>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,7 +10,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <main>
+        <a className="skip-link" href="#main-content">
+          Skip to main content
+        </a>
+        <main id="main-content" tabIndex={-1}>
           <h1>FreelanceFlow</h1>
           <Navigation />
           {children}


### PR DESCRIPTION
Closes #5321.

Summary:
- adds a visible-on-focus skip link before the shared page chrome
- gives the page-specific content wrapper a stable `#main-content` target
- makes the main wrapper programmatically focusable so keyboard users can bypass repeated navigation

Validation:
- `npm.cmd install --ignore-scripts --no-audit --no-fund`
- `npm.cmd run build -w apps/web`
