### PR TITLE
fix: require auth for review creation and use token identity (closes #6259)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,11 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues.map((i) => i.message).join("; "), 400);
+  }
+  // Use authenticated user as reviewerId, ignore client-supplied value
+  const payload = { ...parsed.data, reviewerId: req.user.sub };
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
Requires authentication for POST /api/reviews and derives reviewerId from the token.

- Applies authMiddleware to review POST route
- Uses req.user.sub as reviewerId, ignoring client-supplied value
- Prevents review author spoofing

Closes #6259
/attempt #743