### PR TITLE
fix: prevent caller from overriding server-generated proposal id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...safePayload };
   proposals.push(proposal);
   return proposal;
 }


### PR DESCRIPTION
createProposal spreads the payload after setting the server id, so a caller can override it. destructured out id before spreading.

Closes #5331