### PR TITLE
fix: add Zod validation for review creation payloads (closes #6082)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+﻿import { ok, fail } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map((i) => i.message).join("; "), 400);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function fetchLocal(app, path, options = {}) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const url = `http://127.0.0.1:${port}${path}`;
+  const response = await fetch(url, { ...options, headers: { "Content-Type": "application/json", ...options.headers } });
+  const body = await response.json();
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return { response, body };
+}
+
+test("POST /api/reviews with valid payload creates review", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 4,
+      comment: "Great work!",
+    }),
+  });
+  assert.equal(response.status, 201);
+  assert.equal(body.success, true);
+  assert.equal(body.data.reviewerId, "user_1");
+  assert.equal(body.data.rating, 4);
+});
+
+test("POST /api/reviews with valid payload without comment creates review", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 5,
+    }),
+  });
+  assert.equal(response.status, 201);
+  assert.equal(body.success, true);
+});
+
+test("POST /api/reviews rejects missing reviewerId", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      revieweeId: "user_2",
+      rating: 3,
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/reviews rejects missing revieweeId", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      rating: 3,
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/reviews rejects rating below 1", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 0,
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/reviews rejects rating above 5", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 6,
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/reviews rejects non-integer rating", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 3.5,
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/reviews rejects empty comment", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews", {
+    method: "POST",
+    body: JSON.stringify({
+      reviewerId: "user_1",
+      revieweeId: "user_2",
+      rating: 3,
+      comment: "   ",
+    }),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("GET /api/reviews returns empty list initially", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/reviews");
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert(Array.isArray(body.data));
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,11 @@
+﻿import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1, "reviewerId is required"),
+  revieweeId: z.string().min(1, "revieweeId is required"),
+  rating: z.number().int().min(1).max(5, "rating must be an integer from 1 to 5"),
+  comment: z.string().optional().refine(
+    (val) => val === undefined || val.trim().length > 0,
+    { message: "comment must not be empty" }
+  ),
+});


### PR DESCRIPTION
Adds Zod validation for review creation payloads.

- Created \createReviewSchema\ in \pps/api/src/validators/review.js\
- Requires \eviewerId\, \evieweeId\, and integer \ating\ from 1 through 5
- Rejects empty optional comments
- Returns HTTP 400 for invalid review payloads
- Adds route-level regression coverage for invalid and valid review creation

Closes #6082