### PR TITLE
fix(api): avoid same-ms id collisions

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: createId("job"), status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { id: createId("msg"), ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: createId("ntf"), read: false, ...payload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createId } from "../utils/ids.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: createId("prp"), ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: createId("rev"), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: createId("usr"), ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/ids.test.js
+++ b/apps/api/src/tests/ids.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+async function withPinnedNow(timestamp, run) {
+  const original = Date.now;
+  Date.now = () => timestamp;
+
+  try {
+    await run();
+  } finally {
+    Date.now = original;
+  }
+}
+
+test("record services create distinct ids in the same millisecond", async () => {
+  await withPinnedNow(1780879000000, async () => {
+    const records = [
+      await createJob({ title: "Build API", description: "Build a tested API", budgetMin: 1, budgetMax: 2, categoryId: "dev" }),
+      await createJob({ title: "Build UI", description: "Build a tested UI", budgetMin: 1, budgetMax: 2, categoryId: "dev" }),
+      await createUser({ email: "a@example.com" }),
+      await createUser({ email: "b@example.com" }),
+      await createProposal({ jobId: "job_1", freelancerId: "usr_1" }),
+      await createProposal({ jobId: "job_2", freelancerId: "usr_2" }),
+      await sendMessage({ from: "usr_1", to: "usr_2", body: "hello" }),
+      await sendMessage({ from: "usr_2", to: "usr_1", body: "hi" }),
+      await createReview({ jobId: "job_1", rating: 5 }),
+      await createReview({ jobId: "job_2", rating: 4 }),
+      await createNotification({ userId: "usr_1", message: "one" }),
+      await createNotification({ userId: "usr_2", message: "two" })
+    ];
+
+    const ids = records.map((record) => record.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+});
+
+test("payment intents create distinct payment ids in the same millisecond", async () => {
+  await withPinnedNow(1780879000000, async () => {
+    const first = await createPaymentIntent({ amount: 10, currency: "usd" });
+    const second = await createPaymentIntent({ amount: 20, currency: "usd" });
+
+    assert.notEqual(first.paymentId, second.paymentId);
+    assert.match(first.paymentId, /^pay_1780879000000/);
+    assert.match(second.paymentId, /^pay_1780879000000_/);
+  });
+});

--- a/apps/api/src/utils/ids.js
+++ b/apps/api/src/utils/ids.js
@@ -1,0 +1,10 @@
+const lastSequences = new Map();
+
+export function createId(prefix) {
+  const now = Date.now();
+  const previous = lastSequences.get(prefix);
+  const sequence = previous?.timestamp === now ? previous.sequence + 1 : 0;
+  lastSequences.set(prefix, { timestamp: now, sequence });
+
+  return sequence === 0 ? `${prefix}_${now}` : `${prefix}_${now}_${sequence}`;
+}


### PR DESCRIPTION
Closes #5536.
Refs #743.

Summary:
- add a shared `createId()` helper that preserves readable prefixes and appends a per-prefix same-millisecond sequence only when needed
- replace `Date.now()`-only IDs in job, user, proposal, message, review, notification, and payment services
- add service regression tests that pin `Date.now()` and prove same-millisecond creates receive distinct IDs

Verification:
```text
node.exe --test apps/api/src/tests/ids.test.js apps/api/src/tests/health.test.js
```

Result: 3 tests passed.