### PR TITLE
fix: freelancer profile page resolves mock profiles by username (#5386)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,28 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username: <strong>{params.username}</strong></p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
+      <h3>Skills</h3>
+      <ul>
+        {freelancer.skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #5386: The /freelancers/[username] route now looks up freelancer from mock data.

## Problem

The freelancer profile page rendered placeholder text with the requested username instead of looking up the freelancer from mock data. Unknown usernames also appeared successful.

## Fix

- Import freelancers array from apps/web/lib/mock.ts
- Look up freelancer by username param
- Render skills and hourly rate if found
- Show "not found" message if username does not match

## Scope

Limited to the web freelancer profile route (apps/web/app/freelancers/[username]/page.tsx).