### PR TITLE
Accept Bearer auth scheme case-insensitively

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,13 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const [scheme, token] = authHeader?.split(" ", 2) ?? [];
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
     return fail(res, "Unauthorized", 401);
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(token);
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+}
+
+test("authMiddleware accepts Bearer scheme case-insensitively", () => {
+  const token = signAccessToken({ sub: "user_1" });
+
+  for (const scheme of ["Bearer", "bearer", "BEARER"]) {
+    const req = { headers: { authorization: `${scheme} ${token}` } };
+    const res = createResponse();
+    let nextCalled = false;
+
+    authMiddleware(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(req.user.sub, "user_1");
+    assert.equal(res.statusCode, undefined);
+  }
+});
+
+test("authMiddleware still rejects non-Bearer schemes", () => {
+  const req = { headers: { authorization: `Basic ${signAccessToken({ sub: "user_1" })}` } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 401);
+  assert.deepEqual(res.payload, { success: false, message: "Unauthorized" });
+});


### PR DESCRIPTION
## Summary
- parse the Authorization scheme case-insensitively while still requiring Bearer
- preserve JWT token verification and existing invalid-token handling
- add focused middleware coverage for Bearer, bearer, BEARER, and non-Bearer schemes
- make the API test script target existing *.test.js files explicitly

Fixes #6330

## Validation
- npm run test -w apps/api
- git diff --check