### PR TITLE
Avoid storing submitted user passwords

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...userPayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...userPayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-service.test.js
+++ b/apps/api/src/tests/user-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser does not store submitted password fields", async () => {
+  const user = await createUser({
+    email: "person@example.com",
+    password: "super-secret",
+    name: "Person Example",
+  });
+  const users = await listUsers();
+  const storedUser = users.find((item) => item.id === user.id);
+
+  assert.equal(user.password, undefined);
+  assert.equal(storedUser.password, undefined);
+  assert.equal(user.email, "person@example.com");
+  assert.equal(user.name, "Person Example");
+});


### PR DESCRIPTION
## Summary
- remove submitted `password` fields before storing user records
- preserve non-secret user fields such as email and name
- add focused service coverage to verify password material is not returned or stored

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6334