### PR TITLE
Validate job budget range

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,16 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const validBudgetRange = (payload) =>
+  payload.budgetMin === undefined ||
+  payload.budgetMax === undefined ||
+  payload.budgetMax >= payload.budgetMin;
+
+const budgetRangeMessage = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = jobFieldsSchema.refine(validBudgetRange, budgetRangeMessage);
+
+export const updateJobSchema = jobFieldsSchema.partial().refine(validBudgetRange, budgetRangeMessage);


### PR DESCRIPTION
Closes #5350.

/claim #743

## Summary
- Adds a shared budget range validator for job create/update schemas.
- Rejects payloads where budgetMax is lower than budgetMin.
- Keeps partial update payloads valid when only one budget field is provided.

## Validation
- Verified before the fix that createJobSchema accepted budgetMin: 100 with budgetMax: 10.
- Verified after the fix that createJobSchema rejects that payload on budgetMax.
- Verified valid ranges pass.
- Verified partial updates still pass when only one budget field is provided, and fail when both fields form an invalid range.
- Ran node --test apps/api/src/tests/health.test.js.