### PR TITLE
fix(ids): unique IDs for same-millisecond record creation with tests

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
+import { makeId } from "../utils/id.js";
+
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
-    id: `usr_${Date.now()}`,
+    id: makeId("usr"),
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: makeId("usr"), role: payload.role })
   };
 }
 

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: makeId("job"), status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { id: makeId("msg"), ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: makeId("ntf"), read: false, ...payload };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { makeId } from "../utils/id.js";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: makeId("pay"),
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: makeId("prp"), ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: makeId("rev"), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { makeId } from "../utils/id.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: makeId("usr"), ...payload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/id.test.js
+++ b/apps/api/src/tests/id.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { makeId } from "../utils/id.js";
+
+test("makeId produces prefixed IDs matching prefix_timestamp pattern", () => {
+  const id = makeId("job");
+  assert.match(id, /^job_\d+$/);
+});
+
+test("makeId appends sequence for same-millisecond calls", () => {
+  const origNow = Date.now;
+  const fixed = 1780879000000;
+  Date.now = () => fixed;
+  try {
+    const a = makeId("job");
+    const b = makeId("job");
+    const c = makeId("job");
+    assert.notEqual(a, b, "first and second IDs must differ");
+    assert.notEqual(b, c, "second and third IDs must differ");
+    assert.ok(b.includes("_"), "second ID should have sequence suffix");
+    assert.ok(c.includes("_"), "third ID should have sequence suffix");
+  } finally {
+    Date.now = origNow;
+  }
+});
+
+test("makeId resets sequence when timestamp advances", () => {
+  const origNow = Date.now;
+  let ts = 9999000;
+  Date.now = () => ts;
+  try {
+    const a = makeId("usr");
+    ts = 9999001;
+    const b = makeId("usr");
+    assert.match(a, /^usr_\d+$/);
+    assert.match(b, /^usr_\d+$/);
+    assert.notEqual(a, b);
+  } finally {
+    Date.now = origNow;
+  }
+});
+
+test("different prefixes always produce distinct IDs even at same timestamp", () => {
+  const origNow = Date.now;
+  const fixed = 1780879999000;
+  Date.now = () => fixed;
+  try {
+    const a = makeId("job");
+    const b = makeId("pay");
+    assert.ok(a.startsWith("job_"), "first ID has job prefix");
+    assert.ok(b.startsWith("pay_"), "second ID has pay prefix");
+    assert.notEqual(a, b, "different prefixes must produce different IDs");
+  } finally {
+    Date.now = origNow;
+  }
+});

--- a/apps/api/src/utils/id.js
+++ b/apps/api/src/utils/id.js
@@ -1,0 +1,13 @@
+let lastTs = 0;
+let seq = 0;
+
+export function makeId(prefix) {
+  const ts = Date.now();
+  if (ts === lastTs) {
+    seq += 1;
+  } else {
+    lastTs = ts;
+    seq = 0;
+  }
+  return `${prefix}_${ts}${seq > 0 ? `_${seq}` : ""}`;
+}


### PR DESCRIPTION
## Fix for #5536

All 8 in-memory services used `Date.now()` for prefixed IDs, producing duplicates when multiple records are created in the same millisecond.

### Changes

**New: `apps/api/src/utils/id.js`** — shared ID helper with monotonic sequence counter. Appends `_n` suffix only when timestamp hasn't advanced. Zero dependencies.

**Updated: 8 services** — `userService`, `jobService`, `paymentService`, `messageService`, `authService`, `proposalService`, `notificationService`, `reviewService` — all now use `makeId(prefix)` instead of inline `Date.now()`.

### Tests (4/4 passing)

- Produces prefixed IDs matching `prefix_timestamp` pattern
- Appends sequence suffix for same-millisecond calls (proves uniqueness)
- Resets sequence when timestamp advances
- Different prefixes always produce distinct IDs

```
TAP version 13
ok 1 - makeId produces prefixed IDs matching prefix_timestamp pattern
ok 2 - makeId appends sequence for same-millisecond calls
ok 3 - makeId resets sequence when timestamp advances
ok 4 - different prefixes always produce distinct IDs even at same timestamp
1..4
# pass 4
# fail 0
```

Run: `node --test apps/api/src/tests/id.test.js`