### PR TITLE
fix(api): return 400 for zod validation errors

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import "./middleware/enableAsyncErrors.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";

--- a/apps/api/src/middleware/enableAsyncErrors.js
+++ b/apps/api/src/middleware/enableAsyncErrors.js
@@ -1,0 +1,27 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const Layer = require("express/lib/router/layer");
+
+if (!Layer.prototype.__asyncErrorsPatched) {
+  Layer.prototype.__asyncErrorsPatched = true;
+  const originalHandleRequest = Layer.prototype.handle_request;
+
+  Layer.prototype.handle_request = function handleRequest(req, res, next) {
+    const fn = this.handle;
+
+    if (fn.length > 3) {
+      return originalHandleRequest.call(this, req, res, next);
+    }
+
+    try {
+      const result = fn(req, res, next);
+      if (result && typeof result.then === "function") {
+        return Promise.resolve(result).catch(next);
+      }
+      return result;
+    } catch (error) {
+      return next(error);
+    }
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/zodErrorHandling.test.js
+++ b/apps/api/src/tests/zodErrorHandling.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login returns 400 with Zod issues for invalid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "bad", password: "short" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(Array.isArray(payload.issues));
+    assert.equal(payload.issues.length, 2);
+  });
+});
+
+test("POST /api/jobs forwards async validation failures to the global error handler", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "bad",
+        description: "too short",
+        budgetMin: -1,
+        budgetMax: 10,
+        categoryId: "",
+        skills: [""]
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.length >= 4);
+  });
+});
+
+test("errorHandler keeps returning 500 for non-validation failures", () => {
+  let statusCode = null;
+  let jsonPayload = null;
+  let nextError = null;
+
+  const res = {
+    headersSent: false,
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      jsonPayload = payload;
+      return this;
+    }
+  };
+
+  errorHandler(new Error("boom"), {}, res, (error) => {
+    nextError = error;
+  });
+
+  assert.equal(nextError, null);
+  assert.equal(statusCode, 500);
+  assert.deepEqual(jsonPayload, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});


### PR DESCRIPTION
Closes #5730
Refs #5700
/claim #743

## Summary
- patch Express route layers so async controller rejections reach the global error middleware
- return HTTP 400 with the existing response shape plus Zod `issues` for validation failures
- add regression tests for invalid auth and job payloads, plus a non-validation 500 guard

## Testing
- npm install
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/zodErrorHandling.test.js
- node --check apps/api/src/app.js
- node --check apps/api/src/middleware/errorHandler.js
- node --check apps/api/src/middleware/enableAsyncErrors.js
- node --check apps/api/src/tests/zodErrorHandling.test.js
