### PR TITLE
Disallow admin role during registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema accepts public signup roles", () => {
+  const client = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const freelancer = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(client.role, "client");
+  assert.equal(freelancer.role, "freelancer");
+});
+
+test("registerSchema defaults omitted role to client", () => {
+  const parsed = registerSchema.parse({
+    email: "new-user@example.com",
+    password: "password123"
+  });
+
+  assert.equal(parsed.role, "client");
+});
+
+test("registerSchema rejects admin self-assignment", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  }, /Invalid enum value/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #5621

Parent bounty: #743

Summary:
- remove `admin` from the public registration role enum
- preserve the existing omitted-role default to `client`
- add regression tests for allowed roles, default behavior, and rejected admin self-assignment

Tests:
- `node --test "src/tests/*.test.js"` from `apps/api` (4/4 passing)