### PR TITLE
fix: search query should be validated and length-limited

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = (req.query.q ?? "").trim();
+  if (!raw) {
+    return res.status(400).json({ error: "query parameter q is required" });
+  }
+  if (raw.length > MAX_QUERY_LENGTH) {
+    return res.status(400).json({ error: `query too long (max ${MAX_QUERY_LENGTH} characters)` });
+  }
+  // Strip control characters and normalize whitespace
+  const sanitized = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  return ok(res, await globalSearch(sanitized));
 }


### PR DESCRIPTION
## Problem
Search endpoint passed req.query.q directly without validation or length limits.

## Fix
- Returns 400 if q parameter is missing
- Limits query to 200 characters
- Strips control characters
- Trims whitespace

Closes #2833