### PR TITLE
fix: resolve mock jobs by id in job detail route (Fixes #5484)

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,18 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
+      <p>Viewing details for <strong>{job.id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Fixes #5484

Updates the Next.js job detail page (\/jobs/[id]\) to query the mock data array for a matching job instead of rendering static placeholder text. If the job ID exists, it displays the appropriate title and budget. If the job ID is unknown, it correctly invokes \
otFound()\ to trigger the standard 404 fallback.

Wallet: 0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131