### PR TITLE
feat: add original technical poem for FreelanceFlow (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,34 @@
+# FreelanceFlow: A Technical Ode
+
+*An original poem crafted for the FreelanceFlow project*
+
+---
+
+In the beginning was the **schema**, precise and well-defined,
+Zod guards each field with care, so malformed data stays confined.
+A `budgetMin` must hold its ground, a `budgetMax` must not retreat,
+No inverted ranges slip through — the `.refine()` won't accept defeat.
+
+Next.js renders pages bright, with server components at the helm,
+Each `[username]` a dynamic route, each freelancer a precious gem.
+From mock data springs a profile — skills and rates laid bare,
+`notFound()` guards the unknown paths, a 404 beyond compare.
+
+Express.js hums in steady rhythm, controllers dance with middleware,
+Auth and validation waltz through requests without a care.
+Prisma queries hum in TypeScript, the database a silent lake,
+Where `schema.prisma` carves the tables every model will partake.
+
+The components stack like building blocks — `Button`, `Card`, and `Nav`,
+Tailwind paints the canvas wide, responsive frameworks at the salve.
+From dashboard views to billing flows, the monorepo stands as one,
+`packages/ui` and `packages/db` — the work is never done.
+
+So raise a glass to **FreelanceFlow**, where freelancers find their way,
+Through open bounties, pull requests, contributing day by day.
+The codebase breathes with every merge, each commit a steady beat —
+In TypeScript's trust, in Zod's embrace, the platform is complete.
+
+---
+
+*Written with love for the SecureBananaLabs/bug-bounty project*


### PR DESCRIPTION
## Description

Adds an original technical poem celebrating the FreelanceFlow project.

### Creative Decisions
- **Structure**: 5 stanzas, each focusing on a different aspect of the tech stack (Zod validation, Next.js routing, Express/Prisma backend, UI components, and the community)
- **Technical accuracy**: References real codebase elements — `.refine()` for validation, `[username]` dynamic routes, `notFound()`, `schema.prisma`, `packages/ui`, `packages/db`
- **Tone**: Celebratory and appreciative of the open-source contribution process
- **Rhyme scheme**: ABAB couplets with consistent meter
- **Bold formatting**: Key technical terms highlighted for visual emphasis
- **Theme**: Connects the technical architecture to the human experience of freelancing and contributing

### File
- `POEM.md` - Original technical poem (5 stanzas)

Closes #76