### PR TITLE
Expose db workspace entrypoint

### DIFF
--- a/packages/db/import.test.mjs
+++ b/packages/db/import.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+test("@freelanceflow/db resolves through the workspace package name", () => {
+  const resolved = require.resolve("@freelanceflow/db");
+  const expected = path.resolve(fileURLToPath(new URL("index.js", import.meta.url)));
+
+  assert.equal(resolved, expected);
+});
+
+test("@freelanceflow/db can be imported by package name", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.equal(typeof db.default, "object");
+});

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,31 @@
+"use strict";
+
+let prismaClient;
+
+function getPrismaClient() {
+  if (!prismaClient) {
+    prismaClient = require("@prisma/client");
+  }
+
+  return prismaClient;
+}
+
+module.exports = new Proxy({}, {
+  get(_target, property) {
+    return getPrismaClient()[property];
+  },
+  getOwnPropertyDescriptor(_target, property) {
+    const descriptor = Object.getOwnPropertyDescriptor(getPrismaClient(), property);
+    if (descriptor) {
+      descriptor.configurable = true;
+    }
+
+    return descriptor;
+  },
+  has(_target, property) {
+    return property in getPrismaClient();
+  },
+  ownKeys() {
+    return Reflect.ownKeys(getPrismaClient());
+  }
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test import.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"


### PR DESCRIPTION
## Summary

Closes #2775.

Adds a package entrypoint for `@freelanceflow/db` so workspace consumers can resolve and import the DB package by name.

## Changes

- Add explicit `main`, `types`, and `exports` metadata to `packages/db/package.json`.
- Add a JavaScript package entrypoint that delegates to `@prisma/client`.
- Add TypeScript declarations for package consumers.
- Add a focused import test that resolves and imports `@freelanceflow/db` through the workspace package name.

## Verification

```bash
npm test -w packages/db
node --input-type=module -e 'const db = await import("@freelanceflow/db"); console.log(typeof db.default);'
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
