### PR TITLE
[fix] Add search query validation and length limit (#2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -2,5 +2,23 @@ import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q;
+
+  // Validate query is a string
+  if (typeof query !== "string") {
+    return res.status(400).json({
+      error: "Search query must be a string"
+    });
+  }
+
+  // Trim and validate length
+  const trimmedQuery = query.trim();
+
+  if (trimmedQuery.length > 200) {
+    return res.status(400).json({
+      error: "Search query must be 200 characters or less"
+    });
+  }
+
+  return ok(res, await globalSearch(trimmedQuery));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { search } from "../controllers/searchController.js";
+
+test("search rejects non-string query", async () => {
+  const mockReq = { query: { q: 123 } };
+  let statusCode = 0;
+  let responseBody = null;
+
+  const mockRes = {
+    status: (code) => {
+      statusCode = code;
+      return mockRes;
+    },
+    json: (body) => {
+      responseBody = body;
+      return mockRes;
+    }
+  };
+
+  await search(mockReq, mockRes);
+
+  assert.equal(statusCode, 400);
+  assert.equal(responseBody.error, "Search query must be a string");
+});
+
+test("search rejects query longer than 200 characters", async () => {
+  const longQuery = "a".repeat(201);
+  const mockReq = { query: { q: longQuery } };
+  let statusCode = 0;
+  let responseBody = null;
+
+  const mockRes = {
+    status: (code) => {
+      statusCode = code;
+      return mockRes;
+    },
+    json: (body) => {
+      responseBody = body;
+      return mockRes;
+    }
+  };
+
+  await search(mockReq, mockRes);
+
+  assert.equal(statusCode, 400);
+  assert.equal(responseBody.error, "Search query must be 200 characters or less");
+});
+
+test("search accepts valid query", async () => {
+  const mockReq = { query: { q: "test query" } };
+  let statusCode = 0;
+  let responseBody = null;
+
+  const mockRes = {
+    status: (code) => {
+      statusCode = code;
+      return mockRes;
+    },
+    json: (body) => {
+      responseBody = body;
+      return mockRes;
+    }
+  };
+
+  await search(mockReq, mockRes);
+
+  assert.equal(statusCode, 200);
+});
+
+test("search accepts 200 character query", async () => {
+  const maxQuery = "a".repeat(200);
+  const mockReq = { query: { q: maxQuery } };
+  let statusCode = 0;
+  let responseBody = null;
+
+  const mockRes = {
+    status: (code) => {
+      statusCode = code;
+      return mockRes;
+    },
+    json: (body) => {
+      responseBody = body;
+      return mockRes;
+    }
+  };
+
+  await search(mockReq, mockRes);
+
+  assert.equal(statusCode, 200);
+});


### PR DESCRIPTION
## Summary

This PR adds input validation and length limits to the GET /api/search endpoint.

## Changes

- Validate query is a string
- Trim whitespace from query
- Reject queries longer than 200 characters
- Add comprehensive tests

## Verification

- Rejects non-string queries with 400
- Rejects queries > 200 chars
- Accepts valid queries
- Fixes #2833