### PR TITLE
fix: add file size limit to upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
/claim #6113

Added a 5MB file size limit to the multer upload configuration to prevent abuse.