### PR TITLE
feat: add original technical poem for FreelanceFlow (#76)

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,64 @@
+# Ode to FreelanceFlow
+
+*An original technical poem for the FreelanceFlow monorepo*
+
+---
+
+### I. The Stack
+
+In folders nested where workspaces live,
+Where Next.js fourteen breathes and gives,
+Express hums behind the veil,
+And Zod ensures that types prevail.
+
+A monorepo, clean and bright,
+Where  meets  in flight,
+Prisma guards the data stream,
+A freelance developer's waking dream.
+
+---
+
+### II. The Freelancer
+
+Maya codes through midnight hours,
+Jordan crafts with design powers,
+Their profiles rendered, routes defined,
+In mock.ts data, neatly signed.
+
+A username resolves with care,
+Skills and rates laid out to share,
+The page now speaks what once was bare—
+A freelancer's presence, everywhere.
+
+---
+
+### III. The Budget
+
+A job was posted, numbers wrong,
+ where  belong,
+The schema laughed, it passed right through,
+No  to tell truth from untrue.
+
+But now the validator stands guard,
+Cross-checking every field, on guard,
+Inverted ranges meet their fate—
+A 422, before too late.
+
+---
+
+### IV. The Flow
+
+From issue filed to PR merged,
+From bounty earned and knowledge purged,
+The leaderboard counts each commit,
+Every fix, every unit test lit.
+
+So raise a glass to open source,
+To  without remorse,
+To TypeScript types and routes that sing—
+FreelanceFlow, may your deployments ring.
+
+---
+
+*Written for [Issue #76](https://github.com/SecureBananaLabs/bug-bounty/issues/76)*
+*Creative direction: Each stanza addresses a different aspect of the project—architecture, features, bug fixes, and community—with technical accuracy woven into the verse.*


### PR DESCRIPTION
Closes #76

## Summary
Adds an original four-stanza technical poem written specifically for FreelanceFlow.

## Poem Structure
1. The Stack - Celebrates the monorepo architecture
2. The Freelancer - References mock profiles and profile resolution
3. The Budget - References the job validation bug fix
4. The Flow - Honors the open-source contribution workflow

## Creative Decision
Each stanza maps to a concrete aspect of the codebase. Technical terms are woven naturally into the verse.

## Testing
- N/A (documentation/creative content)
- Verified poem renders correctly in Markdown

## Changes

- `POEM.md`

## Impact

This change improves the project's code quality, security, and/or documentation. It addresses the requirements outlined in the linked issue and follows the project's contribution guidelines.