### PR TITLE
fix: normalize payment currency codes to lowercase (closes #6108)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }


### PR DESCRIPTION
Normalizes payment currency codes to lowercase before returning the payment intent response.

- Applies .toLowerCase() to currency field
- Inputs like 'USD' now produce lowercase 'usd'

Closes #6108
/attempt #743