### PR TITLE
fix: add input validation and length limit to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,32 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q;
+
+  // Reject repeated q parameters (e.g. ?q=a&q=b)
+  if (Array.isArray(raw)) {
+    return fail(res, "Search query must be a single value", 400);
+  }
+
+  // Ensure the query is a string
+  if (typeof raw !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const query = raw.trim();
+
+  // Reject empty queries
+  if (query.length === 0) {
+    return fail(res, "Search query cannot be empty", 400);
+  }
+
+  // Enforce length limit
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Search query must not exceed ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }


### PR DESCRIPTION
## Summary
Fixes #2833

## Changes
- Added input validation to reject non-string and repeated `q` parameters
- Added 200-character length limit on search queries
- Queries are trimmed before processing
- Empty queries are rejected with a clear error message

Closes #2833