### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid proposal payload",
+      issues: result.error.issues
+    });
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can deliver this milestone.",
+  bidAmount: 500,
+  estimatedDays: 7
+};
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function issuePaths(payload) {
+  const result = createProposalSchema.safeParse(payload);
+  assert.equal(result.success, false);
+  return result.error.issues.map((issue) => issue.path.join("."));
+}
+
+test("proposal creation rejects negative bid amounts", () => {
+  assert.deepEqual(issuePaths({ ...validProposal, bidAmount: -1 }), ["bidAmount"]);
+});
+
+test("proposal creation rejects negative estimated days", () => {
+  assert.deepEqual(issuePaths({ ...validProposal, estimatedDays: -2 }), ["estimatedDays"]);
+});
+
+test("proposal creation rejects empty cover letters", () => {
+  assert.deepEqual(issuePaths({ ...validProposal, coverLetter: "   " }), ["coverLetter"]);
+});
+
+test("proposal creation rejects caller-supplied system fields", () => {
+  assert.deepEqual(issuePaths({ ...validProposal, id: "prp_attacker" }), [""]);
+});
+
+test("proposal creation accepts and normalizes valid payloads", () => {
+  assert.deepEqual(
+    createProposalSchema.parse({
+      ...validProposal,
+      coverLetter: "  I can deliver this milestone.  "
+    }),
+    validProposal
+  );
+});
+
+test("POST /api/proposals returns 400 for invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...validProposal, bidAmount: -10 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid proposal payload");
+    assert.deepEqual(payload.issues.map((issue) => issue.path.join(".")), ["bidAmount"]);
+  });
+});
+
+test("POST /api/proposals accepts valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validProposal)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_/);
+    assert.equal(payload.data.coverLetter, validProposal.coverLetter);
+    assert.equal(payload.data.bidAmount, validProposal.bidAmount);
+    assert.equal(payload.data.estimatedDays, validProposal.estimatedDays);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().nonnegative(),
+  estimatedDays: z.number().int().positive()
+}).strict();


### PR DESCRIPTION
## Summary

Closes #6043.

Adds proposal creation validation so malformed proposal payloads are rejected before reaching the service layer.

## Changes

- Add a strict Zod `createProposalSchema`.
- Require non-empty `jobId`, `freelancerId`, and trimmed non-empty `coverLetter`.
- Reject negative `bidAmount` and non-positive `estimatedDays`.
- Reject caller-supplied system fields such as `id`.
- Return HTTP 400 with structured validation issues for invalid API payloads.
- Preserve valid proposal creation behavior.
- Add focused schema and API regression coverage.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Parent bounty: #743
Original issue: #3924
