### PR TITLE
Add Zod validation for message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  try {
+    const payload = createMessageSchema.parse(req.body);
+    return ok(res, await sendMessage(payload), 201);
+  } catch (e) {
+    return fail(res, e.message, 400);
+  }
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,45 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+
+describe("Message API Validation", () => {
+  let app;
+
+  before(() => {
+    app = createApp();
+  });
+
+  it("should allow sending a message with valid data", async () => {
+    const res = await request(app)
+      .post("/api/messages")
+      .send({
+        senderId: "user_1",
+        receiverId: "user_2",
+        content: "Hello there!"
+      });
+    expect(res.status).to.equal(201);
+    expect(res.body.success).to.equal(true);
+  });
+
+  it("should reject message if required fields are missing", async () => {
+    const res = await request(app)
+      .post("/api/messages")
+      .send({
+        content: "Hello without IDs"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  it("should reject message if content is too long", async () => {
+    const res = await request(app)
+      .post("/api/messages")
+      .send({
+        senderId: "user_1",
+        receiverId: "user_2",
+        content: "a".repeat(5001)
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().min(1, "senderId is required"),
+  receiverId: z.string().min(1, "receiverId is required"),
+  content: z.string().min(1, "content is required").max(5000),
+});


### PR DESCRIPTION
Implemented Zod validation for the message creation endpoint to ensure data integrity and prevent invalid submissions.

Changes:
- Created createMessageSchema with constraints for senderId, receiverId, and content (max 5000 chars).
- Integrated validation in messageController.js.
- Added integration tests in apps/api/src/tests/messageValidation.test.js.

Verification:
Run 'cd apps/api && npm test'.
- Valid message -> PASS
- Missing fields -> PASS (400)
- Content too long -> PASS (400)