### PR TITLE
fix(api): accept bearer scheme case-insensitively

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, token] = authHeader?.split(/\s+/, 2) ?? [];
+
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createMockResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+function runAuth(authorization) {
+  const req = { headers: { authorization } };
+  const res = createMockResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { req, res, nextCalled };
+}
+
+for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+  test(`authMiddleware accepts ${scheme} bearer scheme`, () => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const { req, nextCalled } = runAuth(`${scheme} ${token}`);
+
+    assert.equal(nextCalled, true);
+    assert.equal(req.user.sub, "usr_test");
+    assert.equal(req.user.role, "client");
+  });
+}
+
+test("authMiddleware rejects malformed authorization headers", () => {
+  const { res, nextCalled } = runAuth("Bearer");
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { success: false, message: "Unauthorized" });
+});
+
+test("authMiddleware rejects invalid tokens", () => {
+  const { res, nextCalled } = runAuth("bearer not-a-token");
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { success: false, message: "Invalid token" });
+});


### PR DESCRIPTION
Closes #5147.
Refs #743.

## Summary

- Parses the Authorization scheme case-insensitively.
- Accepts canonical `Bearer`, lowercase `bearer`, and uppercase `BEARER` for valid tokens.
- Keeps rejecting missing/malformed headers and invalid tokens.
- Adds focused auth middleware tests.

## Verification

```text
node --test apps/api/src/tests/authMiddleware.test.js apps/api/src/tests/health.test.js
```

Result: 6 tests passed.