### PR TITLE
fix: resolve mock job details by id in job detail route (closes #2760)

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,22 @@
+import { jobs } from "@/lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job matches the identifier <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
+      <p>Job ID: {job.id}</p>
     </section>
   );
 }


### PR DESCRIPTION
Looks up mock jobs by id and renders title, budget, and job ID.

- Known job ids (job-101, job-102, job-103) render matching mock details
- Unknown job ids render a clear not-found fallback

Closes #2760