### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,15 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { parseSearchQuery } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let query;
+
+  try {
+    query = parseSearchQuery(req.query);
+  } catch (error) {
+    return fail(res, error.message, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search accepts a bounded string query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=developer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "developer");
+  });
+});
+
+test("GET /api/search rejects queries over 100 characters", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = "a".repeat(101);
+    const response = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /100 characters or fewer/);
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /single string/);
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,21 @@
+const MAX_SEARCH_QUERY_LENGTH = 100;
+
+export function parseSearchQuery(queryParams) {
+  const rawQuery = queryParams.q;
+
+  if (rawQuery === undefined) {
+    return "";
+  }
+
+  if (typeof rawQuery !== "string") {
+    throw new Error("Search query must be a single string");
+  }
+
+  const query = rawQuery.trim();
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    throw new Error(`Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer`);
+  }
+
+  return query;
+}


### PR DESCRIPTION
Closes #5963.

## Summary
- add a bounded parser for /api/search query parameters
- trim accepted q values and reject repeated/non-string values with HTTP 400
- reject q values over 100 characters with HTTP 400
- add node:test coverage for valid, too-long, and repeated query cases

## Validation
- git diff --check
- Not run: npm run test -w apps/api (local Windows environment cannot execute node.exe: Access is denied; npm is not installed)
