### PR TITLE
Gate admin navigation link by role

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,16 +1,25 @@
 import Link from "next/link";
 
-const links = [
+type NavigationProps = {
+  currentUserRole?: string;
+};
+
+type NavigationLink = readonly [href: string, label: string];
+
+const publicLinks: NavigationLink[] = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
-export function Navigation() {
+const adminLink: NavigationLink = ["/admin", "Admin"];
+
+export function Navigation({ currentUserRole }: NavigationProps) {
+  const links = currentUserRole === "admin" ? [...publicLinks, adminLink] : publicLinks;
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
       {links.map(([href, label]) => (

--- a/apps/web/components/NavigationAdminLink.test.js
+++ b/apps/web/components/NavigationAdminLink.test.js
@@ -1,0 +1,29 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const componentPath = join(__dirname, "Navigation.tsx");
+const layoutPath = join(__dirname, "../app/layout.tsx");
+
+test("default navigation does not expose the admin link", () => {
+  const source = readFileSync(componentPath, "utf8");
+  const publicLinksStart = source.indexOf("const publicLinks");
+  const adminLinkStart = source.indexOf("const adminLink");
+
+  assert.notEqual(publicLinksStart, -1);
+  assert.notEqual(adminLinkStart, -1);
+
+  const publicLinksBlock = source.slice(publicLinksStart, adminLinkStart);
+
+  assert.ok(!publicLinksBlock.includes('"/admin"'));
+  assert.ok(source.includes('const adminLink: NavigationLink = ["/admin", "Admin"];'));
+  assert.ok(source.includes('currentUserRole === "admin"'));
+});
+
+test("root layout renders visitor navigation without admin role", () => {
+  const source = readFileSync(layoutPath, "utf8");
+
+  assert.ok(source.includes("<Navigation />"));
+  assert.ok(!source.includes("currentUserRole="));
+});


### PR DESCRIPTION
Parent bounty: #743

Fixes duplicate issue #6191.
Duplicate of author-limited issue #2685.

Changes:
- Splits default public navigation links from the admin-only link.
- Adds an optional typed `currentUserRole` prop and renders `/admin` only for `currentUserRole === "admin"`.
- Leaves the root layout default `<Navigation />` path as a visitor render, so public navigation does not expose `/admin` by default.

Verification:
- `/mnt/TBT_DATA/nipun/work/tasks/earn-100-legal/workspace/toolchains/node/node-v24.16.0-linux-x64/bin/node --test apps/web/components/NavigationAdminLink.test.js`
- `PATH=/mnt/TBT_DATA/nipun/work/tasks/earn-100-legal/workspace/toolchains/node/node-v24.16.0-linux-x64/bin:$PATH npm run build -w apps/web`
- `git diff --check`
