### PR TITLE
Restrict API CORS origin

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,25 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+function getCorsOptions() {
+  const allowedOrigin = process.env.CORS_ORIGIN ?? "http://localhost:3000";
+
+  return {
+    origin(origin, callback) {
+      if (!origin || origin === allowedOrigin) {
+        return callback(null, true);
+      }
+
+      return callback(null, false);
+    }
+  };
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(getCorsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/corsOrigin.test.js
+++ b/apps/api/src/tests/corsOrigin.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function restoreCorsOrigin(previous) {
+  if (previous === undefined) {
+    delete process.env.CORS_ORIGIN;
+  } else {
+    process.env.CORS_ORIGIN = previous;
+  }
+}
+
+test("CORS allows the default localhost origin", async () => {
+  const previous = process.env.CORS_ORIGIN;
+  delete process.env.CORS_ORIGIN;
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "http://localhost:3000" }
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("access-control-allow-origin"), "http://localhost:3000");
+    });
+  } finally {
+    restoreCorsOrigin(previous);
+  }
+});
+
+test("CORS omits allow-origin for untrusted origins", async () => {
+  const previous = process.env.CORS_ORIGIN;
+  delete process.env.CORS_ORIGIN;
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://evil.example" }
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("access-control-allow-origin"), null);
+    });
+  } finally {
+    restoreCorsOrigin(previous);
+  }
+});
+
+test("CORS allows a configured origin", async () => {
+  const previous = process.env.CORS_ORIGIN;
+  process.env.CORS_ORIGIN = "https://app.example.com";
+
+  try {
+    await withServer(async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://app.example.com" }
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("access-control-allow-origin"), "https://app.example.com");
+    });
+  } finally {
+    restoreCorsOrigin(previous);
+  }
+});


### PR DESCRIPTION
## Summary

Closes #6062.

Restricts API CORS responses to a configured allowed origin instead of allowing every origin.

## Changes

- Configure `cors()` with an origin allowlist.
- Read the allowed origin from `CORS_ORIGIN`, defaulting to `http://localhost:3000`.
- Preserve non-browser requests that do not include an `Origin` header.
- Add route-level tests for default allowed origin, untrusted origin rejection, and configured origin support.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #3879
Parent bounty: #743
