### PR TITLE
Keep job creation fields server-owned

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobServiceOwnership.test.js
+++ b/apps/api/src/tests/jobServiceOwnership.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+const validJob = {
+  title: "Build onboarding flow",
+  description: "Create a reliable onboarding flow for new clients.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJob keeps id and initial status server-owned", async () => {
+  const job = await createJob({
+    ...validJob,
+    id: "job_attacker",
+    status: "closed"
+  });
+
+  assert.match(job.id, /^job_/);
+  assert.notEqual(job.id, "job_attacker");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, validJob.title);
+  assert.deepEqual(job.skills, validJob.skills);
+});


### PR DESCRIPTION
## Summary

Closes #3458.

Keeps job creation server-owned fields under service control so callers cannot override generated job ids or the initial `open` status.

## Changes

- Apply caller payload fields before generated `id` and initial `status` in `createJob()`.
- Preserve accepted job payload fields such as title, budget, category, and skills.
- Add focused service-level regression coverage for caller-supplied `id` and `status` attempts.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Parent bounty: #743
