### PR TITLE
Accept multiple spaces after Bearer scheme

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const bearerMatch = authHeader?.match(/^Bearer +(.+)$/);
+  if (!bearerMatch) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(bearerMatch[1]);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authBearerSpacing.test.js
+++ b/apps/api/src/tests/authBearerSpacing.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth middleware accepts one space after Bearer", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});
+
+test("auth middleware accepts multiple spaces after Bearer", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer   ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});
+
+test("auth middleware still rejects missing bearer credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("auth middleware still rejects invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: "Bearer   invalid-token" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6053.

Updates the auth middleware so valid bearer tokens are accepted when the Authorization header has one or more spaces after the `Bearer` scheme.

## Changes

- Parse bearer credentials with a narrow `Bearer +<token>` match.
- Verify the extracted token without leading spaces.
- Preserve existing `Unauthorized` and `Invalid token` responses for missing or bad credentials.
- Add API regression tests covering one-space success, multiple-space success, missing credentials, and invalid tokens.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #5304
Parent bounty: #743
