### PR TITLE
Expose initial payment intent status

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
+    status: "requires_payment_method",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentIntentStatus.test.js
+++ b/apps/api/src/tests/paymentIntentStatus.test.js
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent exposes the initial payment lifecycle status", async () => {
+  const intent = await createPaymentIntent({ amount: 1250 });
+
+  assert.match(intent.paymentId, /^pay_\d+$/);
+  assert.equal(intent.amount, 1250);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.status, "requires_payment_method");
+  assert.equal(intent.provider, "stripe");
+});


### PR DESCRIPTION
## Summary

Closes #5885.

Exposes the initial Stripe-like lifecycle status on mock payment intent responses.

## Changes

- Add `status: "requires_payment_method"` to `createPaymentIntent()` responses.
- Keep the existing payment id, amount, currency, and provider fields unchanged.
- Add service-level regression coverage for the new initial status.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
