### PR TITLE
Add proposal bidAmount validation (must be positive)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/tests/proposal-bid-validation.test.js
+++ b/apps/api/src/tests/proposal-bid-validation.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validPayload = {
+  coverLetter: "I can deliver this on time",
+  bidAmount: 500,
+  estDuration: "2 weeks",
+  jobId: "job_123",
+  freelancerId: "usr_456"
+};
+
+test("createProposalSchema rejects zero bidAmount", () => {
+  const result = createProposalSchema.safeParse({ ...validPayload, bidAmount: 0 });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some(i => i.path.includes("bidAmount")));
+});
+
+test("createProposalSchema rejects negative bidAmount", () => {
+  const result = createProposalSchema.safeParse({ ...validPayload, bidAmount: -100 });
+  assert.equal(result.success, false);
+});
+
+test("createProposalSchema rejects non-numeric bidAmount", () => {
+  const result = createProposalSchema.safeParse({ ...validPayload, bidAmount: "free" });
+  assert.equal(result.success, false);
+});
+
+test("createProposalSchema accepts valid positive bidAmount", () => {
+  const result = createProposalSchema.safeParse({ ...validPayload, bidAmount: 1500 });
+  assert.equal(result.success, true);
+  assert.equal(result.data.bidAmount, 1500);
+});
+
+test("createProposalSchema accepts decimal bidAmount", () => {
+  const result = createProposalSchema.safeParse({ ...validPayload, bidAmount: 99.99 });
+  assert.equal(result.success, true);
+  assert.equal(result.data.bidAmount, 99.99);
+});
+
+test("createProposalSchema rejects missing bidAmount", () => {
+  const { bidAmount, ...noBid } = validPayload;
+  const result = createProposalSchema.safeParse(noBid);
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
## What this fixes

Closes #5573

`POST /api/proposals` was accepting any value for `bidAmount` — including 0, negative numbers, and non-numeric types. This adds Zod validation requiring a strictly positive number.

## Changes

- **`validators/proposal.js`** — new `createProposalSchema` with `bidAmount: z.number().positive()`
- **`controllers/proposalController.js`** — validate payload before creating
- **`tests/proposal-bid-validation.test.js`** — 6 tests: zero, negative, non-numeric, decimal, missing, valid

## Testing

```bash
cd apps/api
node --test src/tests/proposal-bid-validation.test.js
```

All 6 tests pass.