### PR TITLE
fix: expose workflow pages in navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post a Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
## Summary

Fixes #6377
Parent bounty: #743

Adds top-level navigation links for the workflow pages that already exist in the web app:

- `/jobs/post`
- `/notifications`
- `/billing`
- `/settings`

This keeps the change limited to `apps/web/components/Navigation.tsx` and does not change page content, route behavior, or API/backend code.

## Validation

Ran:

```bash
npm run build -w apps/web
```

Result: production build completed successfully. The generated route list includes `/jobs/post`, `/billing`, `/notifications`, and `/settings`.