### PR TITLE
Validate token before refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,17 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  let result;
+  try {
+    result = await refreshToken(payload.data.token);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
+
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,11 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  if (typeof decoded !== "object" || !decoded.sub || !decoded.role) {
+    throw new Error("Invalid refresh token");
+  }
+
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/refreshToken.test.js
+++ b/apps/api/src/tests/refreshToken.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects missing token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ token: "not-a-token" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh preserves subject and role from a valid token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ token })
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_refresh");
+    assert.equal(decoded.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
+});


### PR DESCRIPTION
Closes #5984.

## Summary
- require a token in POST /api/auth/refresh requests
- return 400 for missing refresh tokens
- verify supplied tokens and return 401 for invalid tokens
- mint replacement access tokens from the decoded subject and role instead of a hard-coded user
- add node:test coverage for missing, invalid, and valid refresh requests

## Validation
- git diff --check
- Not run: npm run test -w apps/api (local Windows environment cannot execute node.exe: Access is denied; npm is not installed)
