### PR TITLE
docs: use readable workspace separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` - Next.js 14 App Router frontend
+- `apps/api` - Express.js backend with layered REST API
+- `packages/db` - Prisma schema and database package
+- `packages/ui` - Shared UI components
 
 ## Frontend
 


### PR DESCRIPTION
/claim #743

Closes #5486

## Summary

- Replace the workspace structure separators in `README.md` with ASCII ` - ` separators.
- Keep the documentation cleanup scoped to the four workspace bullets.
- Avoid touching stack-version wording, schema docs, app code, or API behavior.

## Validation

- `git diff --check`

## Payment preference

- Base USDC / EVM: `0x28bf0e2e9b54598b563dd49a3373fe6ae55d16b1`
- Arbitrum USDC / EVM: `0x28bf0e2e9b54598b563dd49a3373fe6ae55d16b1`