### PR TITLE
feat: add PATCH /api/jobs/:id route for partial job updates (closes #6089)

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,6 +1,6 @@
-import { ok } from "../utils/response.js";
-import { createJobSchema } from "../validators/job.js";
-import { createJob, listJobs } from "../services/jobService.js";
+import { ok, fail } from "../utils/response.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+import { createJob, listJobs, updateJob } from "../services/jobService.js";
 
 export async function getJobs(req, res) {
   return ok(res, await listJobs());
@@ -9,4 +9,17 @@ export async function getJobs(req, res) {
 export async function postJob(req, res) {
   const payload = createJobSchema.parse(req.body);
   return ok(res, await createJob(payload), 201);
+}
+
+export async function patchJob(req, res) {
+  const { id } = req.params;
+  const parsed = updateJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map((i) => i.message).join("; "), 400);
+  }
+  const updated = await updateJob(id, parsed.data);
+  if (!updated) {
+    return fail(res, "Job not found", 404);
+  }
+  return ok(res, updated);
 }

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
-import { getJobs, postJob } from "../controllers/jobController.js";
+import { getJobs, postJob, patchJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);
+jobRoutes.patch("/:id", patchJob);

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -9,3 +9,10 @@ export async function createJob(payload) {
   jobs.push(job);
   return job;
 }
+
+export async function updateJob(id, patch) {
+  const idx = jobs.findIndex((j) => j.id === id);
+  if (idx === -1) return null;
+  jobs[idx] = { ...jobs[idx], ...patch, id: jobs[idx].id };
+  return jobs[idx];
+}

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function fetchLocal(app, path, options = {}) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const url = "http://127.0.0.1:" + port + path;
+  const response = await fetch(url, { ...options, headers: { "Content-Type": "application/json", ...options.headers } });
+  const body = await response.json();
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return { response, body };
+}
+
+test("PATCH /api/jobs/:id updates job fields partially", async () => {
+  const app = createApp();
+  const create = await fetchLocal(app, "/api/jobs", {
+    method: "POST",
+    body: JSON.stringify({
+      title: "Original Title",
+      description: "Original description for the job post",
+      budgetMin: 100, budgetMax: 500, categoryId: "cat_1", skills: ["node", "react"]
+    }),
+  });
+  assert.equal(create.response.status, 201);
+  const jobId = create.body.data.id;
+  const patch = await fetchLocal(app, "/api/jobs/" + jobId, {
+    method: "PATCH", body: JSON.stringify({ title: "Updated Title" })
+  });
+  assert.equal(patch.response.status, 200);
+  assert.equal(patch.body.success, true);
+  assert.equal(patch.body.data.title, "Updated Title");
+  assert.equal(patch.body.data.id, jobId);
+  assert.equal(patch.body.data.description, "Original description for the job post");
+});
+
+test("PATCH /api/jobs/:id returns 404 for unknown id", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/jobs/nonexistent", {
+    method: "PATCH", body: JSON.stringify({ title: "Nope" })
+  });
+  assert.equal(response.status, 404);
+  assert.equal(body.success, false);
+});
+
+test("PATCH /api/jobs/:id rejects invalid payload", async () => {
+  const app = createApp();
+  const { response, body } = await fetchLocal(app, "/api/jobs/someid", {
+    method: "PATCH", body: JSON.stringify({ budgetMin: "not-a-number" })
+  });
+  assert.equal(response.status, 400);
+  assert.equal(body.success, false);
+});


### PR DESCRIPTION
Exposes PATCH /api/jobs/:id for partial updates.

- Uses existing updateJobSchema for validation
- Preserves server-owned id on update
- Returns 404 when the requested job does not exist
- Returns 400 for invalid patches
- Adds focused route-level regression coverage

Closes #6089