### PR TITLE
fix(api): reject oversized JSON bodies

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "JSON body is too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/jsonBodyLimit.test.js
+++ b/apps/api/src/tests/jsonBodyLimit.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("API rejects oversized JSON request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "oversized@example.com",
+        password: "password",
+        padding: "x".repeat(110_000)
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, { success: false, message: "JSON body is too large" });
+  });
+});


### PR DESCRIPTION
Closes #4907.
Refs #743.

## Summary

- Adds an explicit `100kb` limit to the API JSON body parser.
- Returns a clear `413` JSON response when the parser rejects oversized JSON.
- Keeps unexpected errors logged as before, but avoids logging expected oversized-body client errors.
- Adds focused API coverage for the oversized JSON path.

## Verification

```text
node --test apps/api/src/tests/jsonBodyLimit.test.js apps/api/src/tests/health.test.js
```

Result: 2 tests passed.