### PR TITLE
fix(#6198): require auth for notification creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function notificationPayload() {
+  return {
+    message: "Proposal accepted",
+    type: "proposal"
+  };
+}
+
+async function postNotification(baseUrl, options = {}) {
+  return fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers ?? {})
+    },
+    body: JSON.stringify(notificationPayload())
+  });
+}
+
+test("POST /api/notifications rejects unauthenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/notifications keeps existing response for authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${signAccessToken({ sub: "usr_test", role: "client" })}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "Proposal accepted");
+    assert.equal(payload.data.type, "proposal");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
Closes #6198

## Summary
- require Bearer authentication before `POST /api/notifications` reaches the notification controller
- preserve the existing notification creation response for authenticated callers
- add focused tests for unauthenticated rejection and authenticated success
- update the API test script so the Node test runner executes explicit test files

## Validation
- `npm install --prefix /tmp/securebanana-notification-auth-test --ignore-scripts`
- `npm test --prefix /tmp/securebanana-notification-auth-test -w apps/api --foreground-scripts`
- `node -e "JSON.parse(require('fs').readFileSync('apps/api/package.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `git diff --check`

## Payout
USDT wallet: `0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8`
