### PR TITLE
Protect message and notification list routes

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
-  return ok(res, await listMessages());
+  return ok(res, await listMessages(req.user.sub));
 }
 
 export async function postMessage(req, res) {

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -2,7 +2,7 @@ import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
-  return ok(res, await listNotifications());
+  return ok(res, await listNotifications(req.user.sub));
 }
 
 export async function postNotification(req, res) {

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
 const messages = [];
 
-export async function listMessages() {
-  return messages;
+export async function listMessages(userId) {
+  return messages.filter(
+    (message) => message.senderId === userId || message.recipientId === userId
+  );
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
-export async function listNotifications() {
-  return notifications;
+export async function listNotifications(userId) {
+  return notifications.filter((notification) => notification.userId === userId);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/tests/message-notification-auth.test.js
+++ b/apps/api/src/tests/message-notification-auth.test.js
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/messages only returns messages visible to the authenticated user", async () => {
+  await withServer(async (port) => {
+    const createMessage = async (payload) => {
+      const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      assert.equal(response.status, 201);
+      return (await response.json()).data;
+    };
+
+    const sentByAlice = await createMessage({
+      senderId: "usr_alice",
+      recipientId: "usr_bob",
+      body: "Visible because Alice sent it"
+    });
+    const sentToAlice = await createMessage({
+      senderId: "usr_carol",
+      recipientId: "usr_alice",
+      body: "Visible because Alice received it"
+    });
+    const hiddenFromAlice = await createMessage({
+      senderId: "usr_dan",
+      recipientId: "usr_erin",
+      body: "Should stay hidden from Alice"
+    });
+
+    const token = signAccessToken({ sub: "usr_alice", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const returnedIds = payload.data.map((message) => message.id);
+    assert.ok(returnedIds.includes(sentByAlice.id));
+    assert.ok(returnedIds.includes(sentToAlice.id));
+    assert.ok(!returnedIds.includes(hiddenFromAlice.id));
+    assert.ok(
+      payload.data.every(
+        (message) =>
+          message.senderId === "usr_alice" || message.recipientId === "usr_alice"
+      )
+    );
+  });
+});
+
+test("GET /api/notifications rejects missing token", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/notifications only returns notifications owned by the authenticated user", async () => {
+  await withServer(async (port) => {
+    const createNotification = async (payload) => {
+      const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      assert.equal(response.status, 201);
+      return (await response.json()).data;
+    };
+
+    const visibleNotification = await createNotification({
+      userId: "usr_alice",
+      type: "message",
+      text: "Visible to Alice"
+    });
+    const hiddenNotification = await createNotification({
+      userId: "usr_bob",
+      type: "message",
+      text: "Should stay hidden from Alice"
+    });
+
+    const token = signAccessToken({ sub: "usr_alice", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const returnedIds = payload.data.map((notification) => notification.id);
+    assert.ok(returnedIds.includes(visibleNotification.id));
+    assert.ok(!returnedIds.includes(hiddenNotification.id));
+    assert.ok(
+      payload.data.every((notification) => notification.userId === "usr_alice")
+    );
+  });
+});


### PR DESCRIPTION
Parent bounty: #743

Reissue of issue #1584.

## Scope
- Apply auth to GET /api/messages and GET /api/notifications.
- Scope list results to the authenticated user.
- Add regression tests for missing-token rejection and per-user scoping.

## Validation
- node --test apps/api/src/tests/message-notification-auth.test.js
- git diff --check
