### PR TITLE
fix(notification): keep server-owned fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/notifications keeps id and read state server-owned", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/notifications`, {
+      id: "ntf_attacker_controlled",
+      userId: "usr_recipient",
+      title: "Proposal update",
+      body: "A freelancer replied to your job.",
+      read: true
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "ntf_attacker_controlled");
+    assert.match(payload.data.id, /^ntf_\d+$/);
+    assert.equal(payload.data.read, false);
+  });
+});


### PR DESCRIPTION
Closes #5935

/claim #5935

Refs parent bounty #743.

## Summary
- keep notification ids server-owned by assigning the generated id after caller payload fields
- keep new notifications unread by assigning `read: false` after caller payload fields
- add regression coverage proving caller-controlled `id` and `read` are ignored
- update the API test script so Node's test runner runs the existing test files

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`