### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
+  const currency = typeof payload.currency === "string"
+    ? payload.currency.toLowerCase()
+    : payload.currency ?? "usd";
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentCurrencyNormalize.test.js
+++ b/apps/api/src/tests/paymentCurrencyNormalize.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes string currency codes to lowercase", async () => {
+  const intent = await createPaymentIntent({
+    amount: 100,
+    currency: "USD"
+  });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent normalizes mixed-case currency codes", async () => {
+  const intent = await createPaymentIntent({
+    amount: 100,
+    currency: "EuR"
+  });
+
+  assert.equal(intent.currency, "eur");
+});
+
+test("createPaymentIntent keeps default currency when omitted", async () => {
+  const intent = await createPaymentIntent({ amount: 100 });
+
+  assert.equal(intent.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- Normalize string currency codes to lowercase in `createPaymentIntent()` before returning payment intent responses.
- Preserve the existing default `usd` currency when callers omit currency.
- Add focused service-level regression coverage.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6108.
Original limited issue: #2954.
Parent bounty: #743.
