### PR TITLE
Constrain payment status values

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,6 +21,13 @@ enum JobStatus {
   CANCELLED
 }
 
+enum PaymentStatus {
+  PENDING
+  SUCCEEDED
+  FAILED
+  REFUNDED
+}
+
 model User {
   id             String      @id @default(cuid())
   email          String      @unique
@@ -74,7 +81,7 @@ model Payment {
   id            String      @id @default(cuid())
   amount        Float
   currency      String      @default("USD")
-  status        String
+  status        PaymentStatus @default(PENDING)
   stripeRef     String?
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])


### PR DESCRIPTION
Closes #5684

Parent bounty: #743

Summary:
- Add a Prisma PaymentStatus enum for known payment lifecycle states.
- Change Payment.status from an arbitrary String to PaymentStatus with a PENDING default.
- Keep existing payment relations and fields unchanged.

Validation:
- DATABASE_URL=postgresql://user:pass@localhost:5432/freelanceflow prisma validate --schema packages/db/prisma/schema.prisma