### PR TITLE
Primary navigation should expose current page state

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,23 +1,35 @@
-import Link from "next/link";
+"use client";
 
-const links = [
-  ["/", "Home"],
-  ["/jobs", "Jobs"],
-  ["/freelancers/search", "Find Freelancers"],
-  ["/dashboard/client", "Client Dashboard"],
-  ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
-];
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { isActiveNavigationLink, navigationLinks } from "./navigation.mjs";
 
 export function Navigation() {
+  const pathname = usePathname() ?? "/";
+
   return (
-    <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
-      {links.map(([href, label]) => (
-        <Link key={href} href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
-          {label}
-        </Link>
-      ))}
+    <nav aria-label="Primary" style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
+      {navigationLinks.map((link) => {
+        const isActive = isActiveNavigationLink(pathname, link);
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            aria-current={isActive ? "page" : undefined}
+            className="card"
+            style={{
+              padding: "0.5rem 0.8rem",
+              borderColor: isActive ? "#6f8cff" : "#2a3765",
+              background: isActive ? "#24315c" : "#151c35",
+              boxShadow: isActive ? "0 0 0 1px rgba(111, 140, 255, 0.35)" : "none",
+              fontWeight: isActive ? 600 : 400
+            }}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/apps/web/components/navigation.mjs
+++ b/apps/web/components/navigation.mjs
@@ -1,0 +1,17 @@
+export const navigationLinks = [
+  { href: "/", label: "Home", activePrefixes: ["/"] },
+  { href: "/jobs", label: "Jobs", activePrefixes: ["/jobs"] },
+  { href: "/freelancers/search", label: "Find Freelancers", activePrefixes: ["/freelancers"] },
+  { href: "/dashboard/client", label: "Client Dashboard", activePrefixes: ["/dashboard/client"] },
+  { href: "/dashboard/freelancer", label: "Freelancer Dashboard", activePrefixes: ["/dashboard/freelancer"] },
+  { href: "/messaging", label: "Messaging", activePrefixes: ["/messaging"] },
+  { href: "/admin", label: "Admin", activePrefixes: ["/admin"] }
+];
+
+export function isActiveNavigationLink(pathname, link) {
+  if (link.href === "/") {
+    return pathname === "/";
+  }
+
+  return pathname === link.href || link.activePrefixes.some((prefix) => pathname.startsWith(`${prefix}/`));
+}

--- a/apps/web/tests/navigation.test.mjs
+++ b/apps/web/tests/navigation.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isActiveNavigationLink, navigationLinks } from "../components/navigation.mjs";
+
+test("home is only active on the root path", () => {
+  assert.equal(isActiveNavigationLink("/", navigationLinks[0]), true);
+  assert.equal(isActiveNavigationLink("/jobs", navigationLinks[0]), false);
+});
+
+test("nested jobs routes remain active for the jobs nav item", () => {
+  assert.equal(isActiveNavigationLink("/jobs", navigationLinks[1]), true);
+  assert.equal(isActiveNavigationLink("/jobs/post", navigationLinks[1]), true);
+  assert.equal(isActiveNavigationLink("/jobs/123", navigationLinks[1]), true);
+});
+
+test("freelancer routes stay active for the freelancers nav item", () => {
+  assert.equal(isActiveNavigationLink("/freelancers/search", navigationLinks[2]), true);
+  assert.equal(isActiveNavigationLink("/freelancers/alice", navigationLinks[2]), true);
+  assert.equal(isActiveNavigationLink("/dashboard/client", navigationLinks[2]), false);
+});
+
+test("dashboard and admin links do not overlap", () => {
+  assert.equal(isActiveNavigationLink("/dashboard/client/reports", navigationLinks[3]), true);
+  assert.equal(isActiveNavigationLink("/dashboard/freelancer/stats", navigationLinks[4]), true);
+  assert.equal(isActiveNavigationLink("/admin/settings", navigationLinks[6]), true);
+  assert.equal(isActiveNavigationLink("/admin/settings", navigationLinks[3]), false);
+});


### PR DESCRIPTION
Marks the active route with aria-current=page, gives nested routes an active parent link, and adds a visible active-state style tied to that state. Includes focused helper tests plus a successful web build check.