### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -17,3 +17,4 @@
     "zod": "^3.23.8"
   }
 }
+

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a responsive landing page for a SaaS product.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJobPayload);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both values are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema accepts partial budget updates with only one budget value", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,29 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchemaShape = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+export const createJobSchema = z.object(jobSchemaShape).superRefine(validateBudgetRange);
+
+export const updateJobSchema = z.object(jobSchemaShape).partial().superRefine(validateBudgetRange);
+


### PR DESCRIPTION
Fixes #2853

## Summary
- Reject `budgetMax < budgetMin` in `createJobSchema`.
- Apply the same budget range check to partial job updates when both budget fields are present.
- Keep single-field budget partial updates valid.
- Make the API test script run test files via glob on current Node.

## Validation
- `npm test -w apps/api` (5 passed)
- `git diff --check`

Payout if accepted: USDT BEP20 `0x72fc6e1eb0f37eab2c6da4a173020923b852a62a`
