### PR TITLE
fix: reject inverted budget ranges in job validation (#2853)

### DIFF
--- a/apps/api/src/tests/budget-validation.test.js
+++ b/apps/api/src/tests/budget-validation.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a landing page",
+  description: "Need a responsive landing page built with Next.js",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "cat-web-dev",
+  skills: ["Next.js", "TailwindCSS"],
+};
+
+test("createJobSchema accepts valid job data", () => {
+  const result = createJobSchema.safeParse(validJob);
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects budgetMax < budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 500,
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((i) => i.path.includes("budgetMax")));
+});
+
+test("createJobSchema rejects budgetMax < budgetMin (large range)", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 50000,
+    budgetMax: 100,
+  });
+  assert.equal(result.success, false);
+});
+
+test("createJobSchema accepts equal budgetMin and budgetMax", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 750,
+    budgetMax: 750,
+  });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts budgetMax > budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 100,
+    budgetMax: 9999,
+  });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted range when both present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 2000,
+    budgetMax: 500,
+  });
+  assert.equal(result.success, false);
+});
+
+test("updateJobSchema accepts partial update with only budgetMin", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 300 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts partial update with only budgetMax", () => {
+  const result = updateJobSchema.safeParse({ budgetMax: 3000 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema accepts valid partial range", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 100,
+    budgetMax: 500,
+  });
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,43 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+/**
+ * Schema for creating a new job posting.
+ *
+ * Validates that all required fields are present and that
+ * `budgetMax` is not less than `budgetMin` when both values
+ * are provided.
+ */
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([]),
+  })
+  .refine(
+    (data) => data.budgetMax >= data.budgetMin,
+    {
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"],
+    }
+  );
 
-export const updateJobSchema = createJobSchema.partial();
+/**
+ * Schema for updating an existing job posting.
+ * All fields are optional but must still satisfy cross-field
+ * validation when both budget fields are present.
+ */
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,5 +1,14 @@
 import { z } from "zod";
 
+const jobSchemaBase = z.object({
+  title: z.string().min(4),
+  description: z.string().min(10),
+  budgetMin: z.number().nonnegative(),
+  budgetMax: z.number().nonnegative(),
+  categoryId: z.string().min(1),
+  skills: z.array(z.string().min(1)).default([]),
+});
+
 /**
  * Schema for creating a new job posting.
  *
@@ -7,29 +16,20 @@ import { z } from "zod";
  * `budgetMax` is not less than `budgetMin` when both values
  * are provided.
  */
-export const createJobSchema = z
-  .object({
-    title: z.string().min(4),
-    description: z.string().min(10),
-    budgetMin: z.number().nonnegative(),
-    budgetMax: z.number().nonnegative(),
-    categoryId: z.string().min(1),
-    skills: z.array(z.string().min(1)).default([]),
-  })
-  .refine(
-    (data) => data.budgetMax >= data.budgetMin,
-    {
-      message: "budgetMax must be greater than or equal to budgetMin",
-      path: ["budgetMax"],
-    }
-  );
+export const createJobSchema = jobSchemaBase.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"],
+  }
+);
 
 /**
  * Schema for updating an existing job posting.
  * All fields are optional but must still satisfy cross-field
  * validation when both budget fields are present.
  */
-export const updateJobSchema = createJobSchema.partial().refine(
+export const updateJobSchema = jobSchemaBase.partial().refine(
   (data) => {
     if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
       return data.budgetMax >= data.budgetMin;


### PR DESCRIPTION
## Description
Fixes the createJobSchema validator to reject budgetMax < budgetMin values.

### Problem
Previously, the API accepted job postings where budgetMax was less than budgetMin, which is logically invalid.

### Solution
- Added .refine() cross-field validation to createJobSchema
- Also added validation to updateJobSchema for partial updates
- Returns 400 with clear error message when validation fails

### Testing
- Added regression test budget-validation.test.js
- Tests: inverted range, valid range, equal values, single field updates
- All existing tests continue to pass

### Security Impact
- Prevents invalid data from entering the database
- Maintains data integrity for job postings
- Clear error messages for API consumers

### Related Issue
Closes #2853

## Changes

- `apps/api/src/tests/budget-validation.test.js`
- `apps/api/src/validators/job.js`

## Impact

This change improves the project's code quality, security, and/or documentation. It addresses the requirements outlined in the linked issue and follows the project's contribution guidelines.