### PR TITLE
fix: notification creation preserves server-owned id and read state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,10 @@
+/**
+ * Notification Service
+ * 
+ * Fix #2762: Preserve server-owned id and read state during creation.
+ * Caller-supplied `id` and `read` fields are now ignored.
+ */
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +12,16 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Strip any caller-supplied id and read fields to ensure
+  // the server always owns these values.
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload || {};
+  
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    read: false,
+    ...safePayload,
+  };
+  
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Closes #2762

**What**
Strips caller-supplied id and read fields during notification creation so the server always owns these values.

**Why**
A request body could previously override the generated notification id and set notifications as already read.

/bounty $780