### PR TITLE
fix: bind message and notification identity to authenticated user (closes #6250)

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -6,5 +6,8 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  // Derive senderId from authenticated user, ignore client-supplied value
+  const { senderId: _senderId, ...rest } = req.body;
+  const payload = { ...rest, senderId: req.user.sub };
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -6,5 +6,8 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  // Derive userId from authenticated user, ignore client-supplied value
+  const { userId: _userId, ...rest } = req.body;
+  const payload = { ...rest, userId: req.user.sub };
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);


### PR DESCRIPTION
Binds message senderId and notification userId to the authenticated principal instead of trusting client-supplied values.

- Adds authMiddleware to notification POST route
- Strips client-supplied senderId from messages, uses req.user.sub
- Strips client-supplied userId from notifications, uses req.user.sub

Closes #6250
/attempt #743