### PR TITLE
Expose ui workspace entrypoint

### DIFF
--- a/packages/ui/import.test.mjs
+++ b/packages/ui/import.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+test("@freelanceflow/ui resolves through the workspace package name", () => {
+  const resolved = require.resolve("@freelanceflow/ui");
+  const expected = path.resolve(fileURLToPath(new URL("index.js", import.meta.url)));
+
+  assert.equal(resolved, expected);
+});
+
+test("@freelanceflow/ui can be imported by package name", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,5 @@
+import type { ReactElement, ReactNode } from "react";
+
+export function Button({ children }: { children: ReactNode }): ReactElement;
+
+export function Card({ title, children }: { title: string; children: ReactNode }): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+exports.Button = Button;
+exports.Card = Card;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,17 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test import.test.mjs"
+  }
 }


### PR DESCRIPTION
## Summary

Closes #2781.

Adds a real JavaScript entrypoint for `@freelanceflow/ui` so workspace consumers can import Button and Card by package name.

## Changes

- Replace the TypeScript-source `main` entrypoint with `index.js`.
- Add explicit `types` and `exports` metadata.
- Add runtime JavaScript exports for `Button` and `Card`.
- Add TypeScript declarations for consumers.
- Add a focused package-name import test.

## Verification

```bash
npm test -w packages/ui
node --input-type=module -e 'const ui = await import("@freelanceflow/ui"); console.log(typeof ui.Button, typeof ui.Card);'
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
