### PR TITLE
fix: persist job skills relation

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Job {
   client        User        @relation("ClientJobs", fields: [clientId], references: [id])
   categoryId    String
   category      Category    @relation(fields: [categoryId], references: [id])
+  skills        Skill[]
   proposals     Proposal[]
   payments      Payment[]
   createdAt     DateTime    @default(now())
@@ -114,6 +115,7 @@ model Skill {
   id            String      @id @default(cuid())
   name          String      @unique
   users         User[]
+  jobs          Job[]
 }
 
 model Notification {

--- a/packages/db/src/schema.test.js
+++ b/packages/db/src/schema.test.js
@@ -1,0 +1,18 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+
+const schemaPath = join(__dirname, "../prisma/schema.prisma");
+const schema = readFileSync(schemaPath, "utf8");
+
+function modelBlock(modelName) {
+  const match = schema.match(new RegExp(`model ${modelName} \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `Expected ${modelName} model to exist in Prisma schema`);
+  return match[1];
+}
+
+test("Job records can persist accepted skills", () => {
+  assert.match(modelBlock("Job"), /\bskills\s+Skill\[\]/);
+  assert.match(modelBlock("Skill"), /\bjobs\s+Job\[\]/);
+});


### PR DESCRIPTION
﻿## Summary

- add the missing Prisma many-to-many relation between Job and Skill
- add a schema audit test so the accepted API skills contract stays representable by persisted jobs

## Validation

- DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow npm exec -w packages/db -- prisma validate --schema prisma/schema.prisma
- 
ode packages/db/src/schema.test.js
- git diff --check

/claim #5369
Closes #5369
