### PR TITLE
fix: reject missing or blank notification messages

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +6,9 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const message = req.body?.message;
+  if (!message || typeof message !== "string" || !message.trim()) {
+    return fail(res, "Notification message is required and must be a non-empty string", 400);
+  }
+  return ok(res, await createNotification({ message: message.trim() }), 201);
 }


### PR DESCRIPTION
/claim #6100

Added validation in the notification controller to reject requests with missing, non-string, or blank messages.