### PR TITLE
Search endpoint should require authentication

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { search } from "../controllers/searchController.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);

--- a/apps/api/src/tests/search-routes-auth.test.js
+++ b/apps/api/src/tests/search-routes-auth.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=jobs`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/search preserves response shape for authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`${baseUrl}/api/search?q=jobs`, {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        query: "jobs",
+        users: [],
+        jobs: [],
+        freelancers: []
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #6342\n\n- Require auth middleware on GET /api/search\n- Preserve the existing response shape for authenticated requests\n- Return 401 for anonymous requests\n\nValidation:\n- node --test src/tests/health.test.js src/tests/search-routes-auth.test.js