### PR TITLE
CORS configured with no origin restrictions

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,28 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+function parseCorsOrigins(rawOrigins) {
+  return rawOrigins
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function buildCorsOptions() {
+  const configuredOrigins = parseCorsOrigins(process.env.CORS_ORIGINS ?? "");
+
+  if (configuredOrigins.length > 0) {
+    return { origin: configuredOrigins };
+  }
+
+  return { origin: process.env.NODE_ENV === "production" ? false : true };
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(buildCorsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors-allowlist.test.js
+++ b/apps/api/src/tests/cors-allowlist.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function withServer(run) {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousCorsOrigins = process.env.CORS_ORIGINS;
+
+  try {
+    const { createApp } = await import(`../app.js?cors=${Date.now()}`);
+    const app = createApp();
+    const server = app.listen(0);
+
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    try {
+      const { port } = server.address();
+      await run(port);
+    } finally {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  } finally {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.CORS_ORIGINS = previousCorsOrigins;
+  }
+}
+
+test("CORS allows configured origins in production", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.CORS_ORIGINS = "https://allowed.example";
+
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: {
+        Origin: "https://allowed.example"
+      }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "https://allowed.example");
+  });
+});
+
+test("CORS denies unlisted origins in production", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.CORS_ORIGINS = "https://allowed.example";
+
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: {
+        Origin: "https://blocked.example"
+      }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  });
+});


### PR DESCRIPTION
Restricts the API CORS policy to configured origins in production via CORS_ORIGINS, while preserving permissive local development defaults. Includes focused tests for allowed and blocked origins.