### PR TITLE
Prevent privilege escalation during user registration

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/register prevents registering as admin", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "hacker@test.com",
+      password: "password123",
+      role: "admin"
+    })
+  });
+  
+  assert.equal(response.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
# SecureBananaLabs bounty submission: Privilege Escalation

## Candidate issue

Title:

```text
Critical: Public registration allows user privilege escalation to admin
```

Body:

```text
Parent Algora bounty: #743

## Bug
The public registration endpoint (`POST /api/auth/register`) strictly parses requests using zod (`apps/api/src/validators/auth.js`), but mistakenly includes `"admin"` as a valid default role. A malicious user can supply `{"role": "admin"}` in their signup payload, which successfully parses and passes directly to token generation via `payload.role`, granting them immediate unrestricted admin access.

## Reproduction
1. Send `POST /api/auth/register` with `{"email": "hacker@domain.com", "password": "password123", "role": "admin"}`.
2. The endpoint responds with a successful registration payload and returns a token.
3. Decode the JWT token: it will include `role: "admin"`, granting administrative privileges.

## Expected behavior
The user registration process should only permit standard user roles (e.g., `client` or `freelancer`). Supplying the `"admin"` role should be rejected.

## Scope
Remove `"admin"` from the valid list of enums in `registerSchema` inside `apps/api/src/validators/auth.js`. Provide focused regression coverage for validation blocking an invalid admin scope.

/attempt #743
```

## PR

Branch:

```text
fix-register-privilege-escalation
```

Commit:

```text
755edb3 Prevent privilege escalation during user registration
```

Title:

```text
Prevent privilege escalation during user registration
```

Body:

```text
## Summary
- removes `"admin"` from valid zod `registerSchema` role enumeration
- blocks malicious users from registering new administrative accounts
- adds regression test for unprivileged account creation validation

Fixes #<issue-number>
Parent bounty: #743

## Testing
- node --test src\tests\auth.test.js
```

## Verification

```text
node --test src\tests\auth.test.js
1 test passed
```
