### PR TITLE
Add proposal creation timestamps

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${Date.now()}`, ...payload, createdAt: new Date().toISOString() };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalServiceCreatedAt.test.js
+++ b/apps/api/src/tests/proposalServiceCreatedAt.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal includes a server-owned createdAt timestamp", async () => {
+  const proposal = await createProposal({
+    jobId: "job_project",
+    freelancerId: "usr_freelancer",
+    coverLetter: "I can deliver this project.",
+    createdAt: "1999-01-01T00:00:00.000Z"
+  });
+  const proposals = await listProposals();
+  const storedProposal = proposals.find((candidate) => candidate.id === proposal.id);
+
+  assert.match(proposal.id, /^prp_/);
+  assert.equal(proposal.jobId, "job_project");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.coverLetter, "I can deliver this project.");
+  assert.notEqual(proposal.createdAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(proposal.createdAt).toISOString());
+  assert.equal(storedProposal.createdAt, proposal.createdAt);
+});


### PR DESCRIPTION
Fixes duplicate issue #6078.

Related issues:
- Parent bounty route: #743
- Original issue: #3303

Changes:
- adds a server-owned ISO `createdAt` timestamp to `createProposal()` records;
- prevents caller-supplied `createdAt` values from controlling the stored timestamp;
- adds focused service-level regression coverage for returned and stored timestamps.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
