### PR TITLE
Protect generated proposal id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }


### PR DESCRIPTION
Closes #5331.

/claim #743

## Summary
- Reordered proposal creation so caller payload fields are applied before the generated proposal id.
- This prevents payload.id from overriding the service-generated prp_ id.

## Validation
- Verified before the fix that createProposal({ id: "evil", jobId: "j" }) returned id: "evil".
- Verified after the fix that createProposal({ id: "evil", jobId: "j" }) returns a generated prp_ id.
- Ran node --test apps/api/src/tests/health.test.js.