### PR TITLE
Trim payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = payload.currency?.trim() ?? "usd";
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent trims caller-provided currency codes", async () => {
+  const payment = await createPaymentIntent({
+    amount: 2500,
+    currency: " USD "
+  });
+
+  assert.equal(payment.amount, 2500);
+  assert.equal(payment.currency, "USD");
+  assert.equal(payment.provider, "stripe");
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const payment = await createPaymentIntent({ amount: 1200 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
## Description
Trims caller-provided payment currency codes before returning payment intent responses.

Closes #6104

## Changes Made
- Normalize `payload.currency` with `trim()` when present.
- Preserve the existing default currency of `usd` when omitted.
- Added focused service tests for padded currency codes and the default currency path.

## Test
- `node --test "apps/api/src/tests/*.test.js"`