### PR TITLE
Preserve generated message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps message ids server-generated", async () => {
+  const body = `server generated id ${Date.now()}`;
+  const message = await sendMessage({
+    id: "client_supplied_id",
+    fromUserId: "usr_sender",
+    toUserId: "usr_recipient",
+    body
+  });
+
+  assert.match(message.id, /^msg_/);
+  assert.notEqual(message.id, "client_supplied_id");
+  assert.equal(message.fromUserId, "usr_sender");
+  assert.equal(message.toUserId, "usr_recipient");
+  assert.equal(message.body, body);
+
+  const storedMessages = await listMessages();
+  const storedMessage = storedMessages.find((stored) => stored.body === body);
+
+  assert.ok(storedMessage);
+  assert.equal(storedMessage.id, message.id);
+});


### PR DESCRIPTION
## Summary
- Ensure `sendMessage` keeps service-generated `msg_...` ids when payloads include `id`.
- Preserve existing payload fields and generated `sentAt` behavior.
- Add focused regression coverage for client-supplied message ids.

## Tests
- `node --test src/tests/messageService.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Closes #6593
/claim #743