### PR TITLE
Reject empty upload requests

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload-routes.test.js
+++ b/apps/api/src/tests/upload-routes.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects multipart requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("description", "empty upload");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required",
+    });
+  });
+});
+
+test("POST /api/uploads accepts multipart requests with a file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "note.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "note.txt",
+        status: "uploaded",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- return `400 Bad Request` when a multipart upload request does not include a `file` field
- keep successful uploads returning the uploaded filename with `status: "uploaded"`
- add route-level coverage for missing-file and valid-file upload requests

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6328