### PR TITLE
fix: reject upload requests without file with 400 response (#5162)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "Request must include a file in the 'file' field", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads without file returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST"
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5162: POST /api/uploads now returns 400 when no file is included in the multipart request.

## Problem

POST /api/uploads returned 201 with `status: "no-file"` when no file was supplied, treating a missing file as a successful upload.

## Fix

- Check for `req.file` before processing the upload
- Return 400 with error message when file is missing
- Only return 201 when a file is actually present

## Test Coverage

- apps/api/src/tests/upload.test.js - Tests that POST /api/uploads without file returns 400

## Verification

cd apps/api && node --test src/tests/upload.test.js