### PR TITLE
fix: require authentication for job creation (closes #6248)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
Applies authMiddleware to POST /api/jobs so only authenticated users can create jobs.

- Keeps GET /api/jobs public
- Returns 401 for missing/invalid credentials
- Preserves 201 behavior for authenticated requests

Closes #6248
/attempt #743