### PR TITLE
Fix UI package Node entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,7 +2183,10 @@
       }
     },
     "packages/ui": {
-      "name": "@freelanceflow/ui"
+      "name": "@freelanceflow/ui",
+      "peerDependencies": {
+        "react": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
-    "test": "npm run test -w apps/api"
+    "test": "npm run test -w apps/api",
+    "test:ui": "node packages/ui/test-import.mjs"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,21 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./runtime/index.js",
+  "types": "./runtime/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./runtime/index.d.ts",
+      "default": "./runtime/index.js"
+    },
+    "./src/*": "./src/*"
+  },
+  "files": [
+    "runtime",
+    "src"
+  ],
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }

--- a/packages/ui/runtime/index.d.ts
+++ b/packages/ui/runtime/index.d.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+export declare function Button(props: {
+  children: ReactNode;
+}): import("react").ReactElement;
+
+export declare function Card(props: {
+  title: string;
+  children: ReactNode;
+}): import("react").ReactElement;

--- a/packages/ui/runtime/index.js
+++ b/packages/ui/runtime/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/test-import.mjs
+++ b/packages/ui/test-import.mjs
@@ -1,0 +1,7 @@
+const ui = await import("@freelanceflow/ui");
+
+if (typeof ui.Button !== "function" || typeof ui.Card !== "function") {
+  throw new Error("Expected @freelanceflow/ui to export Button and Card");
+}
+
+console.log(Object.keys(ui).sort().join(","));


### PR DESCRIPTION
## Summary
- point `@freelanceflow/ui` at a Node-loadable ESM runtime entrypoint instead of raw TS/TSX source
- add declarations for the exported `Button` and `Card` components
- keep the existing TSX source available through `./src/*` for future bundler/app work
- add a focused package-name import regression check

Closes #5429

## Verification
- reproduced the original failure before the fix with:
  `node -e "import('@freelanceflow/ui').then((m) => console.log(Object.keys(m))).catch((e) => { console.error(e.code || e.name, e.message); process.exit(1); })"`
- after the fix, the same command prints `Button,Card`
- `npm run test:ui`

## Note
- `npm test` is still blocked by the existing API workspace test script issue (`node --test src/tests` cannot resolve `apps/api/src/tests`). That is tracked separately and left out of scope here.