### PR TITLE
Payment creation should reject invalid amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payment-routes-validation.test.js
+++ b/apps/api/src/tests/payment-routes-validation.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid amounts", async () => {
+  await withServer(async (baseUrl) => {
+    for (const body of [{ amount: 0 }, { amount: -10 }, {}, { amount: "10" }]) {
+      const response = await fetch(`${baseUrl}/api/payments`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid payment payload"
+      });
+    }
+  });
+});
+
+test("POST /api/payments accepts a positive amount", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 125, currency: "usd" })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).optional()
+});


### PR DESCRIPTION
Closes #6384\n\n- Validate payment payloads before createPaymentIntent()\n- Reject missing, zero, negative, and nonnumeric amounts with a 400 response\n- Preserve successful payment intent behavior for positive amounts\n\nValidation:\n- node --test src/tests/health.test.js src/tests/payment-routes-validation.test.js