### PR TITLE
Expose job partial updates

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,6 +1,7 @@
-import { ok } from "../utils/response.js";
-import { createJobSchema } from "../validators/job.js";
-import { createJob, listJobs } from "../services/jobService.js";
+import { ZodError } from "zod";
+import { fail, ok } from "../utils/response.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+import { createJob, listJobs, updateJob } from "../services/jobService.js";
 
 export async function getJobs(req, res) {
   return ok(res, await listJobs());
@@ -9,4 +10,26 @@ export async function getJobs(req, res) {
 export async function postJob(req, res) {
   const payload = createJobSchema.parse(req.body);
   return ok(res, await createJob(payload), 201);
+}
+
+export async function patchJob(req, res) {
+  let payload;
+
+  try {
+    payload = updateJobSchema.parse(req.body);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Invalid job update payload", 400);
+    }
+
+    throw error;
+  }
+
+  const job = await updateJob(req.params.id, payload);
+
+  if (!job) {
+    return fail(res, "Job not found", 404);
+  }
+
+  return ok(res, job);
 }

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
-import { getJobs, postJob } from "../controllers/jobController.js";
+import { getJobs, patchJob, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);
+jobRoutes.patch("/:id", patchJob);

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -9,3 +9,14 @@ export async function createJob(payload) {
   jobs.push(job);
   return job;
 }
+
+export async function updateJob(id, payload) {
+  const index = jobs.findIndex((job) => job.id === id);
+
+  if (index === -1) {
+    return null;
+  }
+
+  jobs[index] = { ...jobs[index], ...payload, id: jobs[index].id };
+  return jobs[index];
+}

--- a/apps/api/src/tests/jobPartialUpdate.test.js
+++ b/apps/api/src/tests/jobPartialUpdate.test.js
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validJob = {
+  title: "Build marketplace",
+  description: "Build a marketplace workflow",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_dev",
+  skills: ["api"]
+};
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...options.headers
+    }
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("PATCH /api/jobs/:id updates an existing job and preserves its id", async () => {
+  await withServer(async (baseUrl) => {
+    const created = await requestJson(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      body: JSON.stringify(validJob)
+    });
+
+    const job = created.payload.data;
+    const updated = await requestJson(`${baseUrl}/api/jobs/${job.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ title: "Updated marketplace", budgetMin: 250 })
+    });
+
+    assert.equal(updated.response.status, 200);
+    assert.equal(updated.payload.success, true);
+    assert.equal(updated.payload.data.id, job.id);
+    assert.equal(updated.payload.data.title, "Updated marketplace");
+    assert.equal(updated.payload.data.budgetMin, 250);
+    assert.equal(updated.payload.data.description, validJob.description);
+    assert.equal(updated.payload.data.status, "open");
+  });
+});
+
+test("PATCH /api/jobs/:id returns 404 for missing jobs", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await requestJson(`${baseUrl}/api/jobs/missing_job`, {
+      method: "PATCH",
+      body: JSON.stringify({ title: "Updated marketplace" })
+    });
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(payload, { success: false, message: "Job not found" });
+  });
+});
+
+test("PATCH /api/jobs/:id returns 400 for invalid patches", async () => {
+  await withServer(async (baseUrl) => {
+    const created = await requestJson(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      body: JSON.stringify(validJob)
+    });
+
+    const { response, payload } = await requestJson(`${baseUrl}/api/jobs/${created.payload.data.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ budgetMin: -1 })
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid job update payload" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `PATCH /api/jobs/:id` for partial job updates.
- Validate update payloads with `updateJobSchema` and return 400 for invalid patches.
- Preserve the stored job id while updating existing in-memory jobs and return 404 for missing jobs.
- Add focused route-level regression coverage.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6089.
Original limited issue: #3299.
Parent bounty: #743.
