### PR TITLE
fix: validate proposal payloads and preserve server-owned ids (closes #6257)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,9 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map((i) => i.message).join("; "), 400);
+  }
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _id, ...rest } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...rest };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  freelancerId: z.string().min(1, "freelancerId is required"),
+  coverLetter: z.string().min(1, "coverLetter is required"),
+  bidAmount: z.number().positive("bidAmount must be positive"),
+});


### PR DESCRIPTION
Validates proposal creation payloads and prevents caller-supplied id override.

- Adds createProposalSchema requiring jobId, freelancerId, coverLetter, bidAmount
- Returns 400 for invalid/empty payloads
- Preserves server-generated prp_* id

Closes #6257
/attempt #743