### PR TITLE
Registration token subject should match returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-register-token-sync.test.js
+++ b/apps/api/src/tests/auth-register-token-sync.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("register user keeps response id and token subject in sync", async () => {
+  const originalDateNow = Date.now;
+  let callCount = 0;
+  Date.now = () => (callCount += 1) === 1 ? 1000 : 2000;
+
+  try {
+    const result = await registerUser({
+      email: "user@example.com",
+      password: "password123",
+      role: "client"
+    });
+
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
Scope: generate the registration user id once and reuse it for both the response id and JWT subject. Add regression coverage proving they stay in sync.

Validation:
- node --test apps/api/src/tests/auth-register-token-sync.test.js
- node --test apps/api/src/tests/health.test.js