### PR TITLE
Require file for upload endpoint

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Closes #5357.

/claim #743

## Summary
- Returns a 400 response when upload requests do not include a file.
- Keeps successful upload responses focused on actual uploaded files.

## Validation
- Verified before the fix that POST /api/uploads without a file returned 201 success with filename null.
- Verified after the fix that POST /api/uploads without a file returns 400 and "File is required".
- Ran node --test apps/api/src/tests/health.test.js.