### PR TITLE
Validate and limit search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid search query");
+  }
+
+  return ok(res, await globalSearch(parsed.data.q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_SEARCH_QUERY_LENGTH } from "../validators/search.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims and passes normalized query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20design%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "design");
+  });
+});
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(MAX_SEARCH_QUERY_LENGTH + 1);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design&q=writing`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid search query" });
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const MAX_SEARCH_QUERY_LENGTH = 100;
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().max(MAX_SEARCH_QUERY_LENGTH).default("")
+});


### PR DESCRIPTION
## Description
Validates `GET /api/search` query input before calling the search service.

Closes #5963

## Changes Made
- Added a search query validator that normalizes `q` by trimming whitespace and defaults missing queries to an empty string.
- Rejects non-string query input, including repeated `q` parameters, with a 400 response.
- Rejects queries longer than the bounded maximum length.
- Added API tests for trimming, overly long queries, and repeated query parameters.

## Test
- `node --test "apps/api/src/tests/*.test.js"`