### PR TITLE
fix(api): keep user and proposal ids server-owned

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userProposal.test.js
+++ b/apps/api/src/tests/userProposal.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/users keeps user id server-owned", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/users`, {
+      id: "usr_attacker_controlled",
+      name: "Example User",
+      email: "user@example.com"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "usr_attacker_controlled");
+    assert.match(payload.data.id, /^usr_\d+$/);
+  });
+});
+
+test("POST /api/proposals keeps proposal id server-owned", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/proposals`, {
+      id: "prp_attacker_controlled",
+      jobId: "job_123",
+      freelancerId: "usr_123",
+      coverLetter: "I can complete this job."
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "prp_attacker_controlled");
+    assert.match(payload.data.id, /^prp_\d+$/);
+  });
+});


### PR DESCRIPTION
Closes #5944

/claim #5944

Refs parent bounty #743.

## Summary
- keep user ids server-owned by assigning the generated id after request payload fields
- keep proposal ids server-owned by assigning the generated id after request payload fields
- add regression coverage proving caller-supplied user/proposal ids are ignored
- update the API test script so Node's test runner runs the existing `*.test.js` files

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`
