### PR TITLE
fix: preserve server-generated fields in notification creation (closes #6461)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Fix for #6461. Moved ...payload before server-generated id and read fields so they cannot be overridden by client.