### PR TITLE
fix: prevent admin role self-assignment and token subject mismatch (closes #2832, closes #2768)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,14 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  // Prevent admin role self-assignment 鈥?admins must be provisioned manually
+  const role = payload.role === "admin" ? "client" : payload.role;
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role,
+    token: signAccessToken({ sub: id, role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("authMiddleware rejects missing Authorization header", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware);
+  app.get("/protected", (req, res) => res.json({ ok: true }));
+
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/protected`);
+  assert.equal(res.status, 401);
+
+  await new Promise((r) => server.close(r));
+});
+
+test("authMiddleware accepts valid Bearer token", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware);
+  app.get("/protected", (req, res) => res.json({ user: req.user }));
+
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  const res = await fetch(`http://127.0.0.1:${port}/protected`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.user.sub, "usr_test");
+  assert.equal(body.user.role, "client");
+
+  await new Promise((r) => server.close(r));
+});

--- a/apps/api/src/tests/register.test.js
+++ b/apps/api/src/tests/register.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser strips admin role", async () => {
+  const result = await registerUser({
+    email: "admin@test.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.role, "client");
+});
+
+test("registerUser preserves freelancer role", async () => {
+  const result = await registerUser({
+    email: "freelancer@test.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(result.role, "freelancer");
+});
+
+test("registerUser token subject matches returned id", async () => {
+  const result = await registerUser({
+    email: "user@test.com",
+    password: "password123",
+    role: "client"
+  });
+  // Decode the token to verify subject matches
+  const payload = JSON.parse(
+    Buffer.from(result.token.split(".")[1], "base64url").toString()
+  );
+  assert.equal(payload.sub, result.id);
+  assert.equal(payload.role, result.role);
+});


### PR DESCRIPTION
## Summary
Fixes two authentication vulnerabilities in egisterUser().

### Fixes
- **#2832** ($780): **Admin role self-assignment** - Users could set ole: "admin" during registration. Now the role is sanitized: any attempt to self-assign dmin is downgraded to client.
- **#2768** ($780): **JWT token subject mismatch** - 	oken.sub was generated separately from the returned id, causing a mismatch. Now both use the same generated ID.

### Changes
| File | Change |
|------|--------|
| pps/api/src/services/authService.js | Strip dmin role + unify ID generation |

### Testing
- Added uth.test.js and egister.test.js with 4 test cases covering registration and auth flows