### PR TITLE
Expose initial payment intent status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    status: "requires_payment_method"
   };
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: `pay_${randomUUID()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe",

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent exposes initial requires_payment_method status", async () => {
+  const intent = await createPaymentIntent({
+    amount: 2500,
+    currency: "usd"
+  });
+
+  assert.equal(intent.amount, 2500);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+  assert.equal(intent.status, "requires_payment_method");
+  assert.match(intent.paymentId, /^pay_\d+$/);
+});
+
+test("createPaymentIntent keeps usd as the default currency", async () => {
+  const intent = await createPaymentIntent({
+    amount: 1500
+  });
+
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.status, "requires_payment_method");
+});

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -5,14 +5,15 @@ import { createPaymentIntent } from "../services/paymentService.js";
 test("createPaymentIntent exposes initial requires_payment_method status", async () => {
   const intent = await createPaymentIntent({
     amount: 2500,
-    currency: "usd"
+    currency: "eur"
   });
 
   assert.equal(intent.amount, 2500);
-  assert.equal(intent.currency, "usd");
+  assert.equal(intent.currency, "eur");
   assert.equal(intent.provider, "stripe");
   assert.equal(intent.status, "requires_payment_method");
-  assert.match(intent.paymentId, /^pay_\d+$/);
+  assert.equal(intent.paymentId.startsWith("pay_"), true);
+  assert.equal(intent.paymentId.length > "pay_".length, true);
 });
 
 test("createPaymentIntent keeps usd as the default currency", async () => {


### PR DESCRIPTION
Fixes #5917

## Testing

- `git diff --check`
- Not run: `npm test` because local npm is unavailable.