### PR TITLE
fix(api): protect generated notification id and unread state

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification protects generated id and unread state from payload overrides", async () => {
+  const notification = await createNotification({
+    id: "evil",
+    read: true,
+    userId: "usr_123",
+    type: "message",
+    message: "You have a new proposal."
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+});


### PR DESCRIPTION
Closes #5340.
Refs #743.

Summary:
- Ensures `createNotification` applies request payload fields before server-owned fields.
- Adds a regression test proving payload `id` and `read` cannot override generated values.
- Updates the API test script to run the test files explicitly.

Verification:
- `npm test -w apps/api`

Result:
- 2 tests passed.