### PR TITLE
fix(web): add actionable settings controls

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,8 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+label { display: grid; gap: 0.35rem; margin: 0.75rem 0; }
+input, select, button { font: inherit; border-radius: 8px; border: 1px solid #3a4a7a; padding: 0.55rem 0.7rem; }
+input, select { width: 100%; background: #0f1630; color: #f2f5ff; }
+input[type="checkbox"] { width: auto; margin-right: 0.5rem; }
+button { background: #f2f5ff; color: #0b1020; cursor: pointer; }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,83 @@
 export default function SettingsPage() {
   return (
-    <section className="card">
+    <section>
       <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+
+      <form className="grid">
+        <fieldset className="card" style={{ borderStyle: "solid" }}>
+          <legend>Account</legend>
+          <label>
+            Display name
+            <input name="displayName" defaultValue="Maya Chen" />
+          </label>
+          <label>
+            Email
+            <input name="email" type="email" defaultValue="maya@example.com" />
+          </label>
+          <label>
+            Time zone
+            <select name="timezone" defaultValue="America/New_York">
+              <option value="America/New_York">Eastern Time</option>
+              <option value="America/Chicago">Central Time</option>
+              <option value="America/Denver">Mountain Time</option>
+              <option value="America/Los_Angeles">Pacific Time</option>
+            </select>
+          </label>
+        </fieldset>
+
+        <fieldset className="card" style={{ borderStyle: "solid" }}>
+          <legend>Profile visibility</legend>
+          <label>
+            <input name="publicProfile" type="checkbox" defaultChecked />
+            Public freelancer profile
+          </label>
+          <label>
+            <input name="showRate" type="checkbox" defaultChecked />
+            Show hourly rate
+          </label>
+          <label>
+            <input name="availableForWork" type="checkbox" defaultChecked />
+            Available for new projects
+          </label>
+        </fieldset>
+
+        <fieldset className="card" style={{ borderStyle: "solid" }}>
+          <legend>Notifications</legend>
+          <label>
+            <input name="proposalEmails" type="checkbox" defaultChecked />
+            Proposal emails
+          </label>
+          <label>
+            <input name="messageAlerts" type="checkbox" defaultChecked />
+            Message alerts
+          </label>
+          <label>
+            <input name="billingUpdates" type="checkbox" />
+            Billing updates
+          </label>
+        </fieldset>
+
+        <fieldset className="card" style={{ borderStyle: "solid" }}>
+          <legend>Security</legend>
+          <label>
+            Current password
+            <input name="currentPassword" type="password" />
+          </label>
+          <label>
+            New password
+            <input name="newPassword" type="password" />
+          </label>
+          <label>
+            <input name="twoFactor" type="checkbox" />
+            Require two-factor login
+          </label>
+        </fieldset>
+
+        <div className="card" style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          <button type="submit">Save changes</button>
+          <button type="reset">Reset</button>
+        </div>
+      </form>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the settings placeholder copy with actionable account/profile/notification/security controls
- add basic form styling so the controls remain readable on the existing dark theme

/claim #5449

## Validation
- `npm run build -w apps/web`
- `git diff --check`
