### PR TITLE
Upload endpoint should require authentication

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload-routes-auth.test.js
+++ b/apps/api/src/tests/upload-routes-auth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects missing token", async () => {
+  await withServer(async (port) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/uploads allows authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_uploads", role: "freelancer" });
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
Parent bounty: #743\n\nReissue of issue #6308.\n\n## Scope\n- Require Bearer auth for POST /api/uploads.\n- Keep authenticated upload behavior unchanged.\n- Add tests for missing-token rejection and authenticated access.\n\n## Validation\n- node --test apps/api/src/tests/upload-routes-auth.test.js\n- git diff --check