### PR TITLE
fix(api): exempt health checks from rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,25 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("GET /health bypasses the shared API rate limiter", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  for (let attempt = 0; attempt < 205; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+
+    assert.equal(response.status, 200);
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- register /health before the shared API rate limiter
- keep the shared limiter applied to the rest of the application routes
- add a regression test proving more than 200 health probes still return 200

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5880.