### PR TITLE
fix: add input validation and length limit to search query (#1777)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = searchQuerySchema.safeParse(req.query);
+  if (!result.success) {
+    return fail(res, result.error.errors[0].message);
+  }
+  return ok(res, await globalSearch(result.data.q));
 }

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .max(200, "Search query must be at most 200 characters")
+    .transform((val) => val.replace(/[<>]/g, ""))
+    .default("")
+});


### PR DESCRIPTION
## Description
Adds input validation to the search endpoint to prevent DoS via overly long query strings.

## Changes
1. **New file: pps/api/src/validators/search.js** - Zod validation schema for search query
   - Trims whitespace
   - Limits length to 200 characters
   - Sanitizes by removing HTML angle brackets
   - Defaults to empty string when no query provided

2. **Modified: pps/api/src/controllers/searchController.js**
   - Imports and applies the search query validator
   - Returns 400 error with descriptive message for invalid input
   - Uses safeParse pattern consistent with project's validation approach

## Testing
- Valid query (< 200 chars): passes validation, returns search results
- Empty/missing query: defaults to empty string
- Oversized query (> 200 chars): returns validation error
- Query with HTML tags: tags are stripped before passing to search service

Closes #1777