### PR TITLE
fix(payments): validate amount and currency with 400 rejection + tests

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,32 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
+const SUPPORTED_CURRENCIES = ["usd"];
+
+function validatePayment(body) {
+  const { amount, currency } = body;
+  if (amount === undefined || amount === null) {
+    return "amount is required";
+  }
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    return "amount must be a number";
+  }
+  if (amount <= 0) {
+    return "amount must be positive";
+  }
+  if (currency !== undefined && currency !== null) {
+    if (typeof currency !== "string") {
+      return "currency must be a string";
+    }
+    if (!SUPPORTED_CURRENCIES.includes(currency.toLowerCase())) {
+      return `currency must be one of: ${SUPPORTED_CURRENCIES.join(", ")}`;
+    }
+  }
+  return null;
+}
+
 export async function createPayment(req, res) {
+  const err = validatePayment(req.body);
+  if (err) return fail(res, err);
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPayment } from "../controllers/paymentController.js";
+
+function mockRes() {
+  const r = { statusCode: 0, body: null };
+  r.status = (c) => { r.statusCode = c; return r; };
+  r.json = (d) => { r.body = d; return r; };
+  return r;
+}
+
+test("rejects missing amount", () => {
+  const req = { body: {} };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.ok(res.body.message.includes("amount"));
+});
+
+test("rejects negative amount", () => {
+  const req = { body: { amount: -10 } };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.ok(res.body.message.includes("positive"));
+});
+
+test("rejects string amount", () => {
+  const req = { body: { amount: "ten" } };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.ok(res.body.message.includes("number"));
+});
+
+test("rejects unsupported currency", () => {
+  const req = { body: { amount: 10, currency: "btc" } };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.ok(res.body.message.includes("currency"));
+});
+
+test("accepts valid amount with default currency", async () => {
+  const req = { body: { amount: 50 } };
+  const res = mockRes();
+  await createPayment(req, res);
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.currency, "usd");
+  assert.equal(res.body.data.amount, 50);
+});
+
+test("accepts valid amount with explicit usd currency", async () => {
+  const req = { body: { amount: 25.5, currency: "usd" } };
+  const res = mockRes();
+  await createPayment(req, res);
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.data.amount, 25.5);
+});
+
+test("rejects zero amount", () => {
+  const req = { body: { amount: 0 } };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.ok(res.body.message.includes("positive"));
+});
+
+test("rejects Infinity amount", () => {
+  const req = { body: { amount: Infinity } };
+  const res = mockRes();
+  createPayment(req, res);
+  assert.equal(res.statusCode, 400);
+});


### PR DESCRIPTION
## Fix for #5533

`POST /api/payments` forwarded `req.body` directly into the payment service, accepting missing, negative, non-numeric, and Infinity amounts plus arbitrary currencies.

### Changes

- Added `validatePayment()` guard in `paymentController.js` that rejects invalid payloads with 400 before reaching the service layer
- Amount must be a positive finite number
- Currency must be a supported lowercase code (currently `usd`), existing default preserved
- 8 regression tests covering: missing amount, negative, string, zero, Infinity, unsupported currency, valid with default, valid with explicit currency

### Tests (8/8)

```
ok 1 - rejects missing amount
ok 2 - rejects negative amount
ok 3 - rejects string amount
ok 4 - rejects unsupported currency
ok 5 - accepts valid amount with default currency
ok 6 - accepts valid amount with explicit usd currency
ok 7 - rejects zero amount
ok 8 - rejects Infinity amount
# pass 8  # fail 0
```