### PR TITLE
fix: reject inverted budget ranges in job validation (fixes #2853)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,12 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => data.budgetMax === undefined || data.budgetMin === undefined || data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);


### PR DESCRIPTION
Adds cross-field validation to createJobSchema and updateJobSchema to reject inverted budget ranges where budgetMax < budgetMin. See issue #2853.