### PR TITLE
Return 400 for auth validation errors

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -2,16 +2,24 @@ import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return next(error);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    return next(error);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      issues: err.issues
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/authValidationErrors.test.js
+++ b/apps/api/src/tests/authValidationErrors.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+test("invalid auth registration payloads return validation errors", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "not-an-email",
+      password: "short"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation error");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("email")));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("password")));
+  });
+});
+
+test("valid auth registration payloads keep the success path", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "client@example.com",
+      password: "valid-password",
+      role: "client"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.role, "client");
+    assert.equal(typeof payload.data.token, "string");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5908.

Returns HTTP 400 responses for auth request validation failures instead of letting Zod errors bubble as unexpected server errors.

## Changes

- Add `ZodError` handling in the global API error middleware.
- Return structured validation issues with the existing failure response shape.
- Forward register and login validation errors to the global middleware under Express 4.
- Preserve successful auth response behavior.
- Add API regression coverage for invalid and valid registration payloads.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
