### PR TITLE
fix(api): validate message payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid message payload");
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validMessage = {
+  content: "Hello from the API",
+  recipientId: "usr_receiver",
+  senderId: "usr_sender"
+};
+
+test("POST /api/messages rejects empty, missing, or oversized message payloads", async () => {
+  await withServer(async (port) => {
+    const invalidPayloads = [
+      { ...validMessage, content: "" },
+      { content: "Hello from the API", recipientId: "" },
+      { ...validMessage, content: "x".repeat(5001) }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+    }
+  });
+});
+
+test("POST /api/messages accepts valid message payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validMessage)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.content, validMessage.content);
+    assert.equal(payload.data.recipientId, validMessage.recipientId);
+    assert.equal(payload.data.senderId, validMessage.senderId);
+    assert.match(payload.data.id, /^msg_/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().min(1).max(5000),
+  recipientId: z.string().min(1),
+  senderId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Summary
- add a dedicated message creation validator for the messages API
- reject empty, missing, and oversized message payloads with a 400 response
- add regression tests for invalid and valid message creation requests

## Testing
- node --test src/tests/*.js
- node --check src/controllers/messageController.js
- node --check src/validators/message.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5587-message-validation-demo.mp4

Closes #5587
/claim #743