### PR TITLE
fix: make @freelanceflow/ui package entrypoint directly importable

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*"
+  }
 }


### PR DESCRIPTION
Adds `exports` field to `@freelanceflow/ui` package.json so the package can be directly imported by consumers using Node.js module resolution.

Closes #2781