### PR TITLE
Validate payment creation payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentIntentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentIntentSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(payload.data), 201);
 }

--- a/apps/api/src/tests/paymentPayloadValidation.test.js
+++ b/apps/api/src/tests/paymentPayloadValidation.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects invalid payment payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const invalidPayloads = [
+      {},
+      { amount: -1000 },
+      { amount: "1000" },
+      { amount: 1000, currency: "eur" }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const response = await postPayment(baseUrl, payload);
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(body, { success: false, message: "Invalid payment payload" });
+    }
+  });
+});
+
+test("POST /api/payments defaults valid payments to usd", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 2500 });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.match(body.data.paymentId, /^pay_\d+$/);
+    assert.equal(body.data.amount, 2500);
+    assert.equal(body.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments accepts supported usd currency", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, { amount: 5000, currency: "usd" });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.amount, 5000);
+    assert.equal(body.data.currency, "usd");
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentIntentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.enum(["usd"]).default("usd")
+});


### PR DESCRIPTION
## Summary

Closes #5902.

Validates payment creation payloads before creating mock Stripe payment intents.

## Changes

- Add a Zod schema requiring a positive numeric `amount`.
- Restrict payment currency to the currently supported `usd` code while preserving the default.
- Return `400` for invalid payment payloads instead of creating a successful payment intent.
- Add API regression tests for invalid amount/currency payloads and valid/default-currency requests.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
