### PR TITLE
fix(#6174): require auth for payment creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function paymentPayload() {
+  return {
+    amount: 125,
+    currency: "usd",
+    jobId: "job-101"
+  };
+}
+
+async function postPayment(baseUrl, options = {}) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers ?? {})
+    },
+    body: JSON.stringify(paymentPayload())
+  });
+}
+
+test("POST /api/payments rejects unauthenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/payments keeps existing response for authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${signAccessToken({ sub: "usr_test", role: "client" })}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});


### PR DESCRIPTION
Closes #6174

## Summary
- require Bearer authentication before `POST /api/payments` reaches the payment controller
- preserve the existing payment intent response for authenticated callers
- add focused tests for unauthenticated rejection and authenticated success
- update the API test script so the Node test runner executes explicit test files

## Validation
- `npm install --prefix /tmp/securebanana-payment-auth-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-payment-auth-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
