### PR TITLE
fix(api): restrict cors to configured frontend origin

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { env } from "./config/env.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -19,7 +20,15 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin(origin, callback) {
+      if (!origin || origin === env.frontendOrigin) {
+        return callback(null, true);
+      }
+
+      return callback(null, false);
+    }
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -2,6 +2,7 @@ export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  frontendOrigin: process.env.FRONTEND_ORIGIN ?? "http://localhost:3000",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS only allows the configured frontend origin", async () => {
+  const previousOrigin = env.frontendOrigin;
+  env.frontendOrigin = "https://app.example";
+
+  try {
+    await withServer(async (port) => {
+      const trusted = await fetch(`http://127.0.0.1:${port}/health`, {
+        headers: {
+          Origin: "https://app.example"
+        }
+      });
+      const untrusted = await fetch(`http://127.0.0.1:${port}/health`, {
+        headers: {
+          Origin: "https://evil.example"
+        }
+      });
+
+      assert.equal(trusted.status, 200);
+      assert.equal(trusted.headers.get("access-control-allow-origin"), "https://app.example");
+
+      assert.equal(untrusted.status, 200);
+      assert.equal(untrusted.headers.get("access-control-allow-origin"), null);
+    });
+  } finally {
+    env.frontendOrigin = previousOrigin;
+  }
+});


### PR DESCRIPTION
## Summary
- read a configured frontend origin for API CORS
- only emit browser CORS permission for that trusted origin
- add a focused regression test proving trusted origins receive the CORS header while untrusted origins do not

## Testing
- node --test src/tests/cors.test.js
- node --test src/tests/health.test.js src/tests/cors.test.js
- node --check src/app.js
- node --check src/config/env.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5557-configured-cors-demo.mp4

Closes #5557
/claim #743