### PR TITLE
Keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-service-register.test.js
+++ b/apps/api/src/tests/auth-service-register.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token with the returned user id", async () => {
+  const result = await registerUser({
+    email: "person@example.com",
+    role: "client",
+  });
+  const tokenPayload = verifyAccessToken(result.token);
+
+  assert.match(result.id, /^usr_\d+$/);
+  assert.equal(tokenPayload.sub, result.id);
+  assert.equal(tokenPayload.role, "client");
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once
- reuse the same id for the returned response and JWT subject
- add focused service coverage that verifies the signed token `sub` matches the returned user id

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6351