### PR TITLE
fix: require a valid refresh token for auth refresh (Fixes #5519)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,22 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const result = refreshSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid refresh payload",
+      errors: result.error.errors
+    });
+  }
+
+  try {
+    const data = await refreshToken(result.data.refreshToken);
+    return ok(res, data);
+  } catch (error) {
+    return res.status(401).json({
+      success: false,
+      message: "Invalid or expired refresh token"
+    });
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: id, role: payload.role })
   };
 }
 
@@ -14,10 +16,12 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "client" }),
+    refreshToken: signRefreshToken({ sub: "usr_existing", role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(tokenString) {
+  const decoded = verifyRefreshToken(tokenString);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth issues and refreshes tokens", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/auth`;
+
+  let validRefreshToken = "";
+
+  await t.test("login returns access and refresh tokens", async () => {
+    const response = await fetch(`${baseUrl}/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "test@example.com", password: "password123" })
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.ok(payload.data.token);
+    assert.ok(payload.data.refreshToken);
+    validRefreshToken = payload.data.refreshToken;
+  });
+
+  await t.test("refresh rejects missing refresh token", async () => {
+    const response = await fetch(`${baseUrl}/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    assert.equal(response.status, 400);
+  });
+
+  await t.test("refresh rejects invalid token type (e.g. access token passed as refresh)", async () => {
+    const accessToken = signAccessToken({ sub: "hacker" });
+    const response = await fetch(`${baseUrl}/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: accessToken })
+    });
+    assert.equal(response.status, 401);
+  });
+
+  await t.test("refresh accepts valid refresh token", async () => {
+    const response = await fetch(`${baseUrl}/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: validRefreshToken })
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.ok(payload.data.token);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -8,3 +8,15 @@ export function signAccessToken(payload) {
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }
+
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, type: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
+}
+
+export function verifyRefreshToken(token) {
+  const decoded = jwt.verify(token, env.jwtSecret);
+  if (decoded.type !== "refresh") {
+    throw new Error("Invalid token type");
+  }
+  return decoded;
+}

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
Fixes #5519

Adds comprehensive refresh token validation to the /api/auth/refresh endpoint. Register and login endpoints now mint a refresh token with a specific type claim. The refresh endpoint explicitly demands and verifies this exact claim, rejecting missing payloads, expired tokens, or attempts to pass a standard access token for a refresh operation.

Wallet: 0x7F603CD46BC9C2ff735b8B347ed9F19430A0A131