### PR TITLE
fix(notification): validate notification payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid notification payload");
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notification-controller.test.js
+++ b/apps/api/src/tests/notification-controller.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validPayload = {
+  userId: "usr_1",
+  title: "Deployment complete",
+  body: "Your deployment finished successfully."
+};
+
+test("POST /api/notifications accepts valid notification payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.title, "Deployment complete");
+    assert.equal(payload.data.body, "Your deployment finished successfully.");
+    assert.equal(payload.data.read, false);
+    assert.equal(typeof payload.data.id, "string");
+  });
+});
+
+test("POST /api/notifications rejects empty titles", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, title: "   " })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications rejects client-controlled read state", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, read: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z
+  .object({
+    userId: z.string().trim().min(1).max(64),
+    title: z.string().trim().min(1).max(120),
+    body: z.string().trim().min(1).max(500)
+  })
+  .strict();


### PR DESCRIPTION
## Summary
- validate notification creation payloads before storage
- require non-empty userId/title/body fields and reject client-controlled ead state or other unexpected properties
- add focused API regression coverage for valid, empty-title, and forged read-state payloads

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5822.