### PR TITLE
Add notification creation timestamps

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, createdAt: new Date().toISOString() };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationServiceCreatedAt.test.js
+++ b/apps/api/src/tests/notificationServiceCreatedAt.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("createNotification includes a server-owned createdAt timestamp", async () => {
+  const notification = await createNotification({
+    userId: "usr_client",
+    message: "New proposal received",
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+  const notifications = await listNotifications();
+  const storedNotification = notifications.find((candidate) => candidate.id === notification.id);
+
+  assert.match(notification.id, /^ntf_/);
+  assert.equal(notification.userId, "usr_client");
+  assert.equal(notification.message, "New proposal received");
+  assert.notEqual(notification.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(notification.createdAt).toISOString());
+  assert.equal(storedNotification.createdAt, notification.createdAt);
+});


### PR DESCRIPTION
Fixes duplicate issue #6076.

Related issues:
- Parent bounty route: #743
- Original issue: #3305

Changes:
- adds a server-owned ISO `createdAt` timestamp to `createNotification()` records;
- prevents caller-supplied `createdAt` values from controlling the stored timestamp;
- adds focused service-level regression coverage for returned and stored timestamps.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
