### PR TITLE
fix: add authMiddleware to payment routes

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
/claim #743

## Fix
Payment API routes were missing the authMiddleware, allowing unauthenticated callers to create payment intent records.

### Changes
- Import uthMiddleware in paymentRoutes.js
- Apply uthMiddleware before the POST route
- Follows the same pattern as dminRoutes.js