### PR TITLE
fix(uploads): enforce 5 MiB file size limit on upload route

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,30 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+// Bound the in-memory upload so a single oversized file cannot exhaust the
+// process. 5 MiB is generous for typical avatar / portfolio uploads while
+// still preventing accidental multi-gigabyte buffering.
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE }
+});
+
+// Translate multer errors (notably LIMIT_FILE_SIZE) into controlled HTTP
+// responses. Any non-multer error is forwarded to the global error handler.
+function handleUploadErrors(err, req, res, next) {
+  if (err instanceof multer.MulterError) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File too large", 413);
+    }
+    return fail(res, "Upload failed", 400);
+  }
+  return next(err);
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), handleUploadErrors, uploadFile);

--- a/apps/api/src/tests/uploadRoute.test.js
+++ b/apps/api/src/tests/uploadRoute.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    return await callback(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads accepts a small file", async () => {
+  await withServer(async (port) => {
+    const form = new FormData();
+    form.set("file", new Blob([new Uint8Array(1024)], { type: "text/plain" }), "small.txt");
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.status, "uploaded");
+  });
+});
+
+test("POST /api/uploads rejects an oversize file with 413", async () => {
+  await withServer(async (port) => {
+    // 6 MiB exceeds the 5 MiB cap configured on the multer middleware.
+    const big = new Uint8Array(6 * 1024 * 1024);
+    const form = new FormData();
+    form.set("file", new Blob([big], { type: "application/octet-stream" }), "big.bin");
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File too large");
+  });
+});


### PR DESCRIPTION
Closes #6113

## Summary
- `POST /api/uploads` now enforces a 5 MiB file size limit on the in-memory multer storage so a single oversized file cannot exhaust the process before the controller responds.
- Adds a focused multer error handler that translates `LIMIT_FILE_SIZE` into a controlled 413 `File too large` response and forwards non-multer errors to the global error handler.
- Adds route-level regression coverage for both the accepted and rejected paths.

## Changes
- `apps/api/src/routes/uploadRoutes.js`: set `limits: { fileSize: 5 * 1024 * 1024 }` on the multer instance and add a `handleUploadErrors` middleware that returns 413 for `LIMIT_FILE_SIZE` and 400 for other multer errors.
- `apps/api/src/tests/uploadRoute.test.js`: two HTTP tests using `createApp()` that submit a 1 KiB file (accepted, 201) and a 6 MiB file (rejected, 413).

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 3/3 pass (1 existing health test + 2 new)
- `git diff --check` -> clean