### PR TITLE
fix(#6156): trust first reverse proxy for rate limiting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,8 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  app.set("trust proxy", 1);
+
   app.use(helmet());
   app.use(cors());
   app.use(express.json());

--- a/apps/api/src/tests/trustProxy.test.js
+++ b/apps/api/src/tests/trustProxy.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(app, assertions) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createApp trusts exactly one reverse proxy hop", async () => {
+  const app = createApp();
+
+  assert.equal(app.get("trust proxy"), 1);
+
+  app.get("/__trust-proxy-test", (req, res) => {
+    res.status(200).json({ ip: req.ip });
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/__trust-proxy-test`, {
+      headers: {
+        "X-Forwarded-For": "203.0.113.9, 10.0.0.5"
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.ip, "10.0.0.5");
+  });
+});


### PR DESCRIPTION
Closes #6156

## Summary
- set `app.set("trust proxy", 1)` immediately after Express app creation
- preserve the existing middleware and route order
- add focused regression coverage for the trust proxy setting and forwarded client IP behavior
- update the API test script to run test files explicitly so the suite is executable with Node's test runner

## Validation
- `npm install --prefix /tmp/securebanana-trust-proxy-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-trust-proxy-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
