### PR TITLE
Resolve freelancer profile mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,30 @@
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((profile) => profile.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer profile matches <strong>{params.username}</strong>.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>{freelancer.rate}</p>
+      <h3>Skills</h3>
+      <ul>
+        {freelancer.skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
+      <Link href="/freelancers/search">Back to freelancer search</Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Closes #2849.

Updates the freelancer profile route to resolve profiles from the existing mock data and show a clear fallback for unknown usernames.

## Changes

- Look up `/freelancers/[username]` against `apps/web/lib/mock.ts`.
- Render matching mock profile username, rate, and skills.
- Replace placeholder copy with a not-found fallback for unknown usernames.
- Keep the change scoped to the freelancer profile route.

## Verification

```bash
npm run build -w apps/web
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
