### PR TITLE
Prevent duplicate proposals per job

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -68,6 +68,8 @@ model Proposal {
   freelancerId  String
   freelancer    User        @relation(fields: [freelancerId], references: [id])
   createdAt     DateTime    @default(now())
+
+  @@unique([jobId, freelancerId])
 }
 
 model Payment {


### PR DESCRIPTION
Closes #5678

Parent bounty: #743

Summary:
- Add a Prisma uniqueness constraint on Proposal.jobId and Proposal.freelancerId.
- Prevent duplicate applications from the same freelancer for the same job at the database model layer.
- Keep existing proposal relations and fields unchanged.

Validation:
- DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow prisma validate --schema packages/db/prisma/schema.prisma