### PR TITLE
fix: validate search query q parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = req.query;
+
+  if (q === undefined) {
+    return ok(res, await globalSearch(""));
+  }
+
+  if (typeof q !== "string") {
+    return fail(res, "Search query must be a single string");
+  }
+
+  const query = q.trim();
+
+  if (query.length > 200) {
+    return fail(res, "Search query is too long (max 200 characters)");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(cb) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await cb(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search with valid query", async () => {
+  await withServer(async (url) => {
+    const response = await fetch(`${url}/api/search?q=test`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "test");
+  });
+});
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (url) => {
+    const response = await fetch(`${url}/api/search?q=one&q=two`);
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/search rejects object-shaped q parameters", async () => {
+  await withServer(async (url) => {
+    const response = await fetch(`${url}/api/search?q[foo]=bar`);
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/search rejects queries longer than 200 characters", async () => {
+  await withServer(async (url) => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`${url}/api/search?q=${longQuery}`);
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/search normalizes and trims query", async () => {
+  await withServer(async (url) => {
+    const response = await fetch(`${url}/api/search?q=%20%20hello%20world%20%20`);
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "hello world");
+  });
+});


### PR DESCRIPTION
This PR implements validation for the search query parameter 'q'. It ensures 'q' is a single string, trimmed, and capped at 200 characters. Repeated or object-shaped parameters are rejected with a 400 error. Regression tests included.