### PR TITLE
Align registered user id with token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token subject matching the returned user id", async () => {
+  const originalNow = Date.now;
+  const timestamps = [1000, 1001, 1002];
+  Date.now = () => timestamps.shift() ?? 1002;
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Closes #5648

Parent bounty: #743

Summary:
- generate the registered user id once in registerUser
- reuse that id for both the response id and JWT sub claim
- add regression coverage that decodes the token and verifies sub matches the returned id

Tests:
- node --test "src/tests/*.test.js" from apps/api (2/2 passing)