### PR TITLE
fix: require authentication for payment creation (closes #6246)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
Applies authMiddleware to POST /api/payments requiring a valid bearer token.

- Returns 401 for missing/invalid credentials
- Preserves 201 behavior for authenticated requests

Closes #6246
/attempt #743