### PR TITLE
fix(api): keep health checks outside rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,12 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
 
+  app.use(apiLimiter);
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);
   app.use("/api/jobs", jobRoutes);

--- a/apps/api/src/tests/healthRateLimit.test.js
+++ b/apps/api/src/tests/healthRateLimit.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /health bypasses API rate limiting after the API quota is exhausted", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    for (let i = 0; i < 200; i += 1) {
+      const response = await fetch(`${baseUrl}/api/search?q=ok`);
+      assert.equal(response.status, 200);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/search?q=blocked`);
+    assert.equal(limitedResponse.status, 429);
+
+    const healthResponse = await fetch(`${baseUrl}/health`);
+    const healthPayload = await healthResponse.json();
+
+    assert.equal(healthResponse.status, 200);
+    assert.deepEqual(healthPayload, { ok: true, service: "api" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- move `GET /health` ahead of the shared API limiter
- preserve rate limiting for `/api/*` routes
- add regression coverage showing `/health` still returns 200 after the API quota is exhausted

## Testing
- node --test apps/api/src/tests/health.test.js apps/api/src/tests/healthRateLimit.test.js
- node --check apps/api/src/app.js
- node --check apps/api/src/tests/healthRateLimit.test.js

/claim #5745
