### PR TITLE
fix(api): add Zod validation for payment creation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues, 400);
+  }
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payment with valid input returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payment`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: 100,
+      currency: "usd",
+      jobId: "job_123"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.amount, 100);
+  assert.equal(payload.data.currency, "usd");
+  assert.ok(payload.data.paymentId);
+  assert.equal(payload.data.provider, "stripe");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payment with missing amount returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payment`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      currency: "usd",
+      jobId: "job_123"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payment with negative amount returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payment`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: -50,
+      currency: "usd",
+      jobId: "job_123"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payment with extra fields returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payment`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: 100,
+      currency: "usd",
+      jobId: "job_123",
+      paymentId: "injected_pay_123",
+      provider: "malicious"
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1),
+  jobId: z.string().min(1)
+}).strict();


### PR DESCRIPTION
## Summary

Add input validation for `POST /api/payment` to prevent malformed data from reaching the service layer.

## Changes

### New validator: `apps/api/src/validators/payment.js`
- `createPaymentSchema` validates:
  - `amount`: positive number
  - `currency`: non-empty string
  - `jobId`: non-empty string
- Uses `.strict()` to reject unknown fields like `paymentId` and `provider`

### Updated controller: `apps/api/src/controllers/paymentController.js`
- Parses request body with `createPaymentSchema.safeParse()`
- Returns HTTP 400 with validation issues on invalid input
- Valid requests proceed to service layer

### New tests: `apps/api/src/tests/payment.test.js`
- Valid input returns 201 with correct payment data
- Missing `amount` returns 400
- Negative `amount` returns 400
- Extra fields (`paymentId`, `provider`) return 400

## Verification

```bash
npm test -- apps/api/src/tests/payment.test.js
```

Fixes #5721