### PR TITLE
fix(auth): reject admin role in public registration

### DIFF
--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const basePayload = {
+  email: "person@example.com",
+  password: "password123"
+};
+
+test("registerSchema accepts public roles", () => {
+  const clientPayload = registerSchema.parse(basePayload);
+  const freelancerPayload = registerSchema.parse({
+    ...basePayload,
+    role: "freelancer"
+  });
+
+  assert.equal(clientPayload.role, "client");
+  assert.equal(freelancerPayload.role, "freelancer");
+});
+
+test("registerSchema rejects admin role assignment", () => {
+  const result = registerSchema.safeParse({
+    ...basePayload,
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "role");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- remove dmin from the public registration role enum
- keep registration limited to client and reelancer
- add focused validator coverage proving allowed roles pass and admin is rejected

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5890.