### PR TITLE
Reject invalid login credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,10 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid credentials", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,36 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const users = new Map();
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password,
+    role: payload.role
+  };
+  users.set(user.email, user);
+
+  return {
+    id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const user = users.get(payload.email);
+  if (!user || user.password !== payload.password) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authLoginCredentials.test.js
+++ b/apps/api/src/tests/authLoginCredentials.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/login rejects unknown and wrong credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `client-${Date.now()}@example.com`;
+    const password = "correct-password";
+
+    await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password,
+      role: "client"
+    });
+
+    const unknown = await postJson(baseUrl, "/api/auth/login", {
+      email: `unknown-${Date.now()}@example.com`,
+      password
+    });
+    const wrongPassword = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "wrong-password"
+    });
+
+    assert.equal(unknown.status, 401);
+    assert.deepEqual(await unknown.json(), { success: false, message: "Invalid credentials" });
+
+    assert.equal(wrongPassword.status, 401);
+    assert.deepEqual(await wrongPassword.json(), { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("POST /api/auth/login accepts matching registered credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const email = `client-${Date.now()}@example.com`;
+    const password = "correct-password";
+
+    await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password,
+      role: "freelancer"
+    });
+
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, email);
+    assert.equal(typeof payload.data.token, "string");
+    assert.ok(payload.data.token.length > 0);
+  });
+});


### PR DESCRIPTION
Fixes duplicate issue #6084.

Related issues:
- Parent bounty route: #743
- Original issue: #3466

Changes:
- stores registered users in the existing auth service boundary;
- makes login succeed only for registered matching credentials;
- rejects unknown emails and wrong passwords with HTTP 401;
- adds route-level regression coverage for rejected and accepted login attempts.

Verification:
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
