### PR TITLE
Protect notification metadata on create

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves generated id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client-id",
+    read: true,
+    title: "Proposal update",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.title, "Proposal update");
+});


### PR DESCRIPTION
## Summary
- keep server-generated notification ids from being overwritten by request payloads
- keep new notifications unread even when the payload includes `read: true`
- add focused service coverage for client-controlled `id` and `read` fields

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6325