### PR TITLE
chore: update vulnerable postcss version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,5 +15,8 @@
     "next": "16.2.6",
     "react": "19.2.0",
     "react-dom": "19.2.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
Fixes #1779

Bumps postcss to 8.4.31 to fix CVE-2023-44270.

Wallet: 0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131