### PR TITLE
fix(api): reject uploads without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createMockResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+test("uploadFile rejects requests without a file", async () => {
+  const res = createMockResponse();
+
+  await uploadFile({}, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.payload, { success: false, message: "File is required" });
+});
+
+test("uploadFile preserves successful upload responses", async () => {
+  const res = createMockResponse();
+
+  await uploadFile({ file: { originalname: "proof.txt" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.payload, {
+    success: true,
+    data: {
+      filename: "proof.txt",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
Closes #5416.
Refs #743.

## Summary

- Returns `400` with `File is required` when `uploadFile()` receives no `req.file`.
- Keeps successful upload responses at `201` with filename and `uploaded` status.
- Adds focused controller tests for missing-file and successful-file paths.

## Verification

```text
node --test apps/api/src/tests/uploadController.test.js apps/api/src/tests/health.test.js
```

Result: 3 tests passed.