### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/user-creation-validation.test.js
+++ b/apps/api/src/tests/user-creation-validation.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validUser = {
+  email: "person@example.com",
+  fullName: "Person Example",
+  role: "client",
+  bio: "Available for projects",
+};
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid user payload",
+    });
+  });
+});
+
+test("POST /api/users creates valid users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validUser),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_\d+$/);
+    assert.equal(payload.data.email, validUser.email);
+    assert.equal(payload.data.fullName, validUser.fullName);
+    assert.equal(payload.data.role, validUser.role);
+  });
+});
+
+test("POST /api/users defaults missing role to client", async () => {
+  await withServer(async (baseUrl) => {
+    const { role, ...userWithoutRole } = validUser;
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(userWithoutRole),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "client");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client"),
+  bio: z.string().optional(),
+});


### PR DESCRIPTION
## Summary
- add focused user creation validation
- return `400` for invalid user payloads before writing to the service layer
- preserve the existing `201` response shape for valid user creation
- add route coverage for invalid payloads, valid creation, and default role behavior

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6358