### PR TITLE
fix(web): resolve job and freelancer detail pages from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,17 @@
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+  if (!freelancer) {
+    notFound();
+  }
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Skills: <strong>{freelancer.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,16 @@
+import { notFound } from "next/navigation";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+  if (!job) {
+    notFound();
+  }
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>Job ID: <strong>{job.id}</strong></p>
+      <p>Budget: <strong>{job.budget}</strong></p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Fixes #5472, #5386

The `/jobs/[id]` and `/freelancers/[username]` detail routes were rendering placeholder copy for every URL, never consulting the mock data source. Both pages now look up the requested record and either render it or call notFound().

### Changes
- `apps/web/app/jobs/[id]/page.tsx` - look up by `params.id` against `jobs`; render title + budget; notFound on miss
- `apps/web/app/freelancers/[username]/page.tsx` - look up by `params.username` against `freelancers`; render username + skills + rate; notFound on miss

### Verification
- TypeScript clean: `tsc --noEmit` (no errors)

Parent bounty: #743