### PR TITLE
fix: require authentication for search endpoint (closes #6244)

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);


### PR DESCRIPTION
Applies authMiddleware to GET /api/search requiring a valid bearer token.

- Returns 401 for missing/invalid credentials
- Preserves existing response shape for authenticated requests

Closes #6244
/attempt #743