### PR TITLE
fix: prevent caller from overriding server-generated message id

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignored, ...safePayload } = payload;
+  const message = { id: `msg_${Date.now()}`, ...safePayload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
sendMessage spreads the payload after setting the server id, so a caller can override it. destructured out id before spreading.

Closes #5333