### PR TITLE
Return 400 for upload parser errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,20 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof multer.MulterError) {
+    const message = err.code === "LIMIT_UNEXPECTED_FILE" ? "Unexpected file field" : "Invalid upload";
+
+    return res.status(400).json({
+      success: false,
+      message
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/uploadErrors.test.js
+++ b/apps/api/src/tests/uploadErrors.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads returns 400 for unexpected multipart file fields", async () => {
+  await withServer(async (baseUrl) => {
+    const formData = new FormData();
+    formData.append("avatar", new Blob(["not the expected field"]), "avatar.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: formData
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unexpected file field"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Recognize Multer parser errors in the global API error handler.
- Return a shared 400 API response for unexpected multipart upload fields instead of a generic 500.
- Add a focused multipart regression test for unexpected file fields.

## Tests
- `node --test src/tests/uploadErrors.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Closes #6591
/claim #743