### PR TITLE
Validate refresh token input

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { loginSchema, refreshSchema, registerSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const payload = refreshSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(payload.data.token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/refreshTokenValidation.test.js
+++ b/apps/api/src/tests/refreshTokenValidation.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRefresh(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, {});
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(body, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, { token: "not-a-valid-token" });
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh preserves subject and role from valid token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+    const response = await postRefresh(baseUrl, { token });
+    const body = await response.json();
+    const refreshedPayload = verifyAccessToken(body.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(refreshedPayload.sub, "usr_refresh");
+    assert.equal(refreshedPayload.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #5703.

Requires `POST /api/auth/refresh` to receive and validate a supplied token before issuing a replacement access token.

## Changes

- Add a refresh request schema requiring `token`.
- Verify the supplied token in the refresh service.
- Preserve decoded `sub` and `role` claims in the replacement token.
- Add API tests for missing, invalid, and valid refresh token requests.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
