### PR TITLE
Add user creation timestamps

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: `usr_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userServiceCreatedAt.test.js
+++ b/apps/api/src/tests/userServiceCreatedAt.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser includes a server-owned createdAt timestamp", async () => {
+  const user = await createUser({
+    email: "client@example.com",
+    role: "client",
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+  const users = await listUsers();
+  const storedUser = users.find((candidate) => candidate.id === user.id);
+
+  assert.match(user.id, /^usr_/);
+  assert.equal(user.email, "client@example.com");
+  assert.equal(user.role, "client");
+  assert.notEqual(user.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(user.createdAt).toISOString());
+  assert.equal(storedUser.createdAt, user.createdAt);
+});


### PR DESCRIPTION
Fixes duplicate issue #6070.

Related issues:
- Parent bounty route: #743
- Original issue: #3311

Changes:
- adds a server-owned ISO `createdAt` timestamp to `createUser()` records;
- prevents caller-supplied `createdAt` values from controlling the stored timestamp;
- adds focused service-level regression coverage for returned and stored timestamps.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
