### PR TITLE
Reject non-finite job budgets

### DIFF
--- a/apps/api/src/tests/jobBudgetFinite.test.js
+++ b/apps/api/src/tests/jobBudgetFinite.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build marketplace",
+  description: "Build a marketplace workflow",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_dev",
+  skills: ["api"]
+};
+
+test("createJobSchema rejects non-finite budget values", () => {
+  for (const value of [Infinity, -Infinity, NaN]) {
+    assert.throws(() => createJobSchema.parse({ ...validJob, budgetMin: value }));
+    assert.throws(() => createJobSchema.parse({ ...validJob, budgetMax: value }));
+  }
+});
+
+test("updateJobSchema rejects non-finite budget values", () => {
+  for (const value of [Infinity, -Infinity, NaN]) {
+    assert.throws(() => updateJobSchema.parse({ budgetMin: value }));
+    assert.throws(() => updateJobSchema.parse({ budgetMax: value }));
+  }
+});
+
+test("createJobSchema keeps finite nonnegative budget values valid", () => {
+  const parsed = createJobSchema.parse(validJob);
+
+  assert.equal(parsed.budgetMin, 100);
+  assert.equal(parsed.budgetMax, 500);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
## Summary
- Reject non-finite `budgetMin` and `budgetMax` values in the job schema.
- Add focused regression tests for create and update job validation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6086.
Original limited issue: #3302.
Parent bounty: #743.
