### PR TITLE
fix: prevent caller from overriding server-generated user id

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
the createUser service spreads the request payload after setting the server id, so a caller can pass "id" in the body and overwrite it. destructured out the "id" field before spreading.

Closes #5344