### PR TITLE
fix(web): resolve freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((profile) => profile.username === params.username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p>Skills: <strong>{freelancer.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #5405.
Refs #743.

## Summary

- Resolves `/freelancers/[username]` against the existing mock freelancer records.
- Shows the matched freelancer username, skills, and hourly rate on known profiles.
- Returns the standard Next not-found fallback for unknown usernames.

## Verification

```text
npm run build -w apps/web
```

Result: build completed successfully.