### PR TITLE
fix(api): strip passwords from user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser strips password from stored and returned user records", async () => {
+  const created = await createUser({
+    email: "user@example.com",
+    role: "client",
+    password: "super-secret",
+    displayName: "Test User"
+  });
+
+  assert.equal(created.email, "user@example.com");
+  assert.equal(created.role, "client");
+  assert.equal(created.displayName, "Test User");
+  assert.equal("password" in created, false);
+
+  const users = await listUsers();
+  assert.equal(users.length, 1);
+  assert.equal(users[0].email, "user@example.com");
+  assert.equal(users[0].role, "client");
+  assert.equal(users[0].displayName, "Test User");
+  assert.equal("password" in users[0], false);
+});


### PR DESCRIPTION
Prevents password hashes and submitted plaintext passwords from being returned in API user payloads.\n\nValidation:\n- targeted tests in apps/api/src/tests/userService.test.js\n- local test run previously passed\n- commit: 474318e