### PR TITLE
Fix API test file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Description
Updates the API workspace test script so Node targets concrete test files instead of treating the tests directory as a module entrypoint.

Closes #6066

## Changes Made
- Changed `apps/api` test script from `node --test src/tests` to `node --test "src/tests/*.test.js"`.
- Verified `npm test -w apps/api` now discovers and runs the API test suite successfully.

## Test
- `npm test -w apps/api`