### PR TITLE
fix(build): run web workspace from root build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
+    "build": "npm run build -w apps/web",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
   }


### PR DESCRIPTION
## Summary
- run the web workspace build from the root `build` script instead of echoing a reminder
- keep the fix scoped to the root package scripts

## Testing
- npm run build

Closes #5750
