### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function postReview(port, body) {
+  return fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+const validReview = {
+  reviewerId: "user_reviewer",
+  revieweeId: "user_reviewee",
+  rating: 5,
+  comment: "Great delivery"
+};
+
+test("POST /api/reviews creates a valid review", async () => {
+  await withServer(async (port) => {
+    const response = await postReview(port, validReview);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_/);
+    assert.equal(payload.data.reviewerId, validReview.reviewerId);
+    assert.equal(payload.data.revieweeId, validReview.revieweeId);
+    assert.equal(payload.data.rating, validReview.rating);
+    assert.equal(payload.data.comment, validReview.comment);
+  });
+});
+
+test("POST /api/reviews rejects ratings outside the 1-5 integer range", async () => {
+  await withServer(async (port) => {
+    for (const rating of [0, -1, 6, 2.5, "5", null]) {
+      const response = await postReview(port, { ...validReview, rating });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid review payload"
+      });
+    }
+  });
+});
+
+test("POST /api/reviews rejects missing identifiers and empty comments", async () => {
+  await withServer(async (port) => {
+    for (const body of [
+      { ...validReview, reviewerId: "" },
+      { ...validReview, revieweeId: "" },
+      { ...validReview, comment: "" },
+      { rating: 4, comment: "Missing parties" }
+    ]) {
+      const response = await postReview(port, body);
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(payload.success, false);
+    }
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().trim().min(1),
+  revieweeId: z.string().trim().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1)
+});


### PR DESCRIPTION
﻿Closes #5655
Refs #743

Summary:
- add a focused review creation schema for reviewerId, revieweeId, rating, and comment
- reject invalid review payloads with HTTP 400 before createReview persists them
- cover valid review creation plus invalid ratings, missing identifiers, and empty comments
- update the API package test script to target test files so the regression suite runs under the Node test runner

Validation:
- npm test --workspace @freelanceflow/api
- node --test apps/api/src/tests/review.test.js apps/api/src/tests/health.test.js
- git diff --check

Bounty:
- Parent bounty #743 if accepted.
