### PR TITLE
fix(api): protect generated job id and status

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob protects generated id and default status from payload overrides", async () => {
+  const job = await createJob({
+    id: "evil",
+    status: "closed",
+    title: "Build escrow flow",
+    description: "Implement the first escrow flow milestone.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "engineering",
+    skills: ["node"]
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build escrow flow");
+});


### PR DESCRIPTION
Closes #5336.
Refs #743.

Summary:
- Ensures `createJob` applies request payload fields before server-owned fields.
- Adds a regression test proving payload `id` and `status` cannot override generated values.
- Updates the API test script to run the test files explicitly.

Verification:
- `npm test -w apps/api`

Result:
- 2 tests passed.