### PR TITLE
Do not store submitted user passwords

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password: _password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("createUser does not store or return submitted passwords", async () => {
+  const email = `private-${Date.now()}@example.com`;
+
+  const created = await createUser({
+    email,
+    fullName: "Private User",
+    password: "super-secret-password"
+  });
+
+  assert.equal(Object.hasOwn(created, "password"), false);
+  assert.equal(created.email, email);
+  assert.equal(created.fullName, "Private User");
+
+  const users = await listUsers();
+  const stored = users.find((user) => user.email === email);
+
+  assert.ok(stored);
+  assert.equal(Object.hasOwn(stored, "password"), false);
+  assert.equal(stored.fullName, "Private User");
+});
+
+test("user API does not expose submitted passwords", async () => {
+  const email = `api-private-${Date.now()}@example.com`;
+
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email,
+        fullName: "API Private User",
+        password: "super-secret-password"
+      })
+    });
+    const created = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(Object.hasOwn(created.data, "password"), false);
+    assert.equal(created.data.email, email);
+
+    const listResponse = await fetch(`${baseUrl}/api/users`);
+    const listPayload = await listResponse.json();
+    const stored = listPayload.data.find((user) => user.email === email);
+
+    assert.equal(listResponse.status, 200);
+    assert.ok(stored);
+    assert.equal(Object.hasOwn(stored, "password"), false);
+    assert.equal(stored.fullName, "API Private User");
+  });
+});


### PR DESCRIPTION
## Summary
- strip submitted `password` fields before storing user records
- preserve non-secret profile fields in created/listed users
- add service and API regression coverage proving passwords are not returned

Fixes #6526

/claim #743

## Validation
- `node --test src/tests/*.test.js` from `apps/api` -> 3 passed
- `git diff --check HEAD~1..HEAD` -> passed