### PR TITLE
[fix] Resolve mock freelancer profiles by username (#2849)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,27 @@
+import { freelancers } from "@/lib/mock";
+import Link from "next/link";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Profile</h2>
+        <p>Profile: <strong>{params.username}</strong></p>
+        <p>Freelancer not found.</p>
+        <Link href="/freelancers/search">Back to search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
+      <p>Hourly Rate: {freelancer.rate}</p>
+      <Link href="/freelancers/search">Back to search</Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes the /freelancers/[username] route to properly display freelancer profiles from mock data instead of placeholder text.

## Changes

1. **Modified pps/web/app/freelancers/[username]/page.tsx**:
   - Import reelancers mock data from @/lib/mock
   - Find matching freelancer by username using Array.find()
   - Display skills and hourly rate for known freelancers
   - Show clear 'not found' message for unknown usernames
   - Added back to search link

## Verification

- Known freelancer usernames (maya-dev, jordan-ux) display their skills and hourly rate
- Unknown usernames show a clear not-found fallback
- Fixes #2849

## Related Issues

- Fixes #2849
- Related to parent bounty #743
- Related to #2763