### PR TITLE
[agent] fix(api): validate proposal creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  summary: z.string().min(10),
+  amount: z.number().nonnegative().optional(),
+  jobId: z.string().min(1),
+  userId: z.string().min(1)
+});
+
+export const updateProposalSchema = createProposalSchema.partial();


### PR DESCRIPTION
## Issue
Closes #5651

## Summary
Added `createProposalSchema` (Zod) to validate POST /proposals payloads before they reach the service layer. This mirrors the existing pattern from `postJob`/`createJobSchema`.

## Changes
- `apps/api/src/validators/proposal.js` — new file with `createProposalSchema` and `updateProposalSchema`
- `apps/api/src/controllers/proposalController.js` — `postProposal` now calls `createProposalSchema.parse(req.body)`

## Acceptance criteria
- [x] Proposal creation validates required fields (summary, jobId, userId)
- [x] Invalid payloads return ZodError (handled as 400 by the existing error handler)
- [x] Valid payloads continue to succeed
- [x] Pattern matches existing `postJob` / `createJobSchema` implementation