### PR TITLE
fix(api): own notification createdAt

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = {
+    ...payload,
+    id: `ntf_${Date.now()}`,
+    read: false,
+    createdAt: new Date().toISOString(),
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification owns id, read state, and createdAt timestamp", async () => {
+  const before = Date.now();
+  const notification = await createNotification({
+    id: "attacker_id",
+    read: true,
+    createdAt: "2000-01-01T00:00:00.000Z",
+    type: "message",
+    message: "New message",
+    recipientId: "user_1",
+  });
+  const after = Date.now();
+  const createdAt = Date.parse(notification.createdAt);
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.equal(notification.read, false);
+  assert.notEqual(notification.createdAt, "2000-01-01T00:00:00.000Z");
+  assert.ok(createdAt >= before);
+  assert.ok(createdAt <= after);
+  assert.equal(notification.type, "message");
+  assert.equal(notification.message, "New message");
+  assert.equal(notification.recipientId, "user_1");
+});


### PR DESCRIPTION
## Summary
- generate server-owned `createdAt` for created notifications
- keep caller-supplied notification fields while overriding `id`, `read`, and `createdAt`
- add focused regression coverage for hostile caller-supplied ownership fields

Closes #6602
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/notificationService.test.js apps/api/src/tests/health.test.js`