### PR TITLE
fix: expose importable entrypoint for @freelanceflow/ui (closes #2781)

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
 }


### PR DESCRIPTION
Adds types and exports fields to @freelanceflow/ui package.json.

- Sets main: src/index.ts, types: src/index.ts
- Adds exports map for proper module resolution
- Enables direct imports from @freelanceflow/ui

Closes #2781