### PR TITLE
fix(ci): count only merged PRs in leaderboard

### DIFF
--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -3,7 +3,7 @@ name: Update PR leaderboard
 on:
   pull_request_target:
     types:
-      - opened
+      - closed
 
 permissions:
   contents: write
@@ -40,6 +40,11 @@ jobs:
 
           git checkout "${DEFAULT_BRANCH}"
           git pull --ff-only origin "${DEFAULT_BRANCH}"
+
+          if [ "${{ github.event.pull_request.merged }}" != "true" ]; then
+            echo "PR #${PR_NUMBER} closed without merge; not counting."
+            exit 0
+          fi
 
           if git --no-pager log --format=%s --grep="^chore: update leaderboard for PR #${PR_NUMBER}$" -n 1 | grep -q .; then
             echo "PR #${PR_NUMBER} already counted."

--- a/apps/api/src/tests/leaderboardWorkflow.test.js
+++ b/apps/api/src/tests/leaderboardWorkflow.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workflowPath = new URL("../../../../.github/workflows/update-pr-leaderboard.yml", import.meta.url);
+
+test("leaderboard workflow only runs when pull requests close", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /pull_request_target:\s+types:\s+- closed/s);
+  assert.doesNotMatch(workflow, /types:\s+- opened/s);
+});
+
+test("leaderboard workflow skips closed pull requests that were not merged", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /github\.event\.pull_request\.merged/);
+  assert.match(workflow, /closed without merge; not counting/);
+});
+
+test("leaderboard workflow keeps duplicate-count guard", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /already counted/);
+  assert.match(workflow, /chore: update leaderboard for PR #\$\{PR_NUMBER\}/);
+});


### PR DESCRIPTION
Closes #5570.
Refs #743.

Summary:
- run the leaderboard workflow only when pull requests are closed
- exit without counting if the closed PR was not merged
- preserve the existing duplicate-count guard for PRs already counted by the old opened-PR workflow
- add a focused regression test that checks the workflow trigger, merge guard, and duplicate guard

Verification:
```text
node.exe --test apps/api/src/tests/leaderboardWorkflow.test.js apps/api/src/tests/health.test.js
```

Result: 4 tests passed.