### PR TITLE
Bug: admin metrics endpoint lacks admin role authorization

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function roleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-routes-auth.test.js
+++ b/apps/api/src/tests/admin-routes-auth.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Forbidden"
+    });
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        openJobs: 42,
+        activeFreelancers: 185,
+        flaggedAccounts: 3,
+        monthlyVolume: 128900
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #6310.\n\nAdds admin-role authorization on the admin metrics route so authenticated non-admin users receive 403 while admin tokens continue to work. The change stays limited to admin route auth and tests.