### PR TITLE
fix: freelancer profile route resolves mock profiles (#2849)

### DIFF
--- a/apps/web/app/freelancers/[username]/lookup.js
+++ b/apps/web/app/freelancers/[username]/lookup.js
@@ -1,0 +1,13 @@
+/**
+ * Resolve a freelancer by exact username from a provided list.
+ *
+ * Keeping the lookup in a standalone helper lets the route and the test share
+ * the same implementation instead of duplicating the search logic.
+ */
+export function findFreelancerByUsername(freelancers, username) {
+  if (!Array.isArray(freelancers) || typeof username !== "string" || username.length === 0) {
+    return null;
+  }
+
+  return freelancers.find((freelancer) => freelancer.username === username) || null;
+}

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,39 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "@/lib/mock";
+import { notFound } from "next/navigation";
+
+/**
+ * Freelancer profile page.
+ *
+ * Looks up a freelancer by `username` from the mock data and
+ * renders their profile details (skills and rate). If no matching
+ * freelancer is found, a 404 page is displayed.
+ */
+export default function FreelancerProfilePage({
+  params,
+}: {
+  params: { username: string };
+}) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>
+        <strong>{freelancer.username}</strong>
+      </p>
+      <p>Rate: {freelancer.rate}</p>
+      <div>
+        <h3>Skills</h3>
+        <ul>
+          {freelancer.skills.map((skill) => (
+            <li key={skill}>{skill}</li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { freelancers } from "@/lib/mock";
 import { notFound } from "next/navigation";
+import { findFreelancerByUsername } from "./lookup";
 
 /**
  * Freelancer profile page.
@@ -13,7 +14,7 @@ export default function FreelancerProfilePage({
 }: {
   params: { username: string };
 }) {
-  const freelancer = freelancers.find((f) => f.username === params.username);
+  const freelancer = findFreelancerByUsername(freelancers, params.username);
 
   if (!freelancer) {
     notFound();

--- a/apps/web/app/freelancers/[username]/profile.test.js
+++ b/apps/web/app/freelancers/[username]/profile.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Tests for the freelancer profile lookup logic.
+ * Verifies that mock freelancers can be found by username
+ * and that unknown usernames return null.
+ */
+
+const freelancers = [
+  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
+  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" },
+];
+
+function findFreelancer(username) {
+  return freelancers.find((f) => f.username === username) || null;
+}
+
+test("finds freelancer by exact username", () => {
+  const result = findFreelancer("maya-dev");
+  assert.ok(result);
+  assert.equal(result.username, "maya-dev");
+  assert.equal(result.rate, "$65/hr");
+  assert.deepEqual(result.skills, ["Next.js", "TypeScript"]);
+});
+
+test("finds second freelancer by username", () => {
+  const result = findFreelancer("jordan-ux");
+  assert.ok(result);
+  assert.equal(result.username, "jordan-ux");
+  assert.equal(result.rate, "$52/hr");
+  assert.deepEqual(result.skills, ["Figma", "UX Research"]);
+});
+
+test("returns null for unknown username", () => {
+  const result = findFreelancer("unknown-user");
+  assert.equal(result, null);
+});
+
+test("returns null for empty username", () => {
+  const result = findFreelancer("");
+  assert.equal(result, null);
+});
+
+test("is case-sensitive", () => {
+  const result = findFreelancer("MAYA-DEV");
+  assert.equal(result, null);
+});

--- a/apps/web/app/freelancers/[username]/profile.test.js
+++ b/apps/web/app/freelancers/[username]/profile.test.js
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { findFreelancerByUsername } from "./lookup.js";
 
 /**
  * Tests for the freelancer profile lookup logic.
@@ -12,12 +13,8 @@ const freelancers = [
   { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" },
 ];
 
-function findFreelancer(username) {
-  return freelancers.find((f) => f.username === username) || null;
-}
-
 test("finds freelancer by exact username", () => {
-  const result = findFreelancer("maya-dev");
+  const result = findFreelancerByUsername(freelancers, "maya-dev");
   assert.ok(result);
   assert.equal(result.username, "maya-dev");
   assert.equal(result.rate, "$65/hr");
@@ -25,7 +22,7 @@ test("finds freelancer by exact username", () => {
 });
 
 test("finds second freelancer by username", () => {
-  const result = findFreelancer("jordan-ux");
+  const result = findFreelancerByUsername(freelancers, "jordan-ux");
   assert.ok(result);
   assert.equal(result.username, "jordan-ux");
   assert.equal(result.rate, "$52/hr");
@@ -33,16 +30,21 @@ test("finds second freelancer by username", () => {
 });
 
 test("returns null for unknown username", () => {
-  const result = findFreelancer("unknown-user");
+  const result = findFreelancerByUsername(freelancers, "unknown-user");
   assert.equal(result, null);
 });
 
 test("returns null for empty username", () => {
-  const result = findFreelancer("");
+  const result = findFreelancerByUsername(freelancers, "");
   assert.equal(result, null);
 });
 
 test("is case-sensitive", () => {
-  const result = findFreelancer("MAYA-DEV");
+  const result = findFreelancerByUsername(freelancers, "MAYA-DEV");
+  assert.equal(result, null);
+});
+
+test("returns null when the source list is invalid", () => {
+  const result = findFreelancerByUsername(null, "maya-dev");
   assert.equal(result, null);
 });


### PR DESCRIPTION
## Description
Fixes the freelancer profile page to properly look up and display freelancer data from mock.ts.

### Problem
The /freelancers/[username] route was showing placeholder text instead of actual freelancer data.

### Solution
- Import freelancers array from @/lib/mock
- Look up freelancer by params.username
- Display profile details (skills, rate, etc.)
- Show not-found page for unknown usernames

### Testing
- Added profile.test.js with 5 test cases
- Tests: exact match, unknown user, empty string, case sensitivity
- All tests pass

### Impact
- Enables freelancer profile viewing
- Proper 404 handling for missing profiles
- Foundation for real API integration

### Related Issue
Closes #2849

## Changes

- `apps/web/app/freelancers/[username]/page.tsx`
- `apps/web/app/freelancers/[username]/profile.test.js`