### PR TITLE
fix: require authentication for message creation (closes #6216)

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);


### PR DESCRIPTION
Applies authMiddleware to POST /api/messages.

- Returns 401 for missing/invalid credentials
- Preserves 201 behavior for authenticated requests

Closes #6216
/attempt #743