### PR TITLE
Reject blank auth passwords

### DIFF
--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects whitespace-only passwords", () => {
+  const result = registerSchema.safeParse({
+    email: "person@example.com",
+    password: "        ",
+    role: "client",
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("loginSchema rejects whitespace-only passwords", () => {
+  const result = loginSchema.safeParse({
+    email: "person@example.com",
+    password: "        ",
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("auth password schemas preserve valid minimum-length passwords", () => {
+  assert.equal(
+    registerSchema.safeParse({
+      email: "person@example.com",
+      password: "valid-pass",
+      role: "client",
+    }).success,
+    true
+  );
+
+  assert.equal(
+    loginSchema.safeParse({
+      email: "person@example.com",
+      password: "valid-pass",
+    }).success,
+    true
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,19 @@
 import { z } from "zod";
 
+const passwordSchema = z
+  .string()
+  .min(8)
+  .refine((password) => password.trim().length > 0, {
+    message: "Password cannot be blank"
+  });
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
## Summary
- reuse a shared auth password schema for register and login validation
- reject whitespace-only passwords while preserving the existing minimum-length requirement
- add focused validator coverage for register, login, and valid passwords

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6336