### PR TITLE
fix(api): keep new notifications unread

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications keeps new notifications unread", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_123",
+        title: "Proposal update",
+        message: "A client responded to your proposal.",
+        read: true
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.read, false);
+  });
+});


### PR DESCRIPTION
Closes #5337
/claim #743

## Summary

- Keep server-owned notification fields authoritative during creation.
- Add a route-level regression test proving a client-supplied `read: true` value still creates an unread notification.

## Root Cause

`createNotification()` set `read: false` before spreading client payload, so a request body could override the default and create a new notification as already read.

## Validation

- `npm.cmd ci`
- `node --test src\tests\health.test.js src\tests\notification.test.js`
- `node --check src\tests\notification.test.js`
- `node --check src\services\notificationService.js`
- `git diff --check`

Note: `npm.cmd test -w apps/api` is currently blocked on this Windows/Node setup by the existing package script invoking `node --test src/tests`, which resolves the directory as a missing module path. The focused test files above pass directly.
