### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobBudgetValidation.test.js
+++ b/apps/api/src/tests/jobBudgetValidation.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a dashboard",
+  description: "Create a reporting dashboard for clients.",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "cat_development",
+  skills: ["react", "typescript"]
+};
+
+test("createJobSchema rejects inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("createJobSchema accepts ordered budget range", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted range when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 800,
+    budgetMax: 200
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("updateJobSchema accepts partial budget update when only one field is present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMax: 200
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchemaBase.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchemaBase.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary

Closes #2853.

Rejects inverted job budget ranges during job creation and partial job updates when both budget fields are present.

## Changes

- Add a shared Zod budget range refinement.
- Apply the refinement to `createJobSchema`.
- Apply the same refinement to `updateJobSchema` after partial schema conversion.
- Add focused coverage for invalid create, valid create, invalid update, and valid partial update cases.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
