### PR TITLE
fix(api): require auth for message creation

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/tests/messageAuthorization.test.js
+++ b/apps/api/src/tests/messageAuthorization.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createMessagePayload() {
+  return {
+    recipientId: "usr_recipient",
+    content: "hello from the authenticated sender"
+  };
+}
+
+test("GET /api/messages remains publicly readable", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: []
+    });
+  });
+});
+
+test("POST /api/messages rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createMessagePayload())
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/messages accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_message_author", role: "client" });
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(createMessagePayload())
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.recipientId, "usr_recipient");
+    assert.equal(payload.data.content, "hello from the authenticated sender");
+    assert.match(payload.data.id, /^msg_/);
+    assert.equal(typeof payload.data.sentAt, "string");
+  });
+});


### PR DESCRIPTION
/claim #743

Scoped issue: #5645

## Summary
- require a valid Bearer token for `POST /api/messages` by applying the existing `authMiddleware`
- preserve the current `GET /api/messages` behavior
- add focused regression coverage for public reads, unauthenticated rejection, and authenticated message creation

## Demo video
https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5645-message-auth-demo.mp4

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/messageAuthorization.test.js`
- `node --check apps/api/src/routes/messageRoutes.js`
- `node --check apps/api/src/tests/messageAuthorization.test.js`
- `git diff --check`
