### PR TITLE
fix: restrict file upload size, type, and count

### DIFF
--- a/apps/api/src/middleware/upload.js
+++ b/apps/api/src/middleware/upload.js
@@ -1,0 +1,39 @@
+import multer from "multer";
+import { fail } from "../utils/response.js";
+
+const ALLOWED_MIMES = [
+  "image/jpeg", "image/png", "image/gif", "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain"
+];
+
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_SIZE, files: 1 },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIMES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(null, false);
+    }
+  }
+}).single("file");
+
+export function uploadMiddleware(req, res, next) {
+  upload(req, res, (err) => {
+    if (err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File too large. Max 10 MB", 400);
+    }
+    if (err) {
+      return fail(res, "Upload error: " + err.message, 400);
+    }
+    if (!req.file) {
+      return fail(res, "Invalid file type. Accepted: JPEG, PNG, GIF, WebP, PDF, DOC, DOCX, TXT", 400);
+    }
+    return next();
+  });
+}

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,7 @@
 import { Router } from "express";
-import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
-
-const upload = multer({ storage: multer.memoryStorage() });
+import { uploadMiddleware } from "../middleware/upload.js";
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", uploadMiddleware, uploadFile);


### PR DESCRIPTION
Closes #5759

Refs #743

## Summary
- Add `uploadMiddleware` with multer configuration
- 10 MB file size limit enforced
- Whitelist MIME types: JPEG, PNG, GIF, WebP, PDF, DOC, DOCX, TXT
- Return 400 for oversized files, invalid types, or missing files
- Enforce single file per request

## Testing
- 15 MB image → 400
- `.exe` file → 400
- Valid `.pdf` → 201

/claim #743