### PR TITLE
fix(api): validate payment payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects missing amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments rejects negative amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: -25, currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments rejects wrong amount type", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: "free", currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments rejects unsupported currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 25, currency: "beep" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments creates valid payment with default currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 25 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "usd");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.enum(["usd", "eur", "gbp"]).default("usd")
+});


### PR DESCRIPTION
Closes #5533.
Refs #743.

Summary:
- add a payment creation validator for amount and supported currency values
- reject invalid payment payloads with 400 before they reach the service
- preserve the existing usd default for valid payment requests
- add route regression coverage for missing, negative, wrong-type, unsupported-currency, and valid/default-currency payloads

Verification:
```text
node.exe --test apps/api/src/tests/paymentRoutes.test.js apps/api/src/tests/health.test.js
```

Result: 6 tests passed.