### PR TITLE
Parse bearer auth scheme case-insensitively

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,14 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, token] = authHeader?.split(" ") ?? [];
+
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth-middleware.test.js
+++ b/apps/api/src/tests/auth-middleware.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("authMiddleware accepts Bearer scheme case-insensitively", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1" });
+
+    for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+      const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+        headers: { authorization: `${scheme} ${token}` },
+      });
+
+      assert.equal(response.status, 200);
+    }
+  });
+});
+
+test("authMiddleware rejects non-Bearer schemes", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Basic ${token}` },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- parse the Authorization auth scheme case-insensitively
- continue rejecting non-Bearer schemes and missing tokens
- add route-level coverage for `Bearer`, `bearer`, `BEARER`, and a rejected non-Bearer scheme

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6330