### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messageCreationValidation.test.js
+++ b/apps/api/src/tests/messageCreationValidation.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...options.headers
+    }
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/messages rejects empty and malformed payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const before = await requestJson(`${baseUrl}/api/messages`);
+    const invalidPayloads = [
+      {},
+      { senderId: "", recipientId: "usr_2", content: "Hello" },
+      { senderId: "usr_1", recipientId: " ", content: "Hello" },
+      { senderId: "usr_1", recipientId: "usr_2", content: " " },
+      { senderId: 123, recipientId: "usr_2", content: "Hello" },
+      { senderId: "usr_1", recipientId: "usr_2", content: false }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const result = await requestJson(`${baseUrl}/api/messages`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+      });
+
+      assert.equal(result.response.status, 400);
+      assert.deepEqual(result.payload, { success: false, message: "Invalid message payload" });
+    }
+
+    const after = await requestJson(`${baseUrl}/api/messages`);
+    assert.equal(after.payload.data.length, before.payload.data.length);
+  });
+});
+
+test("POST /api/messages accepts valid message creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const result = await requestJson(`${baseUrl}/api/messages`, {
+      method: "POST",
+      body: JSON.stringify({
+        senderId: "usr_1",
+        recipientId: "usr_2",
+        content: "Hello"
+      })
+    });
+
+    assert.equal(result.response.status, 201);
+    assert.equal(result.payload.success, true);
+    assert.match(result.payload.data.id, /^msg_/);
+    assert.equal(result.payload.data.senderId, "usr_1");
+    assert.equal(result.payload.data.recipientId, "usr_2");
+    assert.equal(result.payload.data.content, "Hello");
+    assert.equal(typeof result.payload.data.sentAt, "string");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const nonblankString = z.string().refine((value) => value.trim().length > 0);
+
+export const createMessageSchema = z.object({
+  senderId: nonblankString,
+  recipientId: nonblankString,
+  content: nonblankString
+});


### PR DESCRIPTION
## Summary
- Add message creation payload validation for `senderId`, `recipientId`, and `content`.
- Return HTTP 400 for missing, blank, or non-string fields before storing a message.
- Preserve the current successful response shape for valid message creation.
- Add focused route-level regression coverage.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6096.
Original limited issue: #3214.
Parent bounty: #743.
