### PR TITLE
fix(auth): accept case-insensitive Bearer scheme with tests

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !/^bearer\s+/i.test(authHeader)) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const token = authHeader.replace(/^bearer\s+/i, "");
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { authMiddleware } from "../middleware/auth.js";
+
+const SECRET = "development-secret";
+
+function makeToken(payload = { id: 1, role: "client" }) {
+  return jwt.sign(payload, SECRET, { expiresIn: "15m" });
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) { res.statusCode = code; return res; },
+    json(data) { res.body = data; return res; },
+  };
+  return res;
+}
+
+test("accepts canonical Bearer scheme", () => {
+  const token = makeToken();
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = mockRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => { nextCalled = true; });
+  assert.ok(nextCalled);
+  assert.ok(req.user);
+  assert.equal(req.user.id, 1);
+});
+
+test("accepts lowercase bearer scheme", () => {
+  const token = makeToken();
+  const req = { headers: { authorization: `bearer ${token}` } };
+  const res = mockRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => { nextCalled = true; });
+  assert.ok(nextCalled);
+  assert.ok(req.user);
+});
+
+test("accepts UPPERCASE BEARER scheme", () => {
+  const token = makeToken();
+  const req = { headers: { authorization: `BEARER ${token}` } };
+  const res = mockRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => { nextCalled = true; });
+  assert.ok(nextCalled);
+  assert.ok(req.user);
+});
+
+test("accepts MiXeD CaSe bearer scheme", () => {
+  const token = makeToken();
+  const req = { headers: { authorization: `BeArEr ${token}` } };
+  const res = mockRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => { nextCalled = true; });
+  assert.ok(nextCalled);
+});
+
+test("rejects missing Authorization header with 401", () => {
+  const req = { headers: {} };
+  const res = mockRes();
+  authMiddleware(req, res, () => { assert.fail("next should not be called"); });
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.success, false);
+});
+
+test("rejects malformed scheme (Basic) with 401", () => {
+  const req = { headers: { authorization: "Basic dXNlcjpwYXNz" } };
+  const res = mockRes();
+  authMiddleware(req, res, () => { assert.fail("next should not be called"); });
+  assert.equal(res.statusCode, 401);
+});
+
+test("rejects blank Authorization with 401", () => {
+  const req = { headers: { authorization: "" } };
+  const res = mockRes();
+  authMiddleware(req, res, () => { assert.fail("next should not be called"); });
+  assert.equal(res.statusCode, 401);
+});
+
+test("rejects invalid token with 401", () => {
+  const req = { headers: { authorization: "Bearer not-a-real-token" } };
+  const res = mockRes();
+  authMiddleware(req, res, () => { assert.fail("next should not be called"); });
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.message, "Invalid token");
+});


### PR DESCRIPTION
## Summary

Fixes `authMiddleware` to accept the Bearer auth scheme case-insensitively, as required by RFC 7235. Closes #5147 (parent bounty #743).

## Problem

`authMiddleware` used `startsWith("Bearer ")` — a case-sensitive check. Valid tokens sent with `Authorization: bearer <token>` or `Authorization: BEARER <token>` were rejected with 401.

## Fix

Replaced `startsWith("Bearer ")` with `/^bearer\s+/i` regex. Same regex extracts the token, so no off-by-one issues.

## Tests (8/8 passing)

| Test | Result |
|------|--------|
| Canonical `Bearer` | passes, user attached |
| Lowercase `bearer` | passes, user attached |
| Uppercase `BEARER` | passes, user attached |
| Mixed case `BeArEr` | passes, user attached |
| Missing header | 401 Unauthorized |
| Basic scheme | 401 Unauthorized |
| Blank header | 401 Unauthorized |
| Invalid token | 401 Invalid token |

Run with: `cd apps/api && node --test src/tests/auth.test.js`

## Scope

Only `apps/api/src/middleware/auth.js` changed (3 lines). New test file added. No other files touched.

Closes #5147
/attempt #743