### PR TITLE
Return defensive create record snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = snapshotRecord({ id: `job_${Date.now()}`, status: "open", ...payload });
   jobs.push(job);
-  return job;
+  return snapshotRecord(job);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = snapshotRecord({ id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() });
   messages.push(message);
-  return message;
+  return snapshotRecord(message);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = snapshotRecord({ id: `ntf_${Date.now()}`, read: false, ...payload });
   notifications.push(notification);
-  return notification;
+  return snapshotRecord(notification);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = snapshotRecord({ id: `prp_${Date.now()}`, ...payload });
   proposals.push(proposal);
-  return proposal;
+  return snapshotRecord(proposal);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = snapshotRecord({ id: `rev_${Date.now()}`, ...payload });
   reviews.push(review);
-  return review;
+  return snapshotRecord(review);
 }

--- a/apps/api/src/services/snapshot.js
+++ b/apps/api/src/services/snapshot.js
@@ -1,0 +1,8 @@
+export function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { snapshotRecord } from "./snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = snapshotRecord({ id: `usr_${Date.now()}`, ...payload });
   users.push(user);
-  return user;
+  return snapshotRecord(user);
 }

--- a/apps/api/src/tests/createServiceSnapshots.test.js
+++ b/apps/api/src/tests/createServiceSnapshots.test.js
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+import { createJob, listJobs } from "../services/jobService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+async function assertDefensiveCreateSnapshot({ create, list, payload, mutate }) {
+  const created = await create(payload);
+  const originalId = created.id;
+  const originalCreated = snapshotRecord(created);
+
+  mutate(created);
+
+  const stored = (await list()).find((record) => record.id === originalId);
+  assert.ok(stored);
+  assert.notEqual(stored, created);
+  assert.equal(stored.id, originalId);
+  assert.deepEqual(stored, originalCreated);
+}
+
+function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      Array.isArray(value) ? [...value] : value
+    ])
+  );
+}
+
+test("create services return snapshots that do not mutate stored records", async () => {
+  await assertDefensiveCreateSnapshot({
+    create: createUser,
+    list: listUsers,
+    payload: { email: "user@example.com", role: "client" },
+    mutate: (user) => {
+      user.email = "changed@example.com";
+    }
+  });
+
+  await assertDefensiveCreateSnapshot({
+    create: createJob,
+    list: listJobs,
+    payload: {
+      title: "Build marketplace",
+      description: "Build a marketplace workflow",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "cat_dev",
+      skills: ["api"]
+    },
+    mutate: (job) => {
+      job.title = "Changed title";
+      job.skills.push("mutated");
+    }
+  });
+
+  await assertDefensiveCreateSnapshot({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_1", freelancerId: "usr_1", amount: 100, duration: 3 },
+    mutate: (proposal) => {
+      proposal.amount = 1;
+    }
+  });
+
+  await assertDefensiveCreateSnapshot({
+    create: createReview,
+    list: listReviews,
+    payload: { reviewerId: "usr_1", revieweeId: "usr_2", rating: 5 },
+    mutate: (review) => {
+      review.rating = 1;
+    }
+  });
+
+  await assertDefensiveCreateSnapshot({
+    create: sendMessage,
+    list: listMessages,
+    payload: { senderId: "usr_1", receiverId: "usr_2", body: "Hello" },
+    mutate: (message) => {
+      message.body = "Changed";
+    }
+  });
+
+  await assertDefensiveCreateSnapshot({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_1", message: "A new update is ready" },
+    mutate: (notification) => {
+      notification.message = "Changed";
+    }
+  });
+});
+
+test("create services copy payload arrays before storing records", async () => {
+  const payload = {
+    title: "Build analytics",
+    description: "Build analytics workflow",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_data",
+    skills: ["analytics"]
+  };
+
+  const created = await createJob(payload);
+
+  payload.skills.push("mutated");
+
+  const stored = (await listJobs()).find((job) => job.id === created.id);
+  assert.deepEqual(stored.skills, ["analytics"]);
+  assert.notEqual(stored.skills, payload.skills);
+});


### PR DESCRIPTION
## Summary
- Store defensive snapshots in create services and return separate response snapshots.
- Copy array fields so later payload or response mutations do not alter stored records.
- Add focused service tests for returned-record mutation and payload-array mutation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6094.
Original limited issue: #3218.
Parent bounty: #743.
