### PR TITLE
fix: require authentication for user creation route (closes #6252)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getUsers, postUser } from "../controllers/userController.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);


### PR DESCRIPTION
Applies authMiddleware to POST /api/users so only authenticated users can create user records.

- Public sign-up remains through /api/auth/register
- Prevents anonymous callers from creating users with arbitrary roles

Closes #6252
/attempt #743