### PR TITLE
security: enforce JWT secret + protect job routes

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,10 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: (() => {
+    if (!process.env.JWT_SECRET) throw new Error("Missing JWT_SECRET");
+    return process.env.JWT_SECRET;
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+const authMiddleware = verifyAccessToken;
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", authMiddleware, getJobs);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
Fixes #1900 (auth) and #1905 (JWT hardcoded default). Adds authMiddleware on job routes and fails fast when JWT_SECRET is missing in production.