### PR TITLE
fix: add admin role check to admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary

`/api/admin/metrics` only checked for a valid JWT token but did not verify the user has the admin role. Any authenticated user (client or freelancer) could access admin endpoints.

## Changes

- Add `adminMiddleware` in `apps/api/src/middleware/auth.js` that checks `req.user.role === "admin"`
- Apply `adminMiddleware` after `authMiddleware` in `adminRoutes.js`
- Non-admin users now receive 403 Forbidden

Closes #6492

/claim #6492