### PR TITLE
Require authentication for notification creation

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_notifications",
+        message: "New proposal received"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/notifications preserves authenticated creation behavior", async () => {
+  const token = signAccessToken({ sub: "usr_notifications", role: "client" });
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        userId: "usr_notifications",
+        message: "New proposal received"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_notifications");
+    assert.equal(payload.data.message, "New proposal received");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
## Summary
- require `authMiddleware` on `POST /api/notifications`
- keep `GET /api/notifications` public and authenticated notification creation behavior unchanged
- add regression coverage for unauthenticated rejection and authenticated success

Fixes #6587

/claim #743

## Validation
- `node --test src/tests/*.test.js` from `apps/api` -> 3 passed
- `git diff --check HEAD~1..HEAD` -> passed