### PR TITLE
Preserve generated proposal ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal keeps proposal ids server-generated", async () => {
+  const coverLetter = `server-owned proposal id ${Date.now()}`;
+  const proposal = await createProposal({
+    id: "client_supplied_proposal_id",
+    jobId: "job_123",
+    freelancerId: "usr_freelancer",
+    coverLetter
+  });
+
+  assert.match(proposal.id, /^prp_/);
+  assert.notEqual(proposal.id, "client_supplied_proposal_id");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.coverLetter, coverLetter);
+
+  const storedProposals = await listProposals();
+  const storedProposal = storedProposals.find((stored) => stored.coverLetter === coverLetter);
+
+  assert.ok(storedProposal);
+  assert.equal(storedProposal.id, proposal.id);
+});


### PR DESCRIPTION
## Summary
- Ensure `createProposal` keeps service-generated `prp_...` ids when payloads include `id`.
- Preserve normal proposal payload fields.
- Add focused regression coverage for caller-supplied proposal ids.

## Tests
- `node --test src/tests/proposalService.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Closes #6597
/claim #743