### PR TITLE
fix(web): render mock job detail pages

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,26 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((candidate) => candidate.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job exists for <strong>{params.id}</strong>.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <p>Responsibilities, milestones, and proposals can be reviewed with the client.</p>
+      <Link href="/jobs">Back to job listings</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,22 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create a chat widget that answers common support questions and hands off complex issues."
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Move existing REST endpoints to a Node.js service while preserving client contracts."
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Design first-run product flows that help teams invite users and complete setup."
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
Fixes #2755.

Updates the job detail page to look up the selected mock job instead of rendering placeholder route text.

Changes:

- known `/jobs/[id]` routes render the matching mock job title, budget, and project summary
- unknown job ids show a clear not-found fallback
- existing listing links continue to use the same mock ids

Verification:

```powershell
npm run build -w apps/web
```

Result: Next.js production build completed successfully.

/claim #2755
