### PR TITLE
fix: validate proposal creation payload with Zod schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  coverLetter: z.string().min(10, "coverLetter must be at least 10 characters"),
+  estimatedDuration: z.string().min(1, "estimatedDuration is required"),
+  rate: z.number().positive("rate must be a positive number")
+});


### PR DESCRIPTION
Closes #5760

Refs #743

## Summary
- Add `createProposalSchema` requiring `jobId`, `coverLetter`, `estimatedDuration`, and `rate`
- Return 400 with structured Zod issues for invalid payloads
- Prevent system field injection via schema whitelist

## Testing
- Empty body → 400 with field-level errors
- Missing rate → 400
- Full valid payload → 201

/claim #743