### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+describe("job validators", () => {
+  describe("createJobSchema", () => {
+    it("accepts valid budget range", () => {
+      const result = createJobSchema.safeParse({
+        title: "Test Job",
+        description: "This is a test job description",
+        budgetMin: 100,
+        budgetMax: 500,
+        categoryId: "cat-1",
+        skills: ["javascript"]
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects inverted budget range", () => {
+      const result = createJobSchema.safeParse({
+        title: "Test Job",
+        description: "This is a test job description",
+        budgetMin: 500,
+        budgetMax: 100,
+        categoryId: "cat-1",
+        skills: []
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("allows equal min and max", () => {
+      const result = createJobSchema.safeParse({
+        title: "Test Job",
+        description: "This is a test job description",
+        budgetMin: 200,
+        budgetMax: 200,
+        categoryId: "cat-1",
+        skills: []
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("updateJobSchema", () => {
+    it("accepts partial update with only budgetMin", () => {
+      const result = updateJobSchema.safeParse({ budgetMin: 100 });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts partial update with only budgetMax", () => {
+      const result = updateJobSchema.safeParse({ budgetMax: 500 });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects inverted range when both fields present", () => {
+      const result = updateJobSchema.safeParse({
+        budgetMin: 500,
+        budgetMax: 100
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid range when both fields present", () => {
+      const result = updateJobSchema.safeParse({
+        budgetMin: 100,
+        budgetMax: 500
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,17 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin" }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  { message: "budgetMax must be greater than or equal to budgetMin" }
+);


### PR DESCRIPTION
## What

Adds Zod refinements to reject inverted budget ranges in job create/update schemas.

## Why

`createJobSchema` accepted payloads where `budgetMax` was less than `budgetMin`, allowing invalid job records.

## Changes

- Added refinement to `createJobSchema` to reject inverted ranges
- Added refinement to `updateJobSchema` to reject inverted ranges when both fields are present
- Partial updates with only one budget field still work
- Added test coverage

Closes #5464