### PR TITLE
fix: reject inverted budget ranges (#2853, $780) + prevent admin self-assignment (#1823, $430)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,12 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Fixes

### #2853 - Reject inverted budget ranges ($780)
Added .refine() to createJobSchema in alidators/job.js that validates udgetMax >= budgetMin. Previously the schema accepted budgetMax lower than budgetMin (e.g. USD 500-100), causing invalid job records and broken client-side filtering.

### #1823 - Prevent admin role self-assignment ($430)
Removed 'admin' from the egisterSchema role enum in alidators/auth.js. Previously anyone could set ole: 'admin' during registration, granting themselves administrator privileges. Admin role assignment must now be done exclusively through admin-protected endpoints.

### Changes
- pps/api/src/validators/job.js: Added budget range refinement
- pps/api/src/validators/auth.js: Restricted registration roles to client/freelancer

/bounty 