### PR TITLE
fix(api): keep default job status canonical

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, ...payload, status: "OPEN" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobStatus.test.js
+++ b/apps/api/src/tests/jobStatus.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob uses the canonical OPEN status and ignores caller overrides", async () => {
+  const job = await createJob({
+    title: "Build API integration",
+    description: "Implement the integration end to end.",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "cat_web",
+    skills: ["node"],
+    status: "DRAFT"
+  });
+
+  assert.equal(job.status, "OPEN");
+});


### PR DESCRIPTION
Closes #5738
/claim #743

## Summary
- keep the in-memory default job status aligned with the Prisma `JobStatus.OPEN` enum value
- make the default job status server-owned so caller payloads cannot override it during creation
- add a focused regression test for canonical status and override protection

## Testing
- npm install
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobStatus.test.js
- node --check apps/api/src/services/jobService.js
- node --check apps/api/src/tests/jobStatus.test.js
