### PR TITLE
fix(api): validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(baseUrl, body) {
+  return fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/messages rejects empty content", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      content: "",
+      recipientId: "usr_recipient"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages rejects missing recipient", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      content: "hello",
+      recipientId: ""
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/messages rejects content over 5000 chars", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      content: "x".repeat(5001),
+      recipientId: "usr_recipient"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/messages accepts valid messages", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      content: "hello",
+      recipientId: "usr_recipient"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.content, "hello");
+    assert.equal(payload.data.recipientId, "usr_recipient");
+    assert.match(payload.data.id, /^msg_/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().trim().min(1).max(5000),
+  recipientId: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #5587.
Refs #743.

Summary:
- add `createMessageSchema` validation for non-empty `content`, max 5000 chars, and non-empty `recipientId`
- return a 400 API envelope for invalid message payloads
- add route coverage for empty content, missing recipient, oversized content, and valid messages

Verification:
```text
node.exe --test apps/api/src/tests/messageValidation.test.js apps/api/src/tests/health.test.js
```

Result: 5 tests passed.