### PR TITLE
fix(reviews): add Zod validation for review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviewRoute.test.js
+++ b/apps/api/src/tests/reviewRoute.test.js
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    return await callback(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validPayload = {
+  reviewerId: "usr_1",
+  revieweeId: "usr_2",
+  rating: 4,
+  comment: "good work"
+};
+
+test("POST /api/reviews creates a review with a valid payload", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validPayload)
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 4);
+    assert.equal(payload.data.reviewerId, "usr_1");
+  });
+});
+
+test("POST /api/reviews allows an omitted comment", async () => {
+  await withServer(async (port) => {
+    const { comment, ...payload } = validPayload;
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const body = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+  });
+});
+
+test("POST /api/reviews rejects an out-of-range rating with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, rating: 6 })
+    });
+    const body = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+  });
+});
+
+test("POST /api/reviews rejects a non-integer rating with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, rating: 3.5 })
+    });
+    const body = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+  });
+});
+
+test("POST /api/reviews rejects an empty comment with 400", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...validPayload, comment: "   " })
+    });
+    const body = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+  });
+});
+
+test("POST /api/reviews rejects a missing reviewerId with 400", async () => {
+  await withServer(async (port) => {
+    const { reviewerId, ...payload } = validPayload;
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const body = await response.json();
+    assert.equal(response.status, 400);
+    assert.equal(body.success, false);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+// `rating` is an integer in [1, 5]. `comment` is optional but must not be the
+// empty string when provided, so we trim first and then apply `min(1)` to
+// catch whitespace-only inputs.
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  revieweeId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+});


### PR DESCRIPTION
Closes #6082

## Summary
- Adds a Zod-backed validator for review creation payloads so `POST /api/reviews` returns 400 for invalid input instead of forwarding it to the service.
- Requires `reviewerId`, `revieweeId`, and an integer `rating` in [1, 5]; an optional `comment` is rejected when it is empty or whitespace-only.
- Adds route-level regression coverage for valid and invalid creation paths.

## Changes
- `apps/api/src/validators/review.js`: new `createReviewSchema` (Zod) covering the required fields, the rating range, and the optional comment rules.
- `apps/api/src/controllers/reviewController.js`: switches `postReview` to `safeParse` the body and call `fail(res, "Invalid review payload", 400)` when validation fails.
- `apps/api/src/tests/reviewRoute.test.js`: six HTTP tests using `createApp()` covering the happy path, omitted comment, out-of-range rating, non-integer rating, whitespace-only comment, and missing reviewerId.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 7/7 pass (1 existing health test + 6 new)
- `git diff --check` -> clean