### PR TITLE
[fix] Require fullName in registration (#2770)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registration.test.js
+++ b/apps/api/src/tests/registration.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerSchema requires fullName", () => {
+  const invalidPayload = {
+    email: "test@example.com",
+    password: "password123"
+  };
+
+  assert.throws(
+    () => registerSchema.parse(invalidPayload),
+    (error) => {
+      return error.errors.some((e) => e.path.includes("fullName"));
+    },
+    "Should reject registration without fullName"
+  );
+});
+
+test("registerSchema accepts valid payload with fullName", () => {
+  const validPayload = {
+    email: "test@example.com",
+    password: "password123",
+    fullName: "Test User"
+  };
+
+  const result = registerSchema.parse(validPayload);
+  assert.equal(result.fullName, "Test User");
+});
+
+test("registerUser returns fullName in response", async () => {
+  const payload = {
+    email: "test@example.com",
+    password: "password123",
+    fullName: "Test User",
+    role: "client"
+  };
+
+  const result = await registerUser(payload);
+  assert.equal(result.fullName, "Test User");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
## Summary

This PR adds fullName requirement to registration to match the User model.

## Changes

- Add fullName field to registerSchema validation
- Include fullName in registerUser response
- Add comprehensive tests

## Verification

- Rejects registration without fullName
- Returns fullName in registration response
- Fixes #2770