### PR TITLE
fix(api): validate review ratings

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, rating) {
+  return fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      rating,
+      comment: "good work",
+      reviewerId: "usr_a",
+      revieweeId: "usr_b"
+    })
+  });
+}
+
+test("POST /api/reviews rejects ratings below 1", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, 0);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews rejects ratings above 5", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, 999);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/reviews accepts ratings from 1 to 5", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, 5);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5)
+}).passthrough();


### PR DESCRIPTION
Closes #5568.
Refs #743.

Summary:
- add `createReviewSchema` validation for integer ratings from 1 to 5
- return a 400 API envelope for invalid review payloads
- add route coverage for below-range, above-range, and valid ratings

Verification:
```text
node.exe --test apps/api/src/tests/reviewValidation.test.js apps/api/src/tests/health.test.js
```

Result: 4 tests passed.