### PR TITLE
fix: preserve server-owned id and read state in notification creation (closes #2762)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...rest } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...rest };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Preserves server-generated id and read:false in notification creation.

- Strips caller-supplied id and read fields before creating the notification
- New notifications always start with read:false
- Uses server-generated id

Closes #2762