### PR TITLE
Prevent admin registration role assignment

### DIFF
--- a/apps/api/src/tests/auth-register-roles.test.js
+++ b/apps/api/src/tests/auth-register-roles.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const result = registerSchema.safeParse({
+    email: "admin@example.com",
+    password: "password123",
+    role: "admin",
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerSchema still accepts public roles", () => {
+  for (const role of ["client", "freelancer"]) {
+    const result = registerSchema.safeParse({
+      email: `${role}@example.com`,
+      password: "password123",
+      role,
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.data.role, role);
+  }
+});
+
+test("registerSchema defaults missing role to client", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "password123",
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- restrict public registration roles to `client` and `freelancer`
- preserve the existing default `client` role when no role is supplied
- add focused validator coverage for rejected admin role, accepted public roles, and default behavior

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6356