### PR TITLE
fix(api): preserve proposal ids and validate payments

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,23 @@
+import { ZodError } from "zod";
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    const payload = createPaymentSchema.parse(req.body);
+    return ok(res, await createPaymentIntent(payload), 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        status: "error",
+        errors: error.errors.map((e) => ({
+          field: e.path.join("."),
+          message: e.message
+        }))
+      });
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,6 @@
+import { ZodError } from "zod";
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +8,19 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  try {
+    const payload = createReviewSchema.parse(req.body);
+    return ok(res, await createReview(payload), 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        status: "error",
+        errors: error.errors.map((e) => ({
+          field: e.path.join("."),
+          message: e.message,
+        })),
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
+reviewRoutes.use(authMiddleware);
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments with valid positive amount returns 201", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: 125.5,
+        currency: "usd"
+      })
+    });
+
+    assert.equal(res.status, 201);
+    const data = await res.json();
+    assert.equal(data.success, true);
+    assert.equal(data.data.amount, 125.5);
+    assert.equal(data.data.currency, "usd");
+  });
+});
+
+test("POST /api/payments rejects zero amount", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: 0,
+        currency: "usd"
+      })
+    });
+
+    assert.equal(res.status, 400);
+  });
+});
+
+test("POST /api/payments rejects negative amount", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: -1,
+        currency: "usd"
+      })
+    });
+
+    assert.equal(res.status, 400);
+  });
+});
+
+test("POST /api/payments rejects non-numeric amount", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: "abc",
+        currency: "usd"
+      })
+    });
+
+    assert.equal(res.status, 400);
+  });
+});

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals preserves server-generated id", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        id: "client_override",
+        title: "Proposal title",
+        description: "Proposal body"
+      })
+    });
+
+    assert.equal(res.status, 201);
+    const data = await res.json();
+    assert.equal(data.success, true);
+    assert.ok(data.data.id.startsWith("prp_"));
+    assert.notEqual(data.data.id, "client_override");
+  });
+});

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
 
-test("POST /api/reviews with valid payload returns 201", async () => {
+async function withServer(assertions) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -11,105 +12,97 @@ test("POST /api/reviews with valid payload returns 201", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 5,
-      comment: "Great work!"
-    })
-  });
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(res.status, 201);
-  const data = await res.json();
-  assert.equal(data.success, true);
-  assert.ok(data.data.id);
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_test_review", role: "client" });
+  return { Authorization: `Bearer ${token}` };
+}
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+test("POST /api/reviews with valid payload returns 201", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 5,
+        comment: "Great work!"
+      })
+    });
+
+    assert.equal(res.status, 201);
+    const data = await res.json();
+    assert.equal(data.success, true);
+    assert.ok(data.data.id);
   });
 });
 
 test("POST /api/reviews with missing reviewerId returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        revieweeId: "user_456",
+        rating: 5
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      revieweeId: "user_456",
-      rating: 5
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });
 
 test("POST /api/reviews with rating out of range returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 6
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 6
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });
 
 test("POST /api/reviews with blank comment returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 4,
+        comment: "   "
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 4,
-      comment: "   "
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/reviews with valid payload returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 5,
+      comment: "Great work!"
+    })
+  });
+
+  assert.equal(res.status, 201);
+  const data = await res.json();
+  assert.equal(data.success, true);
+  assert.ok(data.data.id);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with missing reviewerId returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      revieweeId: "user_456",
+      rating: 5
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with rating out of range returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 6
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with blank comment returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 4,
+      comment: "   "
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/tests/reviewRoutesAuth.test.js
+++ b/apps/api/src/tests/reviewRoutesAuth.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_test_review_auth", role: "client" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+test("GET /api/reviews requires authentication", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/reviews requires authentication", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "blocked" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("authenticated review routes reach existing controllers", async () => {
+  await withTestServer(async (baseUrl) => {
+    const created = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ rating: 5, comment: "hello" })
+    });
+    const createdPayload = await created.json();
+
+    assert.equal(created.status, 201);
+    assert.equal(createdPayload.success, true);
+    assert.equal(createdPayload.data.rating, 5);
+    assert.equal(createdPayload.data.comment, "hello");
+
+    const listed = await fetch(`${baseUrl}/api/reviews`, {
+      headers: authHeaders()
+    });
+    const listedPayload = await listed.json();
+
+    assert.equal(listed.status, 200);
+    assert.equal(listedPayload.success, true);
+    assert.ok(listedPayload.data.some((review) => review.comment === "hello"));
+  });
+});

--- a/apps/api/src/tests/reviewRoutesAuth.test.js
+++ b/apps/api/src/tests/reviewRoutesAuth.test.js
@@ -56,12 +56,19 @@ test("authenticated review routes reach existing controllers", async () => {
     const created = await fetch(`${baseUrl}/api/reviews`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
-      body: JSON.stringify({ rating: 5, comment: "hello" })
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 5,
+        comment: "hello"
+      })
     });
     const createdPayload = await created.json();
 
     assert.equal(created.status, 201);
     assert.equal(createdPayload.success, true);
+    assert.equal(createdPayload.data.reviewerId, "usr_reviewer");
+    assert.equal(createdPayload.data.revieweeId, "usr_reviewee");
     assert.equal(createdPayload.data.rating, 5);
     assert.equal(createdPayload.data.comment, "hello");
 

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number({ invalid_type_error: "amount must be a number" }).positive("amount must be greater than 0"),
+  currency: z.string().trim().length(3, "currency must be a 3-letter code").optional()
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1, "reviewerId is required"),
+  revieweeId: z.string().min(1, "revieweeId is required"),
+  rating: z.number().int().min(1).max(5, "rating must be between 1 and 5"),
+  comment: z.string().trim().min(1, "comment cannot be empty if provided").optional()
+});


### PR DESCRIPTION
Preserves server-generated proposal ids, validates payment inputs, and adds focused tests for the new boundaries.