### PR TITLE
List service responses should be defensive snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/list-services-defense.test.js
+++ b/apps/api/src/tests/list-services-defense.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importFresh(relativePath, tag) {
+  const url = new URL(relativePath, import.meta.url);
+  url.searchParams.set("v", tag);
+  return import(url.href);
+}
+
+async function assertDefensiveList(relativePath, exportName, tag) {
+  const module = await importFresh(relativePath, tag);
+  const listFn = module[exportName];
+
+  const first = await listFn();
+  assert.ok(Array.isArray(first));
+  const originalLength = first.length;
+  first.push({ injected: true });
+
+  const second = await listFn();
+  assert.ok(Array.isArray(second));
+  assert.notStrictEqual(first, second);
+  assert.equal(second.length, originalLength);
+  assert.equal(second.some((item) => item?.injected === true), false);
+}
+
+const cases = [
+  ["../services/userService.js", "listUsers"],
+  ["../services/jobService.js", "listJobs"],
+  ["../services/proposalService.js", "listProposals"],
+  ["../services/reviewService.js", "listReviews"],
+  ["../services/messageService.js", "listMessages"],
+  ["../services/notificationService.js", "listNotifications"]
+];
+
+for (const [relativePath, exportName] of cases) {
+  test(`${exportName} returns a defensive copy`, async () => {
+    await assertDefensiveList(relativePath, exportName, `${exportName}-${Date.now()}`);
+  });
+}


### PR DESCRIPTION
Scope: return shallow copies from the API list services so callers cannot mutate the backing in-memory arrays. Preserve existing record objects and response shapes. Add focused regression coverage proving list results are defensive copies for the affected services.

Validation:
- node --test apps/api/src/tests/list-services-defense.test.js
- node --test apps/api/src/tests/health.test.js