### PR TITLE
fix(api): restrict cors to configured origin

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { env } from "./config/env.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -19,7 +20,17 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(
+    cors({
+      origin(origin, callback) {
+        if (!origin || origin === env.frontendOrigin) {
+          return callback(null, true);
+        }
+
+        return callback(null, false);
+      }
+    })
+  );
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,6 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  frontendOrigin: process.env.FRONTEND_ORIGIN ?? "http://localhost:3000"
 };

--- a/apps/api/src/tests/corsOrigin.test.js
+++ b/apps/api/src/tests/corsOrigin.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("health endpoint allows the configured frontend origin", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "http://localhost:3000" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "http://localhost:3000");
+  });
+});
+
+test("health endpoint does not echo untrusted origins", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://evil.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  });
+});


### PR DESCRIPTION
Closes #5707

Refs #1774

/claim #743

## Summary
- configure CORS to allow only the trusted frontend origin from environment config
- keep requests without an origin header working for server-to-server and local tooling flows
- add API coverage showing the configured origin is allowed while untrusted origins are not echoed

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/corsOrigin.test.js\\`n- \\
ode --check apps/api/src/app.js\\`n- \\
ode --check apps/api/src/config/env.js\\`n- \\
ode --check apps/api/src/tests/corsOrigin.test.js\\`n- \\git diff --check\\`