### PR TITLE
fix(api): return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,13 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use((req, res) => {
+    res.status(404).json({
+      success: false,
+      message: "Not found"
+    });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/notFound.test.js
+++ b/apps/api/src/tests/notFound.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("unknown API routes return the shared JSON 404 envelope", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Not found"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #5725

Refs #5723

/claim #743

## Summary
- add a final API not-found middleware that returns the shared JSON error envelope
- keep existing mounted routes like `/health` unchanged
- add focused regression coverage for unknown API routes

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/notFound.test.js`
- `node --check apps/api/src/app.js`
- `node --check apps/api/src/tests/notFound.test.js`
- `git diff --check`
