### PR TITLE
fix: add input validation for payment creation endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).default("usd")
+});


### PR DESCRIPTION
## Summary

`POST /api/payments` previously accepted any payload without validation, allowing zero, negative, or non-numeric amounts and invalid currency codes.

## Changes

- Add `createPaymentSchema` validator using Zod in `apps/api/src/validators/payment.js`
- Amount must be a positive number
- Currency must be a 3-letter string (defaults to "usd")
- Apply `schema.parse()` in `paymentController.js`

Closes #6374

/claim #6374