### PR TITLE
fix(api): validate proposal creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid proposal request",
+      issues: parsed.error.issues
+    });
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", asyncHandler(getProposals));
+proposalRoutes.post("/", asyncHandler(postProposal));

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,13 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    jobId: payload.jobId,
+    freelancerId: payload.freelancerId,
+    coverLetter: payload.coverLetter,
+    estimatedDuration: payload.estimatedDuration
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals returns 201 for valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        jobId: "job-101",
+        freelancerId: "usr_2",
+        coverLetter: "I can do this work.",
+        estimatedDuration: "3 days"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, "job-101");
+    assert.equal(payload.data.freelancerId, "usr_2");
+    assert.equal(payload.data.coverLetter, "I can do this work.");
+    assert.equal(payload.data.estimatedDuration, "3 days");
+  });
+});
+
+test("POST /api/proposals returns 400 for invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        jobId: "",
+        freelancerId: "",
+        coverLetter: "",
+        estimatedDuration: ""
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid proposal request");
+    assert.ok(Array.isArray(payload.issues));
+    assert.ok(payload.issues.some((issue) => issue.path.includes("jobId")));
+  });
+});
+
+test("POST /api/proposals ignores caller supplied system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        id: "prp_bad",
+        jobId: "job-102",
+        freelancerId: "usr_4",
+        coverLetter: "Ready to help.",
+        estimatedDuration: "1 week"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.notEqual(payload.data.id, "prp_bad");
+    assert.equal(payload.data.jobId, "job-102");
+    assert.equal(payload.data.freelancerId, "usr_4");
+  });
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(fn) {
+  return function handledRequest(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(1),
+  estimatedDuration: z.string().min(1)
+}).strip();


### PR DESCRIPTION
/claim #1739

## Summary
- validate `POST /api/proposals` with Zod before the service runs
- return HTTP 400 with structured issues for malformed proposal payloads
- construct proposals from allowlisted fields so caller-supplied `id` is ignored

## Validation
- `npm test -w apps/api`
- `git diff --check`

Payout wallet: 0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8