### PR TITLE
fix: add admin role check to admin routes

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -5,4 +5,10 @@ import { authMiddleware } from "../middleware/auth.js";
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use((req, res, next) => {
+  if (req.user?.role !== "admin") {
+    return res.status(403).json({ error: "Forbidden: admin access required" });
+  }
+  next();
+});
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
the admin routes check for auth but not for role - any logged in user can hit /metrics. Added a role check middleware.

Closes #5455