### PR TITLE
Rate limit malformed JSON before parsing

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
+  app.use(createApiLimiter());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,14 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
+const apiLimiterOptions = {
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
   legacyHeaders: false
-});
+};
+
+export function createApiLimiter() {
+  return rateLimit(apiLimiterOptions);
+}
+
+export const apiLimiter = createApiLimiter();

--- a/apps/api/src/tests/rateLimitMalformedJson.test.js
+++ b/apps/api/src/tests/rateLimitMalformedJson.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON requests count toward the API rate limit", async () => {
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  try {
+    await withServer(async (baseUrl) => {
+      let finalStatus = 0;
+
+      for (let attempt = 0; attempt < 201; attempt += 1) {
+        const response = await fetch(`${baseUrl}/api/jobs`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{bad json"
+        });
+        finalStatus = response.status;
+        await response.arrayBuffer();
+      }
+
+      assert.equal(finalStatus, 429);
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #6000.

Moves API rate limiting before JSON body parsing so malformed JSON requests count toward the configured quota before parser work is performed.

## Changes

- Register the API limiter before `express.json()` in `createApp()`.
- Add a `createApiLimiter()` factory so app instances get independent limiter state.
- Preserve the existing `apiLimiter` export for compatibility.
- Add regression coverage proving repeated malformed JSON requests eventually receive `429`.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
