### PR TITLE
Expose UI workspace entrypoint

### DIFF
--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,13 @@
+import type { ReactElement, ReactNode } from "react";
+
+export interface ButtonProps {
+  children: ReactNode;
+}
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export declare function Button(props: ButtonProps): ReactElement;
+export declare function Card(props: CardProps): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+exports.Button = Button;
+exports.Card = Card;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,17 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "require": "./index.js",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
 }

--- a/packages/ui/test/import-entrypoint.test.js
+++ b/packages/ui/test/import-entrypoint.test.js
@@ -1,0 +1,28 @@
+const assert = require("node:assert/strict");
+const { createRequire } = require("node:module");
+const test = require("node:test");
+
+const requireFromTest = createRequire(__filename);
+
+test("@freelanceflow/ui resolves and exports runtime components", async () => {
+  const resolvedPath = requireFromTest.resolve("@freelanceflow/ui");
+  assert.match(resolvedPath, /packages[/\\]ui[/\\]index\.js$/);
+
+  const requiredPackage = requireFromTest("@freelanceflow/ui");
+  assert.equal(typeof requiredPackage.Button, "function");
+  assert.equal(typeof requiredPackage.Card, "function");
+
+  const importedPackage = await import("@freelanceflow/ui");
+  assert.equal(typeof importedPackage.Button, "function");
+  assert.equal(typeof importedPackage.Card, "function");
+  assert.equal(typeof importedPackage.default.Button, "function");
+  assert.equal(typeof importedPackage.default.Card, "function");
+
+  const button = requiredPackage.Button({ children: "Hire" });
+  assert.equal(button.type, "button");
+  assert.equal(button.props.children, "Hire");
+
+  const card = requiredPackage.Card({ title: "Milestone", children: "Funded" });
+  assert.equal(card.type, "section");
+  assert.equal(card.props.children[0].type, "h3");
+});


### PR DESCRIPTION
/claim #2781

## Summary
- Added explicit `main`, `types`, and `exports` metadata for `@freelanceflow/ui`.
- Added a root JavaScript runtime entrypoint that exports `Button` and `Card` without relying on unresolved TypeScript source imports.
- Added root TypeScript declarations and a focused `node:test` import check for package-name consumers.

## Validation
- `npm test -w packages/ui`
- `node -e "import('@freelanceflow/ui').then(m=>{ console.log(Object.keys(m).sort().join(',')); console.log(typeof m.Button, typeof m.default.Card); }).catch(e=>{ console.error(e); process.exit(1); })"`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --cached --check`