### PR TITLE
fix(api): preserve user generated id

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps user ids server-generated", async () => {
+  const user = await createUser({
+    id: "attacker_id",
+    email: "user@example.com",
+    fullName: "Test User",
+    role: "client",
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "attacker_id");
+  assert.equal(user.email, "user@example.com");
+  assert.equal(user.fullName, "Test User");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
## Summary
- keep user ids generated by the service
- preserve normal user payload fields
- add focused regression coverage for caller-supplied ids

Closes #6606
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/userService.test.js apps/api/src/tests/health.test.js`