### PR TITLE
fix: return 400 for ZodError instead of 500

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,19 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  const isZodError =
+    err != null &&
+    err.name === "ZodError" &&
+    Array.isArray(err.issues);
+
+  if (isZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/zodErrorHandler.test.js
+++ b/apps/api/src/tests/zodErrorHandler.test.js
@@ -1,0 +1,30 @@
+import http from "node:http";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+describe("Zod error handler", () => {
+  it("returns 400 with structured issues for invalid job payload", (t, done) => {
+    const app = createApp();
+    const server = http.createServer(app);
+    server.listen(0, async () => {
+      try {
+        const { port } = server.address();
+        const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({})
+        });
+        const body = await res.json();
+        assert.equal(res.status, 400);
+        assert.equal(body.success, false);
+        assert.equal(body.message, "Validation failed");
+        assert.ok(Array.isArray(body.issues));
+        assert.ok(body.issues.length > 0);
+      } finally {
+        server.close();
+      }
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The global error handler was returning HTTP 500 for all errors, including Zod validation failures. Client validation errors should be reported as 400 bad requests, not unexpected server failures.

## Changes

- **`apps/api/src/middleware/errorHandler.js`**: Added ZodError duck-typing check (`err.name === 'ZodError' && Array.isArray(err.issues)`) — returns 400 with `{ success, message, issues }` for validation errors. Non-validation errors continue to return 500.
- **`apps/api/src/tests/zodErrorHandler.test.js`**: Focused regression test — POST /api/jobs with empty payload returns 400 with structured Zod issues.

## Validation

- Tested ZodError → returns 400 with issues array ✓
- Tested regular Error → returns 500 ✓
- Tested null error → returns 500 ✓
- `git diff --check`: clean

Fixes #5905
/claim #743