### PR TITLE
fix(api): require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
+function resolveJwtSecret(nodeEnv, jwtSecret) {
+  if (jwtSecret) {
+    return jwtSecret;
+  }
+
+  if (nodeEnv === "development") {
+    return "development-secret";
+  }
+
+  throw new Error("JWT_SECRET must be set outside development");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(
+    process.env.NODE_ENV ?? "development",
+    process.env.JWT_SECRET
+  ),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/envJwtSecret.test.js
+++ b/apps/api/src/tests/envJwtSecret.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+
+const envModulePath = new URL("../config/env.js", import.meta.url).pathname.replaceAll("\\", "/");
+
+function runEnvImport(env) {
+  return spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `import("${envModulePath}").then(({ env }) => console.log(env.jwtSecret)).catch((error) => { console.error(error.message); process.exit(1); });`
+    ],
+    {
+      env: {
+        ...process.env,
+        ...env
+      },
+      encoding: "utf8"
+    }
+  );
+}
+
+test("env uses the development fallback secret locally", () => {
+  const result = runEnvImport({
+    NODE_ENV: "development",
+    JWT_SECRET: ""
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /development-secret/);
+});
+
+test("env rejects missing JWT_SECRET outside development", () => {
+  const result = runEnvImport({
+    NODE_ENV: "production",
+    JWT_SECRET: ""
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET must be set outside development/);
+});
+
+test("env accepts an explicit JWT secret outside development", () => {
+  const result = runEnvImport({
+    NODE_ENV: "production",
+    JWT_SECRET: "super-secret"
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /super-secret/);
+});


### PR DESCRIPTION
## Summary
- require `JWT_SECRET` whenever `NODE_ENV` is not `development`
- keep the existing development fallback for local startup convenience
- add focused regression coverage for development fallback, production failure, and production success

## Testing
- node --test src/tests/health.test.js src/tests/envJwtSecret.test.js
- git diff --check

/claim #743

Scoped issue: #5612
Demo video: https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5612-jwt-secret-demo.mp4