### PR TITLE
fix: avoid persisted leaderboard token URL

### DIFF
--- a/.github/tests/update-pr-leaderboard.test.js
+++ b/.github/tests/update-pr-leaderboard.test.js
@@ -1,0 +1,17 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const workflow = readFileSync(join(__dirname, "../workflows/update-pr-leaderboard.yml"), "utf8");
+
+test("leaderboard workflow does not persist the GitHub token in origin URL", () => {
+  assert.doesNotMatch(workflow, /git remote set-url origin "https:\/\/x-access-token:\$\{GH_TOKEN\}@github\.com/);
+  assert.match(workflow, /git remote set-url origin "https:\/\/github\.com\/\$\{GITHUB_REPOSITORY\}\.git"/);
+});
+
+test("leaderboard workflow authenticates push with an ephemeral header", () => {
+  assert.match(workflow, /auth_header="\$\(printf 'x-access-token:%s' "\$\{GH_TOKEN\}" \| base64 -w0\)"/);
+  assert.match(workflow, /http\.https:\/\/github\.com\/\.extraheader=AUTHORIZATION: basic \$\{auth_header\}/);
+  assert.match(workflow, /git .* push origin "HEAD:\$\{DEFAULT_BRANCH\}"/);
+});

--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -36,7 +36,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
           git checkout "${DEFAULT_BRANCH}"
           git pull --ff-only origin "${DEFAULT_BRANCH}"
@@ -63,4 +63,5 @@ jobs:
 
           git commit -m "chore: update leaderboard for PR #${PR_NUMBER}"
           git pull --rebase origin "${DEFAULT_BRANCH}"
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" push origin "HEAD:${DEFAULT_BRANCH}"


### PR DESCRIPTION
Closes #5480\n/claim #743\n\n## Summary\n\n- Keep the leaderboard workflow origin URL free of embedded GitHub tokens.\n- Authenticate the final push with an ephemeral http.extraheader instead of persisting credentials in git config.\n- Add a focused regression test that checks the workflow credential handling.\n\n## Validation\n\n- C:\\Program Files\\nodejs\\node.exe --test .github\\tests\\update-pr-leaderboard.test.js\n- C:\\Program Files\\nodejs\\node.exe --check .github\\tests\\update-pr-leaderboard.test.js\n- C:\\Program Files\\Git\\bin\\git.exe diff --check