### PR TITLE
Fix: ensure file is provided in upload endpoint

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+  
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadValidation.test.js
+++ b/apps/api/src/tests/uploadValidation.test.js
@@ -1,0 +1,40 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+import fs from "fs";
+import path from "path";
+
+describe("Upload API Validation", () => {
+  let app;
+  const testFilePath = path.join(process.cwd(), "test-file.txt");
+
+  before(() => {
+    app = createApp();
+    fs.writeFileSync(testFilePath, "Hello World");
+  });
+
+  after(() => {
+    if (fs.existsSync(testFilePath)) {
+      fs.unlinkSync(testFilePath);
+    }
+  });
+
+  it("should allow uploading a valid file", async () => {
+    const res = await request(app)
+      .post("/api/uploads")
+      .attach("file", testFilePath);
+    
+    expect(res.status).to.equal(201);
+    expect(res.body.success).to.equal(true);
+    expect(res.body.data.status).to.equal("uploaded");
+  });
+
+  it("should reject upload if no file is provided", async () => {
+    const res = await request(app)
+      .post("/api/uploads");
+    
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+    expect(res.body.message).to.equal("File is required");
+  });
+});


### PR DESCRIPTION
Corrected the behavior of the file upload endpoint to return a 400 Bad Request when no file is attached to the request, instead of returning a 201 with a 'no-file' status.

Changes:
- Added a check for req.file in uploadController.js.
- Integrated fail response for missing files.
- Added integration tests in apps/api/src/tests/uploadValidation.test.js.

Verification:
Run 'cd apps/api && npm test'.
- Valid file upload -> PASS
- Missing file -> PASS (400)