### PR TITLE
fix(api): use Prisma in connectDb

### DIFF
--- a/apps/api/src/config/db.js
+++ b/apps/api/src/config/db.js
@@ -1,4 +1,11 @@
-export async function connectDb() {
-  // TODO: wire Prisma client from @freelanceflow/db package
-  return { connected: true, driver: "prisma-placeholder" };
+async function createPrismaClient() {
+  const { PrismaClient } = await import("@freelanceflow/db");
+  return new PrismaClient();
+}
+
+export async function connectDb(client = null) {
+  const prisma = client ?? await createPrismaClient();
+  await prisma.$connect();
+
+  return { connected: true, driver: "prisma" };
 }

--- a/apps/api/src/tests/dbConfig.test.js
+++ b/apps/api/src/tests/dbConfig.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { connectDb } from "../config/db.js";
+
+test("connectDb awaits the injected Prisma client connection", async () => {
+  let connectCalls = 0;
+  const client = {
+    async $connect() {
+      connectCalls += 1;
+    }
+  };
+
+  const result = await connectDb(client);
+
+  assert.equal(connectCalls, 1);
+  assert.deepEqual(result, {
+    connected: true,
+    driver: "prisma"
+  });
+});
+
+test("connectDb surfaces Prisma connection failures", async () => {
+  const failure = new Error("db unavailable");
+  const client = {
+    async $connect() {
+      throw failure;
+    }
+  };
+
+  await assert.rejects(() => connectDb(client), failure);
+});


### PR DESCRIPTION
## Summary
- replace the placeholder `connectDb()` success path with Prisma-backed behavior from `@freelanceflow/db`
- await a real `$connect()` call before reporting a successful database bootstrap
- add focused regression coverage for successful connection and surfaced connection failures

## Testing
- node --test src/tests/health.test.js src/tests/dbConfig.test.js
- git diff --check

/claim #743

Scoped issue: #5614
Demo video: https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5614-connectdb-prisma-demo.mp4