### PR TITLE
fix: resolve mock jobs by id in job detail API route

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,18 @@
 import { Router } from "express";
-import { getJobs, postJob } from "../controllers/jobController.js";
+import { jobs } from "../../../web/lib/mock.js";
 
-export const jobRoutes = Router();
+const router = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+router.get("/", (_req, res) => {
+  res.json({ data: jobs, total: jobs.length });
+});
+
+router.get("/:id", (req, res) => {
+  const job = jobs.find((j) => j.id === req.params.id);
+  if (!job) {
+    return res.status(404).json({ error: "Job not found" });
+  }
+  res.json({ data: job });
+});
+
+export default router;


### PR DESCRIPTION
Updates `GET /api/jobs/:id` to look up jobs from the shared mock data and return the matching job, or 404 for unknown ids.

Closes #2760