### PR TITLE
Expose db workspace entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("@prisma/client");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "require": "./index.js",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/test/import-entrypoint.test.js
+++ b/packages/db/test/import-entrypoint.test.js
@@ -1,0 +1,16 @@
+const assert = require("node:assert/strict");
+const { createRequire } = require("node:module");
+const test = require("node:test");
+
+const requireFromTest = createRequire(__filename);
+
+test("@freelanceflow/db resolves and loads through the workspace package name", async () => {
+  const resolvedPath = requireFromTest.resolve("@freelanceflow/db");
+  assert.match(resolvedPath, /packages[/\\]db[/\\]index\.js$/);
+
+  const requiredPackage = requireFromTest("@freelanceflow/db");
+  assert.equal(typeof requiredPackage.PrismaClient, "function");
+
+  const importedPackage = await import("@freelanceflow/db");
+  assert.equal(typeof importedPackage.default.PrismaClient, "function");
+});


### PR DESCRIPTION
/claim #2775

## Summary
- Added explicit `main`, `types`, and `exports` metadata for `@freelanceflow/db`.
- Added a tiny CommonJS runtime entrypoint that re-exports `@prisma/client`.
- Added a focused `node:test` import check proving `@freelanceflow/db` resolves and loads by workspace package name.

## Validation
- `npm test -w packages/db`
- `node -e "import('@freelanceflow/db').then(m=>{ console.log(typeof m.default.PrismaClient); }).catch(e=>{ console.error(e); process.exit(1); })"`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --cached --check`

Note: `npm test -w apps/api` currently invokes `node --test src/tests`, which fails on current main because `src/tests` is treated as a missing file path; I used the direct API test glob above to avoid mixing that separate workspace-script issue into this PR.