### PR TITLE
fix: validate amount and currency in payment creation (Fixes #5523)

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid payment payload",
+      errors: result.error.errors
+    });
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments validates amount and currency", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/payments`;
+
+  await t.test("rejects missing amount", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects negative amount", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: -25, currency: "usd" })
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects wrong-type amount", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: "free", currency: "usd" })
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects unsupported currency", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 100, currency: "beep" })
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("accepts valid amount with default currency", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 100 })
+    });
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.amount, 100);
+  });
+
+  await t.test("accepts valid amount with explicit supported currency", async () => {
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 50, currency: "eur" })
+    });
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.data.currency, "eur");
+    assert.equal(payload.data.amount, 50);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.enum(["usd", "eur", "gbp", "cad", "aud", "jpy"]).default("usd")
+});


### PR DESCRIPTION
Fixes #5523

Adds a Zod validator for payment intent creation to reject missing, negative, string amounts, and unsupported currencies. Also adds focused API regression tests.

Wallet: 0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131