### PR TITLE
Validate user creation input

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userCreationValidation.test.js
+++ b/apps/api/src/tests/userCreationValidation.test.js
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+const validUser = {
+  name: "Maya Patel",
+  email: "maya@example.com",
+  role: "freelancer"
+};
+
+test("POST /api/users rejects empty payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {});
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(body, { success: false, message: "Invalid user payload" });
+  });
+});
+
+test("POST /api/users rejects invalid email values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      ...validUser,
+      email: "not-an-email"
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(body, { success: false, message: "Invalid user payload" });
+  });
+});
+
+test("POST /api/users rejects client-controlled ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      ...validUser,
+      id: "usr_attacker"
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(body, { success: false, message: "Invalid user payload" });
+  });
+});
+
+test("POST /api/users stores valid users with server-generated id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, validUser);
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.match(body.data.id, /^usr_/);
+    assert.equal(body.data.name, validUser.name);
+    assert.equal(body.data.email, validUser.email);
+    assert.equal(body.data.role, validUser.role);
+  });
+});
+
+test("POST /api/users defaults missing role to client", async () => {
+  await withServer(async (baseUrl) => {
+    const { role, ...payload } = validUser;
+    const response = await postUser(baseUrl, payload);
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.role, "client");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  name: z.string().trim().min(1),
+  email: z.string().email(),
+  role: z.enum(["client", "freelancer"]).default("client")
+}).strict();


### PR DESCRIPTION
## Summary

Closes #5709.

Validates `POST /api/users` payloads before storing user records and keeps the generated user id server-owned.

## Changes

- Add a strict user creation schema requiring `name` and valid `email`.
- Restrict public user roles to `client` and `freelancer`, defaulting omitted role to `client`.
- Reject unknown fields such as caller-supplied `id`.
- Apply the generated user id after validated payload fields in the user service.
- Add API tests for invalid and valid user creation payloads.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
