### PR TITLE
Validate review creation ratings

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(payload.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(port, body) {
+  return fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/reviews creates a valid review", async () => {
+  await withServer(async (port) => {
+    const response = await postReview(port, {
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee",
+      rating: 5,
+      comment: "Excellent collaboration and communication."
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.reviewerId, "usr_reviewer");
+    assert.equal(payload.data.revieweeId, "usr_reviewee");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent collaboration and communication.");
+    assert.match(payload.data.id, /^rev_/);
+  });
+});
+
+test("POST /api/reviews rejects invalid rating values", async () => {
+  await withServer(async (port) => {
+    for (const rating of [0, -1, 2.5, 6]) {
+      const response = await postReview(port, {
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating,
+        comment: "Rating should be rejected."
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid review payload"
+      });
+    }
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1).max(2000)
+}).strict();


### PR DESCRIPTION
Fixes #5650.

Parent bounty: #743

## Summary

- Adds focused `POST /api/reviews` payload validation for `reviewerId`, `revieweeId`, `rating`, and `comment`.
- Rejects invalid, non-integer, and out-of-range ratings before review persistence.
- Preserves successful creation for valid 1-5 integer ratings.
- Adds API regression coverage for valid review creation and invalid rating values.

## Validation

- `git diff --check`
- `node --check apps/api/src/controllers/reviewController.js`
- `node --check apps/api/src/validators/review.js`
- `node --check apps/api/src/tests/reviewValidation.test.js`

Full `npm test -w apps/api` was not run locally because this environment does not have `npm`, `pnpm`, `bun`, or installed dependencies available.

Demo note: this is an API validation change; the new regression test demonstrates valid review creation and rejected invalid ratings.

/claim #743
