### PR TITLE
fix: reject inverted budget ranges in job schemas

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,17 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);


### PR DESCRIPTION
Add .refine() validation to createJobSchema and updateJobSchema to reject inverted budget ranges (udgetMax < budgetMin).

**Changes:**
- createJobSchema - validates udgetMax >= budgetMin
- updateJobSchema - validates udgetMax >= budgetMin when both fields are present in a partial update
- Existing valid ordered ranges continue to pass

Closes #2853