### PR TITLE
fix: use single timestamp for user id and token sub

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Fix race condition where Date.now() is called twice in egisterUser(), potentially generating different ids for the response and JWT sub claim.

**Changes:**
- Generate the user id once with const id = \usr_\`
- Reuse the same id for both esult.id and 	oken.sub
- Include ullName in the registration response

Closes #2768