### PR TITLE
fix(api): expose initial payment intent status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
+    status: "requires_payment_method",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentStatus.test.js
+++ b/apps/api/src/tests/paymentStatus.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments returns the initial payment intent status", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1500 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 1500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.status, "requires_payment_method");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- return `status: "requires_payment_method"` from the stub payment intent response
- add focused API coverage for `POST /api/payments`
- keep the change scoped to the payment response shape

## Testing
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/paymentStatus.test.js
- node --check apps/api/src/services/paymentService.js
- node --check apps/api/src/tests/paymentStatus.test.js

/claim #5741
