### PR TITLE
Validate search query parameters

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,23 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const maxQueryLength = 200;
+
+function normalizeSearchQuery(value) {
+  if (value === undefined) return "";
+  if (typeof value !== "string") return null;
+
+  const query = value.trim();
+  if (query.length > maxQueryLength) return null;
+  return query;
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = normalizeSearchQuery(req.query.q);
+
+  if (query === null) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims a valid query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});
+
+test("GET /api/search rejects object-shaped q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q[name]=designer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});
+
+test("GET /api/search rejects oversized q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize `q` to a trimmed string before passing it to the search service
- reject repeated and object-shaped `q` parameters
- reject search queries longer than 200 characters
- add route coverage for valid, repeated, object-shaped, and oversized query values

Closes #5476

## Verification
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/search.test.js`

## Note
- root `npm test` is still blocked by the existing API workspace script issue (`node --test src/tests` cannot resolve `apps/api/src/tests`). That is separate from this search validation fix.