### PR TITLE
fix(payment): expose initial intent status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "requires_payment_method"
   };
 }

--- a/apps/api/src/tests/payment-service.test.js
+++ b/apps/api/src/tests/payment-service.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent returns an initial requires_payment_method status", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500,
+    currency: "eur"
+  });
+
+  assert.equal(paymentIntent.amount, 2500);
+  assert.equal(paymentIntent.currency, "eur");
+  assert.equal(paymentIntent.provider, "stripe");
+  assert.equal(paymentIntent.status, "requires_payment_method");
+  assert.match(paymentIntent.paymentId, /^pay_/);
+});


### PR DESCRIPTION
## Summary
- include an initial equires_payment_method lifecycle status in new payment intents
- keep the existing payment id, amount, currency, and provider fields unchanged
- add focused service-level regression coverage for the initial response shape

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5885.