### PR TITLE
fix(api): return 400 for invalid auth payloads

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,27 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  const validation = registerSchema.safeParse(req.body);
+  if (!validation.success) {
+    return fail(res, "Invalid register payload");
+  }
+
+  const payload = validation.data;
+  const data = await registerUser(payload);
+  return ok(res, data, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  const validation = loginSchema.safeParse(req.body);
+  if (!validation.success) {
+    return fail(res, "Invalid login payload");
+  }
+
+  const payload = validation.data;
+  const data = await loginUser(payload);
+  return ok(res, data);
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/tests/authValidation.test.js
+++ b/apps/api/src/tests/authValidation.test.js
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register returns 400 for invalid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "not-an-email",
+        password: "short"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid register payload"
+    });
+  });
+});
+
+test("POST /api/auth/login returns 400 for invalid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "not-an-email",
+        password: "short"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid login payload"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update `register` and `login` to use `safeParse()` instead of throwing on invalid auth payloads
- return the standard `{ success: false, message }` API response envelope with HTTP 400 for invalid register and login bodies
- add focused API regression coverage for invalid `/api/auth/register` and `/api/auth/login` requests

## Testing
- node --test src/tests/health.test.js src/tests/authValidation.test.js
- node --check src/controllers/authController.js
- node --check src/tests/authValidation.test.js
- git diff --check

/claim #743

Scoped issue: #5564
Demo video: https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5564-auth-validation-demo.mp4