### PR TITLE
fix(#6164): require auth for uploads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function writeTempFile() {
+  const filePath = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "securebanana-upload-")), "sample.txt");
+  await fs.writeFile(filePath, "hello world");
+  return filePath;
+}
+
+test("POST /api/uploads rejects unauthenticated callers before multer runs", async () => {
+  await withServer(async (baseUrl) => {
+    const filePath = await writeTempFile();
+    const form = new FormData();
+    form.set("file", new Blob([await fs.readFile(filePath)]), "sample.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/uploads keeps the existing response for authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const filePath = await writeTempFile();
+    const form = new FormData();
+    form.set("file", new Blob([await fs.readFile(filePath)]), "sample.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${signAccessToken({ sub: "usr_test", role: "client" })}`
+      },
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.status, "uploaded");
+    assert.equal(payload.data.filename, "sample.txt");
+  });
+});


### PR DESCRIPTION
Closes #6164

## Summary
- require Bearer authentication before uploads reach `multer`
- preserve the existing upload response for authenticated callers
- add focused tests for unauthenticated rejection and authenticated success
- update the API test script so the Node test runner executes explicit test files

## Validation
- `npm install --prefix /tmp/securebanana-upload-auth-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-upload-auth-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
