### PR TITLE
fix(api): reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build feature",
+  description: "Build a useful product feature",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "engineering"
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("createJobSchema accepts valid budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 500 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,5 +1,19 @@
 import { z } from "zod";
 
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
@@ -7,6 +21,13 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).superRefine(validateBudgetRange);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4),
+  description: z.string().min(10),
+  budgetMin: z.number().nonnegative(),
+  budgetMax: z.number().nonnegative(),
+  categoryId: z.string().min(1),
+  skills: z.array(z.string().min(1))
+}).partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Closes #5464.
Refs #743.

## Summary

- Adds shared range validation for job create/update schemas.
- Rejects payloads where `budgetMax` is lower than `budgetMin`.
- Keeps partial updates valid when only one budget field is provided.
- Adds focused validator regression tests.

## Verification

```text
node --test apps/api/src/tests/jobValidator.test.js apps/api/src/tests/health.test.js
```

Result: 5 tests passed.