### PR TITLE
fix(#6172): prevent admin self-registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,9 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration request", 400);
+  }
+
+  const payload = parsed.data;
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }

--- a/apps/api/src/tests/registerRole.test.js
+++ b/apps/api/src/tests/registerRole.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function register(baseUrl, role) {
+  return fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      email: `test-${role}@example.com`,
+      password: "supersecret",
+      role
+    })
+  });
+}
+
+test("POST /api/auth/register rejects admin self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await register(baseUrl, "admin");
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.ok(payload.message.includes("Invalid"));
+  });
+});
+
+test("POST /api/auth/register accepts public roles", async () => {
+  await withServer(async (baseUrl) => {
+    const clientResponse = await register(baseUrl, "client");
+    const clientPayload = await clientResponse.json();
+    assert.equal(clientResponse.status, 201);
+    assert.equal(clientPayload.success, true);
+    assert.equal(clientPayload.data.role, "client");
+
+    const freelancerResponse = await register(baseUrl, "freelancer");
+    const freelancerPayload = await freelancerResponse.json();
+    assert.equal(freelancerResponse.status, 201);
+    assert.equal(freelancerPayload.success, true);
+    assert.equal(freelancerPayload.data.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #6172

## Summary
- remove `admin` from public registration roles
- return a focused 400 response for invalid registration payloads before token issuance
- preserve successful registration for `client` and `freelancer`
- add focused tests for rejected admin self-assignment and accepted public roles
- update the API test script so the Node test runner executes explicit test files

## Validation
- `npm install --prefix /tmp/securebanana-admin-register-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-admin-register-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
