### PR TITLE
fix(api): restrict cors to configured origin

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,12 +14,17 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { env } from "./config/env.js";
 
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin(origin, callback) {
+      callback(null, !origin || origin === env.corsOrigin);
+    }
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,7 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
+  corsOrigin: process.env.CORS_ORIGIN ?? "http://localhost:3000",
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function requestHealth(origin) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { origin }
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS allows the configured frontend origin", async () => {
+  const response = await requestHealth(env.corsOrigin);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("access-control-allow-origin"), env.corsOrigin);
+});
+
+test("CORS does not allow untrusted browser origins", async () => {
+  const response = await requestHealth("https://evil.example");
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("access-control-allow-origin"), null);
+});


### PR DESCRIPTION
/claim #743

Closes #5541
Refs #743

## Summary

- Adds a configured API CORS origin via `CORS_ORIGIN`, defaulting to the local web app origin.
- Installs CORS with a narrow origin callback instead of open origin reflection.
- Keeps non-browser/no-origin requests working while withholding CORS permission from untrusted browser origins.
- Adds focused regression tests for trusted and untrusted origins.

## Verification

```text
node --test apps/api/src/tests/*.test.js
```

Result: 3 tests passed.
