### PR TITLE
fix: resolve mock freelancer profiles by username (fixes #2849)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "@/lib/mock";
+import Link from "next/link";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find(f => f.username === params.username);
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+        <Link href="/freelancers/search">Browse freelancers</Link>
+      </section>
+    );
+  }
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{profile.username}</h2>
+      <p>Skills: {profile.skills.join(", ")}</p>
+      <p>Rate: {profile.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
Look up mock freelancer data by username. Show profile with skills/rate. Show not-found fallback for unknown usernames.