### PR TITLE
fix(uploads): reject requests without file with 400 + tests

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in upload request", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded",
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function makeApp() {
+  const app = createApp();
+  const server = app.listen(0);
+  const ready = new Promise((r, e) => { server.once("listening", r); server.once("error", e); });
+  return { server, ready };
+}
+
+function close(server) {
+  return new Promise((r, e) => { server.close(err => err ? e(err) : r()); });
+}
+
+test("POST /api/uploads without file returns 400", async () => {
+  const { server, ready } = makeApp();
+  await ready;
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, { method: "POST" });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.success, false);
+  assert.ok(body.message.toLowerCase().includes("no file"));
+
+  await close(server);
+});
+
+test("POST /api/uploads with file returns 201", async () => {
+  const { server, ready } = makeApp();
+  await ready;
+  const { port } = server.address();
+
+  const form = new FormData();
+  form.append("file", new Blob(["hello"]), "test.txt");
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, { method: "POST", body: form });
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(body.data.status, "uploaded");
+  assert.equal(body.data.filename, "test.txt");
+
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Fixes upload endpoint to reject multipart requests that omit the `file` field. Closes #5162 (parent bounty #743).

## Problem

`POST /api/uploads` returned `201 Created` with `success: true` even when the request had no `file` field. The response body included `status: "no-file"` but the HTTP status code signaled success.

## Fix

`uploadController.js` now checks `req.file` first. If missing, returns `400` with `"No file provided in upload request"`. Successful uploads still get `201`.

## Tests (2/2 passing)

| Test | Result |
|------|--------|
| POST without file | 400, success: false |
| POST with file | 201, success: true, filename matches |

Run with: `cd apps/api && node --test src/tests/upload.test.js`

Closes #5162
/attempt #743