### PR TITLE
fix(auth): require fullName during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/authRegistrationName.test.js
+++ b/apps/api/src/tests/authRegistrationName.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+
+test("registerSchema rejects missing fullName", () => {
+  assert.throws(
+    () =>
+      registerSchema.parse({
+        email: "new-user@example.com",
+        password: "password123",
+        role: "client"
+      }),
+    /fullName/
+  );
+});
+
+test("registerUser preserves a valid fullName in the returned payload", async () => {
+  const result = await registerUser({
+    email: "new-user@example.com",
+    fullName: "New User",
+    password: "password123",
+    role: "client"
+  });
+
+  assert.equal(result.fullName, "New User");
+  assert.equal(result.email, "new-user@example.com");
+  assert.equal(result.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
+  fullName: z.string().min(1),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });


### PR DESCRIPTION
Closes #5719

Refs #2770

/claim #743

## Summary
- require a non-empty \\ullName\\ in the registration schema
- carry the validated \\ullName\\ through the registration service response
- add focused tests for missing-name rejection and valid-name preservation

## Validation
- \\
ode --test apps/api/src/tests/health.test.js apps/api/src/tests/authRegistrationName.test.js\\`n- \\
ode --check apps/api/src/validators/auth.js\\`n- \\
ode --check apps/api/src/services/authService.js\\`n- \\
ode --check apps/api/src/tests/authRegistrationName.test.js\\`n- \\git diff --check\\`