### PR TITLE
fix: accept multiple spaces after Bearer scheme in auth header

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,12 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !/^Bearer\s+/.test(authHeader)) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(authHeader.replace(/^Bearer\s+/, ""));
     return next();
   } catch {
     return fail(res, "Invalid token", 401);


### PR DESCRIPTION
the auth middleware used startsWith("Bearer ") which only matches a single space. clients sometimes send extra whitespace after the scheme. switched to a regex that matches Bearer followed by one or more spaces, and strips the scheme before extracting the token.

Closes #5304