### PR TITLE
fix: expose importable entrypoint for @freelanceflow/db (closes #2775)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Adds main, types, and exports fields to @freelanceflow/db package.json.

- Exposes src/index.ts as the package entrypoint
- Enables workspace consumers to import @freelanceflow/db

Closes #2775