### PR TITLE
fix(admin): require admin role for /api/admin/metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,14 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+// Restrict a route to authenticated users whose verified JWT carries the
+// `admin` role. Must be mounted after `authMiddleware` so `req.user` is
+// populated. Non-admin tokens receive 403; missing/invalid tokens are
+// rejected earlier by `authMiddleware` with 401.
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoute.test.js
+++ b/apps/api/src/tests/adminRoute.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    return await callback(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics returns 401 with no token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/admin/metrics returns 401 with an invalid token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: "Bearer not-a-jwt" }
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/admin/metrics returns 403 for a non-admin token", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Forbidden");
+  });
+});
+
+test("GET /api/admin/metrics returns 403 for an admin token missing the role claim", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_2" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("GET /api/admin/metrics returns 200 for an admin token", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.openJobs, "number");
+  });
+});


### PR DESCRIPTION
Closes #6115

## Summary
- `/api/admin/metrics` now requires the verified JWT to carry `role: "admin"`; non-admin authenticated callers receive 403 while missing or invalid tokens continue to receive 401.
- Adds a small `requireAdmin` middleware that is mounted on the admin router after `authMiddleware` so existing token verification is unchanged.
- Adds route-level regression coverage for missing, invalid, non-admin, role-less, and admin tokens.

## Changes
- `apps/api/src/middleware/auth.js`: new `requireAdmin` middleware that returns 403 `Forbidden` when `req.user.role` is not `"admin"`.
- `apps/api/src/routes/adminRoutes.js`: import `requireAdmin` and mount it on the admin router after `authMiddleware` so every admin route is gated by role.
- `apps/api/src/tests/adminRoute.test.js`: five HTTP tests using `createApp()` that exercise the 401 (no token), 401 (invalid token), 403 (non-admin role), 403 (missing role claim), and 200 (admin role) paths.

## Verification
- `node --test apps/api/src/tests/*.test.js` -> 6/6 pass (1 existing health test + 5 new)
- `git diff --check` -> clean