### PR TITLE
fix(api): align registration token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const originalNow = Date.now;
+  let calls = 0;
+
+  Date.now = () => {
+    calls += 1;
+    return calls === 1 ? 1000 : 2000;
+  };
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #2768.

Ensures registration creates the user id once and signs the access token with that same id as the JWT subject.

Changes:

- generates the registration id once in `registerUser`
- returns that same id in the registration response
- signs the token with the same id in `sub`
- adds a focused regression test that stubs `Date.now()` across two values and verifies `decoded.sub === result.id`

Verification:

```powershell
node --test apps/api/src/tests/*.test.js
```

Result: 2 tests passed.

/claim #2768
