### PR TITLE
fix: default payment currency to uppercase USD

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: payload.currency ?? "USD",
     provider: "stripe"
   };
 }


### PR DESCRIPTION
createPaymentIntent defaults currency to lowercase "usd" but the schema expects uppercase "USD". fixed the default to match.

Closes #5348