### PR TITLE
OAuth callback accepts arbitrary provider values without whitelist validation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const allowedOauthProviders = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,13 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const provider = String(req.params.provider ?? "").toLowerCase();
+  if (!allowedOauthProviders.has(provider)) {
+    return fail(res, "Invalid provider", 400);
+  }
+
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }

--- a/apps/api/src/tests/auth-oauth-provider.test.js
+++ b/apps/api/src/tests/auth-oauth-provider.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/auth/oauth/:provider/callback accepts allowed providers", async () => {
+  await withServer(async (port) => {
+    for (const provider of ["github", "google", "GITHUB"]) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/${provider}/callback`);
+      const payload = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(payload, {
+        success: true,
+        data: {
+          provider: provider.toLowerCase(),
+          status: "callback-received"
+        }
+      });
+    }
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback rejects invalid providers", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/oauth/evil_provider/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid provider"
+    });
+  });
+});


### PR DESCRIPTION
Scope: whitelist GET /api/auth/oauth/:provider/callback to accepted providers only and return 400 for invalid providers. Keep the response shape unchanged for valid providers.

Validation:
- node --test apps/api/src/tests/auth-oauth-provider.test.js
- node --test apps/api/src/tests/health.test.js