### PR TITLE
Login should reject unknown or wrong credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -11,6 +11,9 @@ export async function register(req, res) {
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid credentials", 401);
+  }
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,36 @@
+import { randomUUID } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = new Map();
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${randomUUID()}`;
+  const user = {
+    id,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password,
+    role: payload.role
+  };
+
+  registeredUsers.set(user.email, user);
+
+  return {
+    id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const user = registeredUsers.get(payload.email);
+  if (!user || user.password !== payload.password) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/auth-login-credentials.test.js
+++ b/apps/api/src/tests/auth-login-credentials.test.js
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login rejects unknown email", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email: `missing-${randomUUID()}@example.com`,
+        password: "password123"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("POST /api/auth/login rejects wrong password", async () => {
+  await withServer(async (port) => {
+    const email = `known-${randomUUID()}@example.com`;
+
+    const registerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email,
+        password: "password123",
+        role: "client"
+      })
+    });
+    assert.equal(registerResponse.status, 201);
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email,
+        password: "wrongpass"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("POST /api/auth/login succeeds for a registered user", async () => {
+  await withServer(async (port) => {
+    const email = `valid-${randomUUID()}@example.com`;
+
+    const registerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email,
+        password: "password123",
+        role: "freelancer"
+      })
+    });
+    const registerPayload = await registerResponse.json();
+
+    assert.equal(registerResponse.status, 201);
+    assert.equal(registerPayload.success, true);
+    assert.equal(registerPayload.data.email, email);
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        email,
+        password: "password123"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, email);
+    assert.equal(typeof payload.data.token, "string");
+    assert.ok(payload.data.token.length > 0);
+  });
+});


### PR DESCRIPTION
Stores registered users in the existing auth service boundary, rejects unknown emails and wrong passwords with HTTP 401, and keeps the login flow covered with route-level regression tests.