### PR TITLE
fix(api): validate payment payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.issues[0]?.message ?? "Invalid payment payload");
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentValidation.test.js
+++ b/apps/api/src/tests/paymentValidation.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects missing, negative, wrong-type, and unsupported currency payloads", async () => {
+  await withServer(async (port) => {
+    const invalidPayloads = [
+      {},
+      { amount: -10, currency: "usd" },
+      { amount: "10", currency: "usd" },
+      { amount: 10, currency: "gbp" }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(body.success, false);
+    }
+  });
+});
+
+test("POST /api/payments accepts valid payloads and preserves usd default", async () => {
+  await withServer(async (port) => {
+    const validDefault = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 25 })
+    });
+    const validDefaultPayload = await validDefault.json();
+
+    assert.equal(validDefault.status, 201);
+    assert.equal(validDefaultPayload.success, true);
+    assert.equal(validDefaultPayload.data.amount, 25);
+    assert.equal(validDefaultPayload.data.currency, "usd");
+
+    const validExplicit = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 40, currency: "eur" })
+    });
+    const validExplicitPayload = await validExplicit.json();
+
+    assert.equal(validExplicit.status, 201);
+    assert.equal(validExplicitPayload.success, true);
+    assert.equal(validExplicitPayload.data.amount, 40);
+    assert.equal(validExplicitPayload.data.currency, "eur");
+    assert.match(validExplicitPayload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number({ invalid_type_error: "amount must be a positive number" }).positive("amount must be a positive number"),
+  currency: z.enum(["usd", "eur"]).default("usd")
+});


### PR DESCRIPTION
## Summary
- add a dedicated payment creation validator for the payments API
- reject missing, negative, wrong-type, and unsupported-currency payloads with a 400 response
- add regression tests for invalid and valid/default-currency payment requests

## Testing
- node --test src/tests/paymentValidation.test.js
- node --test src/tests/health.test.js src/tests/paymentValidation.test.js
- node --check src/controllers/paymentController.js
- node --check src/validators/payment.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5533-payment-validation-demo.mp4

Closes #5533
/claim #743