### PR TITLE
fix(upload): restrict file types and size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,47 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const allowedMimeTypes = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "application/pdf",
+  "text/plain"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 10 * 1024 * 1024,
+    files: 1
+  },
+  fileFilter(req, file, callback) {
+    if (!allowedMimeTypes.has(file.mimetype)) {
+      return callback(new multer.MulterError("LIMIT_UNEXPECTED_FILE", file.fieldname));
+    }
+
+    return callback(null, true);
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", (req, res) => {
+  upload.single("file")(req, res, (error) => {
+    if (error instanceof multer.MulterError) {
+      if (error.code === "LIMIT_FILE_SIZE") {
+        return fail(res, "Uploaded file must be 10MB or smaller");
+      }
+
+      return fail(res, "Unsupported upload file type");
+    }
+
+    if (error) {
+      return fail(res, "Upload failed");
+    }
+
+    return uploadFile(req, res);
+  });
+});

--- a/apps/api/src/tests/upload-route.test.js
+++ b/apps/api/src/tests/upload-route.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function buildFormData(bytes, filename, mimeType) {
+  const formData = new FormData();
+  formData.append("file", new Blob([bytes], { type: mimeType }), filename);
+  return formData;
+}
+
+test("POST /api/uploads accepts allowed file types under 10MB", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: buildFormData(Uint8Array.from([1, 2, 3]), "avatar.png", "image/png")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "avatar.png");
+  });
+});
+
+test("POST /api/uploads rejects unsupported MIME types", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: buildFormData(Uint8Array.from([1, 2, 3]), "script.exe", "application/x-msdownload")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported upload file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects files larger than 10MB", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: buildFormData(new Uint8Array(10 * 1024 * 1024 + 1), "large.pdf", "application/pdf")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file must be 10MB or smaller"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- limit uploads to a single file up to 10MB when using memory storage
- allow only common image/document MIME types and reject unsupported uploads with 400
- add focused API regression tests for allowed uploads, blocked MIME types, and oversized files

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5900.