### PR TITLE
[fix] Reject inverted budget ranges in job validation (#2853)

### DIFF
--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects inverted budget ranges (budgetMax < budgetMin)", () => {
+  const payload = {
+    title: "Test Job",
+    description: "This is a test job description",
+    budgetMin: 1000,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  assert.throws(
+    () => createJobSchema.parse(payload),
+    (error) => {
+      return error.errors.some(
+        (e) => e.path.includes("budgetMax") && e.message.includes("budgetMax must be greater than or equal to budgetMin")
+      );
+    },
+    "Should reject when budgetMax is less than budgetMin"
+  );
+});
+
+test("createJobSchema accepts valid budget ranges (budgetMax >= budgetMin)", () => {
+  const payload = {
+    title: "Test Job",
+    description: "This is a test job description",
+    budgetMin: 500,
+    budgetMax: 1000,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  const result = createJobSchema.parse(payload);
+  assert.equal(result.budgetMin, 500);
+  assert.equal(result.budgetMax, 1000);
+});
+
+test("createJobSchema accepts equal budgetMin and budgetMax", () => {
+  const payload = {
+    title: "Test Job",
+    description: "This is a test job description",
+    budgetMin: 1000,
+    budgetMax: 1000,
+    categoryId: "cat_1",
+    skills: []
+  };
+
+  const result = createJobSchema.parse(payload);
+  assert.equal(result.budgetMin, 1000);
+  assert.equal(result.budgetMax, 1000);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both are present", () => {
+  const payload = {
+    budgetMin: 1000,
+    budgetMax: 500
+  };
+
+  assert.throws(
+    () => updateJobSchema.parse(payload),
+    (error) => {
+      return error.errors.some(
+        (e) => e.path.includes("budgetMax") && e.message.includes("budgetMax must be greater than or equal to budgetMin")
+      );
+    },
+    "Should reject when updating with inverted budget ranges"
+  );
+});
+
+test("updateJobSchema accepts valid budget ranges", () => {
+  const payload = {
+    budgetMin: 500,
+    budgetMax: 1000
+  };
+
+  const result = updateJobSchema.parse(payload);
+  assert.equal(result.budgetMin, 500);
+  assert.equal(result.budgetMax, 1000);
+});
+
+test("updateJobSchema accepts single budget field", () => {
+  const payloadOnlyMin = {
+    budgetMin: 500
+  };
+
+  const resultMin = updateJobSchema.parse(payloadOnlyMin);
+  assert.equal(resultMin.budgetMin, 500);
+  assert.ok(!("budgetMax" in resultMin));
+
+  const payloadOnlyMax = {
+    budgetMax: 1000
+  };
+
+  const resultMax = updateJobSchema.parse(payloadOnlyMax);
+  assert.equal(resultMax.budgetMax, 1000);
+  assert.ok(!("budgetMin" in resultMax));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,30 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).default([]).optional()
+}).refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Summary

This PR fixes the issue where createJobSchema accepts payloads where udgetMax is lower than udgetMin, creating invalid job records.

## Changes

1. **Modified pps/api/src/validators/job.js**:
   - Added .refine() to createJobSchema to validate that udgetMax >= budgetMin
   - Created a separate updateJobSchema (instead of using .partial()) with the same validation logic that only checks when both fields are present

2. **Added pps/api/src/tests/job.test.js**:
   - Comprehensive test coverage for budget validation
   - Tests for rejection of inverted ranges
   - Tests for acceptance of valid ranges
   - Tests for equal budgetMin and budgetMax
   - Tests for partial update scenarios

## Verification

All tests pass:
- createJobSchema rejects inverted budget ranges (budgetMax < budgetMin)
- createJobSchema accepts valid budget ranges (budgetMax >= budgetMin)
- createJobSchema accepts equal budgetMin and budgetMax
- updateJobSchema rejects inverted budget ranges when both are present
- updateJobSchema accepts valid budget ranges
- updateJobSchema accepts single budget field

## Related Issues

- Fixes #2853
- Related to parent bounty #743