### PR TITLE
Require authentication for message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", authMiddleware, getMessages);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/tests/message-routes-auth.test.js
+++ b/apps/api/src/tests/message-routes-auth.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const messagePayload = {
+  senderId: "usr_1",
+  recipientId: "usr_2",
+  body: "Hello from the project thread",
+};
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized",
+    });
+  });
+});
+
+test("POST /api/messages rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(messagePayload),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized",
+    });
+  });
+});
+
+test("message routes accept authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    };
+
+    const createResponse = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(messagePayload),
+    });
+    const createPayload = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.success, true);
+    assert.match(createPayload.data.id, /^msg_\d+$/);
+    assert.equal(createPayload.data.body, messagePayload.body);
+
+    const listResponse = await fetch(`${baseUrl}/api/messages`, { headers });
+    const listPayload = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listPayload.success, true);
+    assert.equal(Array.isArray(listPayload.data), true);
+  });
+});


### PR DESCRIPTION
## Summary
- require bearer authentication for `GET /api/messages` and `POST /api/messages`
- keep authenticated list and create behavior unchanged
- add route-level coverage for anonymous rejection and authenticated access

## Tests
- `node --test apps/api/src/tests/*.test.js`

Fixes #6362