### PR TITLE
fix(api): require auth for search route

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { search } from "../controllers/searchController.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);

--- a/apps/api/src/tests/searchAuth.test.js
+++ b/apps/api/src/tests/searchAuth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/search requires authentication", async () => {
+  const server = await startServer();
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=maya`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("GET /api/search returns the existing payload for authenticated requests", async () => {
+  const server = await startServer();
+  try {
+    const { port } = server.address();
+    const token = signAccessToken({ sub: "usr_search", role: "client" });
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=maya`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        query: "maya",
+        users: [],
+        jobs: [],
+        freelancers: []
+      }
+    });
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
## Summary
- require `authMiddleware` on `GET /api/search`
- add a focused API regression test for unauthenticated and authenticated search requests
- preserve the existing search response payload for valid bearer tokens

## Testing
- node --test src/tests/health.test.js src/tests/searchAuth.test.js
- git diff --check

/claim #743

Scoped issue: #1255
Demo video: https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-1255-search-auth-demo.mp4