### PR TITLE
fix: resolve freelancer profile by username from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username &quot;{params.username}&quot;.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Rate: {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

The `/freelancers/[username]` route was rendering a static placeholder instead of looking up the freelancer from `apps/web/lib/mock.ts`. This fix imports the `freelancers` array and resolves the matching profile by username.

## Changes

- Import `freelancers` from `apps/web/lib/mock.ts`
- Look up freelancer by `params.username`
- Render skills and hourly rate if found
- Display "Freelancer Not Found" for unknown usernames

## Testing

- `/freelancers/maya-dev` → shows "Next.js, TypeScript" and "$65/hr"
- `/freelancers/jordan-ux` → shows "Figma, UX Research" and "$52/hr"
- `/freelancers/unknown` → shows "Freelancer Not Found" message

Closes #5386