### PR TITLE
fix: add package entrypoints for @freelanceflow/db and @freelanceflow/ui (#5145)

### DIFF
--- a/apps/api/src/tests/dbPackage.test.js
+++ b/apps/api/src/tests/dbPackage.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const repoRoot = "/root/money-maker/SecureBananaLabs-bug-bounty";
+const pkgPath = join(repoRoot, "packages", "db", "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+test("@freelanceflow/db package.json has main field", () => {
+  assert.ok(pkg.main, "package.json should have a main field");
+  assert.equal(pkg.main, "src/index.ts");
+});
+
+test("@freelanceflow/db package.json has types field", () => {
+  assert.ok(pkg.types, "package.json should have a types field");
+  assert.equal(pkg.types, "src/index.ts");
+});
+
+test("@freelanceflow/db package.json has exports field", () => {
+  assert.ok(pkg.exports, "package.json should have an exports field");
+  assert.ok(pkg.exports["."], "exports should have a root entry");
+});
+
+test("@freelanceflow/db source entrypoint exists", () => {
+  const srcPath = join(repoRoot, "packages", "db", "src", "index.ts");
+  const content = readFileSync(srcPath, "utf-8");
+  assert.ok(content.length > 0, "src/index.ts should not be empty");
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #5145: @freelanceflow/db and @freelanceflow/ui now expose valid package entrypoints.

## Problem

The workspace packages did not declare main, types, or exports fields in package.json, so consumers importing by package name did not get an explicit entrypoint contract.

## Fix

- Added main, types, and exports fields to packages/db/package.json
- Added main, types, and exports fields to packages/ui/package.json
- Both packages now expose src/index.ts as the entrypoint

## Test Coverage

- apps/api/src/tests/dbPackage.test.js - 4 tests verifying package.json fields and source existence

## Verification

cd apps/api && node --test src/tests/dbPackage.test.js