### PR TITLE
Health checks should bypass the shared API rate limiter

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health-rate-limit.test.js
+++ b/apps/api/src/tests/health-rate-limit.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("health remains available after API requests exhaust the shared limiter", async () => {
+  await withServer(async (port) => {
+    let apiRateLimited = false;
+
+    for (let attempt = 0; attempt < 210; attempt += 1) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/jobs`);
+      await response.text();
+
+      if (response.status === 429) {
+        apiRateLimited = true;
+        break;
+      }
+    }
+
+    assert.equal(apiRateLimited, true);
+
+    const healthResponse = await fetch(`http://127.0.0.1:${port}/health`);
+    const healthPayload = await healthResponse.json();
+
+    assert.equal(healthResponse.status, 200);
+    assert.deepEqual(healthPayload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
Moves /health ahead of the shared API limiter so liveness checks remain available even after API requests exhaust the quota. Includes a regression test that exhausts the API limiter and confirms /health still returns 200.