### PR TITLE
Reuse registered user id for JWT subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Closes #5325.

/claim #743

Summary:
- stores the generated registered user id once in `registerUser`
- reuses that same id for the response `id` and JWT `sub` claim
- avoids a possible mismatch when separate `Date.now()` calls cross a millisecond boundary

Validation:
- decoded a token returned by `registerUser` and confirmed `payload.sub === result.id`
- `node --test apps/api/src/tests/health.test.js`