### PR TITLE
Require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoleAuthorization.test.js
+++ b/apps/api/src/tests/adminRoleAuthorization.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getMetrics(baseUrl, token) {
+  const headers = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return fetch(`${baseUrl}/api/admin/metrics`, { headers });
+}
+
+test("GET /api/admin/metrics rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await getMetrics(baseUrl);
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await getMetrics(baseUrl, token);
+    const body = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(body, { success: false, message: "Forbidden" });
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await getMetrics(baseUrl, token);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(body.data.openJobs, 42);
+    assert.equal(body.data.flaggedAccounts, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5689.

Restricts `/api/admin` routes to authenticated users with the `admin` role.

## Changes

- Add `adminMiddleware` to enforce admin-role authorization.
- Apply the admin role check after token authentication on admin routes.
- Add API tests for unauthenticated, non-admin, and admin access to admin metrics.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
