### PR TITLE
fix(api): validate notification payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid notification payload");
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validNotification = {
+  type: "message",
+  message: "You have a new message.",
+  recipientId: "usr_receiver"
+};
+
+test("POST /api/notifications rejects empty and blank required fields", async () => {
+  await withServer(async (port) => {
+    const invalidPayloads = [
+      {},
+      { ...validNotification, type: "" },
+      { ...validNotification, message: "" },
+      { ...validNotification, recipientId: "" }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+    }
+  });
+});
+
+test("POST /api/notifications accepts valid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validNotification)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.type, validNotification.type);
+    assert.equal(payload.data.message, validNotification.message);
+    assert.equal(payload.data.recipientId, validNotification.recipientId);
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  type: z.string().min(1),
+  message: z.string().min(1),
+  recipientId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a dedicated notification creation validator for the notifications API
- reject empty and blank required fields with a 400 response
- add regression tests for invalid and valid notification creation requests

## Testing
- node --test src/tests/*.js
- node --check src/controllers/notificationController.js
- node --check src/validators/notification.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5591-notification-validation-demo.mp4

Closes #5591
/claim #743