### PR TITLE
[agent] fix(api): validate message creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().min(1),
+  recipientId: z.string().min(1),
+  jobId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Issue
Closes #5663

## Summary
Added `createMessageSchema` (Zod) to validate POST /messages payloads. Requires `content` (min 1 char) and `recipientId`; `jobId` is optional.

## Changes
- `apps/api/src/validators/message.js` — new file
- `apps/api/src/controllers/messageController.js` — uses schema.parse()