### PR TITLE
Validate message creation input

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid message payload",
+      issues: result.error.issues
+    });
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageIdOwnership.test.js
+++ b/apps/api/src/tests/messageIdOwnership.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "",
+        recipientId: "",
+        jobId: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid message payload");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.length >= 3);
+  });
+});
+
+test("POST /api/messages validates input and ignores system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "msg_attacker_controlled",
+        sentAt: "1999-01-01T00:00:00.000Z",
+        content: "Project files are ready.",
+        recipientId: "usr_freelancer",
+        jobId: "job_123"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "msg_attacker_controlled");
+    assert.notEqual(payload.data.sentAt, "1999-01-01T00:00:00.000Z");
+    assert.match(payload.data.id, /^msg_\d+$/);
+    assert.doesNotThrow(() => new Date(payload.data.sentAt).toISOString());
+    assert.equal(payload.data.content, "Project files are ready.");
+    assert.equal(payload.data.recipientId, "usr_freelancer");
+    assert.equal(payload.data.jobId, "job_123");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().trim().min(1),
+  recipientId: z.string().trim().min(1),
+  jobId: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #5714.

Validates message creation payloads before storing messages and keeps system-managed fields server-owned.

## Changes

- Add a focused message creation schema for `content`, `recipientId`, and `jobId`.
- Return HTTP 400 with structured validation issues for invalid message payloads.
- Pass only validated message fields into the message service.
- Keep generated `id` and `sentAt` values server-owned.
- Add API coverage for invalid payloads and ignored system fields.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
