### PR TITLE
fix: add input validation for review creation endpoint

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

POST /api/reviews previously accepted any payload without validation, allowing invalid ratings (negative, zero, above 5), missing required fields, and empty comments.

## Changes

- Add `createReviewSchema` validator using Zod in `apps/api/src/validators/review.js`
- Rating must be an integer between 1 and 5
- `reviewerId` and `jobId` must be non-empty strings
- `comment` must be a non-empty string
- Apply `schema.parse()` in `reviewController.js` before creating the review

## Testing

Invalid payloads now return 400 with Zod validation errors:
- `{}` → missing required fields
- `{ "rating": -1 }` → rating below minimum
- `{ "rating": 6 }` → rating above maximum
- `{ "rating": 3.5 }` → rating must be integer

Closes #5997

/claim #5997