### PR TITLE
fix(api): require auth and validate review payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,6 @@
+import { ZodError } from "zod";
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +8,19 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  try {
+    const payload = createReviewSchema.parse(req.body);
+    return ok(res, await createReview(payload), 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return res.status(400).json({
+        status: "error",
+        errors: error.errors.map((e) => ({
+          field: e.path.join("."),
+          message: e.message,
+        })),
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
+reviewRoutes.use(authMiddleware);
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
 
-test("POST /api/reviews with valid payload returns 201", async () => {
+async function withServer(assertions) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -11,105 +12,97 @@ test("POST /api/reviews with valid payload returns 201", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 5,
-      comment: "Great work!"
-    })
-  });
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(res.status, 201);
-  const data = await res.json();
-  assert.equal(data.success, true);
-  assert.ok(data.data.id);
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_test_review", role: "client" });
+  return { Authorization: `Bearer ${token}` };
+}
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+test("POST /api/reviews with valid payload returns 201", async () => {
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 5,
+        comment: "Great work!"
+      })
+    });
+
+    assert.equal(res.status, 201);
+    const data = await res.json();
+    assert.equal(data.success, true);
+    assert.ok(data.data.id);
   });
 });
 
 test("POST /api/reviews with missing reviewerId returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        revieweeId: "user_456",
+        rating: 5
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      revieweeId: "user_456",
-      rating: 5
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });
 
 test("POST /api/reviews with rating out of range returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 6
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 6
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });
 
 test("POST /api/reviews with blank comment returns 400", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+  await withServer(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeaders()
+      },
+      body: JSON.stringify({
+        reviewerId: "user_123",
+        revieweeId: "user_456",
+        rating: 4,
+        comment: "   "
+      })
+    });
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      reviewerId: "user_123",
-      revieweeId: "user_456",
-      rating: 4,
-      comment: "   "
-    })
-  });
-
-  assert.equal(res.status, 400);
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(res.status, 400);
   });
 });

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/reviews with valid payload returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 5,
+      comment: "Great work!"
+    })
+  });
+
+  assert.equal(res.status, 201);
+  const data = await res.json();
+  assert.equal(data.success, true);
+  assert.ok(data.data.id);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with missing reviewerId returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      revieweeId: "user_456",
+      rating: 5
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with rating out of range returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 6
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews with blank comment returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      reviewerId: "user_123",
+      revieweeId: "user_456",
+      rating: 4,
+      comment: "   "
+    })
+  });
+
+  assert.equal(res.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/tests/reviewRoutesAuth.test.js
+++ b/apps/api/src/tests/reviewRoutesAuth.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function authHeaders() {
+  const token = signAccessToken({ sub: "usr_test_review_auth", role: "client" });
+  return { Authorization: `Bearer ${token}` };
+}
+
+test("GET /api/reviews requires authentication", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/reviews requires authentication", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "blocked" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("authenticated review routes reach existing controllers", async () => {
+  await withTestServer(async (baseUrl) => {
+    const created = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ rating: 5, comment: "hello" })
+    });
+    const createdPayload = await created.json();
+
+    assert.equal(created.status, 201);
+    assert.equal(createdPayload.success, true);
+    assert.equal(createdPayload.data.rating, 5);
+    assert.equal(createdPayload.data.comment, "hello");
+
+    const listed = await fetch(`${baseUrl}/api/reviews`, {
+      headers: authHeaders()
+    });
+    const listedPayload = await listed.json();
+
+    assert.equal(listed.status, 200);
+    assert.equal(listedPayload.success, true);
+    assert.ok(listedPayload.data.some((review) => review.comment === "hello"));
+  });
+});

--- a/apps/api/src/tests/reviewRoutesAuth.test.js
+++ b/apps/api/src/tests/reviewRoutesAuth.test.js
@@ -56,12 +56,19 @@ test("authenticated review routes reach existing controllers", async () => {
     const created = await fetch(`${baseUrl}/api/reviews`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...authHeaders() },
-      body: JSON.stringify({ rating: 5, comment: "hello" })
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 5,
+        comment: "hello"
+      })
     });
     const createdPayload = await created.json();
 
     assert.equal(created.status, 201);
     assert.equal(createdPayload.success, true);
+    assert.equal(createdPayload.data.reviewerId, "usr_reviewer");
+    assert.equal(createdPayload.data.revieweeId, "usr_reviewee");
     assert.equal(createdPayload.data.rating, 5);
     assert.equal(createdPayload.data.comment, "hello");
 

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1, "reviewerId is required"),
+  revieweeId: z.string().min(1, "revieweeId is required"),
+  rating: z.number().int().min(1).max(5, "rating must be between 1 and 5"),
+  comment: z.string().trim().min(1, "comment cannot be empty if provided").optional()
+});


### PR DESCRIPTION
Tightens review creation by requiring authentication and validating the payload before the service layer runs. Adds regression coverage for auth and invalid payload paths.\n\nValidation:\n- tests in apps/api/src/tests/reviewRoutesAuth.test.js and apps/api/src/tests/review.test.js\n- local review branch already validated\n- issue #6306