### PR TITLE
Preserve generated user ids

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser keeps user ids server-generated", async () => {
+  const email = `server-owned-id-${Date.now()}@example.com`;
+  const user = await createUser({
+    id: "client_supplied_user_id",
+    email,
+    role: "freelancer"
+  });
+
+  assert.match(user.id, /^usr_/);
+  assert.notEqual(user.id, "client_supplied_user_id");
+  assert.equal(user.email, email);
+  assert.equal(user.role, "freelancer");
+
+  const storedUsers = await listUsers();
+  const storedUser = storedUsers.find((stored) => stored.email === email);
+
+  assert.ok(storedUser);
+  assert.equal(storedUser.id, user.id);
+});


### PR DESCRIPTION
## Summary
- Ensure `createUser` keeps service-generated `usr_...` ids when payloads include `id`.
- Preserve normal user payload fields.
- Add focused regression coverage for caller-supplied user ids.

## Tests
- `node --test src/tests/userService.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Closes #6595
/claim #743