### PR TITLE
fix(ui): make workspace entrypoint directly importable

### DIFF
--- a/packages/ui/index.cjs
+++ b/packages/ui/index.cjs
@@ -1,0 +1,29 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Button, Card };

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export function Button({ children }: { children: ReactNode }): ReactNode;
+
+export function Card({ title, children }: { title: string; children: ReactNode }): ReactNode;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs",
+      "types": "./index.d.ts"
+    }
+  }
 }

--- a/packages/ui/test/import.test.mjs
+++ b/packages/ui/test/import.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+test("packages/ui is importable by workspace name", async () => {
+  const mod = await import("@freelanceflow/ui");
+
+  assert.equal(typeof mod.Button, "function");
+  assert.equal(typeof mod.Card, "function");
+});
+
+test("packages/ui is requireable by workspace name", () => {
+  const mod = require("@freelanceflow/ui");
+
+  assert.equal(typeof mod.Button, "function");
+  assert.equal(typeof mod.Card, "function");
+});


### PR DESCRIPTION
/claim #2781

## Summary
- add explicit package metadata for `@freelanceflow/ui`
- provide runtime entrypoints for both ESM and CommonJS consumers
- add a focused import test proving `Button` and `Card` resolve by workspace package name

## Validation
- `node -e "import('@freelanceflow/ui')"`
- `node -e "require('@freelanceflow/ui')"`
- `node --test packages/ui/test/import.test.mjs`
- `git diff --check`

Payout wallet: 0x8f94Eb732F5044dee8C23ECe9A1BDd801288dfc8