### PR TITLE
fix(api): validate proposal bid amounts

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, bidAmount) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      coverLetter: "I can complete this work.",
+      bidAmount,
+      estDuration: "2 weeks",
+      jobId: "job_test",
+      freelancerId: "usr_test"
+    })
+  });
+}
+
+test("POST /api/proposals rejects zero bidAmount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, 0);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals rejects negative bidAmount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, -500);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/proposals rejects non-numeric bidAmount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, "free");
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/proposals accepts positive bidAmount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, 500);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.bidAmount, 500);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  bidAmount: z.number().positive()
+}).passthrough();


### PR DESCRIPTION
Closes #5580.
Refs #743.

Summary:
- add `createProposalSchema` validation for positive numeric `bidAmount`
- return a 400 API envelope for invalid proposal payloads
- add route coverage for zero, negative, non-numeric, and valid bid amounts

Verification:
```text
node.exe --test apps/api/src/tests/proposalValidation.test.js apps/api/src/tests/health.test.js
```

Result: 5 tests passed.