### PR TITLE
Return defensive snapshots from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-services.test.js
+++ b/apps/api/src/tests/list-services.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+const listScenarios = [
+  {
+    name: "users",
+    createRecord: () => createUser({ email: "snapshot-user@example.com", role: "freelancer" }),
+    listRecords: listUsers
+  },
+  {
+    name: "jobs",
+    createRecord: () => createJob({ title: "Snapshot-safe job", budget: 1200 }),
+    listRecords: listJobs
+  },
+  {
+    name: "proposals",
+    createRecord: () => createProposal({ jobId: "job_snapshot", freelancerId: "usr_snapshot" }),
+    listRecords: listProposals
+  },
+  {
+    name: "reviews",
+    createRecord: () =>
+      createReview({ reviewerId: "usr_reviewer", revieweeId: "usr_reviewee", rating: 5, comment: "Solid work" }),
+    listRecords: listReviews
+  },
+  {
+    name: "messages",
+    createRecord: () =>
+      sendMessage({ senderId: "usr_sender", receiverId: "usr_receiver", body: "Snapshot check" }),
+    listRecords: listMessages
+  },
+  {
+    name: "notifications",
+    createRecord: () => createNotification({ userId: "usr_notify", title: "Milestone funded" }),
+    listRecords: listNotifications
+  }
+];
+
+for (const { name, createRecord, listRecords } of listScenarios) {
+  test(`list ${name} returns a defensive snapshot`, async () => {
+    const baseline = await listRecords();
+    const createdRecord = await createRecord();
+
+    const firstView = await listRecords();
+    const createdIndex = firstView.findIndex((record) => record.id === createdRecord.id);
+
+    assert.notEqual(createdIndex, -1);
+    assert.equal(firstView[createdIndex], createdRecord);
+
+    firstView.splice(createdIndex, 1);
+    firstView.push({ id: `${name}_fake` });
+
+    const secondView = await listRecords();
+    const secondIndex = secondView.findIndex((record) => record.id === createdRecord.id);
+
+    assert.equal(secondView.length, baseline.length + 1);
+    assert.notEqual(secondIndex, -1);
+    assert.equal(secondView[secondIndex], createdRecord);
+    assert.equal(secondView.some((record) => record.id === `${name}_fake`), false);
+  });
+}


### PR DESCRIPTION
## Summary
- return shallow array copies from the in-memory list services
- keep record objects and response shapes unchanged
- add focused regression coverage showing callers cannot mutate backing stores through list responses

## Verification
- 
ode --test src/tests/health.test.js src/tests/list-services.test.js

Closes #4530