### PR TITLE
Keep proposal ids server-owned

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalIdOwnership.test.js
+++ b/apps/api/src/tests/proposalIdOwnership.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal ignores caller supplied ids", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker_controlled",
+    jobId: "job_123",
+    freelancerId: "usr_freelancer",
+    coverLetter: "I can deliver this project.",
+    bidAmount: 1200
+  });
+
+  assert.notEqual(proposal.id, "prp_attacker_controlled");
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.bidAmount, 1200);
+});


### PR DESCRIPTION
## Summary

Closes #5999.

Keeps proposal identifiers server-owned by assigning the generated id after caller payload fields are spread.

## Changes

- Change `createProposal()` so a caller-supplied `id` cannot override the generated `prp_<timestamp>` value.
- Add service regression coverage proving caller-controlled proposal ids are ignored.
- Keep unrelated proposal payload fields unchanged.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
