### PR TITLE
fix(api): reuse register user id in token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authRegisterTokenSubject.test.js
+++ b/apps/api/src/tests/authRegisterTokenSubject.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser returns a token subject that matches the created user id", async () => {
+  const result = await registerUser({
+    email: "alice@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const payload = verifyAccessToken(result.token);
+
+  assert.equal(payload.sub, result.id);
+  assert.equal(payload.role, "client");
+});


### PR DESCRIPTION
## Summary
- generate the register user id once and reuse it for the API response and JWT subject
- add a focused regression test that decodes the token and proves `payload.sub === result.id`
- keep the change limited to the auth service and a single test file

## Testing
- node --test src/tests/authRegisterTokenSubject.test.js
- node --test src/tests/health.test.js src/tests/authRegisterTokenSubject.test.js
- node --check src/services/authService.js
- node --check src/tests/authRegisterTokenSubject.test.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5583-register-token-subject-demo.mp4

Closes #5583
/claim #743