### PR TITLE
fix: expose @freelanceflow/db package workspace entrypoint

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Adds `main` field to `@freelanceflow/db` package.json pointing to `src/index.ts` so the Prisma client can be imported by workspace consumers.

Closes #2775