### PR TITLE
fix(api): require jwt secret outside dev

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+function resolveJwtSecret() {
+  if (process.env.JWT_SECRET) {
+    return process.env.JWT_SECRET;
+  }
+
+  if ((process.env.NODE_ENV ?? "development") !== "development") {
+    throw new Error("JWT_SECRET is required outside development");
+  }
+
+  return "development-secret";
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/envJwtSecret.test.js
+++ b/apps/api/src/tests/envJwtSecret.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalJwtSecret = process.env.JWT_SECRET;
+
+async function loadEnv(overrides) {
+  if ("NODE_ENV" in overrides) {
+    if (overrides.NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = overrides.NODE_ENV;
+    }
+  }
+
+  if ("JWT_SECRET" in overrides) {
+    if (overrides.JWT_SECRET === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = overrides.JWT_SECRET;
+    }
+  }
+
+  return import(`../config/env.js?case=${crypto.randomUUID()}`);
+}
+
+function restoreEnv() {
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  if (originalJwtSecret === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = originalJwtSecret;
+  }
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test("development uses fallback JWT secret when JWT_SECRET is missing", async () => {
+  const { env } = await loadEnv({
+    NODE_ENV: "development",
+    JWT_SECRET: undefined
+  });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("production requires JWT_SECRET", async () => {
+  await assert.rejects(
+    () => loadEnv({
+      NODE_ENV: "production",
+      JWT_SECRET: undefined
+    }),
+    /JWT_SECRET is required outside development/
+  );
+});
+
+test("production accepts explicit JWT_SECRET", async () => {
+  const { env } = await loadEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "safe-secret"
+  });
+
+  assert.equal(env.jwtSecret, "safe-secret");
+});


### PR DESCRIPTION
Closes #6224.
Refs #743.

Summary:
- keep `development-secret` fallback only for development
- fail fast outside development when `JWT_SECRET` is missing
- preserve startup when production provides an explicit `JWT_SECRET`
- add focused env regression coverage

Verification:
```text
node.exe --test apps/api/src/tests/envJwtSecret.test.js apps/api/src/tests/health.test.js
```

Result: 4 tests passed.