### PR TITLE
fix: add exports entrypoint for @freelanceflow/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,4 +2,10 @@
   "name": "@freelanceflow/ui",
   "private": true,
   "main": "src/index.ts"
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./Button": "./src/Button.tsx",
+    "./Card": "./src/Card.tsx"
+  }
 }


### PR DESCRIPTION
## What

Adds a proper `exports` field to `@freelanceflow/ui`'s package.json so the package can be directly imported by Node/ESM consumers.

## Why

The package currently only has `main: src/index.ts` which doesn't work for direct imports. Adding the `exports` map makes each component importable individually.

## Changes

- Added `exports` field with entries for `. `, `./Button`, and `./Card`
- Kept existing `main` field for backwards compatibility

## Test

- `node -e "import('@freelanceflow/ui')"` should resolve without errors

Closes #5451