### PR TITLE
Require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? "development-secret";
+
+if (nodeEnv !== "development" && nodeEnv !== "test" && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET is required outside development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env-config.test.js
+++ b/apps/api/src/tests/env-config.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+const envModuleUrl = pathToFileURL(
+  path.resolve("apps/api/src/config/env.js")
+).href;
+
+async function importEnvWith({ nodeEnv, jwtSecret }) {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousJwtSecret = process.env.JWT_SECRET;
+
+  if (nodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = nodeEnv;
+  }
+
+  if (jwtSecret === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = jwtSecret;
+  }
+
+  try {
+    return await import(`${envModuleUrl}?case=${Date.now()}-${Math.random()}`);
+  } finally {
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+
+    if (previousJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = previousJwtSecret;
+    }
+  }
+}
+
+test("env keeps the development JWT fallback", async () => {
+  const { env } = await importEnvWith({
+    nodeEnv: "development",
+    jwtSecret: undefined,
+  });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("env requires JWT_SECRET outside development", async () => {
+  await assert.rejects(
+    () => importEnvWith({ nodeEnv: "production", jwtSecret: undefined }),
+    /JWT_SECRET is required outside development/
+  );
+});
+
+test("env accepts JWT_SECRET outside development", async () => {
+  const { env } = await importEnvWith({
+    nodeEnv: "production",
+    jwtSecret: "strong-secret",
+  });
+
+  assert.equal(env.jwtSecret, "strong-secret");
+});


### PR DESCRIPTION
## Summary
- keep the local development JWT fallback available
- fail fast outside development/test when `JWT_SECRET` is missing
- add focused config coverage for development fallback, production failure, and production success

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6344