### PR TITLE
fix: pin leaderboard checkout action

### DIFF
--- a/.github/tests/update-pr-leaderboard.test.js
+++ b/.github/tests/update-pr-leaderboard.test.js
@@ -1,0 +1,21 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const workflowPath = path.resolve(
+  __dirname,
+  "../workflows/update-pr-leaderboard.yml"
+);
+
+test("leaderboard workflow pins checkout to a full commit SHA", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const match = workflow.match(/uses:\s*actions\/checkout@([^\s#]+)/);
+
+  assert.ok(match, "expected workflow to use actions/checkout");
+  assert.match(
+    match[1],
+    /^[0-9a-f]{40}$/,
+    "actions/checkout should be pinned to an immutable full-length SHA"
+  );
+});

--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout default branch (trusted code only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0


### PR DESCRIPTION
/claim #743

Closes #5713

## Summary

- Pin the leaderboard workflow checkout step to the current full-length `actions/checkout` v4 commit SHA.
- Keep a same-line `# v4` comment so the intended release line remains clear for future updates.
- Add a focused Node regression test that fails if the workflow drifts back to a mutable checkout tag.

## Security context

GitHub Actions secure-use guidance recommends pinning actions to full-length commit SHAs because that is the immutable form of an action reference. This workflow runs on `pull_request_target` and has `contents: write`, so keeping its action dependency immutable reduces the supply-chain blast radius of a moved or compromised tag.

Live duplicate check before opening this PR found no open issue/PR for `actions/checkout@v4`, `checkout SHA`, or workflow action pinning in this repo; matches for broader `pin workflow` terms were unrelated benchmark/admin PRs.

## Validation

- `node --test .github/tests/update-pr-leaderboard.test.js`
- `git diff --check`