### PR TITLE
fix(api): return 400 for upload parser errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.name === "MulterError") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid upload request"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/uploadParserError.test.js
+++ b/apps/api/src/tests/uploadParserError.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("unexpected upload fields return 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const form = new FormData();
+    form.append("avatar", new Blob(["avatar-bytes"], { type: "text/plain" }), "avatar.txt");
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid upload request"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- handle Multer parser errors as client errors
- return the shared API error envelope with HTTP 400 for unexpected upload fields
- add focused regression coverage for multipart requests with the wrong file field

Closes #6617
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/uploadParserError.test.js apps/api/src/tests/health.test.js`