### PR TITLE
Protect generated review id

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
Closes #5342.

/claim #743

## Summary
- Reordered review creation so caller payload fields are applied before the generated review id.
- This prevents payload.id from overriding the service-generated rev_ id.

## Validation
- Verified before the fix that createReview({ id: "evil", rating: 5 }) returned id: "evil".
- Verified after the fix that createReview({ id: "evil", rating: 5 }) returns a generated rev_ id.
- Ran node --test apps/api/src/tests/health.test.js.