### PR TITLE
fix(api): reuse register user id in token

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registerTokenSubject.test.js
+++ b/apps/api/src/tests/registerTokenSubject.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with returned user id", async () => {
+  const result = await registerUser({
+    email: "new@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const payload = verifyAccessToken(result.token);
+
+  assert.match(result.id, /^usr_/);
+  assert.equal(payload.sub, result.id);
+  assert.equal(payload.role, result.role);
+});


### PR DESCRIPTION
Closes #5583.
Refs #743.

Summary:
- generate the register user id once
- reuse that id for both the response `id` and JWT `sub`
- add a regression test that verifies the decoded token subject matches the returned user id

Verification:
```text
node.exe --test apps/api/src/tests/registerTokenSubject.test.js apps/api/src/tests/health.test.js
```

Result: 2 tests passed.