### PR TITLE
fix(api): validate review ratings

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid review payload");
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects ratings outside the 1-5 range", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 0,
+        comment: "Too low",
+        reviewerId: "usr_a",
+        revieweeId: "usr_b"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "rating must be between 1 and 5");
+  });
+});
+
+test("POST /api/reviews accepts ratings inside the 1-5 range", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Excellent work",
+        reviewerId: "usr_c",
+        revieweeId: "usr_d"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent work");
+    assert.match(payload.data.id, /^rev_/);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1, "rating must be between 1 and 5").max(5, "rating must be between 1 and 5"),
+  comment: z.string().min(1),
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a dedicated review payload validator for the reviews API
- reject ratings outside the 1-5 range with a 400 response
- add regression tests for invalid and valid review creation

## Testing
- node --test src/tests/*.js
- node --check src/controllers/reviewController.js
- node --check src/validators/review.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5567-review-validation-demo.mp4

Closes #5567
/claim #743
