### PR TITLE
Reject upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});


### PR DESCRIPTION
Refs #5371

/claim #743

Summary:
- Return `400` with `"File is required"` when `POST /api/uploads` is called without an uploaded file.
- Preserve the existing successful upload response for valid file uploads.
- Add focused regression coverage for the no-file upload path.

Validation:
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/upload.test.js`
- `node --test apps/api/src/tests/*.test.js`

Note: `npm test -w apps/api` currently fails before running tests because the existing script calls `node --test src/tests`, which Node 22 on Windows resolves as a module path rather than expanding test files.

Payout address: 0x378FC1143d46d0378bE812EA43D8B2D7F07CBa9C
