### PR TITLE
Protect generated message id

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
Closes #5333.

/claim #743

## Summary
- Reordered message creation so caller payload fields are applied before the generated message id.
- This prevents payload.id from overriding the service-generated msg_ id while sentAt remains generated by the service.

## Validation
- Verified before the fix that sendMessage({ id: "evil", body: "hi" }) returned id: "evil".
- Verified after the fix that sendMessage({ id: "evil", body: "hi" }) returns a generated msg_ id.
- Ran node --test apps/api/src/tests/health.test.js in the original workspace, where dependencies are installed.