### PR TITLE
fix(job): preserve server-owned fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service.test.js
+++ b/apps/api/src/tests/job-service.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJob } from "../services/jobService.js";
+
+test("createJob ignores caller-supplied id and status", async () => {
+  const job = await createJob({
+    id: "job_attacker",
+    status: "closed",
+    title: "Migrate auth service",
+    description: "Keep the scope tight and production-ready.",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "backend",
+    skills: ["node", "testing"]
+  });
+
+  assert.notEqual(job.id, "job_attacker");
+  assert.match(job.id, /^job_\d+$/);
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Migrate auth service");
+  assert.equal(job.budgetMin, 100);
+  assert.equal(job.budgetMax, 500);
+});


### PR DESCRIPTION
/claim #4285

## Summary
- keep job ids and initial `open` status server-owned during creation
- ignore caller-supplied `id` and `status` values while preserving valid job fields
- add focused service coverage for hostile payload overrides

## Validation
- `node --test src/tests/*.js`
- `git diff --check`

## Note
- `npm test -w apps/api` still points `node --test` at the `src/tests` directory in this repo, so the file-pattern invocation above is the reliable way to run the same suite in this environment.