### PR TITLE
fix: add role-based access control to admin endpoints

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/test_schemas.mjs
+++ b/apps/api/test_schemas.mjs
@@ -1,0 +1,8 @@
+import { createUserSchema } from './src/validators/user.js';
+import { createMessageSchema } from './src/validators/message.js';
+
+const r1 = createUserSchema.safeParse({name: 'T', email: 'bad', password: '123'});
+console.log('User schema:', !r1.success ? 'PASS' : 'FAIL');
+
+const r2 = createMessageSchema.safeParse({});
+console.log('Message schema:', !r2.success ? 'PASS' : 'FAIL');


### PR DESCRIPTION
Closes #5758

Refs #743

## Summary
- Add `requireAdmin` middleware that checks `req.user.role === 'admin'`
- Apply to adminRoutes alongside existing authMiddleware
- Return 403 with descriptive error for non-admin authenticated users

## Testing
- Authenticated `client` role → 403
- Authenticated `admin` role → 200
- Unauthenticated → 401 (preserved)

/claim #743