### PR TITLE
Add Zod validation for notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  try {
+    const payload = createNotificationSchema.parse(req.body);
+    return ok(res, await createNotification(payload), 201);
+  } catch (e) {
+    return fail(res, e.message, 400);
+  }
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,45 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+
+describe("Notification API Validation", () => {
+  let app;
+
+  before(() => {
+    app = createApp();
+  });
+
+  it("should allow creating a notification with valid data", async () => {
+    const res = await request(app)
+      .post("/api/notifications")
+      .send({
+        userId: "user_123",
+        type: "info",
+        message: "Your profile is updated!"
+      });
+    expect(res.status).to.equal(201);
+    expect(res.body.success).to.equal(true);
+  });
+
+  it("should reject notification if type is invalid", async () => {
+    const res = await request(app)
+      .post("/api/notifications")
+      .send({
+        userId: "user_123",
+        type: "super-critical",
+        message: "This type does not exist"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  it("should reject notification if required fields are missing", async () => {
+    const res = await request(app)
+      .post("/api/notifications")
+      .send({
+        type: "info"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1, "userId is required"),
+  type: z.enum(["info", "warning", "error", "success"]),
+  message: z.string().min(1, "message is required").max(500),
+});


### PR DESCRIPTION
Implemented Zod validation for the notification creation endpoint to ensure data integrity and prevent invalid submissions.

Changes:
- Created createNotificationSchema with constraints for userId, type (enum), and message.
- Integrated validation in notificationController.js.
- Added integration tests in apps/api/src/tests/notificationValidation.test.js.

Verification:
Run 'cd apps/api && npm test'.
- Valid notification -> PASS
- Invalid type -> PASS (400)
- Missing fields -> PASS (400)