### PR TITLE
fix(payment): validate payment payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid payment payload");
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment-controller.test.js
+++ b/apps/api/src/tests/payment-controller.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments accepts valid payloads and defaults currency to usd", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 125.5 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125.5);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});
+
+test("POST /api/payments rejects missing or negative amounts", async () => {
+  await withServer(async (port) => {
+    for (const body of [{}, { amount: -1 }]) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid payment payload"
+      });
+    }
+  });
+});
+
+test("POST /api/payments rejects wrong-type and unsupported currency values", async () => {
+  await withServer(async (port) => {
+    for (const body of [{ amount: "50" }, { amount: 50, currency: "cad" }]) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid payment payload"
+      });
+    }
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+const supportedCurrencies = ["usd", "eur", "gbp"];
+
+export const createPaymentSchema = z
+  .object({
+    amount: z.number().positive(),
+    currency: z.enum(supportedCurrencies).default("usd")
+  })
+  .strict();


### PR DESCRIPTION
## Summary
- validate payment creation payloads before reaching the payment service
- require a positive numeric amount, restrict supported currencies, and preserve the existing usd default
- add focused API regression tests for valid, missing, negative, wrong-type, and unsupported-currency payloads

## Testing
- cd apps/api && node --test src/tests/*.js
- git diff --check

Closes #5902.