### PR TITLE
Link navigation to existing core pages

### DIFF
--- a/apps/web/components/Navigation.test.js
+++ b/apps/web/components/Navigation.test.js
@@ -1,0 +1,13 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+test("navigation links to implemented core pages", () => {
+  const source = readFileSync(join(__dirname, "Navigation.tsx"), "utf8");
+  const requiredHrefs = ["/jobs/post", "/billing", "/notifications", "/settings"];
+
+  for (const href of requiredHrefs) {
+    assert.ok(source.includes("[\"" + href + "\""), href);
+  }
+});

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
Fixes #6189

Refs original author-limited issue #2957 and parent bounty #743.

Changes:
- Adds global navigation links to existing core pages: post job, notifications, billing, and settings.
- Preserves existing navigation links and app shell structure.
- Adds a focused static regression test for the required hrefs.

Verification:
- node --test apps/web/components/Navigation.test.js
- npm run build -w apps/web
- git diff --check
