### PR TITLE
fix: validate refresh token before issuing access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,20 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token: bearerToken } = req.headers.authorization
+    ? { token: req.headers.authorization.replace(/^Bearer\s+/i, '').trim() }
+    : {};
+  const bodyToken = refreshSchema.parse(req.body).token;
+  const token = bearerToken || bodyToken;
+  if (!token) {
+    return fail(res, "Refresh token is required", 401);
+  }
+  let payload;
+  try {
+    payload = verifyAccessToken(token);
+  } catch {
+    return fail(res, "Invalid or expired refresh token", 401);
+  }
+  const result = await refreshToken(payload);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
 import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { verifyAccessToken } from "../utils/jwt.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,10 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(payload) {
+  const { sub, role } = payload || {};
+  if (!sub || !role) {
+    throw new Error("Invalid token payload");
+  }
+  return { token: signAccessToken({ sub, role }) };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,174 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import jwt from "jsonwebtoken";
+
+function createTestServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/auth/refresh — no token returns 401", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}`);
+    const payload = await res.json();
+    assert.ok(payload.message, "Should have an error message");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh — invalid token returns 401", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer invalid.token.here",
+      },
+      body: JSON.stringify({}),
+    });
+
+    assert.equal(res.status, 401, `Expected 401, got ${res.status}`);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh — valid token returns 200 with new access token", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    // Issue a valid refresh token with the expected payload shape
+    const refreshToken = jwt.sign(
+      { sub: "usr_testuser", role: "freelancer" },
+      "development-secret",
+      { expiresIn: "1h" }
+    );
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${refreshToken}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    assert.equal(res.status, 200, `Expected 200, got ${res.status} body: ${JSON.stringify(await res.clone().json())}`);
+    const payload = await res.json();
+    assert.ok(payload.data?.token, "Response should contain a new access token");
+
+    // Decode the new token and verify it carries the correct identity
+    const newToken = jwt.decode(payload.data.token);
+    assert.equal(newToken.sub, "usr_testuser", "New token sub should match refresh token sub");
+    assert.equal(newToken.role, "freelancer", "New token role should match refresh token role");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh — token in body also works", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    const refreshToken = jwt.sign(
+      { sub: "usr_bodyuser", role: "client" },
+      "development-secret",
+      { expiresIn: "1h" }
+    );
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: refreshToken }),
+    });
+
+    assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
+    const payload = await res.json();
+    assert.ok(payload.data?.token, "Should return new access token");
+
+    const newToken = jwt.decode(payload.data.token);
+    assert.equal(newToken.sub, "usr_bodyuser");
+    assert.equal(newToken.role, "client");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh — bearer header takes priority over body token", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    const bearerToken = jwt.sign({ sub: "usr_bearer", role: "admin" }, "development-secret", { expiresIn: "1h" });
+    const bodyToken = jwt.sign({ sub: "usr_body", role: "client" }, "development-secret", { expiresIn: "1h" });
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${bearerToken}`,
+      },
+      body: JSON.stringify({ token: bodyToken }),
+    });
+
+    assert.equal(res.status, 200);
+    const payload = await res.json();
+    const newToken = jwt.decode(payload.data.token);
+    assert.equal(newToken.sub, "usr_bearer", "Bearer header should take priority");
+    assert.equal(newToken.role, "admin");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh — expired token returns 401", async () => {
+  const server = await createTestServer();
+  const { port } = server.address();
+
+  try {
+    const expiredToken = jwt.sign(
+      { sub: "usr_expired", role: "client" },
+      "development-secret",
+      { expiresIn: "-1s" } // already expired
+    );
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${expiredToken}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    assert.equal(res.status, 401, "Expired token should be rejected");
+  } finally {
+    await closeServer(server);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().optional()
+});


### PR DESCRIPTION
## Fixes #5703 — $780

**Bug:** `refresh` endpoint calls `refreshToken()` with no arguments and returns a valid JWT for a hardcoded `usr_existing` user. Any unauthenticated caller can obtain a legitimate access token.

**Fix:**

1. **`validators/auth.js`** — Added `refreshSchema` to accept an optional `token` field in the request body.

2. **`controllers/authController.js`** — `refresh` extracts the token from `Authorization: Bearer` header (priority) or `req.body.token`. Returns 401 if absent. Validates via `verifyAccessToken` before proceeding.

3. **`services/authService.js`** — `refreshToken(payload)` accepts the verified JWT payload and issues an access token for the actual user identity instead of the hardcoded `usr_existing`.

```diff
// Before: anyone gets a token for usr_existing
export async function refresh(req, res) {
  const result = await refreshToken();
  return ok(res, result);
}

// After: token required and validated
export async function refresh(req, res) {
  const token = bearerToken || bodyToken;
  if (!token) return fail(res, "Refresh token is required", 401);
  let payload;
  try { payload = verifyAccessToken(token); }
  catch { return fail(res, "Invalid or expired refresh token", 401); }
  const result = await refreshToken(payload);
  return ok(res, result);
}
```

**Tests:** 7/7 passing locally

```
✔ GET /health returns ok payload
✔ POST /api/auth/refresh — no token returns 401
✔ POST /api/auth/refresh — invalid token returns 401
✔ POST /api/auth/refresh — valid token returns 200 with new access token
✔ POST /api/auth/refresh — token in body also works
✔ POST /api/auth/refresh — bearer header takes priority over body token
✔ POST /api/auth/refresh — expired token returns 401
```

**Verification:** All 7 tests pass against the fixed code.