### PR TITLE
Redact password fields from user responses

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,17 @@
 const users = [];
 
+function sanitizeUser(user) {
+  const { password, ...safeUser } = user;
+  return safeUser;
+}
+
 export async function listUsers() {
-  return users;
+  return users.map(sanitizeUser);
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
-  return user;
+  return sanitizeUser(user);
 }

--- a/apps/api/src/tests/user-password-redaction.test.js
+++ b/apps/api/src/tests/user-password-redaction.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users does not echo password fields", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "alice@example.com",
+        password: "s3cret"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "alice@example.com");
+    assert.equal("password" in payload.data, false);
+  });
+});
+
+test("GET /api/users omits stored password fields", async () => {
+  await withServer(async (port) => {
+    await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "bob@example.com",
+        password: "another-secret"
+      })
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.some((user) => user.email === "bob@example.com"));
+    assert.ok(payload.data.every((user) => !("password" in user)));
+  });
+});


### PR DESCRIPTION
Closes #6242.\n\nEnsures user creation and listing never expose stored password fields in API responses. The change is scoped to user response redaction and focused regression coverage.