### PR TITLE
fix(api): validate notification payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postNotification(baseUrl, body) {
+  return fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/notifications rejects empty payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications rejects blank required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      type: "",
+      message: " ",
+      recipientId: ""
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/notifications accepts valid notifications", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      type: "message",
+      message: "You have a new message",
+      recipientId: "usr_recipient"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_/);
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.type, "message");
+    assert.equal(payload.data.message, "You have a new message");
+    assert.equal(payload.data.recipientId, "usr_recipient");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  type: z.string().trim().min(1),
+  message: z.string().trim().min(1),
+  recipientId: z.string().trim().min(1)
+}).passthrough();


### PR DESCRIPTION
Closes #5591.
Refs #743.

Summary:
- add `createNotificationSchema` validation for non-empty `type`, `message`, and `recipientId`
- return a 400 API envelope for invalid notification payloads
- add route coverage for empty payloads, blank required fields, and valid notifications

Verification:
```text
node.exe --test apps/api/src/tests/notificationValidation.test.js apps/api/src/tests/health.test.js
```

Result: 4 tests passed.