### PR TITLE
[agent] fix(api): validate review creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,6 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(5),
+  jobId: z.string().min(1),
+  revieweeId: z.string().min(1)
+});
+
+export const updateReviewSchema = createReviewSchema.partial();


### PR DESCRIPTION
## Issue
Closes #5661

## Summary
Added `createReviewSchema` (Zod) to validate POST /reviews payloads before they reach the service layer. Mirrors the pattern from `postJob`/`createJobSchema` and the proposal validation fix.

## Changes
- `apps/api/src/validators/review.js` — new file with `createReviewSchema` (rating 1-5 int, comment, jobId, revieweeId required)
- `apps/api/src/controllers/reviewController.js` — `postReview` now calls `createReviewSchema.parse(req.body)`

## Acceptance criteria
- [x] Review creation validates required fields (rating, comment, jobId, revieweeId)
- [x] `rating` is constrained to integer 1–5
- [x] Invalid payloads return ZodError (400 via error handler)
- [x] Valid payloads succeed
- [x] Pattern matches existing `postJob`/`createJobSchema` implementation