### PR TITLE
fix(review): validate review payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid review payload");
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/review-controller.test.js
+++ b/apps/api/src/tests/review-controller.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validPayload = {
+  rating: 5,
+  comment: "Great collaboration",
+  reviewerId: "usr_1",
+  revieweeId: "usr_2"
+};
+
+test("POST /api/reviews accepts valid review payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great collaboration");
+    assert.equal(payload.data.reviewerId, "usr_1");
+    assert.equal(payload.data.revieweeId, "usr_2");
+    assert.equal(typeof payload.data.id, "string");
+  });
+});
+
+test("POST /api/reviews rejects ratings outside 1-5", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, rating: 6 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews rejects unexpected properties", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, adminOverride: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createReviewSchema = z
+  .object({
+    rating: z.number().int().min(1).max(5),
+    comment: z.string().trim().min(1).max(500),
+    reviewerId: z.string().trim().min(1).max(64),
+    revieweeId: z.string().trim().min(1).max(64)
+  })
+  .strict();


### PR DESCRIPTION
## Summary
- validate review creation payloads before storing them
- require the expected review fields, keep ratings within 1-5, and reject unexpected properties
- add focused API regression coverage for valid, out-of-range, and extra-field payloads

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5820.