### PR TITLE
Require JWT secret outside development and test

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET?.trim() ?? "";
+
+if (!jwtSecret && nodeEnv !== "development" && nodeEnv !== "test") {
+  throw new Error("JWT_SECRET must be set outside development and test");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: jwtSecret || "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importFreshEnv(tag) {
+  const url = new URL("../config/env.js", import.meta.url);
+  url.searchParams.set("v", tag);
+  return import(url.href);
+}
+
+async function withEnv(overrides, run) {
+  const keys = Object.keys(overrides);
+  const previous = new Map(keys.map((key) => [key, Object.prototype.hasOwnProperty.call(process.env, key) ? process.env[key] : undefined]));
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const key of keys) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("env keeps the development JWT fallback", async () => {
+  await withEnv({ NODE_ENV: undefined, JWT_SECRET: undefined }, async () => {
+    const { env } = await importFreshEnv("development-fallback");
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.jwtSecret, "development-secret");
+  });
+});
+
+test("env keeps the test JWT fallback", async () => {
+  await withEnv({ NODE_ENV: "test", JWT_SECRET: undefined }, async () => {
+    const { env } = await importFreshEnv("test-fallback");
+    assert.equal(env.nodeEnv, "test");
+    assert.equal(env.jwtSecret, "development-secret");
+  });
+});
+
+test("env requires JWT_SECRET outside development and test", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: undefined }, async () => {
+    await assert.rejects(importFreshEnv("production-missing"), /JWT_SECRET must be set outside development and test/);
+  });
+});
+
+test("env uses the provided JWT_SECRET in production", async () => {
+  await withEnv({ NODE_ENV: "production", JWT_SECRET: "prod-secret" }, async () => {
+    const { env } = await importFreshEnv("production-present");
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.jwtSecret, "prod-secret");
+  });
+});


### PR DESCRIPTION
Scope: make JWT_SECRET mandatory outside development/test while preserving the existing development and test fallback. Add regression coverage for development fallback, test fallback, production failure when missing, and production success when provided.

Validation:
- node --test apps/api/src/tests/env.test.js
- node --test apps/api/src/tests/health.test.js