### PR TITLE
Preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and read state", async () => {
+  const notification = await createNotification({
+    id: "attacker_supplied_id",
+    userId: "usr_1",
+    title: "Forged",
+    body: "payload",
+    read: true
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "attacker_supplied_id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_1");
+  assert.equal(notification.title, "Forged");
+  assert.equal(notification.body, "payload");
+});


### PR DESCRIPTION
## Summary
- Ensure notification creation keeps `id` and `read` server-owned.
- Ignore caller-supplied `id` and `read` values by applying generated fields after payload fields.
- Add focused service coverage for hostile payload values.

Closes SecureBananaLabs/bug-bounty#2762

## Validation
- `node --test "apps/api/src/tests/*.test.js"`