### PR TITLE
fix: prevent admin role self-assignment during registration (closes #6226)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Removes admin from the registration role enum so new users cannot self-assign admin privileges.

- Restricts public registration roles to client and freelancer only
- Admin role must be assigned server-side

Closes #6226
/attempt #743