### PR TITLE
fix: use uppercase USD default to match Prisma schema

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: payload.currency ?? "USD",
     provider: "stripe"
   };
 }


### PR DESCRIPTION
Closes #5348

Payment model has @default("USD") in schema. Lowercase was inconsistent.