### PR TITLE
fix(notifications): reject missing or blank message payloads with 400

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/tests/notificationRoute.test.js
+++ b/apps/api/src/tests/notificationRoute.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    return await callback(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications creates a notification with a valid message", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "hello");
+  });
+});
+
+test("POST /api/notifications rejects a missing message with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/notifications rejects a whitespace-only message with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "   " })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/notifications rejects a non-string message with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: 123 })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+// `message` is the only required input for creating a notification. Trim the
+// input so whitespace-only values are caught by `min(1)`.
+export const createNotificationSchema = z.object({
+  message: z.string().trim().min(1)
+});


### PR DESCRIPTION
Closes #6100

## Summary
- `POST /api/notifications` now validates the `message` field and returns 400 when the payload is missing the field, contains a non-string value, or is whitespace-only.
- Adds a dedicated Zod schema for notification creation and routes invalid payloads through the existing `fail(res, ...)` 400 helper.
- Adds route-level regression coverage for both the success and rejection paths.

## Changes
- `apps/api/src/validators/notification.js`: new `createNotificationSchema` (Zod) requiring `message` to be a non-empty string after trimming.
- `apps/api/src/controllers/notificationController.js`: switches `postNotification` to `safeParse` the body and call `fail(res, "Invalid notification payload", 400)` when the schema rejects the payload.
- `apps/api/src/tests/notificationRoute.test.js`: four HTTP tests using `createApp()` covering the valid path, missing field, whitespace-only string, and non-string value.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 5/5 pass (1 existing health test + 4 new)
- `git diff --check` -> clean