### PR TITLE
Restrict registration to public roles

### DIFF
--- a/apps/api/src/tests/registrationRole.test.js
+++ b/apps/api/src/tests/registrationRole.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const baseRegistration = {
+  email: "user@example.com",
+  password: "password123"
+};
+
+test("registration rejects admin role self-assignment", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      ...baseRegistration,
+      role: "admin"
+    });
+  });
+});
+
+test("registration accepts public roles", () => {
+  assert.equal(registerSchema.parse({ ...baseRegistration, role: "client" }).role, "client");
+  assert.equal(registerSchema.parse({ ...baseRegistration, role: "freelancer" }).role, "freelancer");
+});
+
+test("registration defaults omitted role to client", () => {
+  assert.equal(registerSchema.parse(baseRegistration).role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Closes #5890.

Prevents public registration from accepting `role: "admin"` while preserving client/freelancer registration and the default client role.

## Changes

- Restrict `registerSchema.role` to `client` and `freelancer`.
- Preserve the omitted-role default of `client`.
- Add focused validation tests for rejecting admin, accepting public roles, and defaulting omitted role.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
