### PR TITLE
Proposal creation should validate payloads and preserve server-owned ids

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal payload", 400);
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-routes.test.js
+++ b/apps/api/src/tests/proposal-routes.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validProposal = {
+  jobId: "job_1",
+  freelancerId: "freelancer_1",
+  coverLetter: "I can help with this job"
+};
+
+test("POST /api/proposals rejects invalid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ id: "malicious" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid proposal payload"
+    });
+  });
+});
+
+test("POST /api/proposals preserves the server-generated id", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        ...validProposal,
+        id: "malicious_id"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, validProposal.jobId);
+    assert.equal(payload.data.freelancerId, validProposal.freelancerId);
+    assert.equal(payload.data.coverLetter, validProposal.coverLetter);
+    assert.match(payload.data.id, /^prp_/);
+    assert.notEqual(payload.data.id, "malicious_id");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(1)
+});


### PR DESCRIPTION
Scope: validate POST /api/proposals payloads before persistence, return 400 on invalid input, and keep the generated proposal id server-owned even if the client submits an id field. Add focused route/service regression tests for invalid and valid payloads.

Validation:
- node --test apps/api/src/tests/proposal-routes.test.js
- node --test apps/api/src/tests/health.test.js