### PR TITLE
fix: prevent DoS on search endpoint via query length limit and input validation

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { z } from "zod";
+
+const searchSchema = z.object({
+  q: z.string().max(100, { message: "Query too long, max 100 chars" })
+});
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  try {
+    const { q } = searchSchema.parse(req.query);
+    return ok(res, await globalSearch(q));
+  } catch (e) {
+    return fail(res, e.message, 400);
+  }
 }

--- a/apps/api/src/tests/searchValidation.test.js
+++ b/apps/api/src/tests/searchValidation.test.js
@@ -1,0 +1,33 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+
+describe("Search API Validation", () => {
+  let app;
+
+  before(() => {
+    app = createApp();
+  });
+
+  it("should allow search with a valid query string", async () => {
+    const res = await request(app).get("/api/search?q=valid_query");
+    expect(res.status).to.equal(200);
+    expect(res.body.success).to.equal(true);
+    expect(res.body.data).to.have.property("query", "valid_query");
+  });
+
+  it("should reject search with a query string exceeding 100 chars", async () => {
+    const longQuery = "a".repeat(101);
+    const res = await request(app).get(`/api/search?q=${longQuery}`);
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+    expect(res.body.message).to.include("Query too long");
+  });
+
+  it("should reject search without a query parameter", async () => {
+    const res = await request(app).get("/api/search");
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+    expect(res.body.message).to.include("Required"); // Zod's default for missing required fields
+  });
+});


### PR DESCRIPTION
Implemented a query length limit of 100 characters for the search endpoint to prevent potential DoS attacks through extremely long query strings.

Changes:
- Added Zod validation to searchController.js.
- Implemented max length constraint for the 'q' parameter.
- Added integration tests in apps/api/src/tests/searchValidation.test.js.

Verification:
Run 'cd apps/api && npm test'.
- valid query -> PASS
- query > 100 chars -> PASS (400)
- missing query -> PASS (400)