### PR TITLE
fix: require authentication for upload endpoint (closes #6204)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
Applies authMiddleware to POST /api/uploads.

- Returns 401 for missing/invalid credentials
- Preserves existing upload behavior for authenticated requests

Closes #6204
/attempt #743