### PR TITLE
fix(proposals): add server-owned ISO createdAt to createProposal

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,15 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  // Server-owned `createdAt` so caller-supplied values cannot control the
+  // returned timestamp. Strip any incoming `createdAt` from the payload first
+  // and assign the canonical ISO string at the storage boundary.
+  const { createdAt: _ignoredCreatedAt, ...rest } = payload ?? {};
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    createdAt: new Date().toISOString(),
+    ...rest,
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal assigns a server-owned createdAt ISO timestamp", async () => {
+  const before = Date.now();
+  const proposal = await createProposal({ jobId: "job_1", bidAmount: 100 });
+  const after = Date.now();
+
+  assert.ok(typeof proposal.createdAt === "string", "createdAt should be a string");
+  const parsed = Date.parse(proposal.createdAt);
+  assert.ok(!Number.isNaN(parsed), "createdAt should parse as a valid date");
+  assert.ok(parsed >= before && parsed <= after, "createdAt should fall between before/after timestamps");
+  assert.equal(proposal.jobId, "job_1");
+  assert.equal(proposal.bidAmount, 100);
+});
+
+test("createProposal ignores caller-supplied createdAt values", async () => {
+  const proposal = await createProposal({
+    jobId: "job_2",
+    bidAmount: 200,
+    createdAt: "1970-01-01T00:00:00.000Z",
+  });
+  const parsed = Date.parse(proposal.createdAt);
+  assert.ok(parsed > 0, "createdAt should reflect server time, not caller-supplied epoch zero");
+  assert.notEqual(proposal.createdAt, "1970-01-01T00:00:00.000Z");
+});
+
+test("createProposal returns the stored record via listProposals", async () => {
+  const initialLength = (await listProposals()).length;
+  const proposal = await createProposal({ jobId: "job_3", bidAmount: 300 });
+  const stored = await listProposals();
+  assert.equal(stored.length, initialLength + 1);
+  assert.ok(stored.includes(proposal));
+});


### PR DESCRIPTION
Closes #6078

## Summary
- `createProposal()` now stamps each record with a server-owned ISO `createdAt` so caller-supplied values cannot control the returned timestamp.
- Strip any incoming `createdAt` from the payload at the storage boundary and assign `new Date().toISOString()`.
- Add focused service-level regression coverage in `proposalService.test.js`.

## Changes
- `apps/api/src/services/proposalService.js`: destructure and ignore `payload.createdAt`, then assign the canonical ISO string alongside the existing `id` default.
- `apps/api/src/tests/proposalService.test.js`: three tests covering server-owned assignment, caller-supplied value rejection, and the list/storage round-trip.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 4/4 pass (1 existing health test + 3 new)
- `git diff --check` -> clean

## Notes
- Same shape as #6153 (createUser) and #6155 (createNotification) so the API surface stays consistent across services.