### PR TITLE
fix(api): validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid user request", 400, parsed.error.issues);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,11 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = {
+    id: `usr_${Date.now()}`,
+    email: payload.email,
+    name: payload.name
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUser(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/users`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/users accepts valid user creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      email: "alice@example.com",
+      name: "Alice"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "alice@example.com");
+    assert.equal(payload.data.name, "Alice");
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(payload.data.role, undefined);
+  });
+});
+
+test("POST /api/users rejects missing and invalid required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const missingName = await postUser(baseUrl, {
+      email: "alice@example.com"
+    });
+    const missingPayload = await missingName.json();
+
+    assert.equal(missingName.status, 400);
+    assert.equal(missingPayload.success, false);
+    assert.equal(missingPayload.message, "Invalid user request");
+    assert.ok(missingPayload.issues.some((issue) => issue.path.includes("name")));
+
+    const badEmail = await postUser(baseUrl, {
+      email: "not-an-email",
+      name: "Alice"
+    });
+    const badPayload = await badEmail.json();
+
+    assert.equal(badEmail.status, 400);
+    assert.equal(badPayload.success, false);
+    assert.ok(badPayload.issues.some((issue) => issue.path.includes("email")));
+  });
+});
+
+test("POST /api/users ignores caller-supplied system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUser(baseUrl, {
+      email: "alice@example.com",
+      name: "Alice",
+      id: "usr_attacker",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "alice@example.com");
+    assert.equal(payload.data.name, "Alice");
+    assert.match(payload.data.id, /^usr_/);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.role, undefined);
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,10 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, issues) {
+  const payload = { success: false, message };
+  if (issues) {
+    payload.issues = issues;
+  }
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createUserSchema = z
+  .object({
+    email: z.string().email(),
+    name: z.string().min(1)
+  })
+  .strip();


### PR DESCRIPTION
/claim #5709

Fixes #5709

Summary:
- validate `POST /api/users` with Zod
- reject malformed payloads with 400 and structured issues
- ignore caller-supplied system fields by allowlisting `email` and `name`
- keep `id` server-generated in the service layer

Validation:
- `npm test -w apps/api`
- `git diff --check`

Payout wallet (Polygon): `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`