### PR TITLE
Upload response should sanitize original filenames

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,9 @@
 import { ok } from "../utils/response.js";
+import { sanitizeUploadFilename } from "../utils/uploadFilename.js";
 
 export async function uploadFile(req, res) {
   return ok(res, {
-    filename: req.file?.originalname ?? null,
+    filename: sanitizeUploadFilename(req.file?.originalname),
     status: req.file ? "uploaded" : "no-file"
   }, 201);
 }

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  const response = {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    }
+  };
+
+  return response;
+}
+
+test("uploadFile sanitizes path-like filenames in the response", async () => {
+  const res = createResponse();
+
+  await uploadFile({ file: { originalname: "../secret.txt" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.payload, {
+    success: true,
+    data: {
+      filename: "secret.txt",
+      status: "uploaded"
+    }
+  });
+});
+
+test("uploadFile sanitizes control characters in the response", async () => {
+  const res = createResponse();
+
+  await uploadFile({ file: { originalname: "  final\nname.txt  " } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.payload, {
+    success: true,
+    data: {
+      filename: "finalname.txt",
+      status: "uploaded"
+    }
+  });
+});

--- a/apps/api/src/tests/uploadFilename.test.js
+++ b/apps/api/src/tests/uploadFilename.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeUploadFilename } from "../utils/uploadFilename.js";
+
+test("sanitizeUploadFilename keeps the final path segment", () => {
+  assert.equal(sanitizeUploadFilename("../secret.txt"), "secret.txt");
+  assert.equal(sanitizeUploadFilename("nested\\folder\\report.csv"), "report.csv");
+});
+
+test("sanitizeUploadFilename strips control characters and trims whitespace", () => {
+  assert.equal(sanitizeUploadFilename("  \nfinal\rname.txt\t "), "finalname.txt");
+});
+
+test("sanitizeUploadFilename caps overly long names", () => {
+  const longName = `${"a".repeat(80)}.txt`;
+  assert.equal(sanitizeUploadFilename(longName), "a".repeat(64));
+});
+
+test("sanitizeUploadFilename returns null for missing or blank values", () => {
+  assert.equal(sanitizeUploadFilename(null), null);
+  assert.equal(sanitizeUploadFilename("   \n\t  "), null);
+});

--- a/apps/api/src/utils/uploadFilename.js
+++ b/apps/api/src/utils/uploadFilename.js
@@ -1,0 +1,17 @@
+const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]+/g;
+const PATH_SEPARATORS = /[\\/]+/g;
+const MAX_FILENAME_LENGTH = 64;
+
+export function sanitizeUploadFilename(filename) {
+  if (typeof filename !== "string") {
+    return null;
+  }
+
+  const finalSegment = filename.split(PATH_SEPARATORS).pop() ?? "";
+  const normalized = finalSegment.replace(CONTROL_CHARACTERS, "").trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.slice(0, MAX_FILENAME_LENGTH);
+}


### PR DESCRIPTION
Sanitizes uploaded filenames before returning them by stripping path separators, removing control characters, and capping the returned metadata length. Includes focused helper and controller regression tests for path-like and control-character inputs.