### PR TITLE
Protect generated notification id and unread state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Closes #5329.

/claim #743

Summary:
- moves service-owned notification fields after the request payload spread
- prevents callers from overriding the generated `id` or initial `read: false` value

Validation:
- created a notification with `{ id: "evil", read: true }` and confirmed the returned id/read values are protected
- `node --test apps/api/src/tests/health.test.js`