### PR TITLE
Message and notification creation routes should bind authenticated identity

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -6,5 +6,5 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  return ok(res, await sendMessage(req.body, req.user.sub), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -6,5 +6,5 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  return ok(res, await createNotification(req.body, req.user.sub), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -4,8 +4,8 @@ export async function listMessages() {
   return messages;
 }
 
-export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+export async function sendMessage(payload, senderId) {
+  const message = { id: `msg_${Date.now()}`, ...payload, senderId, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -4,8 +4,8 @@ export async function listNotifications() {
   return notifications;
 }
 
-export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+export async function createNotification(payload, userId) {
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, userId };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/message-notification-identity.test.js
+++ b/apps/api/src/tests/message-notification-identity.test.js
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages requires auth and binds senderId", async () => {
+  await withServer(async (baseUrl) => {
+    const anonymous = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_admin",
+        recipientId: "usr_victim",
+        body: "spoofed"
+      })
+    });
+    const anonymousPayload = await anonymous.json();
+
+    assert.equal(anonymous.status, 401);
+    assert.deepEqual(anonymousPayload, {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    const token = signAccessToken({ sub: "usr_auth", role: "client" });
+    const authenticated = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        senderId: "usr_admin",
+        recipientId: "usr_victim",
+        body: "spoofed"
+      })
+    });
+    const authenticatedPayload = await authenticated.json();
+
+    assert.equal(authenticated.status, 201);
+    assert.equal(authenticatedPayload.success, true);
+    assert.equal(authenticatedPayload.data.senderId, "usr_auth");
+    assert.equal(authenticatedPayload.data.recipientId, "usr_victim");
+    assert.equal(authenticatedPayload.data.body, "spoofed");
+    assert.match(authenticatedPayload.data.id, /^msg_/);
+  });
+});
+
+test("POST /api/notifications requires auth and binds userId", async () => {
+  await withServer(async (baseUrl) => {
+    const anonymous = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_victim",
+        type: "message",
+        text: "spoofed"
+      })
+    });
+    const anonymousPayload = await anonymous.json();
+
+    assert.equal(anonymous.status, 401);
+    assert.deepEqual(anonymousPayload, {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    const token = signAccessToken({ sub: "usr_auth", role: "client" });
+    const authenticated = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        userId: "usr_victim",
+        type: "message",
+        text: "spoofed"
+      })
+    });
+    const authenticatedPayload = await authenticated.json();
+
+    assert.equal(authenticated.status, 201);
+    assert.equal(authenticatedPayload.success, true);
+    assert.equal(authenticatedPayload.data.userId, "usr_auth");
+    assert.equal(authenticatedPayload.data.type, "message");
+    assert.equal(authenticatedPayload.data.text, "spoofed");
+    assert.equal(authenticatedPayload.data.read, false);
+    assert.match(authenticatedPayload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
Closes #6380\n\n- Require auth middleware on POST /api/messages and POST /api/notifications\n- Bind senderId and userId to the authenticated subject\n- Ignore caller-supplied identity fields in the request body\n- Add focused regression coverage for anonymous access and identity spoofing\n\nValidation:\n- node --test src/tests/health.test.js src/tests/message-notification-identity.test.js