### PR TITLE
fix(jobs): reject inverted budget ranges in Zod schemas + tests

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a portfolio site built from scratch",
+    budgetMin: 500,
+    budgetMax: 200,
+    categoryId: "web-dev"
+  });
+  assert.equal(result.success, false);
+  const issue = result.error.issues.find(i => i.path.includes("budgetMin"));
+  assert.ok(issue, "should have budgetMin validation error");
+});
+
+test("createJobSchema accepts valid budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a portfolio site built from scratch",
+    budgetMin: 200,
+    budgetMax: 500,
+    categoryId: "web-dev"
+  });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts equal budget values", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a portfolio site built from scratch",
+    budgetMin: 300,
+    budgetMax: 300,
+    categoryId: "web-dev"
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted budget when both provided", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 1000,
+    budgetMax: 500
+  });
+  assert.equal(result.success, false);
+  const issue = result.error.issues.find(i => i.path.includes("budgetMin"));
+  assert.ok(issue, "should have budgetMin validation error");
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMax: 1000
+  });
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  { message: "budgetMin must not exceed budgetMax", path: ["budgetMin"] }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).default([]).optional()
+}).refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMin <= data.budgetMax;
+    }
+    return true;
+  },
+  { message: "budgetMin must not exceed budgetMax", path: ["budgetMin"] }
+);


### PR DESCRIPTION
## Fix for #5464

`createJobSchema` accepted payloads where `budgetMax < budgetMin`. `updateJobSchema` (derived via `.partial()`) had no cross-field validation at all.

### Changes

- Added `.refine()` on `createJobSchema` to enforce `budgetMin <= budgetMax`
- Rebuilt `updateJobSchema` with explicit optional fields + `.refine()` that only checks when both budget fields are present (partial updates still work)
- 6 tests covering: inverted create, valid range, equal values, inverted update, partial budgetMin, partial budgetMax

### Tests (6/6)

```
ok 1 - createJobSchema rejects inverted budget range
ok 2 - createJobSchema accepts valid budget range
ok 3 - createJobSchema accepts equal budget values
ok 4 - updateJobSchema rejects inverted budget when both provided
ok 5 - updateJobSchema accepts partial update with only budgetMin
ok 6 - updateJobSchema accepts partial update with only budgetMax
# pass 6  # fail 0
```