### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-service.test.js
+++ b/apps/api/src/tests/payment-service.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes provided currency to lowercase", async () => {
+  const payment = await createPaymentIntent({ amount: 100, currency: "USD" });
+
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.amount, 100);
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const payment = await createPaymentIntent({ amount: 100 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- normalize provided payment currency codes to lowercase before returning the payment intent payload
- keep missing currency defaulting to `usd`
- add focused service coverage for provided uppercase currency and default currency behavior

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6332