### PR TITLE
fix(db): add main, types, and exports entrypoint for @freelanceflow/db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Fix for #5453 (ref #2775)

`packages/db` had `src/index.ts` but no entrypoint fields in `package.json`. Node package resolution had no way to find the module.

### Changes

Added `main`, `types`, and `exports` to `packages/db/package.json`, matching the existing `@freelanceflow/ui` pattern:

```json
"main": "src/index.ts",
"types": "src/index.ts",
"exports": { ".": "./src/index.ts" }
```

Minimal, surgical — 5 lines added, no behavioral changes.