### PR TITLE
docs: use ASCII workspace separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ FreelanceFlow is a full-stack freelance marketplace monorepo built with a modern
 
 ## Workspace Structure
 
-- `apps/web` — Next.js 14 App Router frontend
-- `apps/api` — Express.js backend with layered REST API
-- `packages/db` — Prisma schema and database package
-- `packages/ui` — Shared UI components
+- `apps/web` - Next.js 14 App Router frontend
+- `apps/api` - Express.js backend with layered REST API
+- `packages/db` - Prisma schema and database package
+- `packages/ui` - Shared UI components
 
 ## Frontend
 

--- a/apps/api/src/tests/readmeWorkspaceStructure.test.js
+++ b/apps/api/src/tests/readmeWorkspaceStructure.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("README workspace structure uses ASCII separators", async () => {
+  const readme = await readFile(new URL("../../../../README.md", import.meta.url), "utf8");
+
+  assert.match(readme, /- `apps\/web` - /);
+  assert.match(readme, /- `apps\/api` - /);
+  assert.match(readme, /- `packages\/db` - /);
+  assert.match(readme, /- `packages\/ui` - /);
+  assert.doesNotMatch(readme, /â€”/);
+});


### PR DESCRIPTION
## Summary
- replace the non-ASCII workspace structure separators in `README.md` with plain ASCII ` - `
- keep the change limited to README readability cleanup
- add a small regression test that reads the README and verifies the workspace structure bullets use ASCII separators

## Testing
- node --test src/tests/readmeWorkspaceStructure.test.js
- node --test src/tests/health.test.js src/tests/readmeWorkspaceStructure.test.js
- node --check src/tests/readmeWorkspaceStructure.test.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5514-readme-separators-demo.mp4

Closes #5514
/claim #743