### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid user payload");
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects invalid payloads and unknown fields", async () => {
+  await withServer(async (port) => {
+    const invalidPayloads = [
+      {
+        email: "not-an-email",
+        fullName: "Alice Example",
+        role: "client"
+      },
+      {
+        email: "alice@example.com",
+        fullName: "Alice Example",
+        role: "client",
+        isAdmin: true
+      }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+    }
+  });
+});
+
+test("POST /api/users accepts valid payloads and does not persist extra fields", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "alice@example.com",
+        fullName: "Alice Example"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "alice@example.com");
+    assert.equal(payload.data.fullName, "Alice Example");
+    assert.equal(payload.data.role, "client");
+    assert.equal("isAdmin" in payload.data, false);
+    assert.match(payload.data.id, /^usr_/);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+}).strict();


### PR DESCRIPTION
## Summary
- add a dedicated user creation validator for the users API
- reject malformed payloads and unknown fields with a 400 response
- add regression tests for invalid and valid user creation requests

## Testing
- node --test src/tests/*.js
- node --check src/controllers/userController.js
- node --check src/validators/user.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5574-user-validation-demo.mp4

Closes #5574
/claim #743