### PR TITLE
Fix API workspace test script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Closes #6055.

Fixes the API workspace test script so `npm test -w apps/api` targets concrete Node test files instead of trying to execute the `src/tests` directory as a module.

## Changes

- Update `apps/api/package.json` test script from `node --test src/tests` to `node --test src/tests/*.test.js`.
- Keep the fix limited to package metadata; no application behavior or test contents are changed.

## Verification

Before the fix:

```bash
npm test -w apps/api
# failed with MODULE_NOT_FOUND for apps/api/src/tests
```

After the fix:

```bash
npm test -w apps/api
git diff --check
```

Original issue: #3870
Parent bounty: #743
