### PR TITLE
fix(api): preserve message generated id

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps message ids server-generated", async () => {
+  const before = Date.now();
+  const message = await sendMessage({
+    id: "attacker_id",
+    senderId: "user_1",
+    recipientId: "user_2",
+    content: "Hello",
+  });
+  const after = Date.now();
+  const sentAt = Date.parse(message.sentAt);
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "attacker_id");
+  assert.ok(sentAt >= before);
+  assert.ok(sentAt <= after);
+  assert.equal(message.senderId, "user_1");
+  assert.equal(message.recipientId, "user_2");
+  assert.equal(message.content, "Hello");
+});


### PR DESCRIPTION
## Summary
- keep message ids generated by the service
- preserve normal message payload fields
- keep `sentAt` server-generated
- add focused regression coverage for caller-supplied ids

Closes #6611
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/messageService.test.js apps/api/src/tests/health.test.js`