### PR TITLE
fix: search endpoint has no input validation or length limit on query (fixes #5802)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+
+  if (typeof q !== "string") {
+    return res.status(400).json({ error: "Query parameter 'q' must be a string." });
+  }
+
+  const trimmed = q.trim();
+
+  if (trimmed.length > MAX_QUERY_LENGTH) {
+    return res.status(400).json({
+      error: `Query parameter 'q' must not exceed ${MAX_QUERY_LENGTH} characters.`,
+    });
+  }
+
+  return ok(res, await globalSearch(trimmed));
 }


### PR DESCRIPTION
## Fix for #5802

### Problem
The `GET /api/v1/search?q=` endpoint passes user input directly to `globalSearch()` without any validation. No type check on `q` and no length limit, allowing potentially very long query strings.

### Solution
Added input validation in the search controller:
1. Type check: ensures `q` is a string (returns 400 if not)
2. Length limit: trims whitespace and rejects queries over 200 characters
3. Clear error messages for invalid input

### Changes
- `apps/api/src/controllers/searchController.js`: Added validation before calling `globalSearch()`

### Testing
- `GET /search?q=test` returns results normally
- `GET /search?q=<200+ chars>` returns 400 with error message
- `GET /search?q[]=nonstring` returns 400 type error