### PR TITLE
Accept case-insensitive Bearer auth scheme

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const match = typeof authHeader === "string" ? authHeader.match(/^Bearer (.+)$/i) : null;
+  if (!match) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(match[1]);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddlewareBearerCase.test.js
+++ b/apps/api/src/tests/authMiddlewareBearerCase.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+}
+
+function runMiddleware(authorization) {
+  const req = { headers: {} };
+  if (authorization !== undefined) {
+    req.headers.authorization = authorization;
+  }
+  const res = createResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { nextCalled, req, res };
+}
+
+test("authMiddleware accepts lowercase bearer auth scheme", () => {
+  const token = signAccessToken({ sub: "usr_client", role: "client" });
+  const result = runMiddleware(`bearer ${token}`);
+
+  assert.equal(result.nextCalled, true);
+  assert.equal(result.req.user.sub, "usr_client");
+  assert.equal(result.req.user.role, "client");
+});
+
+test("authMiddleware accepts uppercase bearer auth scheme", () => {
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+  const result = runMiddleware(`BEARER ${token}`);
+
+  assert.equal(result.nextCalled, true);
+  assert.equal(result.req.user.sub, "usr_admin");
+  assert.equal(result.req.user.role, "admin");
+});
+
+test("authMiddleware rejects missing and malformed bearer credentials", () => {
+  const missing = runMiddleware();
+  const malformed = runMiddleware("Basic abc123");
+  const blank = runMiddleware("Bearer ");
+
+  assert.equal(missing.nextCalled, false);
+  assert.equal(missing.res.statusCode, 401);
+  assert.deepEqual(missing.res.payload, { success: false, message: "Unauthorized" });
+
+  assert.equal(malformed.nextCalled, false);
+  assert.equal(malformed.res.statusCode, 401);
+  assert.deepEqual(malformed.res.payload, { success: false, message: "Unauthorized" });
+
+  assert.equal(blank.nextCalled, false);
+  assert.equal(blank.res.statusCode, 401);
+  assert.deepEqual(blank.res.payload, { success: false, message: "Unauthorized" });
+});


### PR DESCRIPTION
Fixes duplicate issue #6080.

Related issues:
- Parent bounty route: #743
- Original issue: #4900

Changes:
- parses the `Authorization` Bearer scheme case-insensitively;
- continues rejecting missing, blank, and malformed credentials;
- adds focused middleware regression coverage for lowercase and uppercase Bearer schemes.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
