### PR TITLE
fix(api): require auth for payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects unauthenticated requests", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 100, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/payments allows authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ amount: 100, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 100);
+    assert.equal(payload.data.provider, "stripe");
+  });
+});


### PR DESCRIPTION
Closes #5711

Refs #1772

/claim #743

## Summary
- require the existing \\uthMiddleware\\ on \\POST /api/payments\\`n- reject unauthenticated payment creation requests with \\401\\`n- add route coverage for unauthenticated rejection and authenticated success

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentAuth.test.js\\`n- \\
ode --check apps/api/src/routes/paymentRoutes.js\\`n- \\
ode --check apps/api/src/tests/paymentAuth.test.js\\`n- \\git diff --check\\`