### PR TITLE
fix(api): avoid duplicate public ids in record services

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createPublicId } from "../utils/publicId.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = createPublicId("usr");
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: createPublicId("job"), status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { id: createPublicId("msg"), ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: createPublicId("ntf"), read: false, ...payload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { createPublicId } from "../utils/publicId.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: createPublicId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: createPublicId("prp"), ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: createPublicId("rev"), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createPublicId } from "../utils/publicId.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: createPublicId("usr"), ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/publicIdServices.test.js
+++ b/apps/api/src/tests/publicIdServices.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+import { resetPublicIdState } from "../utils/publicId.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("services generate distinct public ids within the same millisecond", async (t) => {
+  const originalNow = Date.now;
+  Date.now = () => 1780879000000;
+  resetPublicIdState();
+
+  await t.test("registerUser reuses the generated user id in the JWT subject", async () => {
+    const first = await registerUser({
+      email: "one@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const second = await registerUser({
+      email: "two@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+
+    assert.equal(first.id, "usr_1780879000000");
+    assert.equal(second.id, "usr_1780879000000_1");
+    assert.equal(verifyAccessToken(first.token).sub, first.id);
+    assert.equal(verifyAccessToken(second.token).sub, second.id);
+  });
+
+  await t.test("in-memory services append a sequence suffix when ids collide", async () => {
+    const [userA, userB] = await Promise.all([
+      createUser({ email: "a@example.com" }),
+      createUser({ email: "b@example.com" })
+    ]);
+    const [jobA, jobB] = await Promise.all([
+      createJob({ title: "Job A" }),
+      createJob({ title: "Job B" })
+    ]);
+    const [proposalA, proposalB] = await Promise.all([
+      createProposal({ bidAmount: 1 }),
+      createProposal({ bidAmount: 2 })
+    ]);
+    const [messageA, messageB] = await Promise.all([
+      sendMessage({ body: "hello" }),
+      sendMessage({ body: "world" })
+    ]);
+    const [reviewA, reviewB] = await Promise.all([
+      createReview({ rating: 5 }),
+      createReview({ rating: 4 })
+    ]);
+    const [notificationA, notificationB] = await Promise.all([
+      createNotification({ title: "one" }),
+      createNotification({ title: "two" })
+    ]);
+    const [paymentA, paymentB] = await Promise.all([
+      createPaymentIntent({ amount: 10 }),
+      createPaymentIntent({ amount: 20 })
+    ]);
+
+    assert.equal(userA.id, "usr_1780879000000_2");
+    assert.equal(userB.id, "usr_1780879000000_3");
+    assert.equal(jobA.id, "job_1780879000000");
+    assert.equal(jobB.id, "job_1780879000000_1");
+    assert.equal(proposalA.id, "prp_1780879000000");
+    assert.equal(proposalB.id, "prp_1780879000000_1");
+    assert.equal(messageA.id, "msg_1780879000000");
+    assert.equal(messageB.id, "msg_1780879000000_1");
+    assert.equal(reviewA.id, "rev_1780879000000");
+    assert.equal(reviewB.id, "rev_1780879000000_1");
+    assert.equal(notificationA.id, "ntf_1780879000000");
+    assert.equal(notificationB.id, "ntf_1780879000000_1");
+    assert.equal(paymentA.paymentId, "pay_1780879000000");
+    assert.equal(paymentB.paymentId, "pay_1780879000000_1");
+  });
+
+  Date.now = originalNow;
+});

--- a/apps/api/src/utils/publicId.js
+++ b/apps/api/src/utils/publicId.js
@@ -1,0 +1,19 @@
+const publicIdState = new Map();
+
+export function createPublicId(prefix) {
+  const timestamp = Date.now();
+  const state = publicIdState.get(prefix);
+
+  if (!state || state.timestamp !== timestamp) {
+    publicIdState.set(prefix, { timestamp, sequence: 0 });
+    return `${prefix}_${timestamp}`;
+  }
+
+  const sequence = state.sequence + 1;
+  publicIdState.set(prefix, { timestamp, sequence });
+  return `${prefix}_${timestamp}_${sequence}`;
+}
+
+export function resetPublicIdState() {
+  publicIdState.clear();
+}


### PR DESCRIPTION
Closes #5536
/claim #743

## Summary
- add a small shared public-id helper that appends a same-millisecond sequence suffix when needed
- replace `Date.now()`-only public ids across auth, user, job, proposal, message, review, notification, and payment services
- add a regression test that freezes `Date.now()` and proves duplicate ids are no longer emitted

## Testing
- npm install
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/publicIdServices.test.js
- node --check apps/api/src/utils/publicId.js
- node --check apps/api/src/tests/publicIdServices.test.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/services/jobService.js
- node --check apps/api/src/services/messageService.js
- node --check apps/api/src/services/notificationService.js
- node --check apps/api/src/services/paymentService.js
- node --check apps/api/src/services/proposalService.js
- node --check apps/api/src/services/reviewService.js
- node --check apps/api/src/services/userService.js
