### PR TITLE
fix: validate refresh token before minting new access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,25 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    return fail(res, err.message, err.status || 400);
+  }
 }
 
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    return fail(res, err.message, err.status || 400);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -22,6 +30,10 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  try {
+    const result = await refreshToken(req.body?.refreshToken);
+    return ok(res, result);
+  } catch (err) {
+    return fail(res, err.message, err.status || 400);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,52 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
+
+const users = [];
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
+  const existing = users.find(u => u.email === payload.email);
+  if (existing) {
+    throw { status: 409, message: "User already exists" };
+  }
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password,
+    role: payload.role
+  };
+  users.push(user);
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role }),
+    refreshToken: signRefreshToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const user = users.find(u => u.email === payload.email);
+  if (!user) {
+    throw { status: 401, message: "Invalid email or password" };
+  }
+  if (user.password !== payload.password) {
+    throw { status: 401, message: "Invalid email or password" };
+  }
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role }),
+    refreshToken: signRefreshToken({ sub: user.id, role: user.role })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  if (!refreshTokenValue) {
+    throw { status: 400, message: "Refresh token is required" };
+  }
+  let decoded;
+  try {
+    decoded = verifyRefreshToken(refreshTokenValue);
+  } catch {
+    throw { status: 401, message: "Invalid or expired refresh token" };
+  }
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -8,3 +8,11 @@ export function signAccessToken(payload) {
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }
+
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "7d" });
+}
+
+export function verifyRefreshToken(token) {
+  return jwt.verify(token, env.jwtSecret);
+}


### PR DESCRIPTION
/claim #6099
/claim #6135

Added signRefreshToken/verifyRefreshToken in jwt utils. Modified refresh flow to require and validate a refresh token before issuing a new access token.