### PR TITLE
Validate job category ids

### DIFF
--- a/apps/api/src/tests/jobCategoryIdValidation.test.js
+++ b/apps/api/src/tests/jobCategoryIdValidation.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a client project.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: " web-design ",
+  skills: ["design"]
+};
+
+test("createJobSchema trims category ids before storage", () => {
+  const payload = createJobSchema.parse(validJob);
+
+  assert.equal(payload.categoryId, "web-design");
+});
+
+test("createJobSchema rejects blank and oversized category ids", () => {
+  assert.throws(() => createJobSchema.parse({ ...validJob, categoryId: "   " }));
+  assert.throws(() => createJobSchema.parse({ ...validJob, categoryId: "a".repeat(81) }));
+});
+
+test("updateJobSchema normalizes category ids when present", () => {
+  assert.equal(updateJobSchema.parse({ categoryId: " analytics " }).categoryId, "analytics");
+  assert.throws(() => updateJobSchema.parse({ categoryId: "   " }));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -5,7 +5,7 @@ export const createJobSchema = z.object({
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
+  categoryId: z.string().trim().min(1).max(80),
   skills: z.array(z.string().min(1)).default([])
 });
 


### PR DESCRIPTION
## Summary

Closes #5855.

Normalizes and validates job category ids before job records are accepted.

## Changes

- Trim `categoryId` values in the job validator.
- Reject category ids that are blank after trimming.
- Cap category id length at 80 characters.
- Preserve category id validation for partial update payloads.
- Add focused validator regression coverage.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
