### PR TITLE
fix: add createdAt to notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,16 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Server-owned `createdAt` so caller-supplied values cannot control the
+  // returned timestamp. Strip any incoming `createdAt` from the payload first
+  // and assign the canonical ISO string at the storage boundary.
+  const { createdAt: _ignoredCreatedAt, ...rest } = payload ?? {};
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    read: false,
+    createdAt: new Date().toISOString(),
+    ...rest,
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("createNotification assigns a server-owned createdAt ISO timestamp", async () => {
+  const before = Date.now();
+  const notification = await createNotification({ message: "hello" });
+  const after = Date.now();
+
+  assert.ok(typeof notification.createdAt === "string", "createdAt should be a string");
+  const parsed = Date.parse(notification.createdAt);
+  assert.ok(!Number.isNaN(parsed), "createdAt should parse as a valid date");
+  assert.ok(parsed >= before && parsed <= after, "createdAt should fall between before/after timestamps");
+  assert.equal(notification.message, "hello");
+  assert.equal(notification.read, false, "default read should be false");
+});
+
+test("createNotification ignores caller-supplied createdAt values", async () => {
+  const notification = await createNotification({
+    message: "world",
+    createdAt: "1970-01-01T00:00:00.000Z",
+  });
+  const parsed = Date.parse(notification.createdAt);
+  assert.ok(parsed > 0, "createdAt should reflect server time, not caller-supplied epoch zero");
+  assert.notEqual(notification.createdAt, "1970-01-01T00:00:00.000Z");
+});
+
+test("createNotification returns the stored record via listNotifications", async () => {
+  const initialLength = (await listNotifications()).length;
+  const notification = await createNotification({ message: "stored" });
+  const stored = await listNotifications();
+  assert.equal(stored.length, initialLength + 1);
+  assert.ok(stored.includes(notification));
+});


### PR DESCRIPTION
Adds server-owned createdAt metadata to notification creation and covers the behavior with tests.