### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = payload.currency?.toLowerCase() ?? "usd";
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes provided currency codes", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500,
+    currency: "USD"
+  });
+
+  assert.equal(paymentIntent.currency, "usd");
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500
+  });
+
+  assert.equal(paymentIntent.currency, "usd");
+});


### PR DESCRIPTION
Closes #6108

/claim #743

## Summary
- normalize caller-provided payment currency codes to lowercase before returning the mock payment intent
- preserve the existing `usd` default when no currency is provided
- add focused service-level regression coverage for uppercase input and default currency behavior

## Validation
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/paymentService.test.js`