### PR TITLE
fix(auth): validate registration payload

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/register.test.js
+++ b/apps/api/src/tests/register.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register requires fullName", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "missing-name@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/register rejects admin self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      fullName: "Admin Attempt",
+      email: "admin-attempt@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/register preserves fullName and token subject", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      fullName: "Freelance Builder",
+      email: "builder@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fullName, "Freelance Builder");
+    assert.equal(payload.data.email, "builder@example.com");
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(decoded.sub, payload.data.id);
+    assert.equal(decoded.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1),
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #5965

/claim #5965

Refs #5953 and parent bounty #743.

## Summary
- require a non-empty `fullName` during public registration
- limit public registration roles to `client` and `freelancer`
- preserve `fullName` in the returned user payload
- issue a token whose subject matches the returned user id
- add regression coverage for missing `fullName`, admin self-assignment rejection, and successful registration
- update the API test script to run test files directly under Node 24

## Tests
- `npm test -w apps/api`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`