### PR TITLE
docs: use ascii workspace separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` - Next.js 14 App Router frontend
+- `apps/api` - Express.js backend with layered REST API
+- `packages/db` - Prisma schema and database package
+- `packages/ui` - Shared UI components
 
 ## Frontend
 


### PR DESCRIPTION
﻿## Summary

- replace the workspace structure em dash separators with plain ASCII  -  separators
- keep the cleanup limited to README readability/encoding consistency

## Validation

- git diff --check

/claim #5607
Closes #5607
