### PR TITLE
Require authentication for search route

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
+searchRoutes.use(authMiddleware);
 searchRoutes.get("/", search);

--- a/apps/api/src/tests/searchRoutesAuth.test.js
+++ b/apps/api/src/tests/searchRoutesAuth.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search requires bearer authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/search rejects invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design`, {
+      headers: { Authorization: "Bearer invalid-token" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("GET /api/search returns results for a valid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_searcher", role: "client" });
+    const response = await fetch(`${baseUrl}/api/search?q=design`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "design");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6057.

Requires bearer authentication before `GET /api/search` returns search results.

## Changes

- Apply the existing `authMiddleware` to the search router.
- Preserve the existing search response for valid bearer tokens.
- Reject missing and invalid bearer tokens with HTTP 401.
- Add focused route-level regression coverage for missing, invalid, and valid bearer credentials.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #4592
Parent bounty: #743
