### PR TITLE
Trim payment currency codes

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").trim(),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-currency-trim.test.js
+++ b/apps/api/src/tests/payment-currency-trim.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent trims provided currency codes", async () => {
+  const payment = await createPaymentIntent({
+    amount: 100,
+    currency: " usd ",
+  });
+
+  assert.equal(payment.currency, "usd");
+});
+
+test("createPaymentIntent keeps missing currency default", async () => {
+  const payment = await createPaymentIntent({ amount: 100 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- trim whitespace from provided payment currency codes
- keep missing currency defaulting to `usd`
- add focused service coverage for padded and missing currency values

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6349