### PR TITLE
Bypass API rate limit for health checks

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+const RATE_LIMIT = 200;
+
+async function withServer(callback) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -12,13 +14,43 @@ test("GET /health returns ok payload", async () => {
   });
 
   const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+test("GET /health returns ok payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+test("GET /health is not rate-limited by the shared API limiter", async () => {
+  await withServer(async (baseUrl) => {
+    for (let index = 0; index < RATE_LIMIT + 1; index += 1) {
+      const response = await fetch(`${baseUrl}/health`);
+      assert.equal(response.status, 200);
+    }
+  });
+});
+
+test("shared API limiter still applies to API routes", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+
+    for (let index = 0; index < RATE_LIMIT + 1; index += 1) {
+      response = await fetch(`${baseUrl}/api/search`);
+    }
+
+    assert.equal(response.status, 429);
   });
 });


### PR DESCRIPTION
## Summary

Closes #5880.

Keeps health checks outside the shared API rate-limit bucket while preserving rate limiting for API routes.

## Changes

- Register `GET /health` before `apiLimiter`.
- Keep security and JSON parsing middleware before the health route.
- Keep `apiLimiter` active for `/api/*` routes.
- Add regression coverage for repeated health checks staying HTTP 200.
- Add regression coverage for an API route still returning HTTP 429 after the shared limit is exceeded.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
