### PR TITLE
fix(api): validate search query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,20 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 120;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q ?? "";
+
+  if (typeof query !== "string") {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  const normalizedQuery = query.trim();
+
+  if (normalizedQuery.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query is too long", 400);
+  }
+
+  return ok(res, await globalSearch(normalizedQuery));
 }

--- a/apps/api/src/tests/searchController.test.js
+++ b/apps/api/src/tests/searchController.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid query strings", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Search query must be a single string" });
+  });
+});
+
+test("GET /api/search rejects object-shaped q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q[$ne]=x`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Search query must be a single string" });
+  });
+});
+
+test("GET /api/search rejects oversized q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"x".repeat(121)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Search query is too long" });
+  });
+});


### PR DESCRIPTION
Closes #5423.
Refs #743.

## Summary

- Normalizes `q` to a trimmed string before searching.
- Rejects repeated/object-shaped query parameters with `400`.
- Rejects oversized query values with `400`.
- Adds route tests for valid, repeated, object-shaped, and oversized query values.

## Verification

```text
node --test apps/api/src/tests/searchController.test.js apps/api/src/tests/health.test.js
```

Result: 5 tests passed.