### PR TITLE
fix(api): validate oauth callback inputs

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const supportedOauthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +17,15 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  if (!supportedOauthProviders.has(req.params.provider)) {
+    return fail(res, "Unsupported OAuth provider");
+  }
+
+  const code = req.query.code;
+  if (typeof code !== "string" || !code.trim()) {
+    return fail(res, "Authorization code is required");
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/oauthCallback.test.js
+++ b/apps/api/src/tests/oauthCallback.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("oauth callback rejects unsupported providers and invalid code values", async () => {
+  await withServer(async (port) => {
+    const invalidUrls = [
+      `http://127.0.0.1:${port}/api/auth/oauth/not-real/callback?code=abc123`,
+      `http://127.0.0.1:${port}/api/auth/oauth/github/callback`,
+      `http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=`,
+      `http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=a&code=b`
+    ];
+
+    for (const url of invalidUrls) {
+      const response = await fetch(url);
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(payload.success, false);
+    }
+  });
+});
+
+test("oauth callback accepts supported providers with a valid code", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/github/callback?code=abc123`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      provider: "github",
+      status: "callback-received"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- validate OAuth callback provider names before reporting success
- require a single non-empty authorization code query value
- add focused API regression tests for invalid and valid callback requests

## Testing
- node --test src/tests/oauthCallback.test.js
- node --test src/tests/health.test.js src/tests/oauthCallback.test.js
- node --check src/controllers/authController.js
- node --check src/tests/oauthCallback.test.js

## Demo
- https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/demo-artifacts/issue-5599-oauth-callback-demo.mp4

Closes #5599
/claim #743