### PR TITLE
fix: ensure JWT sub matches returned user id during registration (closes #2768)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Fixes duplicate Date.now() calls during registration that could produce mismatched id and token sub.

- Generates the user id once
- Returns the same id in the registration response
- Signs the access token with the same id as the sub claim

Closes #2768