### PR TITLE
Restrict upload file types and size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,8 +2,57 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const allowedMimeTypes = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "text/csv",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+]);
+
+function uploadFileFilter(req, file, callback) {
+  if (allowedMimeTypes.has(file.mimetype)) {
+    return callback(null, true);
+  }
+
+  const error = new Error("Unsupported file type");
+  error.code = "UNSUPPORTED_UPLOAD_TYPE";
+  return callback(error);
+}
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_UPLOAD_BYTES,
+    files: 1
+  },
+  fileFilter: uploadFileFilter
+});
+
+function uploadErrorHandler(err, req, res, next) {
+  if (err instanceof multer.MulterError) {
+    return res.status(400).json({
+      success: false,
+      message:
+        err.code === "LIMIT_FILE_SIZE" ? "Uploaded file is too large" : "Invalid upload"
+    });
+  }
+
+  if (err?.code === "UNSUPPORTED_UPLOAD_TYPE") {
+    return res.status(400).json({
+      success: false,
+      message: "Unsupported file type"
+    });
+  }
+
+  return next(err);
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), uploadErrorHandler, uploadFile);

--- a/apps/api/src/tests/uploadRestrictions.test.js
+++ b/apps/api/src/tests/uploadRestrictions.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUpload(baseUrl, file) {
+  const form = new FormData();
+  form.append("file", file.blob, file.name);
+
+  return fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+}
+
+test("POST /api/uploads accepts allowed file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUpload(baseUrl, {
+      name: "profile.png",
+      blob: new Blob(["png data"], { type: "image/png" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "profile.png",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUpload(baseUrl, {
+      name: "script.js",
+      blob: new Blob(["alert(1)"], { type: "application/javascript" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects files larger than 10MB", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUpload(baseUrl, {
+      name: "large.pdf",
+      blob: new Blob([new Uint8Array(MAX_UPLOAD_BYTES + 1)], {
+        type: "application/pdf"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file is too large"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5900.

Restricts uploads to a bounded set of common file types and enforces a 10MB maximum before the controller accepts the file.

## Changes

- Configure multer with a 10MB `fileSize` limit and a single-file limit.
- Allow common image and document MIME types.
- Return HTTP 400 for unsupported MIME types.
- Return HTTP 400 for oversized uploads.
- Add API regression tests for allowed files, blocked file types, and max-size enforcement.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
