### PR TITLE
fix: accept Bearer auth scheme case-insensitively

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,7 +3,7 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
     return fail(res, "Unauthorized", 401);
   }
 


### PR DESCRIPTION
Makes auth parsing accept Bearer case-insensitively and covers the behavior with direct tests.