### PR TITLE
Validate payment creation amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const { amount, currency = "usd" } = req.body;
+
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return fail(res, "Payment amount must be a positive number");
+  }
+
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    return fail(res, "Payment currency must be a 3-letter code");
+  }
+
+  return ok(res, await createPaymentIntent({ ...req.body, amount, currency }), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const invalidBodies = [
+      { amount: -100, currency: "usd" },
+      { amount: 0, currency: "usd" },
+      { amount: "free", currency: "usd" }
+    ];
+
+    for (const body of invalidBodies) {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(payload.success, false);
+      assert.match(payload.message, /amount/i);
+    }
+  });
+});
+
+test("POST /api/payments creates payment for a valid amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25, currency: "EUR" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 25);
+    assert.equal(payload.data.currency, "EUR");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});
+
+test("POST /api/payments validates optional currency codes", async () => {
+  await withServer(async (baseUrl) => {
+    const missingCurrencyResponse = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25 })
+    });
+    const missingCurrencyPayload = await missingCurrencyResponse.json();
+
+    assert.equal(missingCurrencyResponse.status, 201);
+    assert.equal(missingCurrencyPayload.data.currency, "usd");
+
+    const invalidCurrencyResponse = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 25, currency: "us1" })
+    });
+    const invalidCurrencyPayload = await invalidCurrencyResponse.json();
+
+    assert.equal(invalidCurrencyResponse.status, 400);
+    assert.equal(invalidCurrencyPayload.success, false);
+    assert.match(invalidCurrencyPayload.message, /currency/i);
+  });
+});


### PR DESCRIPTION
Closes #6522

/claim #743

## Summary
- Validate `POST /api/payments` request bodies before creating a payment intent.
- Reject non-positive, non-numeric, or non-finite `amount` values with the existing `{ success: false, message }` 400 shape.
- Keep `currency` optional with the existing `usd` default and reject malformed currency codes.
- Preserve valid payment creation behavior.

## Validation
- `node --test src/tests/*.test.js`
- `git diff --check`