### PR TITLE
fix(api): return json for unknown routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,13 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use((req, res) => {
+    res.status(404).json({
+      success: false,
+      message: "Not found"
+    });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+async function withTestServer(callback) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -12,13 +12,35 @@ test("GET /health returns ok payload", async () => {
   });
 
   const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+test("GET /health returns ok payload", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+test("unknown API routes return JSON 404 payload", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("content-type").includes("application/json"), true);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Not found"
+    });
   });
 });


### PR DESCRIPTION
/claim #5723

## Summary
- add final Express not-found middleware after all mounted API routes
- return a consistent JSON 404 payload for unknown routes
- keep existing `/health` behavior covered by the same focused test file

## Tests
- `node --test apps/api/src/tests/health.test.js`
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/health.test.js`
- `git diff --cached --check`
