### PR TITLE
fix(api): reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API routes",
+  description: "Implement and validate the missing API routes for jobs.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_web",
+  skills: ["node", "zod"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const payload = createJobSchema.parse(validJob);
+
+  assert.equal(payload.budgetMin, 100);
+  assert.equal(payload.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema rejects inverted ranges when both values are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema still allows partial budget updates", () => {
+  const payload = updateJobSchema.parse({ budgetMin: 500 });
+
+  assert.equal(payload.budgetMin, 500);
+  assert.equal(payload.budgetMax, undefined);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const hasOrderedBudgetRange = ({ budgetMin, budgetMax }) => budgetMax >= budgetMin;
+
+const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +11,15 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchemaBase.refine(hasOrderedBudgetRange, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchemaBase.partial().refine(
+  ({ budgetMin, budgetMax }) => budgetMin == null || budgetMax == null || budgetMax >= budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
Closes #5695

Refs #2827

/claim #743

## Summary
- reject create-job payloads where \\udgetMax < budgetMin\\`n- reject partial update payloads with the same inverted range when both fields are present
- keep valid ordered ranges and one-sided partial updates working as before

## Validation
- \\
ode --test apps/api/src/tests/jobValidator.test.js apps/api/src/tests/health.test.js\\`n- \\
ode --check apps/api/src/validators/job.js\\`n- \\
ode --check apps/api/src/tests/jobValidator.test.js\\`n- \\git diff --check\\`