### PR TITLE
Bind job creation to authenticated client

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
+  if (req.body.clientId !== undefined && req.body.clientId !== req.user.sub) {
+    return fail(res, "Client id does not match authenticated user", 403);
+  }
+
   const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  return ok(res, await createJob({ ...payload, clientId: req.user.sub }), 201);
 }

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobClientOwnership.test.js
+++ b/apps/api/src/tests/jobClientOwnership.test.js
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const validJob = {
+  title: "Build onboarding flow",
+  description: "Create a reliable onboarding flow for new clients.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeader(userId = "usr_client") {
+  return `Bearer ${signAccessToken({ sub: userId, role: "client" })}`;
+}
+
+test("POST /api/jobs rejects unauthenticated creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/jobs rejects spoofed client ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: authHeader("usr_real_client"),
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ ...validJob, clientId: "usr_other_client" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Client id does not match authenticated user"
+    });
+  });
+});
+
+test("POST /api/jobs stores client id from authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: authHeader("usr_real_client"),
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^job_/);
+    assert.equal(payload.data.clientId, "usr_real_client");
+    assert.equal(payload.data.status, "open");
+    assert.equal(payload.data.title, validJob.title);
+  });
+});
+
+test("GET /api/jobs remains public", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`);
+
+    assert.equal(response.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6045.

Prevents job creation from spoofing another client account by binding created jobs to the authenticated user's `sub` claim.

## Changes

- Require `authMiddleware` for `POST /api/jobs` while keeping `GET /api/jobs` public.
- Reject caller-supplied `clientId` values that do not match `req.user.sub`.
- Set the persisted job `clientId` from the authenticated user.
- Preserve valid job creation behavior for authenticated callers.
- Add focused API regression coverage for unauthenticated rejection, spoofed `clientId` rejection, authenticated creation, and public listing.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Parent bounty: #743
Original issue: #5807
