### PR TITLE
Fix API test script file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- update the API workspace test script to discover `src/tests/**/*.test.js` files
- avoid passing the `src/tests` directory as a module entry to `node --test`

## Verification
Before:
- `npm run test -w apps/api` failed with `Cannot find module .../apps/api/src/tests`

After:
- `npm run test -w apps/api` passes
- `npm test` passes

Closes #4935