### PR TITLE
fix(payments): trim whitespace from payment intent currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  // Trim the currency code so callers that send " USD " do not get back a
+  // padded response. The default "usd" fallback applies when the caller
+  // omits a currency so existing behavior is preserved.
+  const currency = (payload.currency ?? "usd").trim();
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentServiceTrim.test.js
+++ b/apps/api/src/tests/paymentServiceTrim.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent trims surrounding whitespace from a currency code", async () => {
+  const intent = await createPaymentIntent({ amount: 1000, currency: " USD " });
+  assert.equal(intent.currency, "USD");
+  assert.equal(intent.amount, 1000);
+  assert.equal(intent.provider, "stripe");
+});
+
+test("createPaymentIntent trims leading whitespace from a currency code", async () => {
+  const intent = await createPaymentIntent({ amount: 500, currency: "  eur" });
+  assert.equal(intent.currency, "eur");
+});
+
+test("createPaymentIntent trims trailing whitespace from a currency code", async () => {
+  const intent = await createPaymentIntent({ amount: 750, currency: "gbp\t" });
+  assert.equal(intent.currency, "gbp");
+});
+
+test("createPaymentIntent defaults to usd when no currency is provided", async () => {
+  const intent = await createPaymentIntent({ amount: 250 });
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.amount, 250);
+});


### PR DESCRIPTION
Closes #6104

## Summary
- `createPaymentIntent()` now trims surrounding whitespace from the returned `currency` code so callers that pass `" USD "` get back the cleaned value.
- Default to `usd` is preserved when the caller omits a currency.
- Adds focused service-level regression coverage for the trim behavior.

## Changes
- `apps/api/src/services/paymentService.js`: compute `currency` from `payload.currency ?? "usd"` and call `.trim()` before placing it on the response object.
- `apps/api/src/tests/paymentServiceTrim.test.js`: four tests covering surrounding whitespace, leading whitespace, trailing whitespace, and the omitted-currency default.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 5/5 pass (1 existing health test + 4 new)
- `git diff --check` -> clean

## Notes
- This fix is intentionally focused on the trim behavior only. Lowercase normalization is tracked in #6160 and is not combined here so each issue can be closed independently.