### PR TITLE
fix(api): require auth for user creation

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/tests/userAuthorization.test.js
+++ b/apps/api/src/tests/userAuthorization.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createUserPayload() {
+  return {
+    email: "authed-user@example.com",
+    fullName: "Authed User",
+    role: "client"
+  };
+}
+
+test("GET /api/users remains publicly readable", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: []
+    });
+  });
+});
+
+test("POST /api/users rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createUserPayload())
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/users accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_user_author", role: "client" });
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(createUserPayload())
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "authed-user@example.com");
+    assert.equal(payload.data.fullName, "Authed User");
+    assert.equal(payload.data.role, "client");
+    assert.match(payload.data.id, /^usr_/);
+  });
+});


### PR DESCRIPTION
/claim #743

Scoped issue: #5638

## Summary
- require a valid Bearer token for `POST /api/users` by applying the existing `authMiddleware`
- preserve public read access to `GET /api/users`
- add focused regression coverage for public reads, unauthenticated rejection, and authenticated user creation

## Demo video
https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5638-user-auth-demo.mp4

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/userAuthorization.test.js`
- `node --check apps/api/src/routes/userRoutes.js`
- `node --check apps/api/src/tests/userAuthorization.test.js`
- `git diff --check`
