### PR TITLE
fix: resolve mock freelancer profile by username (closes #2849)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find((f) => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer matches the username <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{profile.username}</h2>
+      <p>Skills: <strong>{profile.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{profile.rate}</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
Looks up mock freelancers by username and renders skills, rate, and username.

- Known usernames (maya-dev, jordan-ux) render matching profile details
- Unknown usernames render a clear not-found fallback

Closes #2849