### PR TITLE
Reject upload requests without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("uploadFile rejects requests without a file", async () => {
+  const res = createResponse();
+
+  await uploadFile({}, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "File is required"
+  });
+});
+
+test("uploadFile returns uploaded metadata when a file is present", async () => {
+  const res = createResponse();
+
+  await uploadFile({ file: { originalname: "invoice.pdf" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      filename: "invoice.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
Closes #5618

Parent bounty: #743

Summary:
- reject upload requests that do not include `req.file`
- keep valid upload metadata responses at HTTP 201
- add focused regression tests for missing-file and valid-file cases

Tests:
- `node --test "src/tests/*.test.js"` from `apps/api` (3/3 passing)

Note:
- The existing `npm test` script on current main still invokes `node --test src/tests`, which fails under the local Node 24 runtime by treating the directory as a module path. I kept this PR scoped to the upload validation issue and used the explicit test-file glob above for validation.