### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,30 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(value) {
+  if (value === undefined) {
+    return { query: "" };
+  }
+
+  if (typeof value !== "string") {
+    return { error: "Search query must be a string" };
+  }
+
+  const query = value.replace(/[\u0000-\u001F\u007F]/g, "").trim();
+  if (query.length > MAX_QUERY_LENGTH) {
+    return { error: `Search query must be ${MAX_QUERY_LENGTH} characters or fewer` };
+  }
+
+  return { query };
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const result = normalizeSearchQuery(req.query.q);
+  if (result.error) {
+    return fail(res, result.error, 400);
+  }
+
+  return ok(res, await globalSearch(result.query));
 }

--- a/apps/api/src/tests/searchValidation.test.js
+++ b/apps/api/src/tests/searchValidation.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims and sanitizes valid query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%00%20%20hello%00world%20%20%00`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "helloworld");
+  });
+});
+
+test("GET /api/search keeps omitted query as an empty search", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Search query must be a string" });
+  });
+});
+
+test("GET /api/search rejects query longer than 200 characters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5888.

Validates the `GET /api/search` query parameter before it reaches the search service.

## Changes

- Preserve omitted `q` as an empty search.
- Reject repeated or otherwise non-string `q` values.
- Strip ASCII control characters and trim the query.
- Reject queries longer than 200 characters.
- Add focused API coverage for valid sanitization, omitted query, repeated query parameters, and length rejection.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
