### PR TITLE
fix: preserve server-generated message id from payload override

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
## Summary

`POST /api/messages` used `{ id: `msg_${Date.now()}`, ...payload, sentAt: ... }` which allows the client to override the server-generated `id` by including an `id` field in the request body.

## Changes

- Reorder spread to `{ ...payload, id: `msg_${Date.now()}`, sentAt: ... }` so server-generated `id` always takes precedence

Closes #6373

/claim #6373