### PR TITLE
Fix bearer token spacing in auth middleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/);
+  if (!match) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(match[1].trim());
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("auth middleware trims extra Bearer credential spacing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const token = signAccessToken({ sub: "usr_test", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        Authorization: `Bearer    ${token}`,
+      },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- parse bearer credentials with a narrow `Bearer\s+<token>` match
- trim the extracted credential before JWT verification
- add a regression test for `Authorization: Bearer    <token>` on an authenticated admin route

Closes #5459

## Verification
- `node --test apps/api/src/tests/auth.test.js`

## Note
- root `npm test` is still blocked by the existing API workspace script issue (`node --test src/tests` cannot resolve `apps/api/src/tests`). That is separate from this auth parser fix.