### PR TITLE
Add job creation timestamps

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${Date.now()}`, status: "open", ...payload, createdAt: new Date().toISOString() };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobServiceCreatedAt.test.js
+++ b/apps/api/src/tests/jobServiceCreatedAt.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob includes a server-owned createdAt timestamp", async () => {
+  const job = await createJob({
+    title: "Build landing page",
+    clientId: "usr_client",
+    budgetMin: 100,
+    budgetMax: 500,
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+  const jobs = await listJobs();
+  const storedJob = jobs.find((candidate) => candidate.id === job.id);
+
+  assert.match(job.id, /^job_/);
+  assert.equal(job.title, "Build landing page");
+  assert.equal(job.clientId, "usr_client");
+  assert.notEqual(job.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(job.createdAt).toISOString());
+  assert.equal(storedJob.createdAt, job.createdAt);
+});


### PR DESCRIPTION
## Summary

Closes #6067.

Adds a server-owned creation timestamp to job records produced by the in-memory job service.

## Changes

- Add `createdAt` to `createJob()` records using the service creation time.
- Keep caller-supplied `createdAt` from controlling the stored or returned timestamp.
- Preserve existing job payload fields.
- Add focused service-level regression coverage proving the returned and stored timestamps match.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check
```

Original issue: #3313
Parent bounty: #743
