### PR TITLE
fix(payments): normalize payment intent currency codes to lowercase

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  // Normalize the currency code to lowercase ISO-4217 form so callers that
+  // send "USD" do not get back uppercase responses. Defaults to "usd" when
+  // the caller omits a currency so the existing fallback path still applies.
+  const currency = (payload.currency ?? "usd").toLowerCase();
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent lowercases an uppercase currency code", async () => {
+  const intent = await createPaymentIntent({ amount: 1000, currency: "USD" });
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.amount, 1000);
+  assert.equal(intent.provider, "stripe");
+});
+
+test("createPaymentIntent leaves an already-lowercase currency unchanged", async () => {
+  const intent = await createPaymentIntent({ amount: 500, currency: "eur" });
+  assert.equal(intent.currency, "eur");
+});
+
+test("createPaymentIntent defaults to usd when no currency is provided", async () => {
+  const intent = await createPaymentIntent({ amount: 250 });
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.amount, 250);
+});
+
+test("createPaymentIntent lowercases a mixed-case currency code", async () => {
+  const intent = await createPaymentIntent({ amount: 750, currency: "GbP" });
+  assert.equal(intent.currency, "gbp");
+});


### PR DESCRIPTION
Closes #6108

## Summary
- `createPaymentIntent()` now normalizes the returned `currency` code to lowercase ISO-4217 form so callers that pass uppercase or mixed-case values get back a consistent lowercase response.
- Default to `usd` is preserved when the caller omits a currency.
- Add focused regression coverage in `paymentService.test.js`.

## Changes
- `apps/api/src/services/paymentService.js`: compute `currency` from `payload.currency ?? "usd"` and call `.toLowerCase()` before placing it on the response object.
- `apps/api/src/tests/paymentService.test.js`: four tests covering uppercase normalization, already-lowercase passthrough, omitted-currency default, and mixed-case normalization.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 5/5 pass (1 existing health test + 4 new)
- `git diff --check` -> clean