### PR TITLE
Validate payment creation payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects missing amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments rejects negative amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: -1, currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments rejects wrong-type amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: "10", currency: "usd" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments rejects unsupported currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 10, currency: "jpy" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments creates payment intent with default usd currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 25 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.equal(typeof payload.data.paymentId, "string");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z
+  .object({
+    amount: z.number().positive(),
+    currency: z.enum(["usd", "eur", "gbp"]).default("usd")
+  })
+  .strict();


### PR DESCRIPTION
## Summary
- Add a strict payment creation schema requiring a positive numeric amount.
- Preserve the default `usd` currency while rejecting unsupported currency codes and unexpected fields.
- Return a 400 response for invalid payment payloads before creating a payment intent.
- Add focused API tests for missing, negative, wrong-type, unsupported, and valid default-currency payment requests.

Closes SecureBananaLabs/bug-bounty#5902

## Validation
- `node --test "apps/api/src/tests/*.test.js"`