### PR TITLE
fix(auth): accept case-insensitive Bearer scheme in auth middleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,14 +1,20 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+// Match the Bearer scheme case-insensitively. RFC 6750 only mandates that the
+// scheme name be matched case-insensitively by servers, so clients sending
+// "bearer", "BEARER", or "Bearer" should all be accepted.
+const BEARER_PATTERN = /^Bearer\s+/i;
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !BEARER_PATTERN.test(authHeader)) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const token = authHeader.replace(BEARER_PATTERN, "");
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("authMiddleware accepts a lowercase bearer scheme", () => {
+  const token = signAccessToken({ sub: "usr_1" });
+  const req = { headers: { authorization: `bearer ${token}` } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, "usr_1");
+});
+
+test("authMiddleware accepts an uppercase BEARER scheme", () => {
+  const token = signAccessToken({ sub: "usr_2" });
+  const req = { headers: { authorization: `BEARER ${token}` } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, "usr_2");
+});
+
+test("authMiddleware accepts a mixed-case BeArEr scheme", () => {
+  const token = signAccessToken({ sub: "usr_3" });
+  const req = { headers: { authorization: `BeArEr ${token}` } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+  assert.equal(req.user.sub, "usr_3");
+});
+
+test("authMiddleware rejects a missing Authorization header", () => {
+  const req = { headers: {} };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.success, false);
+});
+
+test("authMiddleware rejects a non-Bearer scheme", () => {
+  const req = { headers: { authorization: "Basic dXNlcjpwYXNz" } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+});
+
+test("authMiddleware rejects a malformed bearer with no token", () => {
+  const req = { headers: { authorization: "Bearer" } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+});
+
+test("authMiddleware rejects an invalid token", () => {
+  const req = { headers: { authorization: "Bearer not-a-jwt" } };
+  const res = makeRes();
+  let nextCalled = false;
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.message, "Invalid token");
+});


### PR DESCRIPTION
Closes #6080

## Summary
- `authMiddleware` now matches the `Authorization: Bearer ...` scheme case-insensitively, in line with RFC 6750.
- Missing, blank, non-Bearer, and malformed-token credentials continue to be rejected with 401.
- Adds focused middleware regression coverage that exercises lowercase, uppercase, and mixed-case schemes along with the rejection paths.

## Changes
- `apps/api/src/middleware/auth.js`: replace the `startsWith("Bearer ")` check with a `/^Bearer\s+/i` regex; the same regex is used to strip the scheme from the header before token verification.
- `apps/api/src/tests/authMiddleware.test.js`: seven unit tests covering lowercase, uppercase, and mixed-case accepted schemes, plus missing header, non-Bearer scheme, malformed `Bearer` with no token, and an invalid token rejection path.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 8/8 pass (1 existing health test + 7 new)
- `git diff --check` -> clean