### PR TITLE
fix: preserve server-generated id in review creation (closes #6459)

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
Fix for #6459. Moved ...payload before id in createReview so server-generated id always takes priority.