### PR TITLE
fix: prevent admin role self-assignment during registration (fixes #5801)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Fix for #5801

### Problem
Public registration accepts `role: "admin"` in the request body, allowing new users to self-assign admin privileges and receive a JWT signed with the admin role.

### Solution
Removed `"admin"` from the role enum in `registerSchema` (`apps/api/src/validators/auth.js`). Now only `"client"` and `"freelancer"` are accepted during public registration.

### Changes
- `apps/api/src/validators/auth.js`: Changed `z.enum(["client", "freelancer", "admin"])` to `z.enum(["client", "freelancer"])`

### Testing
- Attempting to register with `role: "admin"` will now return a Zod validation error
- Default role remains `"client"` when role is omitted
- Login and other flows are unaffected