### PR TITLE
Return defensive list array copies

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServiceCopies.test.js
+++ b/apps/api/src/tests/listServiceCopies.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+async function assertDefensiveArrayCopy({ create, list, payload }) {
+  const initial = await list();
+  const created = await create(payload);
+  const snapshot = await list();
+
+  assert.equal(snapshot.length, initial.length + 1);
+  assert.equal(snapshot[snapshot.length - 1], created);
+
+  snapshot.length = 0;
+
+  const nextSnapshot = await list();
+  assert.equal(nextSnapshot.length, initial.length + 1);
+  assert.equal(nextSnapshot[nextSnapshot.length - 1], created);
+  assert.notEqual(nextSnapshot, snapshot);
+}
+
+test("list services return defensive array copies", async () => {
+  await assertDefensiveArrayCopy({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "user@example.com", role: "client" }
+  });
+
+  await assertDefensiveArrayCopy({
+    create: createJob,
+    list: listJobs,
+    payload: {
+      title: "Build marketplace",
+      description: "Build a marketplace workflow",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "cat_dev",
+      skills: ["api"]
+    }
+  });
+
+  await assertDefensiveArrayCopy({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_1", freelancerId: "usr_1", amount: 100, duration: 3 }
+  });
+
+  await assertDefensiveArrayCopy({
+    create: createReview,
+    list: listReviews,
+    payload: { reviewerId: "usr_1", revieweeId: "usr_2", rating: 5 }
+  });
+
+  await assertDefensiveArrayCopy({
+    create: sendMessage,
+    list: listMessages,
+    payload: { senderId: "usr_1", receiverId: "usr_2", body: "Hello" }
+  });
+
+  await assertDefensiveArrayCopy({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_1", message: "A new update is ready" }
+  });
+});


### PR DESCRIPTION
## Summary
- Return shallow array copies from user, job, proposal, review, message, and notification list services.
- Preserve existing record objects and response shape.
- Add focused regression coverage proving mutating a returned list does not corrupt the backing store.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6091.
Original limited issue: #3216.
Parent bounty: #743.
