### PR TITLE
fix: prevent caller from overriding server-generated notification id and read state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignored, read: _ignoredRead, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
createNotification spreads the payload after setting id and read, so a caller can override both. destructured out id and read before spreading.

Closes #5329