### PR TITLE
Keep review timestamps server-owned

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}`, createdAt: new Date().toISOString() };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewServiceCreatedAt.test.js
+++ b/apps/api/src/tests/reviewServiceCreatedAt.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps createdAt server-owned", async () => {
+  const review = await createReview({
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5,
+    comment: "Excellent work.",
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+
+  assert.match(review.id, /^rev_/);
+  assert.notEqual(review.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(review.createdAt).toISOString());
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Excellent work.");
+});


### PR DESCRIPTION
## Summary

Closes #3456.

Keeps review creation timestamps under service control so callers cannot backdate or future-date reviews through `createdAt` in the request payload.

## Changes

- Apply caller payload fields before generated service-owned fields in `createReview()`.
- Assign `createdAt` in the service with the current timestamp.
- Preserve accepted review payload fields.
- Add focused service-level regression coverage proving caller-supplied `createdAt` is not stored.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Parent bounty: #743
