### PR TITLE
fix: track mutable record updates

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Payment {
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }
 
 model Review {
@@ -101,6 +102,7 @@ model Message {
   receiver      User        @relation("ReceivedMessages", fields: [receiverId], references: [id])
   isRead        Boolean     @default(false)
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }
 
 model Category {
@@ -124,4 +126,5 @@ model Notification {
   body          String
   read          Boolean     @default(false)
   createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
 }

--- a/packages/db/src/schema.test.js
+++ b/packages/db/src/schema.test.js
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+
+const schemaPath = join(__dirname, "../prisma/schema.prisma");
+const schema = readFileSync(schemaPath, "utf8");
+
+function modelBlock(modelName) {
+  const match = schema.match(new RegExp(`model ${modelName} \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `Expected ${modelName} model to exist in Prisma schema`);
+  return match[1];
+}
+
+test("mutable operational records track updates", () => {
+  for (const modelName of ["Payment", "Message", "Notification"]) {
+    assert.match(modelBlock(modelName), /\bupdatedAt\s+DateTime\s+@updatedAt\b/);
+  }
+});


### PR DESCRIPTION
﻿## Summary

- add Prisma updatedAt @updatedAt fields to mutable operational records: Payment, Message, and Notification
- add a schema audit test so those mutable models continue to track update timestamps

## Validation

- DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow npm exec -w packages/db -- prisma validate --schema prisma/schema.prisma
- 
ode packages/db/src/schema.test.js
- git diff --check

/claim #5375
Closes #5375
