### PR TITLE
fix: job detail route should resolve mock jobs by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,23 @@
+import { jobs } from "../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job matches the id <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <p style={{ fontSize: "1.2rem", fontWeight: 600 }}>{job.title}</p>
+      <p style={{ fontSize: "1.1rem", color: "var(--green, #4ade80)" }}>{job.budget}</p>
+      <p style={{ marginTop: 12 }}>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Problem
Job detail route rendered placeholder text instead of looking up mock data.

## Fix
- Looks up job from apps/web/lib/mock.ts by params.id
- Shows title and budget for matched jobs
- Shows clear not-found fallback for unknown ids

Closes #2790