### PR TITLE
fix: resolve mock freelancer profile and job detail pages

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found for <strong>{params.username}</strong>.</p>
+        <p><a href="/freelancers/search">Browse freelancers</a></p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
     </section>
   );
 }

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,23 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job found with id <strong>{params.id}</strong>.</p>
+        <p><a href="/jobs">Browse all jobs</a></p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Full job description, proposals, and applicant details appear here.</p>
     </section>
   );
 }


### PR DESCRIPTION
Updates the freelancer profile page and job detail page to resolve matching mock data from `apps/web/lib/mock.ts`. Known freelancers display skills and rate; unknown usernames show a not-found fallback. Known jobs display title and budget.

Closes #2763
Closes #2755