### PR TITLE
Enforce admin role on metrics route

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function roleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("admin metrics require an admin token", async () => {
+  await withServer(async (baseUrl) => {
+    const missingTokenResponse = await fetch(`${baseUrl}/api/admin/metrics`);
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${clientToken}` }
+    });
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const adminResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    const adminPayload = await adminResponse.json();
+
+    assert.equal(missingTokenResponse.status, 401);
+    assert.equal(clientResponse.status, 403);
+    assert.equal(adminResponse.status, 200);
+    assert.equal(adminPayload.success, true);
+    assert.equal(typeof adminPayload.data.flaggedAccounts, "number");
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable role guard for authenticated routes
- require `role: "admin"` before serving `/api/admin/metrics`
- add API regression coverage for missing, non-admin, and admin tokens

## Validation
- node --test apps/api/src/tests/*.test.js

Closes #6235