### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid review payload",
+      issues: result.error.issues
+    });
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewIdOwnership.test.js
+++ b/apps/api/src/tests/reviewIdOwnership.test.js
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createReview } from "../services/reviewService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects invalid and unexpected fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 6,
+        comment: "",
+        reviewerId: "usr_client",
+        revieweeId: "usr_freelancer",
+        adminOverride: true
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid review payload");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("rating")));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("comment")));
+    assert.ok(payload.issues.some((issue) => issue.code === "unrecognized_keys"));
+  });
+});
+
+test("POST /api/reviews validates payloads before storage", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rating: 5,
+        comment: "Excellent delivery.",
+        reviewerId: "usr_client",
+        revieweeId: "usr_freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_\d+$/);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent delivery.");
+    assert.equal(payload.data.reviewerId, "usr_client");
+    assert.equal(payload.data.revieweeId, "usr_freelancer");
+  });
+});
+
+test("createReview keeps ids server-owned", async () => {
+  const review = await createReview({
+    id: "rev_attacker_controlled",
+    reviewerId: "usr_client",
+    revieweeId: "usr_freelancer",
+    rating: 5,
+    comment: "Excellent delivery."
+  });
+
+  assert.notEqual(review.id, "rev_attacker_controlled");
+  assert.match(review.id, /^rev_\d+$/);
+  assert.equal(review.reviewerId, "usr_client");
+  assert.equal(review.revieweeId, "usr_freelancer");
+  assert.equal(review.rating, 5);
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1),
+  reviewerId: z.string().trim().min(1),
+  revieweeId: z.string().trim().min(1)
+}).strict();


### PR DESCRIPTION
## Summary

Closes #5820.

Validates review creation payloads before storage and keeps review ids server-owned.

## Changes

- Add a strict review creation schema for `rating`, `comment`, `reviewerId`, and `revieweeId`.
- Enforce integer ratings from 1 through 5.
- Reject blank strings and unexpected properties with HTTP 400 and structured issues.
- Pass only validated review fields into the review service.
- Keep generated review ids server-owned.
- Add API coverage for invalid and valid review payloads plus service-level id ownership.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
