### PR TITLE
Redact user passwords from API responses

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,17 @@
 const users = [];
 
+function withoutPassword(user) {
+  const { password, ...safeUser } = user;
+  return safeUser;
+}
+
 export async function listUsers() {
-  return users;
+  return users.map(withoutPassword);
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
-  return user;
+  return withoutPassword(user);
 }

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("user responses do not expose submitted passwords", async () => {
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "user@example.com",
+        name: "Example User",
+        password: "s3cret-pass"
+      })
+    });
+    const createdUser = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createdUser.data.email, "user@example.com");
+    assert.equal("password" in createdUser.data, false);
+
+    const listResponse = await fetch(`${baseUrl}/api/users`);
+    const listedUsers = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.ok(listedUsers.data.some((user) => user.email === "user@example.com"));
+    assert.equal(listedUsers.data.some((user) => "password" in user), false);
+  });
+});


### PR DESCRIPTION
## Summary
- remove submitted `password` fields before storing user records
- return redacted user snapshots from `listUsers()`
- add HTTP regression coverage for `POST /api/users` and `GET /api/users`

## Validation
- node --test apps/api/src/tests/*.test.js

Closes #6242