### PR TITLE
Return bad request for invalid auth payloads

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,24 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid request", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0]?.message ?? "Invalid request", 400);
+  }
+
+  const result = await loginUser(parsed.data);
   return ok(res, result);
 }
 


### PR DESCRIPTION
Closes #5360.

/claim #743

## Summary
- Uses safeParse for auth register/login payloads.
- Returns a 400 API response for validation failures instead of throwing ZodError from the controller.

## Validation
- Verified before the fix that POST /api/auth/register with invalid email/short password throws a ZodError during request handling.
- Verified after the fix that invalid register and login payloads return 400 with success: false.
- Ran node --test apps/api/src/tests/health.test.js.