### PR TITLE
fix(db): constrain payment status with Prisma enum

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -21,6 +21,14 @@ enum JobStatus {
   CANCELLED
 }
 
+enum PaymentStatus {
+  PENDING
+  PROCESSING
+  SUCCEEDED
+  FAILED
+  CANCELLED
+}
+
 model User {
   id             String      @id @default(cuid())
   email          String      @unique
@@ -74,7 +82,7 @@ model Payment {
   id            String      @id @default(cuid())
   amount        Float
   currency      String      @default("USD")
-  status        String
+  status        PaymentStatus @default(PENDING)
   stripeRef     String?
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])


### PR DESCRIPTION
Closes #5732
Refs #5684
/claim #743

## Summary
- add a dedicated Prisma `PaymentStatus` enum for known lifecycle values
- constrain `Payment.status` to the enum instead of an arbitrary string
- default new payments to `PENDING` while preserving the existing job relation

## Testing
- npm install
- $env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/freelanceflow'; npx prisma validate --schema packages/db/prisma/schema.prisma
