### PR TITLE
fix(api): return 400 for malformed json

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("malformed JSON request bodies return 400 without unhandled error logging", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  const originalError = console.error;
+  const errors = [];
+  console.error = (...args) => errors.push(args);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"email":'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+    assert.equal(errors.length, 0);
+  } finally {
+    console.error = originalError;
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- handle body-parser `entity.parse.failed` as a client error
- return the shared API error envelope with HTTP 400 for malformed JSON
- avoid logging malformed JSON as an unhandled server error
- add focused API regression coverage

Closes #6614
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/malformedJson.test.js apps/api/src/tests/health.test.js`