### PR TITLE
fix: reject inverted job budget ranges in job validation (fixes #5803)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,31 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([]),
+  })
+  .refine((data) => data.budgetMin <= data.budgetMax, {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMin"],
+  });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.innerType().partial().extend({
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+}).refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMin <= data.budgetMax;
+    }
+    return true;
+  },
+  {
+    message: "budgetMin must be less than or equal to budgetMax",
+    path: ["budgetMin"],
+  }
+);


### PR DESCRIPTION
## Fix for #5803

### Problem
The job creation schema accepts `budgetMin` and `budgetMax` but does not validate that `budgetMin <= budgetMax`. This allows creating jobs with inverted budget ranges (e.g., budgetMin: 10000, budgetMax: 100).

### Solution
Added `.refine()` validation to both `createJobSchema` and `updateJobSchema`:
- **createJobSchema**: Always checks `budgetMin <= budgetMax`
- **updateJobSchema**: Checks only when both values are provided in the same request

### Changes
- `apps/api/src/validators/job.js`: Added Zod refine checks for budget range validation

### Testing
- Creating a job with `budgetMin: 100, budgetMax: 50` returns validation error
- Creating a job with `budgetMin: 50, budgetMax: 100` succeeds normally
- Partial updates with only one budget field are not affected