### PR TITLE
fix(upload): sanitize returned filenames

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,24 @@
 import { ok } from "../utils/response.js";
 
+export function sanitizeFilename(originalname) {
+  if (typeof originalname !== "string") {
+    return null;
+  }
+
+  const filename = originalname
+    .replaceAll("\\", "/")
+    .split("/")
+    .at(-1)
+    .replace(/[\x00-\x1F\x7F]/g, "")
+    .trim()
+    .slice(0, 100);
+
+  return filename || null;
+}
+
 export async function uploadFile(req, res) {
   return ok(res, {
-    filename: req.file?.originalname ?? null,
+    filename: sanitizeFilename(req.file?.originalname),
     status: req.file ? "uploaded" : "no-file"
   }, 201);
 }

--- a/apps/api/src/tests/upload-controller.test.js
+++ b/apps/api/src/tests/upload-controller.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeFilename, uploadFile } from "../controllers/uploadController.js";
+
+function createResponseDouble() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("sanitizeFilename keeps only the final path segment and removes control characters", () => {
+  assert.equal(sanitizeFilename(" ..\\reports\\quarterly.pdf\r\n "), "quarterly.pdf");
+  assert.equal(sanitizeFilename("../secret.txt"), "secret.txt");
+});
+
+test("sanitizeFilename caps returned metadata length", () => {
+  const sanitized = sanitizeFilename(`${"a".repeat(150)}.pdf`);
+
+  assert.equal(sanitized.length, 100);
+});
+
+test("uploadFile returns the sanitized filename in the response payload", async () => {
+  const res = createResponseDouble();
+
+  await uploadFile(
+    {
+      file: {
+        originalname: " ../contracts/final-agreement.pdf\r\n "
+      }
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      filename: "final-agreement.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize upload response filenames before returning them to clients
- keep only the final path segment, strip control characters, trim whitespace, and cap metadata length
- add focused regression tests for path-like names, control characters, length capping, and controller output

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5859.