### PR TITLE
Add payment intent creation timestamps

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -4,6 +4,7 @@ export async function createPaymentIntent(payload) {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
-    provider: "stripe"
+    provider: "stripe",
+    createdAt: new Date().toISOString()
   };
 }

--- a/apps/api/src/tests/paymentServiceCreatedAt.test.js
+++ b/apps/api/src/tests/paymentServiceCreatedAt.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent includes a server-owned createdAt timestamp", async () => {
+  const payment = await createPaymentIntent({
+    amount: 2500,
+    currency: "usd",
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+
+  assert.match(payment.paymentId, /^pay_/);
+  assert.equal(payment.amount, 2500);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+  assert.notEqual(payment.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(payment.createdAt).toISOString());
+});


### PR DESCRIPTION
## Summary

Closes #6064.

Adds a server-owned creation timestamp to payment intent responses.

## Changes

- Add `createdAt` to `createPaymentIntent()` responses using the service creation time.
- Keep caller-supplied `createdAt` from controlling the returned timestamp.
- Preserve existing amount, currency, provider, and payment id behavior.
- Add focused service-level regression coverage.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #3316
Parent bounty: #743
