### PR TITLE
Require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? "development-secret";
+
+if (nodeEnv !== "development" && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET is required outside development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalEnv = {
+  NODE_ENV: process.env.NODE_ENV,
+  JWT_SECRET: process.env.JWT_SECRET
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function importEnv(label) {
+  return import(`../config/env.js?case=${label}-${Date.now()}-${Math.random()}`);
+}
+
+test("env keeps the development JWT secret fallback", async () => {
+  delete process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+
+  try {
+    const { env } = await importEnv("development-fallback");
+
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.jwtSecret, "development-secret");
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("env requires JWT_SECRET outside development", async () => {
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  try {
+    await assert.rejects(
+      importEnv("production-missing-secret"),
+      /JWT_SECRET is required outside development/
+    );
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("env accepts JWT_SECRET outside development", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.JWT_SECRET = "production-secret";
+
+  try {
+    const { env } = await importEnv("production-secret");
+
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.jwtSecret, "production-secret");
+  } finally {
+    restoreEnv();
+  }
+});


### PR DESCRIPTION
## Summary
- keep the local development JWT secret fallback
- fail fast when `JWT_SECRET` is missing outside development
- add env config regression coverage for development fallback, production failure, and production success

Fixes #6583

/claim #743

## Validation
- `node --test src/tests/*.test.js` from `apps/api` -> 4 passed
- `git diff --check HEAD~1..HEAD` -> passed