### PR TITLE
Payment currency codes should trim whitespace

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: payload.currency?.trim() || "usd",
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-service-currency.test.js
+++ b/apps/api/src/tests/payment-service-currency.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent trims currency codes", async () => {
+  const result = await createPaymentIntent({
+    amount: 1500,
+    currency: " USD "
+  });
+
+  assert.equal(result.currency, "USD");
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const result = await createPaymentIntent({
+    amount: 1500
+  });
+
+  assert.equal(result.currency, "usd");
+});


### PR DESCRIPTION
Scope: trim whitespace from the payment currency before returning the payment intent response. Keep the missing-currency default of usd and add focused service coverage for padded and missing currency values.

Validation:
- node --test apps/api/src/tests/payment-service-currency.test.js
- node --test apps/api/src/tests/health.test.js