### PR TITLE
Sanitize upload response filenames

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,25 @@
 import { ok } from "../utils/response.js";
 
+const MAX_UPLOAD_FILENAME_LENGTH = 120;
+
+export function sanitizeUploadFilename(filename) {
+  if (typeof filename !== "string") {
+    return null;
+  }
+
+  const basename = filename
+    .replace(/[\x00-\x1F\x7F]/g, "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    .trim();
+
+  return (basename || "upload").slice(0, MAX_UPLOAD_FILENAME_LENGTH);
+}
+
 export async function uploadFile(req, res) {
   return ok(res, {
-    filename: req.file?.originalname ?? null,
+    filename: req.file ? sanitizeUploadFilename(req.file.originalname) : null,
     status: req.file ? "uploaded" : "no-file"
   }, 201);
 }

--- a/apps/api/src/tests/uploadFilenameSanitization.test.js
+++ b/apps/api/src/tests/uploadFilenameSanitization.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeUploadFilename, uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("sanitizeUploadFilename strips paths, controls, whitespace, and long metadata", () => {
+  assert.equal(sanitizeUploadFilename("../secret.txt"), "secret.txt");
+  assert.equal(sanitizeUploadFilename("nested\\path\\invoice\n2026.pdf"), "invoice2026.pdf");
+  assert.equal(sanitizeUploadFilename("  report\tfinal.csv  "), "reportfinal.csv");
+  assert.equal(sanitizeUploadFilename("a".repeat(150)).length, 120);
+});
+
+test("uploadFile returns sanitized filename metadata", async () => {
+  const res = createResponse();
+
+  await uploadFile({
+    file: {
+      originalname: "../private\nstatement.pdf"
+    }
+  }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      filename: "privatestatement.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5859.

Sanitizes upload response filename metadata before returning it to clients.

## Changes

- Add upload filename metadata sanitization.
- Strip path separators to the final filename segment.
- Remove control characters, trim whitespace, and cap returned filename length.
- Keep upload storage behavior and file contents unchanged.
- Add focused regression coverage for path-like and control-character filenames.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
