### PR TITLE
fix: default payment currency to USD

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: payload.currency ?? "USD",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults to uppercase USD", async () => {
+  const intent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(intent.currency, "USD");
+});
+
+test("createPaymentIntent preserves an explicit currency", async () => {
+  const intent = await createPaymentIntent({
+    amount: 2500,
+    currency: "EUR"
+  });
+
+  assert.equal(intent.currency, "EUR");
+});


### PR DESCRIPTION
## Summary
- Defaults payment intent currency to uppercase `USD` to match the schema and ISO currency style.
- Preserves explicit currency values when callers provide them.
- Adds focused service coverage for the default and explicit paths.

## Validation
- `node --test src/tests/paymentService.test.js` -> 2 passed
- `node --test src/tests/health.test.js` -> 1 passed
- `git diff --check`

/claim #5367

Closes #5367