### PR TITLE
fix(#6169): restrict admin metrics to admins

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,18 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
+function adminOnly(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}
+
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminOnly);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuth.test.js
+++ b/apps/api/src/tests/adminAuth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeader(role) {
+  return {
+    Authorization: `Bearer ${signAccessToken({ sub: `usr_${role}`, role })}`
+  };
+}
+
+test("GET /api/admin/metrics rejects missing and non-admin tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missingResponse = await fetch(`${baseUrl}/api/admin/metrics`);
+    const missingPayload = await missingResponse.json();
+
+    assert.equal(missingResponse.status, 401);
+    assert.equal(missingPayload.success, false);
+    assert.equal(missingPayload.message, "Unauthorized");
+
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: authHeader("client")
+    });
+    const clientPayload = await clientResponse.json();
+
+    assert.equal(clientResponse.status, 403);
+    assert.equal(clientPayload.success, false);
+    assert.equal(clientPayload.message, "Forbidden");
+  });
+});
+
+test("GET /api/admin/metrics allows admin tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: authHeader("admin")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+    assert.equal(payload.data.activeFreelancers, 185);
+  });
+});


### PR DESCRIPTION
Closes #6169

## Summary
- add admin-only authorization for `/api/admin/metrics`
- keep missing and invalid tokens returning 401 through the existing auth middleware
- reject authenticated non-admins with 403 before the metrics handler runs
- add focused tests for missing token, client token, and admin token behavior
- update the API test script so the Node test runner executes explicit test files

## Validation
- `npm install --prefix /tmp/securebanana-admin-metrics-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-admin-metrics-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
