### PR TITLE
fix(api): require admin role for admin metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminRoleMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { adminRoleMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminRoleMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoutes.test.js
+++ b/apps/api/src/tests/adminRoutes.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects unauthenticated requests", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Forbidden");
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});


### PR DESCRIPTION
Closes #5689

Refs #1764

/claim #743

## Summary
- add an admin-role middleware that returns \\403\\ for authenticated non-admin users
- apply the role check after the existing auth middleware on admin routes
- add route coverage for unauthenticated, non-admin, and admin access paths

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/adminRoutes.test.js\\`n- \\
ode --check apps/api/src/middleware/auth.js\\`n- \\
ode --check apps/api/src/routes/adminRoutes.js\\`n- \\
ode --check apps/api/src/tests/adminRoutes.test.js\\`n- \\git diff --check\\`