### PR TITLE
fix(ci): count leaderboard entries only after merge

### DIFF
--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -3,7 +3,7 @@ name: Update PR leaderboard
 on:
   pull_request_target:
     types:
-      - opened
+      - closed
 
 permissions:
   contents: write
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   update-leaderboard:
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Closes #5570
/claim #743

## Summary
- trigger the leaderboard workflow on pull request close instead of open
- run the job only when the pull request was actually merged
- keep the existing duplicate guard so previously counted PRs are not incremented twice

## Validation
- reviewed the workflow structure after the edit
- confirmed the YAML file stays well-formed for the updated trigger and job condition
