### PR TITLE
fix: prevent caller from overriding server-generated review id

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const review = { id: `rev_${Date.now()}`, ...safePayload };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
createReview spreads the payload after setting the server id, so a caller can override it. destructured out id before spreading.

Closes #5342