### PR TITLE
fix(api): validate proposal bid amounts

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid proposal payload");
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validProposal = {
+  coverLetter: "I can deliver this quickly.",
+  bidAmount: 250,
+  estDuration: "2 weeks",
+  jobId: "job_test",
+  freelancerId: "usr_test"
+};
+
+test("POST /api/proposals rejects zero, negative, and non-numeric bid amounts", async () => {
+  await withServer(async (port) => {
+    for (const bidAmount of [0, -500, "oops"]) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...validProposal, bidAmount })
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(payload.success, false);
+      assert.equal(payload.message, "bidAmount must be a positive number");
+    }
+  });
+});
+
+test("POST /api/proposals accepts a positive numeric bidAmount", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validProposal)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.bidAmount, 250);
+    assert.equal(payload.data.coverLetter, validProposal.coverLetter);
+    assert.match(payload.data.id, /^prp_/);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(1),
+  bidAmount: z.number({ invalid_type_error: "bidAmount must be a positive number" }).positive("bidAmount must be a positive number"),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a dedicated proposal payload validator for proposal creation
- reject zero, negative, and non-numeric bid amounts with a 400 response
- add regression tests for invalid and valid bid amounts

## Testing
- node --test src/tests/*.js
- node --check src/controllers/proposalController.js
- node --check src/validators/proposal.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5577-proposal-bid-validation-demo.mp4

Closes #5577
/claim #743
