### PR TITLE
fix(workflow): count leaderboard entries after merge

### DIFF
--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -3,7 +3,7 @@ name: Update PR leaderboard
 on:
   pull_request_target:
     types:
-      - opened
+      - closed
 
 permissions:
   contents: write
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   update-leaderboard:
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- run the leaderboard workflow when pull requests close instead of when they open
- skip the job unless the closed pull request was merged
- keep the existing commit-subject guard so PRs already counted by the old workflow are not counted twice later

/claim #5570

## Validation
- `git diff --check`

This is limited to workflow trigger/eligibility behavior; app tests are not affected.
