### PR TITLE
fix(web): link navigation to core pages

### DIFF
--- a/apps/web/components/Navigation.test.js
+++ b/apps/web/components/Navigation.test.js
@@ -1,0 +1,12 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+
+const source = readFileSync(join(__dirname, "Navigation.tsx"), "utf8");
+
+test("global navigation links to implemented core pages", () => {
+  for (const href of ["/jobs/post", "/notifications", "/billing", "/settings"]) {
+    assert.match(source, new RegExp(`\\["${href}",`));
+  }
+});

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
Closes #6194

/claim #6194

Refs #2957 and parent bounty #743.

## Summary
- add navigation links to existing core pages: post job, notifications, billing, and settings
- preserve the existing global navigation structure and styling
- add static regression coverage for the required hrefs

## Tests
- `node --test apps/web/components/Navigation.test.js`
- `npm run build -w apps/web`

Payout: Base USDC `0x42430d6ade79041f569dc5e28153052ccef82ea6`