### PR TITLE
Payment creation should require authentication

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/payment-routes-auth.test.js
+++ b/apps/api/src/tests/payment-routes-auth.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/payments allows authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_payments", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.equal(typeof payload.data.paymentId, "string");
+  });
+});

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -110,7 +110,7 @@
   "CuboYe": 2,
   "crystal-tensor": 12,
   "sravan27": 5,
-  "q404365631": 5,
+  "q404365631": 4,
   "Tori-TIC": 2,
   "JunkingA1": 6,
   "1150654748m-dev": 1,
@@ -611,9 +611,9 @@
   "dallasnetprofu02-design": 68,
   "michaelapollopimentel-svg": 1,
   "None-Feeling": 1,
-  "Kyou2474": 6,
+  "Kyou2474": 5,
   "crhywun": 4,
-  "xiaofengzii": 21,
+  "xiaofengzii": 16,
   "SnowfallHD": 7,
   "AldrikM": 3,
   "jiangyj545": 3,
@@ -628,7 +628,6 @@
   "Valentinasmith722": 1,
   "poem123123": 9,
   "Procoder1234556": 2,
-  "vibhor-aggr": 37,
-  "adesinamichael669-beep": 2,
-  "MAWXHUB": 1
+  "vibhor-aggr": 33,
+  "adesinamichael669-beep": 2
 }

--- a/leaderboard.json
+++ b/leaderboard.json
@@ -110,7 +110,7 @@
   "CuboYe": 2,
   "crystal-tensor": 12,
   "sravan27": 5,
-  "q404365631": 4,
+  "q404365631": 5,
   "Tori-TIC": 2,
   "JunkingA1": 6,
   "1150654748m-dev": 1,
@@ -611,9 +611,9 @@
   "dallasnetprofu02-design": 68,
   "michaelapollopimentel-svg": 1,
   "None-Feeling": 1,
-  "Kyou2474": 5,
+  "Kyou2474": 6,
   "crhywun": 4,
-  "xiaofengzii": 16,
+  "xiaofengzii": 21,
   "SnowfallHD": 7,
   "AldrikM": 3,
   "jiangyj545": 3,
@@ -628,6 +628,7 @@
   "Valentinasmith722": 1,
   "poem123123": 9,
   "Procoder1234556": 2,
-  "vibhor-aggr": 33,
-  "adesinamichael669-beep": 2
+  "vibhor-aggr": 37,
+  "adesinamichael669-beep": 2,
+  "MAWXHUB": 1
 }


### PR DESCRIPTION
Parent bounty: #743\n\nReissue of issue #6304.\n\n## Scope\n- Apply the existing auth middleware to POST /api/payments.\n- Keep the change scoped to the payment route.\n- Add route-level tests for missing auth and valid bearer auth.\n\n## Validation\n- node --test apps/api/src/tests/payment-routes-auth.test.js\n- git diff --check