### PR TITLE
fix: add exports entrypoint for @freelanceflow/db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,6 +5,11 @@
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"
   },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.17.0"
   },


### PR DESCRIPTION
## What

Adds `main`, `types`, and `exports` fields to `@freelanceflow/db`'s package.json.

## Why

The package has `src/index.ts` but no declared entrypoint, so Node can't resolve imports properly.

## Changes

- Added `main` pointing to `src/index.ts`
- Added `types` pointing to `src/index.ts`
- Added `exports` map with root entry

Closes #5453