### PR TITLE
Return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,13 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof SyntaxError && err.type === "entity.parse.failed") {
+    return fail(res, "Malformed JSON request body", 400);
   }
 
   return res.status(500).json({

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,6 @@
 import { fail } from "../utils/response.js";
 
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
@@ -10,8 +9,6 @@ export function errorHandler(err, req, res, next) {
     return fail(res, "Malformed JSON request body", 400);
   }
 
-  return res.status(500).json({
-    success: false,
-    message: "Unexpected server error"
-  });
+  console.error("Unhandled API error:", err);
+  return fail(res, "Unexpected server error", 500);
 }

--- a/apps/api/src/tests/jsonBodyErrors.test.js
+++ b/apps/api/src/tests/jsonBodyErrors.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createJsonResponse() {
+  return {
+    headersSent: false,
+    statusCode: null,
+    body: null,
+    status(statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("malformed JSON request bodies return 400", async () => {
+  const error = new SyntaxError("Unexpected end of JSON input");
+  error.type = "entity.parse.failed";
+  const response = createJsonResponse();
+
+  errorHandler(error, {}, response, () => {
+    throw new Error("next should not be called for malformed JSON");
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "Malformed JSON request body"
+  });
+});

--- a/apps/api/src/tests/jsonBodyErrors.test.js
+++ b/apps/api/src/tests/jsonBodyErrors.test.js
@@ -18,7 +18,7 @@ function createJsonResponse() {
   };
 }
 
-test("malformed JSON request bodies return 400", async () => {
+test("malformed JSON request bodies return 400", () => {
   const error = new SyntaxError("Unexpected end of JSON input");
   error.type = "entity.parse.failed";
   const response = createJsonResponse();


### PR DESCRIPTION
Closes #5955

/claim #743

## Summary
- detect Express/body-parser malformed JSON syntax errors in the shared API error handler
- return the existing API failure shape with HTTP 400 instead of the generic 500 response
- add focused regression coverage for the malformed JSON branch

## Validation
- `/Users/jialeli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test apps/api/src/tests/jsonBodyErrors.test.js` -> 1 passed
- `/Users/jialeli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/middleware/errorHandler.js`
- `/Users/jialeli/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --check apps/api/src/tests/jsonBodyErrors.test.js`
- `git diff --check`

Note: the full app route tests were not run locally because this environment has Node but no npm-installed API dependencies (`cors`, `express`, etc.). The added regression test is scoped to the error handler and runs without those external packages.