### PR TITLE
Reject whitespace-only auth passwords

### DIFF
--- a/apps/api/src/tests/authValidators.test.js
+++ b/apps/api/src/tests/authValidators.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects whitespace-only passwords", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "user@example.com",
+      password: "        "
+    });
+  });
+});
+
+test("loginSchema rejects whitespace-only passwords", () => {
+  assert.throws(() => {
+    loginSchema.parse({
+      email: "user@example.com",
+      password: "        "
+    });
+  });
+});
+
+test("auth schemas still accept non-whitespace passwords of sufficient length", () => {
+  assert.equal(
+    registerSchema.parse({
+      email: "user@example.com",
+      password: "correct horse"
+    }).password,
+    "correct horse"
+  );
+
+  assert.equal(
+    loginSchema.parse({
+      email: "user@example.com",
+      password: "correct horse"
+    }).password,
+    "correct horse"
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
+const passwordSchema = z
+  .string()
+  .min(8)
+  .refine((value) => value.trim().length > 0, "Password must contain a non-whitespace character");
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
Closes #6254

/claim #743

## Summary
- share a password schema between registration and login validators
- keep the existing minimum length requirement
- reject passwords made entirely of whitespace
- add focused validator regression coverage for registration and login

## Validation
- `node --check apps/api/src/validators/auth.js`
- `node --check apps/api/src/tests/authValidators.test.js`
- `node --test apps/api/src/tests/authValidators.test.js` could not complete in this local workspace because dependencies are not installed (`ERR_MODULE_NOT_FOUND: Cannot find package 'zod'`)