### PR TITLE
Enforce upload file size limit

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,31 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const MAX_UPLOAD_FILE_SIZE_BYTES = 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_UPLOAD_FILE_SIZE_BYTES
+  }
+});
+
+function parseSingleFile(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File too large", 413);
+    }
+
+    if (error) {
+      return next(error);
+    }
+
+    return next();
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", parseSingleFile, uploadFile);

--- a/apps/api/src/tests/uploadFileSizeLimit.test.js
+++ b/apps/api/src/tests/uploadFileSizeLimit.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function uploadBody(size) {
+  const form = new FormData();
+  form.append("file", new Blob([new Uint8Array(size)]), "upload.bin");
+  return form;
+}
+
+test("POST /api/uploads accepts files within the size limit", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody(128)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "upload.bin",
+      status: "uploaded"
+    });
+  });
+});
+
+test("POST /api/uploads returns a controlled error for oversized files", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody(MAX_UPLOAD_FILE_SIZE_BYTES + 1)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, { success: false, message: "File too large" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a bounded file-size limit to the in-memory multer upload parser.
- Return a controlled JSON 413 response when a file exceeds the limit.
- Preserve successful upload behavior for files within the limit.
- Add focused route-level regression coverage.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Fixes duplicate issue #6113.
Original limited issue: #2951.
Parent bounty: #743.
