### PR TITLE
fix(payments): require positive numeric amount on POST /api/payments

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,15 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request body",
+      errors: result.error.issues
+    });
+  }
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  try {
+    return await fn(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(port, body) {
+  return fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments rejects missing amount", async () => {
+  await withServer(async (port) => {
+    const response = await postPayment(port, { currency: "usd" });
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+    assert.ok(Array.isArray(payload.errors));
+  });
+});
+
+test("POST /api/payments rejects zero amount", async () => {
+  await withServer(async (port) => {
+    const response = await postPayment(port, { amount: 0, currency: "usd" });
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/payments rejects negative amount", async () => {
+  await withServer(async (port) => {
+    const response = await postPayment(port, { amount: -10, currency: "usd" });
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/payments rejects non-numeric amount", async () => {
+  await withServer(async (port) => {
+    const response = await postPayment(port, { amount: "free", currency: "usd" });
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/payments accepts positive amount", async () => {
+  await withServer(async (port) => {
+    const response = await postPayment(port, { amount: 2599, currency: "usd" });
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2599);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Fixes #6384

`POST /api/payments` previously forwarded `req.body` directly into `createPaymentIntent()` with no amount validation. The service accepted zero, negative, missing, or non-numeric amounts and still returned a created payment intent. This PR validates the amount at the route layer with a Zod schema before it reaches the provider integration stub.

### Changes
- `apps/api/src/validators/payment.js` — new `createPaymentSchema` (amount must be a positive number; currency optional)
- `apps/api/src/controllers/paymentController.js` — `safeParse` the request body, return structured 400 on failure, continue to call the service with the parsed payload
- `apps/api/src/tests/payment.test.js` — regression coverage for missing, zero, negative, non-numeric, and valid positive amounts

### Notes
- Scope is limited to amount validation per #6384. Currency normalization (PR #6160) and trim (PR #6167) keep working unchanged because the controller now passes the parsed object straight through.
- Provider integration, auth, and other payment behavior are untouched.
- All tests pass locally: `node --test src/tests` → 5/5 payment + 1/1 health.