### PR TITLE
Validate payment amounts before creation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  const response = await fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("payment creation rejects invalid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const negativeAmount = await postPayment(baseUrl, { amount: -10, currency: "usd" });
+    const missingAmount = await postPayment(baseUrl, { currency: "usd" });
+    const validPayment = await postPayment(baseUrl, { amount: 25, currency: "usd" });
+
+    assert.equal(negativeAmount.response.status, 400);
+    assert.equal(negativeAmount.payload.success, false);
+    assert.equal(missingAmount.response.status, 400);
+    assert.equal(missingAmount.payload.success, false);
+    assert.equal(validPayment.response.status, 201);
+    assert.equal(validPayment.payload.success, true);
+    assert.equal(validPayment.payload.data.amount, 25);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("usd")
+});


### PR DESCRIPTION
## Summary
- add focused payment payload validation
- reject missing or non-positive `amount` values with a structured 400 response
- keep valid payment creation behavior unchanged

## Validation
- node --test apps/api/src/tests/*.test.js

Closes #6384