### PR TITLE
fix(auth): keep registration token subject aligned with returned id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser keeps returned id and token subject in sync", async () => {
+  const result = await registerUser({
+    email: "new-user@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const payload = verifyAccessToken(result.token);
+
+  assert.equal(payload.sub, result.id);
+  assert.equal(result.email, "new-user@example.com");
+  assert.equal(result.role, "client");
+});


### PR DESCRIPTION
Closes #5682

Refs #1743

/claim #743

## Summary
- generate the registration user id once inside \\egisterUser\\`n- reuse that id for both the returned \\id\\ and JWT \\sub\\`n- add a focused regression test that decodes the token and proves the two values stay in sync

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/authRegistration.test.js\\`n- \\
ode --check apps/api/src/services/authService.js\\`n- \\
ode --check apps/api/src/tests/authRegistration.test.js\\`n- \\git diff --check\\`n
## Notes
- \\
pm test -w apps/api\\ currently fails on the existing workspace script because it runs \\
ode --test src/tests\\, which Node resolves as a module path instead of expanding test files. The focused file-level Node test command above passes for this change.