### PR TITLE
fix: add admin role authorization to admin routes

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,8 @@
+﻿import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden — admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
-import { Router } from "express";
+﻿import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
/claim #6115

## Fix
Adds admin role authorization middleware to admin routes.

### Changes
- New: apps/api/src/middleware/admin.js — checks req.user.role === admin
- Modified: apps/api/src/routes/adminRoutes.js — applies adminMiddleware after authMiddleware

### Behavior
- Missing/invalid token → 401 (unchanged)
- Valid non-admin token → 403 (new)
- Valid admin token → 200 (unchanged)

### Files changed: 2
### Lines: +11 -1