### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.errors.map((error) => error.message).join("; "), 400);
+  }
+
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, body) {
+  return fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/reviews rejects invalid review payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const missingRequired = await postReview(baseUrl, {
+      reviewerId: "usr_reviewer",
+      rating: 5
+    });
+    const invalidRating = await postReview(baseUrl, {
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee",
+      rating: 6
+    });
+    const emptyComment = await postReview(baseUrl, {
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee",
+      rating: 4,
+      comment: ""
+    });
+
+    assert.equal(missingRequired.status, 400);
+    assert.equal(invalidRating.status, 400);
+    assert.equal(emptyComment.status, 400);
+
+    assert.equal((await missingRequired.json()).success, false);
+    assert.equal((await invalidRating.json()).success, false);
+    assert.equal((await emptyComment.json()).success, false);
+  });
+});
+
+test("POST /api/reviews creates valid reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      reviewerId: "usr_reviewer",
+      revieweeId: "usr_reviewee",
+      rating: 5,
+      comment: "Excellent work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_/);
+    assert.equal(payload.data.reviewerId, "usr_reviewer");
+    assert.equal(payload.data.revieweeId, "usr_reviewee");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent work");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).optional()
+});


### PR DESCRIPTION
Fixes duplicate issue #6082.

Related issues:
- Parent bounty route: #743
- Original issue: #3651

Changes:
- adds `createReviewSchema` for review creation payloads;
- requires `reviewerId`, `revieweeId`, and integer `rating` from 1 through 5;
- rejects empty optional comments;
- returns HTTP 400 for invalid review payloads;
- adds route-level regression coverage for invalid and valid review creation.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
