### PR TITLE
Validate refresh token before issuing new access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,12 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  try {
+    const { token } = refreshSchema.parse(req.body);
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch (err) {
+    const message = err?.issues?.[0]?.message || err.message || "Invalid refresh request";
+    return fail(res, message, 400);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/auth/refresh rejects missing token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await listen(server);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/auth/refresh rejects invalid token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await listen(server);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: "garbage-token-value" })
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.success, false);
+
+  await close(server);
+});
+
+test("POST /api/auth/refresh returns a new token for valid refresh", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await listen(server);
+  const { port } = server.address();
+
+  // Login first to get a valid token
+  const loginRes = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "test@example.com", password: "password123" })
+  });
+  const loginBody = await loginRes.json();
+  assert.ok(loginBody.data.token, "Login should return a token");
+
+  // Use the login token to refresh
+  const refreshRes = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: loginBody.data.token })
+  });
+
+  assert.equal(refreshRes.status, 200);
+  const refreshBody = await refreshRes.json();
+  assert.ok(refreshBody.data.token, "Refresh should return a new token");
+
+  await close(server);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1, "Refresh token is required")
+});


### PR DESCRIPTION
## Summary

Fixes #5937 (parent bounty: #743)

`POST /api/auth/refresh` was ignoring the request body entirely and always minting a fresh access token for the hardcoded `usr_existing` user — no credential required. Any unauthenticated caller could get a valid token.

## What changed

- **validators/auth.js**: Added `refreshSchema` requiring a non-empty `token` field.
- **authService.js**: `refreshToken()` now calls `verifyAccessToken()` on the supplied token and preserves the decoded `sub` and `role` when signing the replacement.
- **authController.js**: Wrapped the refresh handler in try/catch so Zod validation errors and JWT verification failures return a proper 400 JSON response instead of leaking 500s.
- **auth-refresh.test.js**: 3 regression tests covering missing token, invalid token, and valid refresh round-trip.

## Testing

```
node --test src/tests/*.test.js
✔ 4 tests pass (1 existing + 3 new)
```

No existing behavior is affected — the login and register flows work exactly as before.