### PR TITLE
fix(db): make workspace entrypoint directly importable

### DIFF
--- a/packages/db/index.cjs
+++ b/packages/db/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs",
+      "types": "./index.d.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"

--- a/packages/db/test/import.test.mjs
+++ b/packages/db/test/import.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+test("packages/db is importable by workspace name", async () => {
+  const mod = await import("@freelanceflow/db");
+
+  assert.ok(mod);
+});
+
+test("packages/db is requireable by workspace name", () => {
+  const mod = require("@freelanceflow/db");
+
+  assert.ok(mod);
+});


### PR DESCRIPTION
/claim #2775

## Summary
- add explicit package metadata for `@freelanceflow/db`
- provide runtime entrypoints for both ESM and CommonJS consumers
- add a focused import test proving the package resolves by workspace name

## Validation
- `node -e "import('@freelanceflow/db')"`
- `node -e "require('@freelanceflow/db')"`
- `node --test packages/db/test/import.test.mjs`
- `git diff --check`

Payout wallet: 0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8