### PR TITLE
fix(api): validate payment creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid payment request", 400, result.error.issues);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/payments accepts a valid payment payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 125,
+      currency: "usd",
+      jobId: "job-101"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});
+
+test("POST /api/payments rejects missing and non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const missingAmount = await postPayment(baseUrl, {
+      currency: "usd",
+      jobId: "job-101"
+    });
+    const missingPayload = await missingAmount.json();
+
+    assert.equal(missingAmount.status, 400);
+    assert.equal(missingPayload.success, false);
+    assert.equal(missingPayload.message, "Invalid payment request");
+    assert.ok(missingPayload.issues.some((issue) => issue.path.includes("amount")));
+
+    const negativeAmount = await postPayment(baseUrl, {
+      amount: -1,
+      currency: "usd",
+      jobId: "job-101"
+    });
+    const negativePayload = await negativeAmount.json();
+
+    assert.equal(negativeAmount.status, 400);
+    assert.equal(negativePayload.success, false);
+    assert.ok(negativePayload.issues.some((issue) => issue.path.includes("amount")));
+  });
+});
+
+test("POST /api/payments rejects caller-supplied system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 125,
+      currency: "usd",
+      jobId: "job-101",
+      paymentId: "pay_attacker",
+      provider: "manual"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.ok(payload.issues.some((issue) => issue.code === "unrecognized_keys"));
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,12 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, issues = undefined) {
+  const body = { success: false, message };
+
+  if (issues) {
+    body.issues = issues;
+  }
+
+  return res.status(status).json(body);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z
+  .object({
+    amount: z.number().positive(),
+    currency: z.string().trim().min(1),
+    jobId: z.string().trim().min(1)
+  })
+  .strict();


### PR DESCRIPTION
## Summary

- Add a strict Zod schema for payment creation payloads.
- Validate `amount`, `currency`, and `jobId` before calling the payment service.
- Reject caller-supplied system fields such as `paymentId` and `provider`.
- Add API route coverage for valid, invalid, and extra-field payment payloads.
- Make the API test script target test files explicitly so the route tests run.

Closes #5721

/claim #5721

Payout wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`

## Validation

```bash
npm test -w apps/api
git diff --check
```