### PR TITLE
Normalize job skills

### DIFF
--- a/apps/api/src/tests/jobSkillsValidation.test.js
+++ b/apps/api/src/tests/jobSkillsValidation.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build marketplace API",
+  description: "Create a production-ready API for marketplace jobs.",
+  budgetMin: 1000,
+  budgetMax: 3000,
+  categoryId: "backend",
+  skills: [" Node.js ", "API", "Node.js", "Testing "]
+};
+
+test("createJobSchema trims and deduplicates skills", () => {
+  const payload = createJobSchema.parse(validJob);
+
+  assert.deepEqual(payload.skills, ["Node.js", "API", "Testing"]);
+});
+
+test("createJobSchema rejects blank, oversized, and excessive skills", () => {
+  assert.throws(() => createJobSchema.parse({ ...validJob, skills: ["   "] }));
+  assert.throws(() => createJobSchema.parse({ ...validJob, skills: ["a".repeat(41)] }));
+  assert.throws(() => createJobSchema.parse({ ...validJob, skills: Array.from({ length: 21 }, (_, index) => `skill-${index}`) }));
+});
+
+test("createJobSchema keeps skills optional with an empty default", () => {
+  const payload = createJobSchema.parse({ ...validJob, skills: undefined });
+
+  assert.deepEqual(payload.skills, []);
+});
+
+test("updateJobSchema normalizes skills when present", () => {
+  const payload = updateJobSchema.parse({ skills: [" React ", "React", "CSS "] });
+
+  assert.deepEqual(payload.skills, ["React", "CSS"]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
+const skillSchema = z.string().trim().min(1).max(40);
+
+const skillsSchema = z.array(skillSchema)
+  .max(20)
+  .transform((skills) => [...new Set(skills)])
+  .default([]);
+
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: skillsSchema
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary

Closes #5850.

Normalizes and caps job skills arrays before job records are accepted.

## Changes

- Trim skill names before storage.
- Reject blank skill names after trimming.
- Cap individual skill names at 40 characters.
- Cap skills arrays at 20 entries.
- Deduplicate repeated trimmed skill names.
- Preserve the empty array default for omitted skills.
- Add focused validator regression coverage.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
