### PR TITLE
Validate OAuth callback providers

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { loginSchema, oauthProviderSchema, registerSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +15,13 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = oauthProviderSchema.safeParse(req.params.provider);
+  if (!provider.success) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider: provider.data,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/oauthProviderValidation.test.js
+++ b/apps/api/src/tests/oauthProviderValidation.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const unsupportedProviders = ["github-enterprise", "null", "this-provider-is-not-supported"];
+
+    for (const provider of unsupportedProviders) {
+      const response = await fetch(`${baseUrl}/api/auth/oauth/${provider}/callback`);
+      const body = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(body, { success: false, message: "Unsupported OAuth provider" });
+    }
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback accepts supported providers", async () => {
+  await withServer(async (baseUrl) => {
+    for (const provider of ["github", "google"]) {
+      const response = await fetch(`${baseUrl}/api/auth/oauth/${provider}/callback`);
+      const body = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(body, {
+        success: true,
+        data: {
+          provider,
+          status: "callback-received"
+        }
+      });
+    }
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,5 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const oauthProviderSchema = z.enum(["github", "google"]);


### PR DESCRIPTION
## Summary

Closes #5882.

Validates OAuth callback provider names before reflecting them in the API response.

## Changes

- Add an OAuth provider whitelist for `github` and `google`.
- Return `400` for unsupported OAuth provider path values.
- Keep supported provider callback behavior unchanged.
- Add API regression tests for unsupported and supported providers.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
