### PR TITLE
fix(search): validate query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,19 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 128;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q ?? "";
+
+  if (typeof query !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query must be 128 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(normalizedQuery));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid query strings", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20backend%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "backend");
+  });
+});
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(129)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 128 characters or fewer"
+    });
+  });
+});
+
+test("GET /api/search rejects non-string queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=backend&q=frontend`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a string"
+    });
+  });
+});


### PR DESCRIPTION
Closes #5963

/claim #5963

Refs #5958 and parent bounty #743.

## Summary
- normalize valid search query strings by trimming whitespace
- reject repeated/non-string query inputs with a 400 response
- reject search queries longer than 128 characters with a 400 response
- add regression coverage for trimming, long query rejection, and non-string query rejection
- update the API test script to run test files directly under Node 24

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`