### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,11 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, ...payload, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects client-controlled read state", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_1",
+        title: "Forged",
+        body: "payload",
+        read: true
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications creates unread notifications from valid input", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_1",
+        title: "Proposal update",
+        body: "Your proposal was accepted."
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.title, "Proposal update");
+    assert.equal(payload.data.body, "Your proposal was accepted.");
+    assert.equal(payload.data.read, false);
+    assert.equal(typeof payload.data.id, "string");
+  });
+});
+
+test("POST /api/notifications rejects empty required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_1",
+        title: "",
+        body: "payload"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z
+  .object({
+    userId: z.string().min(1),
+    title: z.string().trim().min(1),
+    body: z.string().trim().min(1)
+  })
+  .strict();


### PR DESCRIPTION
## Summary
- Add a strict notification creation schema for `userId`, `title`, and `body`.
- Reject unexpected client-controlled properties such as `read`.
- Keep `read: false` server-owned when notifications are created.
- Add API tests for rejected forged read state, valid creation, and empty required fields.

Closes SecureBananaLabs/bug-bounty#5822

## Validation
- `node --test "apps/api/src/tests/*.test.js"`