### PR TITLE
Require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? (nodeEnv === "development" ? "development-secret" : undefined);
+
+if (!jwtSecret) {
+  throw new Error("JWT_SECRET is required when NODE_ENV is not development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url);
+let importCounter = 0;
+
+async function withEnv(overrides, callback) {
+  const previous = {};
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    if (overrides[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = overrides[key];
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function loadFreshEnv() {
+  importCounter += 1;
+  return import(`${envModuleUrl.href}?case=${importCounter}`);
+}
+
+test("env keeps the development JWT fallback for local use", async () => {
+  const module = await withEnv({ NODE_ENV: undefined, JWT_SECRET: undefined }, loadFreshEnv);
+
+  assert.equal(module.env.nodeEnv, "development");
+  assert.equal(module.env.jwtSecret, "development-secret");
+});
+
+test("env requires JWT_SECRET outside development", async () => {
+  await assert.rejects(
+    () => withEnv({ NODE_ENV: "production", JWT_SECRET: undefined }, loadFreshEnv),
+    /JWT_SECRET is required/
+  );
+});
+
+test("env accepts an explicit JWT_SECRET outside development", async () => {
+  const module = await withEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret" }, loadFreshEnv);
+
+  assert.equal(module.env.nodeEnv, "production");
+  assert.equal(module.env.jwtSecret, "prod-secret");
+});


### PR DESCRIPTION
## Summary

- Keep the local development fallback JWT secret for unset development environments.
- Fail fast when `JWT_SECRET` is missing outside development.
- Add focused environment config regression tests for development fallback, production failure, and production success.

Closes #5657
Refs #743

## Validation

- `node --test apps/api/src/tests/env.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/env.test.js apps/api/src/tests/health.test.js`
- `git diff --check`

Note: focused validation uses direct Node test-file commands because the API workspace test script currently targets the tests directory rather than concrete test files, which is outside this issue scope.

## Bounty request

Parent bounty #743 if accepted.