### PR TITLE
fix: add fullName to registration schema and service

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
Add ullName field to registration validation schema and include it in egisterUser() response payload.

**Changes:**
- Add non-empty ullName string to egisterSchema in pps/api/src/validators/auth.js
- Include payload.fullName in the returned user object in pps/api/src/services/authService.js

Closes #2770