### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a new product",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "web",
+  skills: ["react"],
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 500,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema rejects inverted budget ranges when both budgets are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 1000,
+    budgetMax: 500,
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 1000 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 1000 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,15 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function hasValidBudgetRange(payload) {
+  return (
+    payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMax >= payload.budgetMin
+  );
+}
+
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +18,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"],
+});
+
+export const updateJobSchema = jobSchema.partial().refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"],
+});


### PR DESCRIPTION
## Summary
- add a shared budget range refinement for job create/update validation
- reject create payloads where `budgetMax < budgetMin`
- reject update payloads with inverted ranges while preserving partial budget updates
- add focused validator regression tests

Closes #5464

## Verification
- `node --test apps/api/src/tests/job-validator.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/job-validator.test.js`

## Note
- root `npm test` is still blocked by the existing API workspace script issue (`node --test src/tests` cannot resolve `apps/api/src/tests`). That is separate from this validator fix.