### PR TITLE
Use Prisma for database bootstrap

### DIFF
--- a/apps/api/src/config/db.js
+++ b/apps/api/src/config/db.js
@@ -1,4 +1,15 @@
-export async function connectDb() {
-  // TODO: wire Prisma client from @freelanceflow/db package
-  return { connected: true, driver: "prisma-placeholder" };
+import { PrismaClient } from "@freelanceflow/db";
+
+let prismaClient;
+
+function getPrismaClient() {
+  if (!prismaClient) {
+    prismaClient = new PrismaClient();
+  }
+  return prismaClient;
+}
+
+export async function connectDb(client = getPrismaClient()) {
+  await client.$connect();
+  return { connected: true, driver: "prisma" };
 }

--- a/apps/api/src/tests/db.test.js
+++ b/apps/api/src/tests/db.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { connectDb } from "../config/db.js";
+
+test("connectDb uses the provided Prisma-style client", async () => {
+  let calls = 0;
+  const result = await connectDb({
+    async $connect() {
+      calls += 1;
+    }
+  });
+
+  assert.equal(calls, 1);
+  assert.deepEqual(result, { connected: true, driver: "prisma" });
+});
+
+test("connectDb surfaces Prisma connection failures", async () => {
+  await assert.rejects(
+    () =>
+      connectDb({
+        async $connect() {
+          throw new Error("database unavailable");
+        }
+      }),
+    /database unavailable/
+  );
+});

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export { PrismaClient } from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "index.js",
+  "exports": "./index.js",
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
﻿Closes #5658
Refs #743

Summary:
- add a runtime ESM entry for @freelanceflow/db so the API package can import PrismaClient
- replace the placeholder connectDb result with a PrismaClient-backed $connect() call
- add focused tests for successful injected client connections and surfaced connection failures

Validation:
- node -e "import('@freelanceflow/db').then(m=>console.log(Object.keys(m).join(',')))"
- node --test apps/api/src/tests/db.test.js apps/api/src/tests/health.test.js
- git diff --check

Bounty:
- Parent bounty #743 if accepted.
