### PR TITLE
fix: prevent caller from overriding server-generated job id and status

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _ignored, status: _ignoredStatus, ...safePayload } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safePayload };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
createJob spreads the request payload after setting id and status, so a caller can override both. destructured out id and status before spreading.

Closes #5336