### PR TITLE
fix(api): preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-supplied id", async () => {
+  const notification = await createNotification({
+    id: "ntf_client_supplied",
+    message: "Proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_client_supplied");
+});
+
+test("createNotification always starts unread", async () => {
+  const notification = await createNotification({
+    message: "Invoice paid",
+    read: true
+  });
+
+  assert.equal(notification.read, false);
+});
+
+test("createNotification preserves caller-owned fields", async () => {
+  const notification = await createNotification({
+    message: "New milestone",
+    type: "project"
+  });
+
+  assert.equal(notification.message, "New milestone");
+  assert.equal(notification.type, "project");
+});


### PR DESCRIPTION
Fixes #2762.

Ensures notification creation keeps server-owned fields authoritative.

Changes:

- caller-supplied `id` can no longer override the generated notification id
- caller-supplied `read` can no longer create already-read notifications
- caller-owned fields such as `message` and `type` are still preserved
- adds focused service tests for the ownership behavior

Verification:

```powershell
node --test apps/api/src/tests/*.test.js
```

Result: 4 tests passed.

/claim #2762
