### PR TITLE
fix: reject inverted job budget ranges in job validation

### DIFF
--- a/apps/api/src/tests/job-validation.test.js
+++ b/apps/api/src/tests/job-validation.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects inverted budget when budgetMax < budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A valid test job description",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "cat_123",
+  });
+
+  assert.equal(result.success, false);
+  assert.ok(
+    result.error.issues.some((i) => i.path.includes("budgetMax")),
+    "expected error on budgetMax path"
+  );
+});
+
+test("createJobSchema accepts valid budget when budgetMax > budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A valid test job description",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_123",
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts equal budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test Job",
+    description: "A valid test job description",
+    budgetMin: 250,
+    budgetMax: 250,
+    categoryId: "cat_123",
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
+
+export const updateJobSchema = baseJobSchema.partial();


### PR DESCRIPTION
## Fix

Add  to  that validates , preventing invalid job records where max < min.

## Changes

- ****: Add refinement check on 
- ****: Add 3 tests (reject inverted, accept valid, accept equal)

## Testing



Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)