### PR TITLE
fix: admin role self-assign prevention, search validation, freelancer profiles, settings (closes #2832, #2833, #2849, #2822)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,8 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { freelancerRoutes } from "./routes/freelancerRoutes.js";
+import { settingsRoutes } from "./routes/settingsRoutes.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +40,8 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+  app.use("/api/freelancers", freelancerRoutes);
+  app.use("/api/settings", settingsRoutes);
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/controllers/freelancerController.js
+++ b/apps/api/src/controllers/freelancerController.js
@@ -1,0 +1,28 @@
+import { ok, fail } from "../utils/response.js";
+import {
+  getFreelancerByUsername,
+  getFreelancerById,
+} from "../services/freelancerService.js";
+
+/**
+ * GET /freelancers/:usernameOrId
+ * Resolves a freelancer profile by username or ID (#2849).
+ */
+export async function getFreelancer(req, res) {
+  const param = req.params.usernameOrId;
+  if (!param) {
+    return fail(res, "Username or ID is required", 400);
+  }
+
+  // Try username first (more common), then ID
+  let profile = await getFreelancerByUsername(param);
+  if (!profile) {
+    profile = await getFreelancerById(param);
+  }
+
+  if (!profile) {
+    return fail(res, "Freelancer not found", 404);
+  }
+
+  return ok(res, profile);
+}

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,43 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
+/**
+ * Validates the search query parameter before passing it to the service.
+ * Prevents:
+ *   - Missing or empty query from wasting resources
+ *   - Excessively long queries from causing DoS (#2833)
+ *   - Non-string queries from crashing the service
+ */
+function validateSearchQuery(raw) {
+  if (raw === undefined || raw === null) {
+    return { valid: false, error: "Missing required query parameter 'q'" };
+  }
+
+  if (typeof raw !== "string") {
+    return { valid: false, error: "Query parameter 'q' must be a string" };
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { valid: false, error: "Query parameter 'q' must not be empty" };
+  }
+
+  if (trimmed.length > MAX_QUERY_LENGTH) {
+    return {
+      valid: false,
+      error: `Query parameter 'q' exceeds maximum length of ${MAX_QUERY_LENGTH} characters`,
+    };
+  }
+
+  return { valid: true, value: trimmed };
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = validateSearchQuery(req.query.q);
+  if (!result.valid) {
+    return fail(res, result.error, 400);
+  }
+  return ok(res, await globalSearch(result.value));
 }

--- a/apps/api/src/controllers/settingsController.js
+++ b/apps/api/src/controllers/settingsController.js
@@ -1,0 +1,54 @@
+import { ok } from "../utils/response.js";
+
+/**
+ * Available account settings with descriptions (#2822).
+ */
+const ACCOUNT_SETTINGS = [
+  {
+    key: "email_notifications",
+    label: "Email Notifications",
+    description: "Receive email notifications for new messages and job alerts",
+    type: "toggle",
+    defaultValue: true,
+  },
+  {
+    key: "two_factor_auth",
+    label: "Two-Factor Authentication",
+    description: "Add an extra layer of security to your account",
+    type: "action",
+    actionLabel: "Enable 2FA",
+    actionUrl: "/settings/2fa/setup",
+  },
+  {
+    key: "change_password",
+    label: "Change Password",
+    description: "Update your account password",
+    type: "action",
+    actionLabel: "Change Password",
+    actionUrl: "/settings/password",
+  },
+  {
+    key: "profile_visibility",
+    label: "Profile Visibility",
+    description: "Control who can see your freelancer profile",
+    type: "select",
+    options: ["public", "registered_users", "private"],
+    defaultValue: "public",
+  },
+  {
+    key: "delete_account",
+    label: "Delete Account",
+    description: "Permanently delete your account and all associated data. This action cannot be undone.",
+    type: "danger",
+    actionLabel: "Delete Account",
+    actionUrl: "/settings/delete",
+  },
+];
+
+/**
+ * GET /settings
+ * Returns actionable account controls for the settings page (#2822).
+ */
+export async function getSettings(req, res) {
+  return ok(res, { controls: ACCOUNT_SETTINGS });
+}

--- a/apps/api/src/routes/freelancerRoutes.js
+++ b/apps/api/src/routes/freelancerRoutes.js
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getFreelancer } from "../controllers/freelancerController.js";
+
+export const freelancerRoutes = Router();
+
+freelancerRoutes.get("/:usernameOrId", getFreelancer);

--- a/apps/api/src/routes/settingsRoutes.js
+++ b/apps/api/src/routes/settingsRoutes.js
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { getSettings } from "../controllers/settingsController.js";
+
+export const settingsRoutes = Router();
+
+settingsRoutes.get("/", getSettings);

--- a/apps/api/src/services/freelancerService.js
+++ b/apps/api/src/services/freelancerService.js
@@ -1,0 +1,46 @@
+/**
+ * Freelancer profile service.
+ * Resolves mock profiles by username or ID (#2849).
+ */
+
+const MOCK_PROFILES = {
+  alice_dev: {
+    username: "alice_dev",
+    name: "Alice Chen",
+    skills: ["React", "Node.js", "TypeScript"],
+    hourlyRate: 45,
+    rating: 4.8,
+    completedJobs: 32,
+    bio: "Full-stack developer specializing in React and Node.js",
+  },
+  bob_pm: {
+    username: "bob_pm",
+    name: "Bob Martinez",
+    skills: ["Product Management", "Agile", "SaaS"],
+    hourlyRate: 60,
+    rating: 4.9,
+    completedJobs: 18,
+    bio: "Product manager with 8 years of SaaS experience",
+  },
+};
+
+export async function getFreelancerByUsername(username) {
+  if (!username || typeof username !== "string") {
+    return null;
+  }
+  const normalized = username.trim().toLowerCase();
+  return MOCK_PROFILES[normalized] || null;
+}
+
+export async function getFreelancerById(id) {
+  if (!id || typeof id !== "string") {
+    return null;
+  }
+  // Mock: iterate profiles, match against generated ID
+  for (const [username, profile] of Object.entries(MOCK_PROFILES)) {
+    if (id === `usr_${username}` || id === username) {
+      return { id: `usr_${username}`, ...profile };
+    }
+  }
+  return null;
+}

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,40 @@
 const users = [];
 
+const ALLOWED_ROLES = ["client", "freelancer"];
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 254;
+
+/**
+ * Sanitize incoming user payload to prevent privilege escalation.
+ */
+function sanitizeUserPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Invalid user payload: must be an object");
+  }
+
+  const { role, id, createdAt, updatedAt, ...rest } = payload;
+
+  // Prevent admin role self-assignment (#2832)
+  const safeRole = (role && ALLOWED_ROLES.includes(role)) ? role : "freelancer";
+
+  // Truncate long fields
+  const name = typeof rest.name === "string"
+    ? rest.name.slice(0, MAX_NAME_LENGTH)
+    : rest.name;
+  const email = typeof rest.email === "string"
+    ? rest.email.slice(0, MAX_EMAIL_LENGTH)
+    : rest.email;
+
+  return { ...rest, name, email, role: safeRole };
+}
+
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const sanitized = sanitizeUserPayload(payload);
+  const user = { id: `usr_${Date.now()}`, ...sanitized };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Closes #2832
Closes #2833
Closes #2849
Closes #2822

## Changes

### Admin Role Self-Assignment (#2832)
- Sanitized user payload in createUser to strip any unauthorized roles
- Only allows client and freelancer roles
- Additionally truncates overly long name/email fields

### Search Input Validation (#2833)
- Added input validation to search endpoint
- Max 200 character query length (prevents DoS)
- Type check (must be string)
- Non-empty validation
- Returns 400 with clear error message

### Freelancer Profile Route (#2849)
- New GET /api/freelancers/:usernameOrId
- Resolves mock profiles by username first, then falls back to ID
- Returns 404 if no profile found
- Mock profiles for alice_dev and bob_pm

### Settings Page Controls (#2822)
- New GET /api/settings endpoint
- Returns actionable account controls: email notifications, 2FA, password change, profile visibility, account deletion
- Each control includes type, description, and action labels/URLs

Wallet: 0x76485924c7CA4EFcC03e622441fF3ab633c86143