### PR TITLE
fix(api): validate search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse({ q: req.query.q ?? "" });
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Invalid search query";
+    return fail(res, message, 400);
+  }
+
+  return ok(res, await globalSearch(parsed.data.q));
 }

--- a/apps/api/src/tests/searchValidation.test.js
+++ b/apps/api/src/tests/searchValidation.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withServer(async (port) => {
+    const q = "a".repeat(201);
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${q}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/search trims and sanitizes accepted queries", async () => {
+  await withServer(async (port) => {
+    const q = encodeURIComponent("  <script>alert(1)</script> jobs  ");
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${q}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "scriptalert(1)/script jobs");
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .max(200)
+    .transform((value) => value.replace(/[<>]/g, ""))
+    .default("")
+});


### PR DESCRIPTION
Closes #5704

Refs #1781

/claim #743

## Summary
- validate and sanitize the \\q\\ query parameter before calling the search service
- reject overly long queries with a clean \\400\\ response
- trim accepted queries and strip angle brackets before they reach the search layer

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/searchValidation.test.js\\`n- \\
ode --check apps/api/src/controllers/searchController.js\\`n- \\
ode --check apps/api/src/validators/search.js\\`n- \\
ode --check apps/api/src/tests/searchValidation.test.js\\`n- \\git diff --check\\`