### PR TITLE
[Bug] Resolve job detail mock data by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,24 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+  const job = jobs.find((job) => job.id === id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>
+        <strong>Budget:</strong> {job.budget}
+      </p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary
- update the existing App Router `/jobs/[id]` page to resolve jobs from `apps/web/lib/mock.ts`
- render the selected mock job title and budget for known ids
- use the standard not-found fallback for unknown job ids

## Validation
- npx.cmd tsc --noEmit -p apps/web/tsconfig.json
- npm.cmd run build -w apps/web
- production route smoke: `/jobs/job-101` returns 200 with title and budget; `/jobs/missing-job` returns 404
- git diff --check
- identity hygiene scan clean

Closes #5484
/claim #5484