### PR TITLE
fix(review): preserve server-generated ids

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-service.test.js
+++ b/apps/api/src/tests/review-service.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller-supplied ids", async () => {
+  const review = await createReview({
+    id: "rev_client_supplied",
+    rating: 5,
+    comment: "Fast turnaround"
+  });
+
+  assert.notEqual(review.id, "rev_client_supplied");
+  assert.match(review.id, /^rev_\d+$/);
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Fast turnaround");
+});


### PR DESCRIPTION
/claim #5867

## Summary
- keep review ids server-generated during creation
- ignore caller-supplied `id` values while preserving the rest of the payload
- add focused service coverage for hostile payload ids

## Validation
- `node --test src/tests/*.js`
- `git diff --check`

## Note
- `npm test -w apps/api` currently fails on this Windows environment before the fix because the workspace script points `node --test` at the directory path `src/tests`; the explicit file-pattern invocation above runs the same suite successfully.