### PR TITLE
fix(message): preserve server-generated ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied ids", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker",
+    body: "Hello there",
+    senderId: "usr_1",
+    recipientId: "usr_2"
+  });
+
+  assert.notEqual(message.id, "msg_attacker");
+  assert.match(message.id, /^msg_\d+$/);
+  assert.equal(message.body, "Hello there");
+  assert.equal(message.senderId, "usr_1");
+  assert.equal(message.recipientId, "usr_2");
+  assert.match(message.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+});


### PR DESCRIPTION
## Summary
- ignore caller-supplied message ids when persisting new messages
- keep server-generated ids authoritative in the service layer
- add a regression test covering the overwrite attempt

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5874.