### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
the register schema accepted "admin" as a valid role, so anyone could register as an admin. removed it from the enum - admin roles should be assigned through a separate admin flow.

Closes #5316