### PR TITLE
Require proposal estimated duration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalDurationValidation.test.js
+++ b/apps/api/src/tests/proposalDurationValidation.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can complete this safely.",
+  bidAmount: 250,
+  estDuration: "2 weeks"
+};
+
+test("POST /api/proposals rejects missing estDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const { estDuration, ...payload } = validProposal;
+    const response = await postProposal(baseUrl, payload);
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Invalid proposal payload");
+  });
+});
+
+test("POST /api/proposals rejects blank estDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, {
+      ...validProposal,
+      estDuration: "   "
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "Invalid proposal payload");
+  });
+});
+
+test("POST /api/proposals stores valid estDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, validProposal);
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.match(body.data.id, /^prp_/);
+    assert.equal(body.data.estDuration, validProposal.estDuration);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1),
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #5697.

Requires proposal creation to include a valid estimated duration before a proposal record is stored.

## Changes

- Add a focused proposal creation schema for required proposal fields.
- Require non-empty `estDuration` and positive `bidAmount`.
- Validate `POST /api/proposals` payloads before calling the proposal service.
- Add API coverage for missing `estDuration`, blank `estDuration`, and valid proposal creation.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
