### PR TITLE
Protect generated user id

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Closes #5344.

/claim #743

## Summary
- Reordered user creation so caller payload fields are applied before the generated user id.
- This prevents payload.id from overriding the service-generated usr_ id.

## Validation
- Verified before the fix that createUser({ id: "evil", email: "u@example.com" }) returned id: "evil".
- Verified after the fix that createUser({ id: "evil", email: "u@example.com" }) returns a generated usr_ id.
- Ran node --test apps/api/src/tests/health.test.js.