### PR TITLE
[agent] fix(api): validate payment creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(2).max(10).default("usd"),
+  jobId: z.string().min(1)
+});


### PR DESCRIPTION
## Issue
Closes #5664

## Summary
Added `createPaymentSchema` (Zod) to validate POST /payments payloads before reaching the service layer.

## Changes
- `apps/api/src/validators/payment.js` — amount (positive), currency (string), jobId (required)
- `apps/api/src/controllers/paymentController.js` — uses schema.parse()