### PR TITLE
Preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-supplied id and read fields", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1700000000000;
+
+  try {
+    const notification = await createNotification({
+      id: "ntf_attacker",
+      read: true,
+      userId: "usr_1",
+      message: "New proposal received",
+      type: "proposal"
+    });
+
+    assert.equal(notification.id, "ntf_1700000000000");
+    assert.equal(notification.read, false);
+    assert.equal(notification.userId, "usr_1");
+    assert.equal(notification.message, "New proposal received");
+    assert.equal(notification.type, "proposal");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #2762.

Ensures notification creation always returns a server-generated id and starts new notifications with `read: false`, even if callers include `id` or `read` in the request payload.

## Changes

- Apply caller payload fields before server-owned notification fields.
- Preserve non-server payload fields such as `userId`, `message`, and `type`.
- Add focused service coverage proving caller-supplied `id` and `read` are ignored during creation.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
