### PR TITLE
fix: validate OAuth provider against whitelist

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const ALLOWED_PROVIDERS = ["google", "github"];
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,12 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+  if (!ALLOWED_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }


### PR DESCRIPTION
## Summary

`GET /api/auth/oauth/:provider/callback` accepted any string as the provider parameter. Arbitrary provider names were echoed back in the response without validation.

## Changes

- Add `ALLOWED_PROVIDERS` whitelist (["google", "github"])
- Return 400 for unsupported providers
- Import `fail` from response utils

Closes #6491

/claim #6491