### PR TITLE
fix: redact password from user creation and listing responses (closes #6242)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,16 @@
 const users = [];
 
+function redact(user) {
+  const { password, ...safe } = user;
+  return safe;
+}
+
 export async function listUsers() {
-  return users;
+  return users.map(redact);
 }
 
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  return redact(user);
 }


### PR DESCRIPTION
Strips password field from all user API responses.

- Adds redact() helper to strip password before returning
- Applies to both createUser() and listUsers()
- Prevents password exposure through GET /api/users

Closes #6242
/attempt #743