### PR TITLE
Require fullName during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/registrationFullName.test.js
+++ b/apps/api/src/tests/registrationFullName.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+const validRegistration = {
+  email: "client@example.com",
+  fullName: "Avery Client",
+  password: "correct-horse-battery-staple",
+  role: "client"
+};
+
+test("registerSchema rejects missing fullName", () => {
+  const payload = { ...validRegistration };
+  delete payload.fullName;
+
+  assert.equal(registerSchema.safeParse(payload).success, false);
+});
+
+test("registerSchema rejects blank fullName", () => {
+  const payload = { ...validRegistration, fullName: "   " };
+
+  assert.equal(registerSchema.safeParse(payload).success, false);
+});
+
+test("registerUser preserves validated fullName in returned user payload", async () => {
+  const payload = registerSchema.parse(validRegistration);
+  const result = await registerUser(payload);
+
+  assert.equal(result.email, "client@example.com");
+  assert.equal(result.fullName, "Avery Client");
+  assert.equal(result.role, "client");
+  assert.match(result.token, /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const registerSchema = z.object({
   email: z.string().email(),
+  fullName: z.string().trim().min(1),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });


### PR DESCRIPTION
## Summary

Closes #2770.

Requires a non-empty `fullName` during registration and carries that validated value into the returned registration payload.

## Changes

- Add `fullName` to `registerSchema` with trimming and non-empty validation.
- Include `fullName` in `registerUser()` results.
- Add focused coverage for missing `fullName`, blank `fullName`, and preserving a valid name.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
