### PR TITLE
fix: resolve mock freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Profile</h2>
+        <p>No freelancer found for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
Resolves mock freelancer profiles by username in the freelancer profile page. Previously the page showed a placeholder for any username. Now it looks up the freelancer from mock.ts and displays their skills and hourly rate, or shows a 
ot found message for unknown usernames.

**Changes:**
- Import reelancers from pps/web/lib/mock.ts
- Look up freelancer by params.username
- Display skills and rate for known profiles
- Show not-found message for unknown usernames

Closes #2849