### PR TITLE
Replace placeholder settings card with actionable overview

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,3 +4,37 @@ a { color: inherit; text-decoration: none; }
 main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
 .card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.eyebrow { margin: 0 0 0.5rem; color: #8aa1ff; font-size: 0.82rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.settings-shell { display: grid; gap: 1rem; }
+.settings-hero { display: grid; gap: 1rem; }
+.settings-hero h2 { margin: 0; font-size: 1.8rem; }
+.settings-lead { margin: 0.75rem 0 0; max-width: 42rem; color: #c9d3ff; line-height: 1.55; }
+.settings-summary { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.settings-grid { align-items: start; }
+.settings-card { display: grid; gap: 1rem; }
+.settings-card h3 { margin: 0; font-size: 1.1rem; }
+.settings-card p { margin: 0.4rem 0 0; color: #b8c3ea; line-height: 1.5; }
+.settings-card-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 0.75rem; }
+.status-chip { display: inline-flex; align-items: center; border-radius: 999px; padding: 0.38rem 0.7rem; font-size: 0.8rem; font-weight: 700; white-space: nowrap; }
+.status-chip-success { background: rgba(48, 190, 120, 0.16); color: #88efb3; border: 1px solid rgba(88, 225, 147, 0.4); }
+.status-chip-warning { background: rgba(255, 183, 77, 0.14); color: #ffd28a; border: 1px solid rgba(255, 183, 77, 0.4); }
+.status-chip-muted { background: rgba(114, 135, 218, 0.14); color: #d7e0ff; border: 1px solid rgba(114, 135, 218, 0.35); }
+.settings-list { display: grid; gap: 0.8rem; margin: 0; }
+.settings-list-row { display: flex; justify-content: space-between; gap: 1rem; padding-bottom: 0.8rem; border-bottom: 1px solid #243055; }
+.settings-list-row:last-child { padding-bottom: 0; border-bottom: none; }
+.settings-list-row dt { color: #8ea1d6; }
+.settings-list-row dd { margin: 0; text-align: right; color: #f4f7ff; font-weight: 600; }
+.settings-actions { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+.settings-action-button { border: 1px solid #39539b; background: #1a2448; color: #f2f5ff; border-radius: 999px; padding: 0.65rem 0.95rem; font: inherit; font-weight: 600; cursor: pointer; }
+.settings-action-button:hover { background: #22305f; }
+
+@media (max-width: 640px) {
+  .settings-card-header,
+  .settings-list-row {
+    flex-direction: column;
+  }
+
+  .settings-list-row dd {
+    text-align: left;
+  }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,114 @@
+const settingsSections = [
+  {
+    title: "Account and profile",
+    description: "Identity, profile visibility, and portfolio readiness for client discovery.",
+    status: "Public profile on",
+    items: [
+      { label: "Display name", value: "Avery Stone" },
+      { label: "Visibility", value: "Listed in freelancer search" },
+      { label: "Portfolio", value: "4 featured case studies" }
+    ],
+    actions: ["Review profile", "Update portfolio", "Preview public page"]
+  },
+  {
+    title: "Notifications",
+    description: "Stay on top of proposals, replies, contract milestones, and billing updates.",
+    status: "Inbox under control",
+    items: [
+      { label: "Proposal alerts", value: "Instant email + in-app" },
+      { label: "Client messages", value: "Desktop and mobile" },
+      { label: "Weekly digest", value: "Every Monday at 9:00 AM" }
+    ],
+    actions: ["Tune alerts", "Pause digests", "Open notifications"]
+  },
+  {
+    title: "Security",
+    description: "Protect access, review recovery posture, and keep sessions tidy.",
+    status: "Needs one action",
+    items: [
+      { label: "Password", value: "Updated 42 days ago" },
+      { label: "Two-factor auth", value: "Not enabled" },
+      { label: "Active sessions", value: "2 trusted devices" }
+    ],
+    actions: ["Enable 2FA", "Rotate password", "Sign out other sessions"]
+  },
+  {
+    title: "Billing and payouts",
+    description: "Track payout preferences, invoice defaults, and tax details before the next milestone clears.",
+    status: "Payout ready",
+    items: [
+      { label: "Primary payout", value: "ACH ending in 1842" },
+      { label: "Default invoice terms", value: "Net 7 days" },
+      { label: "Tax profile", value: "W-9 verified" }
+    ],
+    actions: ["Update payout method", "Review invoices", "Download tax docs"]
+  }
+];
+
+const activityChecks = [
+  "Profile score: 92% complete",
+  "Last security review: May 18",
+  "Next payout window: Tomorrow",
+  "Unread billing alerts: 1"
+];
+
 export default function SettingsPage() {
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+    <section className="settings-shell">
+      <div className="card settings-hero">
+        <div>
+          <p className="eyebrow">Settings</p>
+          <h2>Account controls that are actually useful</h2>
+          <p className="settings-lead">
+            Review profile visibility, notification coverage, security posture, and payout readiness
+            from one place.
+          </p>
+        </div>
+        <div className="settings-summary" aria-label="Settings health summary">
+          {activityChecks.map((item) => (
+            <span key={item} className="status-chip status-chip-muted">
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid settings-grid">
+        {settingsSections.map((section) => (
+          <article key={section.title} className="card settings-card">
+            <div className="settings-card-header">
+              <div>
+                <h3>{section.title}</h3>
+                <p>{section.description}</p>
+              </div>
+              <span
+                className={`status-chip ${
+                  section.status === "Needs one action" ? "status-chip-warning" : "status-chip-success"
+                }`}
+              >
+                {section.status}
+              </span>
+            </div>
+
+            <dl className="settings-list">
+              {section.items.map((item) => (
+                <div key={item.label} className="settings-list-row">
+                  <dt>{item.label}</dt>
+                  <dd>{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+
+            <div className="settings-actions" aria-label={`${section.title} actions`}>
+              {section.actions.map((action) => (
+                <button key={action} type="button" className="settings-action-button">
+                  {action}
+                </button>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the placeholder /settings card with a static settings overview
- add account, notifications, security, and billing/payout sections with status chips and next actions
- add focused shared styles for the settings layout and responsive controls

## Verification
- 
pm run build -w apps/web

Closes #5998