### PR TITLE
fix: prevent caller from overriding server-owned notification id and read state (#5319)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _callerId, read: _callerRead, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification strips caller-supplied id", async () => {
+  const result = await createNotification({ id: "caller-id-123", message: "Hello" });
+  assert.ok(!result.id.startsWith("caller-"), "Server should generate its own id, not use caller-supplied id");
+  assert.ok(result.id.startsWith("ntf_"), "Server-generated id should start with ntf_");
+});
+
+test("createNotification strips caller-supplied read state", async () => {
+  const result = await createNotification({ read: true, message: "Hello" });
+  assert.equal(result.read, false, "New notifications should always be unread");
+});
+
+test("createNotification preserves other payload fields", async () => {
+  const result = await createNotification({ message: "Test message", userId: "usr_1" });
+  assert.equal(result.message, "Test message");
+  assert.equal(result.userId, "usr_1");
+  assert.equal(result.read, false);
+});
+
+test("createNotification always sets read to false regardless of caller payload", async () => {
+  const a = await createNotification({ read: true, message: "A" });
+  const b = await createNotification({ read: true, message: "B" });
+  assert.equal(a.read, false);
+  assert.equal(b.read, false);
+  assert.ok(a.id.startsWith("ntf_"));
+  assert.ok(b.id.startsWith("ntf_"));
+});


### PR DESCRIPTION
## Summary

Fixes #5319: Notification service now strips caller-supplied `id` and `read` fields from the payload before creating records.

## Problem

The notification service used spread syntax (`{ id: generated, read: false, ...payload }`), allowing callers to override both the generated notification id and the initial unread state.

## Fix

- Destructure and discard caller-supplied `id` and `read` fields
- Server always generates the id and sets `read: false` for new notifications
- Other payload fields are preserved

## Test Coverage

- apps/api/src/tests/notificationService.test.js - 4 tests covering:
  - Caller-supplied id is stripped
  - Caller-supplied read state is stripped
  - Other payload fields preserved
  - Server always sets read=false

## Verification

cd apps/api && node --test src/tests/notificationService.test.js