### PR TITLE
Add Zod validation for proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    const payload = createProposalSchema.parse(req.body);
+    return ok(res, await createProposal(payload), 201);
+  } catch (e) {
+    return fail(res, e.message, 400);
+  }
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,47 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+
+describe("Proposal API Validation", () => {
+  let app;
+
+  before(() => {
+    app = createApp();
+  });
+
+  it("should allow creating a proposal with valid data", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        jobId: "job_123",
+        userId: "user_456",
+        bidAmount: 500,
+        coverLetter: "I am the best for this job!"
+      });
+    expect(res.status).to.equal(201);
+    expect(res.body.success).to.equal(true);
+  });
+
+  it("should reject proposal if bidAmount is negative or zero", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        jobId: "job_123",
+        userId: "user_456",
+        bidAmount: -10,
+        coverLetter: "Cheap price!"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  it("should reject proposal if required fields are missing", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        bidAmount: 100
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  userId: z.string().min(1, "userId is required"),
+  bidAmount: z.number().positive("bid amount must be positive"),
+  coverLetter: z.string().min(1, "cover letter is required").max(2000),
+});


### PR DESCRIPTION
Implemented Zod validation for the proposal creation endpoint to ensure data integrity and prevent invalid submissions.

Changes:
- Created createProposalSchema with constraints for jobId, userId, bidAmount (positive), and coverLetter.
- Integrated validation in proposalController.js.
- Added integration tests in apps/api/src/tests/proposalValidation.test.js.

Verification:
Run 'cd apps/api && npm test'.
- Valid proposal -> PASS
- Negative/Zero bid -> PASS (400)
- Missing fields -> PASS (400)