### PR TITLE
Trust first reverse proxy for rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,8 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  app.set("trust proxy", 1);
+
   app.use(helmet());
   app.use(cors());
   app.use(express.json());

--- a/apps/api/src/tests/trustProxy.test.js
+++ b/apps/api/src/tests/trustProxy.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("createApp trusts the first reverse proxy", () => {
+  const app = createApp();
+
+  assert.equal(app.get("trust proxy"), 1);
+});


### PR DESCRIPTION
## Summary

Closes #6142.

Refs original author-limited issue #2681 and parent bounty #743.

Configures the Express app to trust the first reverse proxy hop so IP-aware middleware and rate limiting can evaluate the client address correctly in the intended deployment topology.

## Changes

- Sets `app.set("trust proxy", 1)` immediately after the Express app is created.
- Preserves the existing middleware and route registration order.
- Adds a focused `createApp()` regression test for the configured trust proxy setting.

## Verification

```bash
node --test apps/api/src/tests/*.test.js
git diff --check HEAD~1..HEAD
```

Parent bounty: #743
