### PR TITLE
Validate auth token identity claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,19 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
+function isValidUserClaims(payload) {
+  return (
+    payload &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    typeof payload.sub === "string" &&
+    payload.sub.trim() !== "" &&
+    allowedRoles.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +21,11 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const user = verifyAccessToken(authHeader.slice(7));
+    if (!isValidUserClaims(user)) {
+      return fail(res, "Invalid token", 401);
+    }
+    req.user = user;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authIdentityClaims.test.js
+++ b/apps/api/src/tests/authIdentityClaims.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestMetrics(baseUrl, token) {
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const payload = await response.json();
+  return { response, payload };
+}
+
+test("auth middleware rejects signed string JWT payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const token = jwt.sign("usr_admin", env.jwtSecret);
+    const { response, payload } = await requestMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("auth middleware rejects JWTs missing sub", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ role: "admin" });
+    const { response, payload } = await requestMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("auth middleware rejects JWTs with unsupported roles", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "owner" });
+    const { response, payload } = await requestMetrics(baseUrl, token);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("auth middleware preserves valid app-issued access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const { response, payload } = await requestMetrics(baseUrl, token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #6059.

Adds identity-claim validation after JWT verification so protected routes only accept app-shaped bearer tokens.

## Changes

- Reject verified JWT payloads that are not plain objects.
- Reject JWTs missing a non-empty string `sub`.
- Reject JWTs with unsupported `role` values.
- Preserve valid app-issued access tokens.
- Add focused route-level regression tests through `/api/admin/metrics`.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #3421
Parent bounty: #743
