### PR TITLE
fix(ui): expose runtime package entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "runtime/index.cjs",
+  "types": "runtime/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./runtime/index.d.ts",
+      "default": "./runtime/index.cjs"
+    }
+  },
+  "peerDependencies": {
+    "react": "^19.2.0"
+  }
 }

--- a/packages/ui/runtime/index.cjs
+++ b/packages/ui/runtime/index.cjs
@@ -1,0 +1,34 @@
+"use strict";
+
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = {
+  Button,
+  Card
+};

--- a/packages/ui/runtime/index.d.ts
+++ b/packages/ui/runtime/index.d.ts
@@ -1,0 +1,11 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Button({ children }: { children: ReactNode }): ReactElement;
+
+export declare function Card({
+  title,
+  children
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement;


### PR DESCRIPTION
Fixes #2781.

Updates @freelanceflow/ui so the workspace package can be imported directly by Node/ESM consumers instead of pointing main at TypeScript source.

Changes:

- points main/types/exports at a checked-in runtime entrypoint
- adds a CommonJS runtime implementation for Button and Card
- adds TypeScript declarations for package consumers
- preserves the existing source files

Verification:

```powershell
node -e "import('@freelanceflow/ui').then(m => { console.log(Object.keys(m).sort().join(',')); if (!m.Button || !m.Card) process.exit(1); })"
```

Result:

```text
Button,Card,default,module.exports
```

/claim #2781
