### PR TITLE
fix(api): return defensive list snapshots

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const listCases = [
+  {
+    name: "users",
+    create: () => createUser({ email: `user-${Date.now()}@example.com` }),
+    list: listUsers
+  },
+  {
+    name: "jobs",
+    create: () => createJob({ title: `Job ${Date.now()}` }),
+    list: listJobs
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ jobId: "job_snapshot", userId: "usr_snapshot" }),
+    list: listProposals
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ userId: "usr_snapshot", rating: 5 }),
+    list: listReviews
+  },
+  {
+    name: "messages",
+    create: () => sendMessage({ from: "usr_a", to: "usr_b", body: "snapshot check" }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ userId: "usr_snapshot", message: "snapshot check" }),
+    list: listNotifications
+  }
+];
+
+for (const { name, create, list } of listCases) {
+  test(`${name} list returns a defensive snapshot`, async () => {
+    const created = await create();
+    const snapshot = await list();
+
+    snapshot.push({ id: `mutated_${name}` });
+    snapshot.pop();
+    snapshot[0] = { id: `reassigned_${name}` };
+
+    const nextSnapshot = await list();
+
+    assert.ok(nextSnapshot.some((item) => item.id === created.id));
+    assert.equal(nextSnapshot.some((item) => item.id === `mutated_${name}`), false);
+    assert.equal(nextSnapshot.some((item) => item.id === `reassigned_${name}`), false);
+    assert.notEqual(nextSnapshot, snapshot);
+  });
+}


### PR DESCRIPTION
Closes #5403.
Refs #743.

## Summary

- Return defensive array snapshots from all in-memory list services instead of exposing backing arrays.
- Add regression coverage for users, jobs, proposals, reviews, messages, and notifications.
- Make the API test script target test files explicitly so `npm test -w apps/api` runs reliably on Windows/Node 24.

## Verification

```text
npm test -w apps/api
```

Result: 7 tests passed.