### PR TITLE
Auth validators should reject whitespace-only passwords

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("auth validators reject whitespace-only passwords", () => {
+  const registerResult = registerSchema.safeParse({
+    email: "alice@example.com",
+    password: "        ",
+    role: "client"
+  });
+
+  const loginResult = loginSchema.safeParse({
+    email: "alice@example.com",
+    password: "        "
+  });
+
+  assert.equal(registerResult.success, false);
+  assert.equal(loginResult.success, false);
+  assert.deepEqual(
+    registerResult.error.flatten().fieldErrors.password,
+    ["String must contain at least 8 character(s)"]
+  );
+  assert.deepEqual(
+    loginResult.error.flatten().fieldErrors.password,
+    ["String must contain at least 8 character(s)"]
+  );
+});
+
+test("auth validators still accept real passwords", () => {
+  const registerResult = registerSchema.safeParse({
+    email: "alice@example.com",
+    password: "correct horse battery staple",
+    role: "freelancer"
+  });
+
+  const loginResult = loginSchema.safeParse({
+    email: "alice@example.com",
+    password: "correct horse battery staple"
+  });
+
+  assert.equal(registerResult.success, true);
+  assert.equal(loginResult.success, true);
+  assert.equal(registerResult.data.role, "freelancer");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+export const authPasswordSchema = z.string().trim().min(8);
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: authPasswordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: authPasswordSchema
 });


### PR DESCRIPTION
Closes #6300.\n\nAdds a shared auth password schema that trims and rejects whitespace-only passwords while keeping the minimum-length requirement for real passwords. Includes validator-level coverage for register and login inputs.