### PR TITLE
Validate notification message payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notificationMessageValidation.test.js
+++ b/apps/api/src/tests/notificationMessageValidation.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...options.headers
+    }
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/notifications rejects missing and blank messages", async () => {
+  await withServer(async (baseUrl) => {
+    const before = await requestJson(`${baseUrl}/api/notifications`);
+    const invalidPayloads = [
+      {},
+      { message: "" },
+      { message: "   " },
+      { message: 123 },
+      { message: false }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const result = await requestJson(`${baseUrl}/api/notifications`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+      });
+
+      assert.equal(result.response.status, 400);
+      assert.deepEqual(result.payload, { success: false, message: "Invalid notification payload" });
+    }
+
+    const after = await requestJson(`${baseUrl}/api/notifications`);
+    assert.equal(after.payload.data.length, before.payload.data.length);
+  });
+});
+
+test("POST /api/notifications accepts valid messages", async () => {
+  await withServer(async (baseUrl) => {
+    const result = await requestJson(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      body: JSON.stringify({
+        userId: "usr_1",
+        message: "A new update is ready"
+      })
+    });
+
+    assert.equal(result.response.status, 201);
+    assert.equal(result.payload.success, true);
+    assert.match(result.payload.data.id, /^ntf_/);
+    assert.equal(result.payload.data.userId, "usr_1");
+    assert.equal(result.payload.data.message, "A new update is ready");
+    assert.equal(result.payload.data.read, false);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+const nonblankString = z.string().refine((value) => value.trim().length > 0);
+
+export const createNotificationSchema = z.object({
+  message: nonblankString
+}).passthrough();


### PR DESCRIPTION
## Summary
- Add notification creation payload validation for required nonblank `message` values.
- Return HTTP 400 JSON for missing, blank, or non-string messages before storing notifications.
- Preserve the valid notification creation response shape, including passthrough fields.
- Add focused route-level regression coverage.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6100.
Original limited issue: #3159.
Parent bounty: #743.
