### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, body) {
+  return fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/users rejects invalid user payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      email: "not-an-email",
+      fullName: ""
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid user payload"
+    });
+  });
+});
+
+test("POST /api/users rejects unknown fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      email: "user@example.com",
+      fullName: "User Example",
+      adminNotes: "should not persist"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/users creates valid users with default role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      email: "valid@example.com",
+      fullName: "Valid User"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(payload.data.email, "valid@example.com");
+    assert.equal(payload.data.fullName, "Valid User");
+    assert.equal(payload.data.role, "client");
+    assert.equal("adminNotes" in payload.data, false);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  passwordHash: z.string().min(1).optional(),
+  bio: z.string().optional(),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+}).strict();


### PR DESCRIPTION
Closes #5574.
Refs #743.

Summary:
- add a strict `createUserSchema` for public user creation fields
- return a 400 API envelope for invalid or unknown user payload fields
- preserve the generated `usr_` id and default client role for valid requests
- add route coverage for invalid payloads, unknown fields, and valid user creation

Verification:
```text
node.exe --test apps/api/src/tests/userValidation.test.js apps/api/src/tests/health.test.js
```

Result: 4 tests passed.