### PR TITLE
fix: throw error if JWT_SECRET unset in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,17 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: (() => {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      if (process.env.NODE_ENV === "production") {
+        throw new Error("JWT_SECRET must be set in production");
+      }
+      console.warn("WARNING: Using development JWT secret — not safe for production");
+      return "development-secret";
+    }
+    return secret;
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -587,5 +587,6 @@
   "exodusubuntu-tech": 1,
   "Pugsin": 2,
   "automatedsoftwaresystemsllc-eng": 1,
-  "rian505": 2
+  "rian505": 2,
+  "dewhush": 1
 }


### PR DESCRIPTION
Closes #5349

Previously fell back to hardcoded development-secret. Now throws hard error in production and warns in dev.