### PR TITLE
fix(api): preserve notification server-owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-controlled id and read fields", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    read: true,
+    userId: "usr_123",
+    title: "Payment received",
+    body: "Your payment has cleared."
+  });
+
+  assert.notEqual(notification.id, "ntf_attacker");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.title, "Payment received");
+});


### PR DESCRIPTION
Closes #5715

Refs #2762

/claim #743

## Summary
- ignore caller-supplied \\id\\ and \\ead\\ fields during notification creation
- keep server-generated notification ids authoritative
- ensure new notifications always start unread

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/notificationService.test.js\\`n- \\
ode --check apps/api/src/services/notificationService.js\\`n- \\
ode --check apps/api/src/tests/notificationService.test.js\\`n- \\git diff --check\\`