### PR TITLE
Add createdAt to notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload, createdAt: new Date().toISOString() };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+
+test("createNotification keeps createdAt server-generated", async () => {
+  const title = `server-owned createdAt ${Date.now()}`;
+  const clientCreatedAt = "2000-01-01T00:00:00.000Z";
+  const notification = await createNotification({
+    userId: "usr_recipient",
+    title,
+    body: "Notification timestamp should come from the service.",
+    createdAt: clientCreatedAt
+  });
+
+  assert.equal(notification.userId, "usr_recipient");
+  assert.equal(notification.title, title);
+  assert.equal(notification.body, "Notification timestamp should come from the service.");
+  assert.notEqual(notification.createdAt, clientCreatedAt);
+  assert.equal(Number.isNaN(Date.parse(notification.createdAt)), false);
+
+  const storedNotifications = await listNotifications();
+  const storedNotification = storedNotifications.find((stored) => stored.title === title);
+
+  assert.ok(storedNotification);
+  assert.equal(storedNotification.createdAt, notification.createdAt);
+});


### PR DESCRIPTION
## Summary
- Add a server-owned `createdAt` timestamp when notifications are created.
- Ensure caller-supplied `createdAt` cannot control the returned or stored timestamp.
- Add focused regression coverage for notification creation timestamps.

## Tests
- `node --test src/tests/notificationService.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`

Closes #6599
/claim #743