### PR TITLE
Prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/auth-validators.test.js
+++ b/apps/api/src/tests/auth-validators.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("register schema defaults role to client", () => {
+  const result = registerSchema.parse({
+    email: "user@example.com",
+    password: "password123"
+  });
+
+  assert.equal(result.role, "client");
+});
+
+test("register schema accepts public roles and rejects admin", () => {
+  const client = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const freelancer = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(client.role, "client");
+  assert.equal(freelancer.role, "freelancer");
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  }, /Invalid enum value/);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Scope: restrict public registration to client/freelancer roles and keep the default client role behavior. Add focused validator coverage proving admin is rejected while public roles continue to pass.

Validation:
- node --test apps/api/src/tests/auth-validators.test.js
- node --test apps/api/src/tests/health.test.js