### PR TITLE
fix: preserve server-generated proposal id from payload override

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }


### PR DESCRIPTION
## Summary

`POST /api/proposals` used `{ id: `prp_${Date.now()}`, ...payload }` which allows the client to override the server-generated `id` by including an `id` field in the request body.

## Changes

- Reorder spread to `{ ...payload, id: `prp_${Date.now()}` }` so server-generated `id` always takes precedence

Closes #6372

/claim #6372