### PR TITLE
Bind message and notification identity to auth user

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -6,5 +6,5 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  return ok(res, await sendMessage(req.body, req.user.sub), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -6,5 +6,5 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  return ok(res, await createNotification(req.body, req.user.sub), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -4,8 +4,8 @@ export async function listMessages() {
   return messages;
 }
 
-export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+export async function sendMessage(payload, senderId) {
+  const message = { id: `msg_${Date.now()}`, ...payload, senderId, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -4,8 +4,8 @@ export async function listNotifications() {
   return notifications;
 }
 
-export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+export async function createNotification(payload, userId) {
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, userId };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/message-notification-identity.test.js
+++ b/apps/api/src/tests/message-notification-identity.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body, token) {
+  const headers = { "content-type": "application/json" };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("message and notification creation bind identity to the authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    const anonymousMessage = await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_attacker",
+      recipientId: "usr_target",
+      body: "spoofed"
+    });
+    const anonymousNotification = await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_target",
+      type: "message",
+      text: "spoofed"
+    });
+    const token = signAccessToken({ sub: "usr_actor", role: "client" });
+    const message = await postJson(baseUrl, "/api/messages", {
+      senderId: "usr_attacker",
+      recipientId: "usr_target",
+      body: "hello"
+    }, token);
+    const notification = await postJson(baseUrl, "/api/notifications", {
+      userId: "usr_target",
+      type: "message",
+      text: "hello"
+    }, token);
+
+    assert.equal(anonymousMessage.response.status, 401);
+    assert.equal(anonymousNotification.response.status, 401);
+    assert.equal(message.response.status, 201);
+    assert.equal(message.payload.data.senderId, "usr_actor");
+    assert.equal(notification.response.status, 201);
+    assert.equal(notification.payload.data.userId, "usr_actor");
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication for message and notification creation
- bind `senderId` and `userId` to the authenticated token subject
- add API regression coverage for anonymous requests and spoofed identity fields

## Validation
- node --test apps/api/src/tests/*.test.js

Closes #6380