### PR TITLE
Hide admin navigation by default

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,16 +1,25 @@
 import Link from "next/link";
 
-const links = [
+type UserRole = "client" | "freelancer" | "admin";
+
+const publicLinks = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
-export function Navigation() {
+const adminLink = ["/admin", "Admin"];
+
+type NavigationProps = {
+  currentUserRole?: UserRole;
+};
+
+export function Navigation({ currentUserRole }: NavigationProps) {
+  const links = currentUserRole === "admin" ? [...publicLinks, adminLink] : publicLinks;
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
       {links.map(([href, label]) => (


### PR DESCRIPTION
## Summary
- split public navigation links from the admin-only destination
- add a typed `currentUserRole` prop so `/admin` is only appended for admins
- keep the root layout visitor path unchanged, hiding Admin by default

## Validation
- npm run build -w apps/web

Closes #6191