### PR TITLE
fix(api): target concrete API test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- point the API workspace test script at concrete `*.test.js` files instead of the `src/tests` directory
- keep the built-in Node test runner unchanged
- restore both `npm test -w apps/api` and the root `npm test` command on the current Node runtime

## Testing
- npm test -w apps/api
- npm test
- git diff --check

/claim #743

Scoped issue: #5616
Demo video: https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5616-api-test-script-demo.mp4