### PR TITLE
fix(proposal): preserve server-generated ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-service.test.js
+++ b/apps/api/src/tests/proposal-service.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal ignores caller-supplied ids", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker",
+    jobId: "job_123",
+    freelancerId: "usr_456",
+    coverLetter: "I can deliver this in three days.",
+    bidAmount: 250,
+    estDuration: "3 days"
+  });
+
+  assert.notEqual(proposal.id, "prp_attacker");
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_456");
+  assert.equal(proposal.bidAmount, 250);
+});


### PR DESCRIPTION
/claim #5872

## Summary
- keep proposal ids server-generated during creation
- ignore caller-supplied `id` values while preserving valid proposal fields
- add focused service coverage for hostile payload overrides

## Validation
- `node --test src/tests/*.js`
- `git diff --check`

## Note
- `npm test -w apps/api` still points `node --test` at the `src/tests` directory in this repo, so the file-pattern invocation above is the reliable way to run the same suite in this environment.