### PR TITLE
fix: resolve freelancer profile from mock data by username (Closes #5386)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,23 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>The freelancer &quot;{params.username}&quot; does not exist.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Rate: {freelancer.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Changes

- Import `freelancers` from `@/lib/mock` in the freelancer profile page
- Look up the freelancer by `username` route param
- Render skills and hourly rate when found
- Show a "not found" message when username doesn't match any mock entry

Closes #5386

Wallet: `0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131`