### PR TITLE
fix(api): return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,15 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof SyntaxError && err.type === "entity.parse.failed") {
+    return fail(res, "Malformed JSON request body", 400);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformed-json.test.js
+++ b/apps/api/src/tests/malformed-json.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs returns 400 for malformed JSON request body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"title\":"
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});


### PR DESCRIPTION
Closes #5961

/claim #5961

Refs #5955 and parent bounty #743.

## Summary
- detect Express/body-parser malformed JSON parse errors in the global API error handler
- return the shared API error shape with HTTP 400 instead of the generic 500 response
- add focused regression coverage for malformed JSON submitted to a JSON-consuming route
- update the API test script to run test files directly under Node 24

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`