### PR TITLE
fix: require JWT_SECRET in non-development environments (closes #6224)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,13 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: (() => {
+    if (process.env.JWT_SECRET) return process.env.JWT_SECRET;
+    if ((process.env.NODE_ENV ?? "development") === "development") {
+      return "development-secret";
+    }
+    throw new Error("JWT_SECRET environment variable is required");
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Fails fast when JWT_SECRET is missing outside development.

- Development keeps the existing fallback for local convenience
- Non-development environments throw a clear error
- Supplying JWT_SECRET keeps startup working normally

Closes #6224
/attempt #743