### PR TITLE
fix(db): add importable workspace entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
+    "test": "node --test test/import.test.js",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"
   },

--- a/packages/db/test/import.test.js
+++ b/packages/db/test/import.test.js
@@ -1,0 +1,9 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+test("workspace package can be imported by name", async () => {
+  const mod = await import("@freelanceflow/db");
+  const prismaClient = mod.PrismaClient ?? mod.default?.PrismaClient;
+
+  assert.equal(typeof prismaClient, "function");
+});


### PR DESCRIPTION
/claim #2775

## Summary
- add a real JavaScript root entrypoint for `@freelanceflow/db`
- declare explicit `main`, `types`, and `exports` metadata in `packages/db/package.json`
- add a focused workspace import test that verifies the package resolves by name

## Validation
- `npm test -w packages/db`
- `node -e "import('@freelanceflow/db').then((m)=>{const ok=typeof (m.PrismaClient ?? m.default?.PrismaClient)==='function'; if(!ok){throw new Error('PrismaClient export missing')} console.log('ok')})"`
- `git diff --check`