### PR TITLE
fix: reject malformed and oversized search q parameters (Fixes #5476)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchSchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = searchSchema.safeParse(req.query);
+  
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid search query",
+      errors: result.error.errors
+    });
+  }
+
+  return ok(res, await globalSearch(result.data.q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/search validates query parameters", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/search`;
+
+  await t.test("accepts valid q parameter", async () => {
+    const response = await fetch(`${baseUrl}?q=test`);
+    assert.equal(response.status, 200);
+  });
+
+  await t.test("accepts missing q parameter and defaults to empty string", async () => {
+    const response = await fetch(baseUrl);
+    assert.equal(response.status, 200);
+  });
+
+  await t.test("trims q parameter with surrounding spaces", async () => {
+    const response = await fetch(`${baseUrl}?q=  test  `);
+    assert.equal(response.status, 200);
+  });
+
+  await t.test("rejects oversized q parameter", async () => {
+    const oversizedQ = "a".repeat(201);
+    const response = await fetch(`${baseUrl}?q=${oversizedQ}`);
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects repeated q parameters (array)", async () => {
+    const response = await fetch(`${baseUrl}?q=a&q=b`);
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("rejects object-shaped q parameter", async () => {
+    const response = await fetch(`${baseUrl}?q[a]=1`);
+    assert.equal(response.status, 400);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchSchema = z.object({
+  q: z.string().max(200).trim().default("")
+});


### PR DESCRIPTION
Fixes #5476

Adds a Zod validator for the search route to properly parse and sanitize the \q\ parameter. Normalizes \q\ to a single trimmed string, limits length to 200 characters, and explicitly rejects object-shaped or repeated parameters to prevent denial-of-service edge cases.

Wallet: 0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131