### PR TITLE
[fix] Render matching mock job and not-found fallback (#2755)

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,26 @@
+import { jobs } from "@/lib/mock";
+import Link from "next/link";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Detail</h2>
+        <p>Job not found.</p>
+        <Link href="/jobs">Back to jobs</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <p>Job ID: <strong>{job.id}</strong></p>
+      <p>Title: <strong>{job.title}</strong></p>
+      <p>Budget: <strong>{job.budget}</strong></p>
+      <Link href="/jobs">Back to jobs</Link>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes the /jobs/[id] route to display job details from mock data instead of placeholder text.

## Changes

- Import jobs mock data from @/lib/mock
- Find matching job by id
- Display job title and budget for known jobs
- Show clear not-found fallback for unknown job ids

## Verification

- Known job ids display title and budget
- Unknown job ids show not-found message
- Fixes #2755