### PR TITLE
Add API request body validation detector

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/workflow.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
-export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+export async function postMessage(req, res, next) {
+  try {
+    const payload = createMessageSchema.parse(req.body);
+    return ok(res, await sendMessage(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/workflow.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
-export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+export async function postNotification(req, res, next) {
+  try {
+    const payload = createNotificationSchema.parse(req.body);
+    return ok(res, await createNotification(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/workflow.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    const payload = createPaymentSchema.parse(req.body);
+    return ok(res, await createPaymentIntent(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/workflow.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
-export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+export async function postProposal(req, res, next) {
+  try {
+    const payload = createProposalSchema.parse(req.body);
+    return ok(res, await createProposal(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/workflow.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
-export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+export async function postReview(req, res, next) {
+  try {
+    const payload = createReviewSchema.parse(req.body);
+    return ok(res, await createReview(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/workflow.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
-export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+export async function postUser(req, res, next) {
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request body",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/body-validation.test.js
+++ b/apps/api/src/tests/body-validation.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST controllers reject invalid request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const paths = [
+      "/api/messages",
+      "/api/notifications",
+      "/api/payments",
+      "/api/proposals",
+      "/api/reviews",
+      "/api/users"
+    ];
+
+    for (const path of paths) {
+      const response = await postJson(baseUrl, path, {});
+      const payload = await response.json();
+
+      assert.equal(response.status, 400, path);
+      assert.equal(payload.success, false, path);
+      assert.equal(payload.message, "Invalid request body", path);
+      assert.ok(Array.isArray(payload.issues), path);
+      assert.ok(payload.issues.length > 0, path);
+    }
+  });
+});
+
+test("POST controllers accept validated payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const cases = [
+      ["/api/messages", { senderId: "usr_1", recipientId: "usr_2", body: "Hello" }],
+      ["/api/notifications", { userId: "usr_1", type: "proposal", message: "New proposal" }],
+      ["/api/payments", { amount: 125, currency: "usd" }],
+      [
+        "/api/proposals",
+        {
+          jobId: "job_1",
+          freelancerId: "usr_2",
+          coverLetter: "I can ship this quickly.",
+          bidAmount: 500
+        }
+      ],
+      ["/api/reviews", { reviewerId: "usr_1", revieweeId: "usr_2", rating: 5, comment: "Great work" }],
+      ["/api/users", { email: "person@example.com", name: "Person Example", role: "client" }]
+    ];
+
+    for (const [path, body] of cases) {
+      const response = await postJson(baseUrl, path, body);
+      const payload = await response.json();
+
+      assert.equal(response.status, 201, path);
+      assert.equal(payload.success, true, path);
+      assert.ok(payload.data, path);
+    }
+  });
+});

--- a/apps/api/src/validators/workflow.js
+++ b/apps/api/src/validators/workflow.js
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+const idSchema = z.string().min(1);
+
+export const createMessageSchema = z.object({
+  senderId: idSchema,
+  recipientId: idSchema,
+  body: z.string().min(1)
+});
+
+export const createNotificationSchema = z.object({
+  userId: idSchema,
+  type: z.string().min(1),
+  message: z.string().min(1)
+});
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(3).max(3).default("usd")
+});
+
+export const createProposalSchema = z.object({
+  jobId: idSchema,
+  freelancerId: idSchema,
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().nonnegative()
+});
+
+export const createReviewSchema = z.object({
+  reviewerId: idSchema,
+  revieweeId: idSchema,
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).optional()
+});
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});

--- a/detect_bugs.py
+++ b/detect_bugs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Detect API controllers that pass req.body without schema validation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+FUNCTION_RE = re.compile(r"export\s+async\s+function\s+(\w+)\s*\([^)]*\)\s*\{", re.MULTILINE)
+RAW_BODY_RE = re.compile(r"\breq\.body\b")
+PARSE_RE = re.compile(r"\b\w+Schema\.parse\(\s*req\.body\s*\)")
+
+
+def iter_functions(source: str):
+    for match in FUNCTION_RE.finditer(source):
+        index = match.end()
+        depth = 1
+        while index < len(source) and depth:
+            char = source[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            index += 1
+        yield match.group(1), source[match.end() : index - 1]
+
+
+def scan_controller(path: Path):
+    source = path.read_text()
+    findings = []
+
+    for function_name, body in iter_functions(source):
+        if RAW_BODY_RE.search(body) and not PARSE_RE.search(body):
+            findings.append((path, function_name))
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--controllers-dir",
+        default="apps/api/src/controllers",
+        help="Directory containing API controller files",
+    )
+    args = parser.parse_args()
+
+    controllers_dir = Path(args.controllers_dir)
+    findings = []
+
+    for controller in sorted(controllers_dir.glob("*Controller.js")):
+      findings.extend(scan_controller(controller))
+
+    if not findings:
+        print("No missing req.body validation found in API controllers.")
+        return 0
+
+    print("Missing req.body validation detected:")
+    for path, function_name in findings:
+        print(f"- {path}: {function_name}")
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `detect_bugs.py` to scan API controllers for direct `req.body` use without nearby schema parsing
- add Zod validation schemas for messages, notifications, payments, proposals, reviews, and users
- update the affected controllers to parse request bodies before service calls and route validation errors through Express
- return structured `400` responses for Zod validation failures
- add API regression tests for invalid and valid POST bodies

## Bounty
/claim #5626

Related: #743, #5625

Payment details can be provided privately after acceptance/merge.

## Verification
- `python3 detect_bugs.py`
- `npm test --workspace apps/api`
- `git diff --check`