### PR TITLE
fix: return defensive copies from service list and create functions

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,11 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);
-  return job;
+  return { ...job };
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,11 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {
   const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return { ...message };
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,11 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {
   const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
   notifications.push(notification);
-  return notification;
+  return { ...notification };
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,11 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {
   const proposal = { id: `prp_${Date.now()}`, ...payload };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,11 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return { ...review };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,11 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  return { ...user };
 }


### PR DESCRIPTION
/claim #6091
/claim #6094

All service list functions now return shallow copies of internal arrays, and create functions return shallow copies of created objects to prevent external mutation.