### PR TITLE
[agent] fix(auth): require and validate token in refresh endpoint

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,8 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : req.body?.token;
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 
@@ -18,6 +19,14 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(incomingToken) {
+  if (!incomingToken) {
+    const err = new Error("Refresh token required");
+    err.status = 401;
+    throw err;
+  }
+  // Verify the incoming token and extract the subject
+  const decoded = verifyAccessToken(incomingToken);
+  // Issue a fresh access token for the same subject
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }


### PR DESCRIPTION
## Issue
Closes #5669

## Summary
Fixed refresh endpoint to actually validate the incoming token instead of returning a hardcoded JWT for usr_existing.

## Changes
- authController.js: extracts token from Bearer header or body and passes to service
- authService.js: validates incoming token via verifyAccessToken(); new token inherits sub+role; missing token throws 401