### PR TITLE
Resolve freelancer profiles from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((item) => item.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No freelancer profile exists for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Rate: {freelancer.rate}</p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- resolve `/freelancers/[username]` from the shared mock freelancer data
- render known freelancer skills and hourly rate
- show a clear not-found fallback for unknown usernames

Closes #5468

## Verification
- `npm run build -w apps/web`