### PR TITLE
feat(jobs): add search, category filter, and summary counts

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,13 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.muted { color: #aeb8df; }
+.button-link { display: inline-flex; align-items: center; justify-content: center; min-height: 2.5rem; padding: 0 1rem; border-radius: 8px; background: #eef2ff; color: #10172f; font-weight: 700; }
+.toolbar { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); margin-bottom: 1rem; }
+.toolbar label { display: grid; gap: 0.4rem; color: #cbd5ff; }
+.toolbar input, .toolbar select { width: 100%; border: 1px solid #2a3765; border-radius: 8px; background: #111832; color: #f2f5ff; padding: 0.7rem 0.8rem; }
+.summary-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem 0.75rem; margin-bottom: 1rem; color: #cbd5ff; }
+.summary-row strong { color: #ffffff; }
+.text-link { color: #9bb0ff; font-weight: 700; }
+.empty-state { border: 1px dashed #3a4a80; border-radius: 8px; padding: 1rem; color: #cbd5ff; }

--- a/apps/web/app/jobs/page.tsx
+++ b/apps/web/app/jobs/page.tsx
@@ -1,18 +1,81 @@
+"use client";
+
 import Link from "next/link";
+import { useMemo, useState } from "react";
 import { jobs } from "../../lib/mock";
 
 export default function JobsPage() {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("All");
+
+  const categories = useMemo(
+    () => ["All", ...Array.from(new Set(jobs.map((j) => j.category)))],
+    []
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return jobs.filter((j) => {
+      if (q && !j.title.toLowerCase().includes(q)) return false;
+      if (category !== "All" && j.category !== category) return false;
+      return true;
+    });
+  }, [query, category]);
+
+  const topBudget = filtered.reduce((max, j) => Math.max(max, j.budgetValue), 0);
+
   return (
     <section>
-      <h2>Job Listings</h2>
+      <div className="page-header">
+        <div>
+          <h2>Job Listings</h2>
+          <p className="muted">
+            Search, filter, and compare open projects before sending a proposal.
+          </p>
+        </div>
+        <Link className="button-link" href="/jobs/post">Post job</Link>
+      </div>
+
+      <div className="toolbar">
+        <label>
+          <span>Search</span>
+          <input
+            type="search"
+            placeholder="Search by title…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </label>
+        <label>
+          <span>Category</span>
+          <select value={category} onChange={(e) => setCategory(e.target.value)}>
+            {categories.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="summary-row">
+        <strong>{filtered.length}</strong> <span>matching ·</span>
+        <strong>{category}</strong> <span>category ·</span>
+        <strong>${topBudget.toLocaleString()}</strong> <span>top budget</span>
+      </div>
+
       <div className="grid">
-        {jobs.map((job) => (
+        {filtered.map((job) => (
           <article className="card" key={job.id}>
             <h3>{job.title}</h3>
+            <p className="muted">{job.category}</p>
             <p>{job.budget}</p>
-            <Link href={`/jobs/${job.id}`}>View details</Link>
+            <Link className="text-link" href={`/jobs/${job.id}`}>
+              View details
+            </Link>
           </article>
         ))}
+        {filtered.length === 0 && (
+          <p className="empty-state">No projects match your filters.</p>
+        )}
       </div>
     </section>
   );

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,10 +1,13 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500", budgetValue: 1500, category: "AI/ML" },
+  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800", budgetValue: 2800, category: "Backend" },
+  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900", budgetValue: 900, category: "Design" },
+  { id: "job-104", title: "Set up CI/CD pipeline for microservices", budget: "$1,200", budgetValue: 1200, category: "DevOps" },
+  { id: "job-105", title: "Build real-time chat with WebSockets", budget: "$2,100", budgetValue: 2100, category: "Backend" },
+  { id: "job-106", title: "Create ML-powered product recommendations", budget: "$3,500", budgetValue: 3500, category: "AI/ML" },
 ];
 
 export const freelancers = [
   { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" },
 ];


### PR DESCRIPTION
## Summary

Adds a lightweight client-side project triage surface to the jobs page (`apps/web/app/jobs/page.tsx`), as described in #5151 (parent bounty #743).

## Changes

**`apps/web/lib/mock.ts`**
- Added `category` and `budgetValue` fields to each job entry
- Added 3 more jobs to cover additional categories (DevOps, Backend, AI/ML)

**`apps/web/app/jobs/page.tsx`**
- Converted to client component (`"use client"`)
- Search input: filters jobs by title (case-insensitive substring match)
- Category dropdown: derived from distinct categories in data, defaults to "All"
- Summary row: shows matching count, active category, and top budget
- Post-job link in page header (links to existing `/jobs/post` route)
- Empty state message when no jobs match the active filters

**`apps/web/app/globals.css`**
- Small shared CSS additions for `.page-header`, `.toolbar`, `.summary-row`, `.muted`, `.button-link`, `.text-link`, `.empty-state`

## Validation

- Static analysis: all fields referenced in JSX exist in the mock data types
- The mock data now includes `category` and `budgetValue` — no runtime crashes from missing properties
- Scope is limited to the jobs page, mock data, and small CSS additions as requested

Closes #5151
/attempt #743