### PR TITLE
fix: accept case-insensitive Bearer scheme in auth middleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,7 +3,7 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
     return fail(res, "Unauthorized", 401);
   }
 


### PR DESCRIPTION
/claim #6080

Changed Bearer check to be case-insensitive so tokens with 'bearer' or 'BEARER' are accepted.