### PR TITLE
fix(users): add server-owned ISO createdAt to createUser

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,15 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  // Server-owned `createdAt` so caller-supplied values cannot control the
+  // returned timestamp. Strip any incoming `createdAt` from the payload first
+  // and assign the canonical ISO string at the storage boundary.
+  const { createdAt: _ignoredCreatedAt, ...rest } = payload ?? {};
+  const user = {
+    id: `usr_${Date.now()}`,
+    createdAt: new Date().toISOString(),
+    ...rest,
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser assigns a server-owned createdAt ISO timestamp", async () => {
+  const before = Date.now();
+  const user = await createUser({ name: "alice" });
+  const after = Date.now();
+
+  assert.ok(typeof user.createdAt === "string", "createdAt should be a string");
+  const parsed = Date.parse(user.createdAt);
+  assert.ok(!Number.isNaN(parsed), "createdAt should parse as a valid date");
+  assert.ok(parsed >= before && parsed <= after, "createdAt should fall between before/after timestamps");
+  assert.equal(user.name, "alice");
+});
+
+test("createUser ignores caller-supplied createdAt values", async () => {
+  const user = await createUser({ name: "bob", createdAt: "1970-01-01T00:00:00.000Z" });
+  const parsed = Date.parse(user.createdAt);
+  assert.ok(parsed > 0, "createdAt should reflect server time, not caller-supplied epoch zero");
+  assert.notEqual(user.createdAt, "1970-01-01T00:00:00.000Z");
+});
+
+test("createUser returns the stored record via listUsers", async () => {
+  const initialLength = (await listUsers()).length;
+  const user = await createUser({ name: "carol" });
+  const stored = await listUsers();
+  assert.equal(stored.length, initialLength + 1);
+  assert.ok(stored.includes(user));
+});


### PR DESCRIPTION
Closes #6070

## Problem

`createUser()` spreads the entire payload into the stored record, so any caller-supplied `createdAt` value lands in the API response unchanged. The expected behavior is that the server owns the timestamp and that caller-supplied values cannot control the returned `createdAt`.

## Changes

- `apps/api/src/services/userService.js`: strip `createdAt` from the inbound payload and assign `new Date().toISOString()` as the server-owned timestamp on the stored record. The function signature and the rest of the record shape are unchanged.
- `apps/api/src/tests/userService.test.js`: new focused service-level regression coverage that:
  1. Asserts `createdAt` is an ISO string parseable as a valid date and falls inside the before/after window.
  2. Asserts a caller-supplied `createdAt` of `"1970-01-01T00:00:00.000Z"` does not control the returned timestamp.
  3. Asserts the record returned by `listUsers()` is the same object returned by `createUser()`.

## Verification

```
$ node --test apps/api/src/tests/health.test.js apps/api/src/tests/userService.test.js
? GET /health returns ok payload
? createUser assigns a server-owned createdAt ISO timestamp
? createUser ignores caller-supplied createdAt values
? createUser returns the stored record via listUsers
? tests 4
? pass 4
? fail 0
```

`git diff --check` is clean.

## Scope

Touches only `createUser()` and a new test file. No other services, controllers, middleware, validators, or package metadata are modified.

Bounty reference: parent route #743