### PR TITLE
User creation endpoint should validate input

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const parsed = createUserSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(parsed.data), 201);
 }

--- a/apps/api/src/tests/user-routes-validation.test.js
+++ b/apps/api/src/tests/user-routes-validation.test.js
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    for (const body of [
+      {},
+      { email: "not-an-email", password: "password123" },
+      { email: "user@example.com", password: "short" },
+      { email: "user@example.com", password: "password123", role: "invalid" }
+    ]) {
+      const response = await fetch(`${baseUrl}/api/users`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Invalid user payload"
+      });
+    }
+  });
+});
+
+test("POST /api/users accepts valid payloads and preserves extra fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "user@example.com",
+        password: "password123",
+        role: "freelancer",
+        displayName: "Maya"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "user@example.com");
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(payload.data.displayName, "Maya");
+    assert.match(payload.data.id, /^usr_/);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z
+  .object({
+    email: z.string().email(),
+    password: z.string().min(8),
+    role: z.enum(["client", "freelancer", "admin"]).default("client")
+  })
+  .passthrough();


### PR DESCRIPTION
Closes #6358\n\n- Add a focused Zod schema for user creation\n- Reject malformed payloads with a 400 response\n- Preserve the existing 201 response shape for valid requests\n- Keep extra metadata fields intact for valid requests\n\nValidation:\n- node --test src/tests/health.test.js src/tests/user-routes-validation.test.js