### PR TITLE
fix(db): prevent duplicate proposals per job

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -68,6 +68,8 @@ model Proposal {
   freelancerId  String
   freelancer    User        @relation(fields: [freelancerId], references: [id])
   createdAt     DateTime    @default(now())
+
+  @@unique([jobId, freelancerId])
 }
 
 model Payment {


### PR DESCRIPTION
Closes #5734
Refs #5678
/claim #743

## Summary
- add a Prisma unique constraint for the proposal `jobId`/`freelancerId` pair
- enforce at most one proposal per freelancer on a given job
- keep the change scoped to the proposal model and existing relations intact

## Testing
- npm install
- $env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/freelanceflow'; npx prisma validate --schema packages/db/prisma/schema.prisma
