### PR TITLE
fix(api): validate message creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid message request",
+      issues: parsed.error.issues
+    });
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", asyncHandler(getMessages));
+messageRoutes.post("/", asyncHandler(postMessage));

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    id: `msg_${Date.now()}`,
+    content: payload.content,
+    recipientId: payload.recipientId,
+    jobId: payload.jobId,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages returns 201 for valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        content: "Hello",
+        recipientId: "usr_2",
+        jobId: "job_101"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.content, "Hello");
+    assert.equal(payload.data.recipientId, "usr_2");
+    assert.equal(payload.data.jobId, "job_101");
+    assert.equal(payload.data.sentAt.length > 0, true);
+  });
+});
+
+test("POST /api/messages returns 400 for invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        content: "",
+        recipientId: "",
+        jobId: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid message request");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("content")));
+  });
+});
+
+test("POST /api/messages ignores caller supplied system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        id: "msg_bad",
+        sentAt: "2000-01-01T00:00:00.000Z",
+        content: "Ping",
+        recipientId: "usr_4",
+        jobId: "job_102"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.notEqual(payload.data.id, "msg_bad");
+    assert.notEqual(payload.data.sentAt, "2000-01-01T00:00:00.000Z");
+    assert.equal(payload.data.content, "Ping");
+  });
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return function handledRequest(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().min(1),
+  recipientId: z.string().min(1),
+  jobId: z.string().min(1)
+}).strip();


### PR DESCRIPTION
/claim #5714

## Summary
- validate `POST /api/messages` with Zod before calling the service
- reject malformed message payloads with HTTP 400 and structured issues
- construct messages from allowlisted client fields so `id` and `sentAt` remain server-owned

## Validation
- `npm test -w apps/api`
- `git diff --check`

Payout wallet: 0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8