### PR TITLE
fix: use payload role in loginUser instead of hardcoded client

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -14,7 +14,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: payload.role ?? "client" })
   };
 }
 


### PR DESCRIPTION
Closes #5346

Previously loginUser always issued JWTs with role client. Now respects role from payload.