### PR TITLE
fix: enforce admin role on admin metrics endpoint (closes #6261)

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,15 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use((req, res, next) => {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin role required", 403);
+  }
+  return next();
+});
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Adds role-based access control to admin routes.

- Verifies req.user.role === 'admin' after authMiddleware
- Returns 403 Forbidden for non-admin authenticated users
- Prevents freelancers and clients from accessing admin metrics

Closes #6261
/attempt #743