### PR TITLE
fix(api): count malformed json before parsing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
+import { jsonErrorHandler } from "./middleware/jsonErrorHandler.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -15,13 +16,14 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp({ limiter = apiLimiter } = {}) {
   const app = express();
 
   app.use(helmet());
   app.use(cors());
+  app.use(limiter);
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(jsonErrorHandler);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/jsonErrorHandler.js
+++ b/apps/api/src/middleware/jsonErrorHandler.js
@@ -1,0 +1,10 @@
+export function jsonErrorHandler(err, req, res, next) {
+  if (err instanceof SyntaxError && "body" in err) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid JSON payload"
+    });
+  }
+
+  return next(err);
+}

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,13 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export function createApiLimiter(options = {}) {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    ...options
+  });
+}
+
+export const apiLimiter = createApiLimiter();

--- a/apps/api/src/tests/rate-limit.test.js
+++ b/apps/api/src/tests/rate-limit.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createApiLimiter } from "../middleware/rateLimit.js";
+
+async function withServer(assertions, appFactory = createApp) {
+  const app = appFactory();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON consumes rate limit budget before parsing", async () => {
+  const limiter = createApiLimiter({ limit: 1 });
+
+  await withServer(async (baseUrl) => {
+    const malformedResponse = await fetch(`${baseUrl}/health`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: "{"
+    });
+
+    assert.equal(malformedResponse.status, 400);
+    assert.equal((await malformedResponse.json()).message, "Invalid JSON payload");
+
+    const firstGood = await fetch(`${baseUrl}/health`);
+    assert.equal(firstGood.status, 429);
+  }, () => createApp({ limiter }));
+});


### PR DESCRIPTION
/claim #1735

## Summary
- run the API rate limiter before JSON body parsing so malformed JSON requests consume quota
- return a focused HTTP 400 response for malformed JSON payloads
- add a regression test using a low-limit injected limiter to prove malformed JSON counts before parsing

## Validation
- `npm test -w apps/api`
- `git diff --check`

Payout wallet: 0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8