### PR TITLE
fix(api): preserve proposal generated id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal keeps proposal ids server-generated", async () => {
+  const proposal = await createProposal({
+    id: "attacker_id",
+    jobId: "job_1",
+    freelancerId: "user_1",
+    bidAmount: 250,
+    coverLetter: "I can help",
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "attacker_id");
+  assert.equal(proposal.jobId, "job_1");
+  assert.equal(proposal.freelancerId, "user_1");
+  assert.equal(proposal.bidAmount, 250);
+  assert.equal(proposal.coverLetter, "I can help");
+});


### PR DESCRIPTION
## Summary
- keep proposal ids generated by the service
- preserve normal proposal payload fields
- add focused regression coverage for caller-supplied ids

Closes #6604
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/proposalService.test.js apps/api/src/tests/health.test.js`