### PR TITLE
fix(job): normalize and validate category ids

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validPayload = {
+  title: "Backend platform",
+  description: "Need an engineer to harden our hiring workflow.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: " engineering ",
+  skills: ["node", "testing"]
+};
+
+test("createJobSchema trims valid category ids", () => {
+  const payload = createJobSchema.parse(validPayload);
+
+  assert.equal(payload.categoryId, "engineering");
+});
+
+test("createJobSchema rejects blank category ids after trimming", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    categoryId: "   "
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "categoryId");
+});
+
+test("createJobSchema rejects oversized category ids", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    categoryId: "a".repeat(65)
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "categoryId");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -5,7 +5,7 @@ export const createJobSchema = z.object({
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
+  categoryId: z.string().trim().min(1).max(64),
   skills: z.array(z.string().min(1)).default([])
 });
 


### PR DESCRIPTION
## Summary
- trim categoryId before using it in the job schema
- reject blank category ids after trimming and cap the stored identifier length
- add focused schema tests for normalization and rejection cases

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5855.