### PR TITLE
fix(job): normalize and cap skills arrays

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validPayload = {
+  title: "Backend platform",
+  description: "Need an engineer to harden our hiring workflow.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "engineering",
+  skills: [" node ", "testing", "node", "testing "]
+};
+
+test("createJobSchema trims and deduplicates skills", () => {
+  const payload = createJobSchema.parse(validPayload);
+
+  assert.deepEqual(payload.skills, ["node", "testing"]);
+});
+
+test("createJobSchema rejects blank skills after trimming", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    skills: ["   "]
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "skills.0");
+});
+
+test("createJobSchema rejects oversized skill names", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    skills: ["a".repeat(33)]
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "skills.0");
+});
+
+test("createJobSchema rejects oversized skill arrays", () => {
+  const result = createJobSchema.safeParse({
+    ...validPayload,
+    skills: Array.from({ length: 21 }, (_, index) => `skill-${index}`)
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "skills");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+const skillSchema = z.string().trim().min(1).max(32);
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: z.array(skillSchema).max(20).default([]).transform((skills) => [...new Set(skills)])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary
- trim skill names before validation and storage
- reject blank or oversized skill names, cap the total number of skills, and deduplicate repeated entries
- add focused schema tests for normalization and rejection cases

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5850.