### PR TITLE
fix: reject non-finite numbers in job budget validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().finite().nonnegative(),
+  budgetMax: z.number().finite().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
 });


### PR DESCRIPTION
/claim #6086

Added Zod .finite() check to budgetMin and budgetMax to reject NaN and Infinity values.