### PR TITLE
Normalize payment currency codes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = (payload.currency ?? "usd").toLowerCase();
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes currency to lowercase", async () => {
+  const intent = await createPaymentIntent({ amount: 1500, currency: "GBP" });
+
+  assert.equal(intent.amount, 1500);
+  assert.equal(intent.currency, "gbp");
+  assert.equal(intent.provider, "stripe");
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const intent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(intent.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- normalize payment intent currency codes to lowercase before returning the response
- preserve the existing usd default when currency is omitted
- add focused service tests for uppercase currency and default currency behavior
- make the API test script target existing *.test.js files explicitly

Fixes #6332

## Validation
- npm run test -w apps/api
- git diff --check