### PR TITLE
[agent] fix(api): validate notification creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,6 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+const NOTIFICATION_TYPES = ["job_update", "proposal_received", "message", "review", "payment", "system"];
+
+export const createNotificationSchema = z.object({
+  type: z.enum(NOTIFICATION_TYPES),
+  userId: z.string().min(1),
+  message: z.string().min(1),
+  jobId: z.string().min(1).optional(),
+  read: z.boolean().default(false)
+});


### PR DESCRIPTION
## Issue
Closes #5667

## Summary
Adds createNotificationSchema (Zod) with required type (enum), userId, message; optional jobId; boolean read with default false.

## Changes
- apps/api/src/validators/notification.js — new file
- apps/api/src/controllers/notificationController.js — uses schema.parse()