### PR TITLE
Protect generated job id and status from payload overrides

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
Closes #5327.

/claim #743

Summary:
- moves generated job fields after the request payload spread
- prevents callers from overriding the service-generated `id` or initial `status: "open"`

Validation:
- created a job with `{ id: "evil", status: "closed" }` and confirmed the returned id/status are protected
- `node --test apps/api/src/tests/health.test.js`