### PR TITLE
fix(api): default payment currency to USD

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: payload.currency ?? "USD",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults missing currency to uppercase USD", async () => {
+  const intent = await createPaymentIntent({ amount: 500 });
+
+  assert.equal(intent.currency, "USD");
+});
+
+test("createPaymentIntent preserves explicit currency", async () => {
+  const intent = await createPaymentIntent({ amount: 500, currency: "eur" });
+
+  assert.equal(intent.currency, "eur");
+});


### PR DESCRIPTION
Closes #5367.
Refs #743.

## Summary

- Defaults `createPaymentIntent()` currency to uppercase `USD` when no currency is provided.
- Preserves explicit caller-provided currency values.
- Adds focused service coverage for both behaviors.

## Verification

```text
node --test apps/api/src/tests/paymentService.test.js
```

Result: 2 tests passed.

Note: I ran the focused test directly because the current base branch API test script still uses `node --test src/tests`, which is tracked separately and can fail on Windows/Node 24 by loading the directory as a module.