### PR TITLE
[SnowfallHD] Preserve notification server-owned id and read state

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...clientPayload } = payload ?? {};
+  const notification = { ...clientPayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller supplied id and read state", async () => {
+  const notification = await createNotification({
+    id: "ntf_reserved",
+    read: true,
+    title: "Server-owned fields should win",
+    message: "Client values must not override generated values",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_reserved");
+  assert.equal(notification.read, false);
+  assert.equal(notification.title, "Server-owned fields should win");
+  assert.equal(notification.message, "Client values must not override generated values");
+});


### PR DESCRIPTION
/claim #2762

## Summary
- Preserve server-owned notification fields during creation.
- Ignore caller-supplied `id` and `read` values before constructing the notification.
- Add a regression test proving new notifications always keep a generated `ntf_*` id and `read: false` even when the request payload tries to override them.

## Verification
```text
npm test

TAP version 13
# Subtest: GET /health returns ok payload
ok 1 - GET /health returns ok payload
# Subtest: createNotification ignores caller supplied id and read state
ok 2 - createNotification ignores caller supplied id and read state
1..2
# tests 2
# pass 2
# fail 0
```

Also ran:
```text
git diff --check
```

## Scope note
Kept the product behavior change limited to notification creation as requested. The only adjacent change is the API package test glob so `npm test` runs the existing/new test files reliably under the current Node test runner.
