### PR TITLE
Require authentication on message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/message-routes-auth.test.js
+++ b/apps/api/src/tests/message-routes-auth.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/messages allows authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_messages", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: []
+    });
+  });
+});
+
+test("POST /api/messages rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ text: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/messages allows authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_messages", role: "freelancer" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ text: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.text, "hello");
+    assert.equal(typeof payload.data.id, "string");
+    assert.equal(typeof payload.data.sentAt, "string");
+  });
+});


### PR DESCRIPTION
## Summary
- requires authentication before GET /api/messages and POST /api/messages reach handlers
- adds route-level regression coverage for unauthenticated and authenticated message requests
- replaces #6123 with a branch rebased onto current main and avoids unrelated leaderboard changes

## Verification
- 
ode --test apps/api/src/tests/*.test.js (5 passing)
- git diff --check (only Windows LF-to-CRLF warning)
- 
pm test currently fails because the existing package script runs 
ode --test src/tests, which Node 25 resolves as a module path on this Windows environment

/claim #743

Payout address if accepted: 0x30cE495ea6fE4C7d8Ad7D8c576EcAE8e4f900A92 (USDC on Base or any EVM-compatible network).