### PR TITLE
fix(api): generate unique record ids

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,15 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createRecordId } from "../utils/id.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = createRecordId("usr");
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: createRecordId("job"), status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { id: createRecordId("msg"), ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: createRecordId("ntf"), read: false, ...payload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createRecordId } from "../utils/id.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createRecordId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: createRecordId("prp"), ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: createRecordId("rev"), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createRecordId } from "../utils/id.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: createRecordId("usr"), ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/recordIds.test.js
+++ b/apps/api/src/tests/recordIds.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withFixedNow(timestamp, callback) {
+  const originalNow = Date.now;
+  Date.now = () => timestamp;
+
+  try {
+    return await callback();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+function assertSameMillisecondIds(first, second, key, prefix, timestamp) {
+  assert.notEqual(first[key], second[key]);
+  assert.match(first[key], new RegExp(`^${prefix}_${timestamp}(?:_\\d+)?$`));
+  assert.match(second[key], new RegExp(`^${prefix}_${timestamp}(?:_\\d+)?$`));
+}
+
+test("record services create unique ids within the same millisecond", async () => {
+  const timestamp = 1780879000000;
+
+  await withFixedNow(timestamp, async () => {
+    assertSameMillisecondIds(
+      await createJob({ title: "One" }),
+      await createJob({ title: "Two" }),
+      "id",
+      "job",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await createUser({ email: "one@example.com" }),
+      await createUser({ email: "two@example.com" }),
+      "id",
+      "usr",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await createProposal({ jobId: "job_1", freelancerId: "usr_1" }),
+      await createProposal({ jobId: "job_1", freelancerId: "usr_2" }),
+      "id",
+      "prp",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await sendMessage({ senderId: "usr_1", recipientId: "usr_2", content: "One" }),
+      await sendMessage({ senderId: "usr_2", recipientId: "usr_1", content: "Two" }),
+      "id",
+      "msg",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await createReview({ rating: 5, reviewerId: "usr_1", revieweeId: "usr_2" }),
+      await createReview({ rating: 4, reviewerId: "usr_2", revieweeId: "usr_1" }),
+      "id",
+      "rev",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await createNotification({ recipientId: "usr_1", message: "One" }),
+      await createNotification({ recipientId: "usr_2", message: "Two" }),
+      "id",
+      "ntf",
+      timestamp
+    );
+    assertSameMillisecondIds(
+      await createPaymentIntent({ amount: 1000 }),
+      await createPaymentIntent({ amount: 2000 }),
+      "paymentId",
+      "pay",
+      timestamp
+    );
+  });
+});
+
+test("registration uses the same generated user id in the access token", async () => {
+  const timestamp = 1780879000001;
+
+  await withFixedNow(timestamp, async () => {
+    const first = await registerUser({ email: "one@example.com", role: "client" });
+    const second = await registerUser({ email: "two@example.com", role: "client" });
+
+    assertSameMillisecondIds(first, second, "id", "usr", timestamp);
+    assert.equal(verifyAccessToken(first.token).sub, first.id);
+    assert.equal(verifyAccessToken(second.token).sub, second.id);
+  });
+});

--- a/apps/api/src/utils/id.js
+++ b/apps/api/src/utils/id.js
@@ -1,0 +1,11 @@
+const idSequences = new Map();
+
+export function createRecordId(prefix) {
+  const timestamp = Date.now();
+  const previous = idSequences.get(prefix);
+  const sequence = previous?.timestamp === timestamp ? previous.sequence + 1 : 0;
+
+  idSequences.set(prefix, { timestamp, sequence });
+
+  return sequence === 0 ? `${prefix}_${timestamp}` : `${prefix}_${timestamp}_${sequence}`;
+}


### PR DESCRIPTION
/claim #5536

## Summary
- add a shared in-memory record ID helper that preserves readable prefixed IDs
- append a same-millisecond sequence so repeated creates do not collide
- update job, user, proposal, message, review, notification, payment, and registration ID generation
- keep registration access-token subject aligned with the generated user id

## Tests
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/recordIds.test.js`
- `node --check apps/api/src/utils/id.js`
- `node --check apps/api/src/tests/recordIds.test.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/services/jobService.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/services/notificationService.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/services/proposalService.js`
- `node --check apps/api/src/services/reviewService.js`
- `node --check apps/api/src/services/userService.js`
- `git diff --cached --check`
