### PR TITLE
fix: createJobSchema rejects inverted budget ranges (#5124)

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Test Job",
+  description: "A test job description that is long enough",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_1"
+};
+
+test("createJobSchema accepts valid budget range", () => {
+  const result = createJobSchema.safeParse(validJob);
+  assert.ok(result.success, "Should accept valid budget range");
+});
+
+test("createJobSchema accepts equal budget min and max", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 500, budgetMax: 500 });
+  assert.ok(result.success, "Should accept equal budget min and max");
+});
+
+test("createJobSchema rejects budgetMax below budgetMin", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 500, budgetMax: 100 });
+  assert.ok(!result.success, "Should reject budgetMax below budgetMin");
+  const issue = result.error.issues.find(i => i.path.includes("budgetMax"));
+  assert.ok(issue, "Error should reference budgetMax field");
+});
+
+test("createJobSchema rejects negative budget values", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: -10 });
+  assert.ok(!result.success, "Should reject negative budget values");
+});
+
+test("updateJobSchema allows partial updates", () => {
+  const result = updateJobSchema.safeParse({ title: "Updated" });
+  assert.ok(result.success, "Should accept partial updates");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine((data) => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobBaseSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin when both are provided",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Summary

Fixes #5124: createJobSchema now rejects payloads where budgetMax is lower than budgetMin.

## Problem

createJobSchema validated budgetMin and budgetMax as nonnegative numbers, but accepted payloads where budgetMax was lower than budgetMin, creating impossible budget ranges.

## Fix

- Added `.refine()` to createJobSchema to reject inverted budget ranges
- updateJobSchema also validates the range when both fields are present
- Partial updates that only change one field are still allowed

## Test Coverage

- apps/api/src/tests/jobValidator.test.js - 5 tests covering:
  - Valid budget range accepted
  - Equal min/max accepted
  - Inverted range rejected
  - Negative values rejected
  - Partial updates work

## Verification

cd apps/api && node --test src/tests/jobValidator.test.js