### PR TITLE
fix(api): accept bearer tokens with flexible spacing

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/);
+  if (!match) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(match[1].trim());
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth middleware accepts bearer tokens with flexible spacing", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_test", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        Authorization: `Bearer    ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});
+
+test("auth middleware still rejects non-bearer and invalid tokens", async () => {
+  await withServer(async (port) => {
+    const nonBearer = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        Authorization: "Token abc123"
+      }
+    });
+    const nonBearerPayload = await nonBearer.json();
+
+    assert.equal(nonBearer.status, 401);
+    assert.equal(nonBearerPayload.message, "Unauthorized");
+
+    const invalidBearer = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        Authorization: "Bearer invalid-token"
+      }
+    });
+    const invalidPayload = await invalidBearer.json();
+
+    assert.equal(invalidBearer.status, 401);
+    assert.equal(invalidPayload.message, "Invalid token");
+  });
+});


### PR DESCRIPTION
## Summary
- update auth middleware to accept one or more spaces after the `Bearer` scheme
- trim the extracted bearer credential before JWT verification
- add focused admin-route regression tests for flexible spacing, non-Bearer headers, and invalid tokens

## Testing
- node --test src/tests/authMiddleware.test.js
- node --test src/tests/health.test.js src/tests/authMiddleware.test.js
- node --check src/middleware/auth.js
- node --check src/tests/authMiddleware.test.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5595-auth-bearer-spacing-demo.mp4

Closes #5595
/claim #743