### PR TITLE
fix(auth): preserve mock login role in JWT

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -14,7 +14,7 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authLoginRole.test.js
+++ b/apps/api/src/tests/authLoginRole.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login signs JWTs with the validated login role", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "admin@example.com",
+        password: "supersecure",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+    const claims = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(claims.role, "admin");
+    assert.equal(claims.sub, "usr_existing");
+  });
+});
+
+test("POST /api/auth/login defaults mock JWT role to client", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "supersecure"
+      })
+    });
+    const payload = await response.json();
+    const claims = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(claims.role, "client");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -8,5 +8,6 @@ export const registerSchema = z.object({
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
 });


### PR DESCRIPTION
Closes #5728
Refs #5346
/claim #743

## Summary
- preserve the validated login role when issuing mock JWTs
- allow an optional role in the login validator with a safe default of `client`
- add regression tests covering explicit and defaulted login roles

## Testing
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/authLoginRole.test.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/validators/auth.js
- node --check apps/api/src/tests/authLoginRole.test.js
