### PR TITLE
docs: use readable README workspace separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` - Next.js 14 App Router frontend
+- `apps/api` - Express.js backend with layered REST API
+- `packages/db` - Prisma schema and database package
+- `packages/ui` - Shared UI components
 
 ## Frontend
 


### PR DESCRIPTION
Closes #5514.
Refs #743.

## Summary

- Replaces the workspace structure list separators with plain ASCII ` - `.
- Keeps the cleanup limited to README readability/encoding consistency.

## Verification

```text
git diff --check -- README.md
```

Result: exit 0.