### PR TITLE
fix(api): require auth for payment creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, headers = {}) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers
+    },
+    body: JSON.stringify({
+      amount: 250,
+      currency: "usd"
+    })
+  });
+}
+
+test("POST /api/payments rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments rejects invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      authorization: "Bearer not-a-valid-token"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/payments allows authenticated payment creation", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_payment_client", role: "client" });
+    const response = await postPayment(baseUrl, {
+      authorization: `Bearer ${token}`
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.paymentId, /^pay_\d+$/);
+    assert.equal(payload.data.amount, 250);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
Closes #5946

/claim #5946

Refs parent bounty #743.

## Summary
- require bearer authentication before creating payment intents
- add regression coverage for missing, invalid, and valid bearer tokens on `POST /api/payments`
- update the API test script so Node's test runner runs the existing `*.test.js` files

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`