### PR TITLE
Align registration token subject with returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token with the returned user id as subject", async () => {
+  const originalNow = Date.now;
+  const timestamps = [1700000000000, 1700000001234];
+  Date.now = () => timestamps.shift() ?? 1700000009999;
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "correct-horse-battery-staple",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1700000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #2768.

Ensures registration generates the user id once and signs the JWT access token with that same value as the `sub` claim.

## Changes

- Store the generated registration user id in a local `userId`.
- Return `userId` in the registration response.
- Sign the access token with `{ sub: userId, role: payload.role }`.
- Add focused service coverage proving the decoded token subject matches `result.id`.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
