### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+
+  if (typeof rawQuery !== "string") {
+    return fail(res, "Search query must be a string");
+  }
+
+  const query = rawQuery.trim();
+
+  if (query.length > 200) {
+    return fail(res, "Search query must be 200 characters or fewer");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims valid string queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "designer");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=designer&q=developer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be a string"
+    });
+  });
+});
+
+test("GET /api/search rejects queries longer than 200 characters", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});


### PR DESCRIPTION
/claim #6571

## Summary
- validate `q` before calling the search service
- trim valid string queries
- reject repeated/non-string query parameters and queries over 200 characters with 400 responses
- add focused API coverage for search query validation

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`