### PR TITLE
Bug: Proposal creation rejects records missing estimated duration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    const payload = createProposalSchema.parse(req.body);
+    return ok(res, await createProposal(payload), 201);
+  } catch (e) {
+    const message = e.errors ? e.errors[0].message : e.message;
+    return fail(res, message, 400);
+  }
 }

--- a/apps/api/src/tests/proposalDuration.test.js
+++ b/apps/api/src/tests/proposalDuration.test.js
@@ -1,0 +1,53 @@
+import request from "supertest";
+import { createApp } from "../app.js";
+import { expect } from "chai";
+
+describe("Proposal Duration Validation", () => {
+  let app;
+
+  before(() => {
+    app = createApp();
+  });
+
+  it("should allow creating a proposal with estimated duration", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        jobId: "job_123",
+        userId: "user_456",
+        bidAmount: 500,
+        estimatedDuration: 14,
+        coverLetter: "I can do it in 2 weeks!"
+      });
+    expect(res.status).to.equal(201);
+    expect(res.body.success).to.equal(true);
+  });
+
+  it("should reject proposal if estimated duration is missing", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        jobId: "job_123",
+        userId: "user_456",
+        bidAmount: 500,
+        coverLetter: "Forgot the duration!"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+    expect(res.body.message).to.include("estimated duration");
+  });
+
+  it("should reject proposal if estimated duration is not positive", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({
+        jobId: "job_123",
+        userId: "user_456",
+        bidAmount: 500,
+        estimatedDuration: 0,
+        coverLetter: "I'll do it for free and in 0 time!"
+      });
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  userId: z.string().min(1, "userId is required"),
+  bidAmount: z.number().positive("bid amount must be positive"),
+  estimatedDuration: z.number({ required_error: "estimated duration is required" }).positive("estimated duration must be positive"),
+  coverLetter: z.string().min(1, "cover letter is required").max(2000),
+});


### PR DESCRIPTION
Implemented validation for the 'estimatedDuration' field in proposal creation to ensure that all proposals include a valid, positive time estimate.

Changes:
- Updated createProposalSchema in proposal.js to require estimatedDuration.
- Added a positive number constraint to estimatedDuration.
- Integrated error handling in proposalController.js.
- Added integration tests in apps/api/src/tests/proposalDuration.test.js.

Verification:
Run 'cd apps/api && npm test'.
- Proposal with duration -> PASS
- Proposal without duration -> PASS (400)
- Proposal with non-positive duration -> PASS (400)