### PR TITLE
fix(api): trim bearer credentials after flexible spacing

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const token = authHeader?.match(/^Bearer\s+(.+)$/)?.[1]?.trim();
+
+  if (!token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function requestAdminMetrics(authorization) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: authorization ? { authorization } : {}
+    });
+    const payload = await response.json();
+    return { response, payload };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth middleware accepts a valid bearer token with canonical spacing", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "admin" });
+  const { response, payload } = await requestAdminMetrics(`Bearer ${token}`);
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+});
+
+test("auth middleware trims a valid bearer token after flexible spacing", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "admin" });
+  const { response, payload } = await requestAdminMetrics(`Bearer    ${token}`);
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+});
+
+test("auth middleware rejects malformed authorization headers", async () => {
+  const { response, payload } = await requestAdminMetrics("Token not-a-bearer-token");
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+});
+
+test("auth middleware rejects invalid bearer tokens", async () => {
+  const { response, payload } = await requestAdminMetrics("Bearer not-a-valid-token");
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(payload, { success: false, message: "Invalid token" });
+});


### PR DESCRIPTION
/claim #743

Closes #5435
Refs #743

## Summary

- Parses bearer credentials with flexible spacing after the `Bearer` scheme.
- Trims the extracted JWT before verification so valid headers like `Bearer    <token>` are accepted.
- Keeps malformed headers and invalid JWTs rejected.
- Adds focused auth middleware regression coverage.

## Verification

```text
node --test apps/api/src/tests/*.test.js
```

Result: 5 tests passed.
