### PR TITLE
Add review rating validation (1-5 range)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,6 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,13 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: err.errors.map(e => e.message).join(", ")
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/review-rating-validation.test.js
+++ b/apps/api/src/tests/review-rating-validation.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReviewSchema } from "../validators/review.js";
+
+test("createReviewSchema rejects rating below 1", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 0, comment: "bad", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some(i => i.path.includes("rating")));
+});
+
+test("createReviewSchema rejects rating above 5", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 6, comment: "great", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some(i => i.path.includes("rating")));
+});
+
+test("createReviewSchema rejects negative rating", () => {
+  const result = createReviewSchema.safeParse({
+    rating: -1, comment: "terrible", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, false);
+});
+
+test("createReviewSchema accepts valid rating 1", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 1, comment: "poor", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.rating, 1);
+});
+
+test("createReviewSchema accepts valid rating 5", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 5, comment: "excellent", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.rating, 5);
+});
+
+test("createReviewSchema rejects non-integer rating", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 3.5, comment: "okay", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, false);
+});
+
+test("createReviewSchema rejects missing rating", () => {
+  const result = createReviewSchema.safeParse({
+    comment: "no rating", reviewerId: "usr_a", revieweeId: "usr_b"
+  });
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1),
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});


### PR DESCRIPTION
## What this fixes

Closes #5566

`POST /api/reviews` was accepting any integer for `rating` — including 0, negative numbers, and values above 5. This adds Zod validation enforcing the standard 1–5 range.

## Changes

- **`validators/review.js`** — new `createReviewSchema` with `rating: z.number().int().min(1).max(5)`
- **`controllers/reviewController.js`** — validate payload with `createReviewSchema.parse()` before creating
- **`middleware/errorHandler.js`** — catch `ZodError` and return 400 instead of letting it bubble to 500
- **`tests/review-rating-validation.test.js`** — 7 tests covering: below 1, above 5, negative, non-integer, missing, valid min, valid max

## Testing

```bash
cd apps/api
node --test src/tests/review-rating-validation.test.js
```

All 7 tests pass:

```
✔ createReviewSchema rejects rating below 1
✔ createReviewSchema rejects rating above 5
✔ createReviewSchema rejects negative rating
✔ createReviewSchema accepts valid rating 1
✔ createReviewSchema accepts valid rating 5
✔ createReviewSchema rejects non-integer rating
✔ createReviewSchema rejects missing rating
```