### PR TITLE
fix(job): reject inverted budget ranges

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validPayload = {
+  title: "Backend platform",
+  description: "Need an engineer to harden our hiring workflow.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "engineering",
+  skills: ["node", "testing"]
+};
+
+test("createJobSchema accepts matching budget ranges", () => {
+  const payload = createJobSchema.parse(validPayload);
+
+  assert.deepEqual(payload, validPayload);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    budgetMin: 1000,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues, [
+    {
+      code: "custom",
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    }
+  ]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,15 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema
+  .superRefine((value, ctx) => {
+    if (value.budgetMin > value.budgetMax) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "budgetMax must be greater than or equal to budgetMin",
+        path: ["budgetMax"]
+      });
+    }
+  });
+
+export const updateJobSchema = jobSchema.partial();


### PR DESCRIPTION
## Summary
- reject job payloads where udgetMin is greater than udgetMax
- keep the cross-field error attached to udgetMax with a clear validation message
- add focused regression tests for valid and inverted budget ranges

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5878.