### PR TITLE
fix(api): add createdAt to in-memory services

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const createdAt = new Date().toISOString();
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...payload,
+    createdAt,
+    sentAt: createdAt,
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    read: false,
+    ...payload,
+    createdAt: new Date().toISOString(),
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,11 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    ...payload,
+    createdAt: new Date().toISOString(),
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    id: `rev_${Date.now()}`,
+    ...payload,
+    createdAt: new Date().toISOString(),
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/serviceCreatedAt.test.js
+++ b/apps/api/src/tests/serviceCreatedAt.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+
+function assertIsoTimestamp(value) {
+  assert.equal(typeof value, "string");
+  assert.ok(!Number.isNaN(Date.parse(value)), `expected parseable ISO timestamp, got ${value}`);
+}
+
+test("in-memory services return createdAt timestamps consistent with Prisma models", async () => {
+  const proposal = await createProposal({
+    coverLetter: "I can help",
+    bidAmount: 500,
+    estDuration: "2 weeks",
+    jobId: "job_test",
+    freelancerId: "usr_test",
+  });
+  assertIsoTimestamp(proposal.createdAt);
+
+  const review = await createReview({
+    rating: 5,
+    comment: "Great work",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+  });
+  assertIsoTimestamp(review.createdAt);
+
+  const message = await sendMessage({
+    body: "Hello there",
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+  });
+  assertIsoTimestamp(message.createdAt);
+  assert.equal(message.sentAt, message.createdAt);
+
+  const notification = await createNotification({
+    userId: "usr_notify",
+    type: "message",
+    title: "New message",
+    body: "You have a new message",
+  });
+  assertIsoTimestamp(notification.createdAt);
+});


### PR DESCRIPTION
## Summary
- add `createdAt` timestamps to in-memory proposal, review, message, and notification records
- align `sentAt` with the new `createdAt` timestamp for messages
- add a focused service-level regression test that verifies parseable ISO timestamps are returned

## Validation
- `node --test apps/api/src/tests/serviceCreatedAt.test.js`
- `node --check apps/api/src/tests/serviceCreatedAt.test.js`
- `git diff --check`

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5560-created-at-demo.mp4

Closes #5560.
/claim #743
