### PR TITLE
fix(api): require auth for review reads

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
+reviewRoutes.get("/", authMiddleware, getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/reviewReadAuth.test.js
+++ b/apps/api/src/tests/reviewReadAuth.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/reviews rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/reviews accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_review_reader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: []
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Scoped issue: #5652

## Summary
- require a valid Bearer token for `GET /api/reviews` by applying the existing `authMiddleware`
- keep `POST /api/reviews` out of scope
- add focused regression coverage for unauthenticated rejection and authenticated review reads

## Demo video
https://raw.githubusercontent.com/dallasnetprofu02-design/bug-bounty/demo-artifacts/issue-5652-review-read-auth-demo.mp4

## Verification
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/reviewReadAuth.test.js`
- `node --check apps/api/src/routes/reviewRoutes.js`
- `node --check apps/api/src/tests/reviewReadAuth.test.js`
- `git diff --check`
