### PR TITLE
Return defensive list snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-service-snapshots.test.js
+++ b/apps/api/src/tests/list-service-snapshots.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import {
+  createNotification,
+  listNotifications,
+} from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const cases = [
+  {
+    name: "jobs",
+    create: () =>
+      createJob({
+        title: "Build dashboard",
+        description: "Build an analytics dashboard",
+        budgetMin: 100,
+        budgetMax: 200,
+        categoryId: "web",
+        skills: [],
+      }),
+    list: listJobs,
+  },
+  {
+    name: "messages",
+    create: () =>
+      sendMessage({
+        senderId: "usr_1",
+        recipientId: "usr_2",
+        body: "hello",
+      }),
+    list: listMessages,
+  },
+  {
+    name: "notifications",
+    create: () => createNotification({ title: "Update" }),
+    list: listNotifications,
+  },
+  {
+    name: "proposals",
+    create: () => createProposal({ jobId: "job_1", freelancerId: "usr_1" }),
+    list: listProposals,
+  },
+  {
+    name: "reviews",
+    create: () => createReview({ reviewerId: "usr_1", rating: 5 }),
+    list: listReviews,
+  },
+  {
+    name: "users",
+    create: () => createUser({ email: "person@example.com" }),
+    list: listUsers,
+  },
+];
+
+for (const service of cases) {
+  test(`${service.name} list returns a defensive array snapshot`, async () => {
+    const created = await service.create();
+    const snapshot = await service.list();
+
+    snapshot.length = 0;
+
+    const nextList = await service.list();
+    assert.equal(
+      nextList.some((item) => item.id === created.id),
+      true
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- return shallow array snapshots from list service functions
- prevent callers from mutating the module-level in-memory stores through returned arrays
- add focused service coverage for jobs, messages, notifications, proposals, reviews, and users

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6346