### PR TITLE
Ensure message ids are server-owned

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,12 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { content, recipientId } = payload;
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-id-server-owned.test.js
+++ b/apps/api/src/tests/message-id-server-owned.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+test("POST /api/messages ignores client-supplied id", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await listen(server);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      id: "msg_attacker_controlled",
+      content: "hello",
+      recipientId: "usr_123"
+    })
+  });
+
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.ok(body.data.id.startsWith("msg_"), "id should be server-generated");
+  assert.notEqual(body.data.id, "msg_attacker_controlled", "client-supplied id should be ignored");
+
+  await close(server);
+});
+
+test("POST /api/messages returns server-generated id and sentAt", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await listen(server);
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      content: "test message",
+      recipientId: "usr_456"
+    })
+  });
+
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.ok(body.data.id, "should have an id");
+  assert.ok(body.data.sentAt, "should have sentAt");
+  assert.equal(body.data.content, "test message");
+  assert.equal(body.data.recipientId, "usr_456");
+
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Fixes #5939 (parent bounty: #743)

`POST /api/messages` was spreading the caller payload before assigning the generated id, so a client could include an `id` field and override the server-generated one.

## What changed

- **messageService.js**: Moved `id` and `sentAt` assignments after the payload spread so server-owned fields always take precedence over anything the caller provides.
- **message-id-server-owned.test.js**: 2 regression tests confirming that a client-supplied `id` is ignored and that the normal message creation flow still works.

## Testing

```
node --test src/tests/*.test.js
✔ 3 tests pass (1 existing + 2 new)
```

No existing behavior is affected — messages without a caller-supplied `id` work exactly as before.