### PR TITLE
fix(api): add record creation timestamps

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const createdAt = new Date().toISOString();
+  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: createdAt, createdAt };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, createdAt: new Date().toISOString() };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: `rev_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/recordTimestamps.test.js
+++ b/apps/api/src/tests/recordTimestamps.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+
+function assertIsoTimestamp(value) {
+  assert.equal(typeof value, "string");
+  assert.equal(Number.isNaN(Date.parse(value)), false);
+  assert.equal(new Date(value).toISOString(), value);
+}
+
+test("proposal records include a createdAt timestamp", async () => {
+  const proposal = await createProposal({
+    coverLetter: "test",
+    bidAmount: 500,
+    estDuration: "2 weeks",
+    jobId: "job_test",
+    freelancerId: "usr_test"
+  });
+
+  assertIsoTimestamp(proposal.createdAt);
+});
+
+test("review records include a createdAt timestamp", async () => {
+  const review = await createReview({
+    jobId: "job_test",
+    reviewerId: "usr_test",
+    revieweeId: "usr_other",
+    rating: 5,
+    comment: "great"
+  });
+
+  assertIsoTimestamp(review.createdAt);
+});
+
+test("message records include createdAt while preserving sentAt", async () => {
+  const message = await sendMessage({
+    senderId: "usr_test",
+    recipientId: "usr_other",
+    body: "hello"
+  });
+
+  assertIsoTimestamp(message.createdAt);
+  assertIsoTimestamp(message.sentAt);
+  assert.equal(message.sentAt, message.createdAt);
+});
+
+test("notification records include a createdAt timestamp", async () => {
+  const notification = await createNotification({
+    userId: "usr_test",
+    type: "system",
+    message: "hello"
+  });
+
+  assertIsoTimestamp(notification.createdAt);
+});


### PR DESCRIPTION
Closes #5560.
Refs #743.

Summary:
- add ISO `createdAt` timestamps to proposal, review, message, and notification records
- preserve message `sentAt` while aligning it with `createdAt`
- add service-level timestamp regression coverage

Verification:
```text
node.exe --test apps/api/src/tests/recordTimestamps.test.js apps/api/src/tests/health.test.js
```

Result: 5 tests passed.