### PR TITLE
Return defensive snapshots from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs];
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications];
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const services = [
+  {
+    name: "jobs",
+    create: () =>
+      createJob({
+        title: "Snapshot Test Job",
+        description: "A job used to verify list snapshot behavior.",
+        budgetMin: 10,
+        budgetMax: 20,
+        categoryId: "cat_snapshot",
+        skills: ["testing"]
+      }),
+    list: listJobs
+  },
+  {
+    name: "messages",
+    create: () =>
+      sendMessage({
+        senderId: "usr_snapshot_sender",
+        receiverId: "usr_snapshot_receiver",
+        body: "hello"
+      }),
+    list: listMessages
+  },
+  {
+    name: "notifications",
+    create: () =>
+      createNotification({
+        userId: "usr_snapshot",
+        message: "hello"
+      }),
+    list: listNotifications
+  },
+  {
+    name: "proposals",
+    create: () =>
+      createProposal({
+        jobId: "job_snapshot",
+        freelancerId: "usr_snapshot_freelancer",
+        bidAmount: 100
+      }),
+    list: listProposals
+  },
+  {
+    name: "reviews",
+    create: () =>
+      createReview({
+        reviewerId: "usr_snapshot_reviewer",
+        revieweeId: "usr_snapshot_reviewee",
+        rating: 5,
+        comment: "Great work"
+      }),
+    list: listReviews
+  },
+  {
+    name: "users",
+    create: () =>
+      createUser({
+        name: "Snapshot User",
+        email: "snapshot@example.com",
+        role: "client"
+      }),
+    list: listUsers
+  }
+];
+
+for (const service of services) {
+  test(`${service.name} list returns a defensive snapshot`, async () => {
+    const created = await service.create();
+    const firstList = await service.list();
+
+    assert.ok(firstList.some((item) => item === created));
+
+    const injectedRecord = { id: `${service.name}_injected` };
+    firstList.push(injectedRecord);
+
+    const secondList = await service.list();
+
+    assert.ok(secondList.some((item) => item === created));
+    assert.ok(!secondList.some((item) => item === injectedRecord));
+  });
+}


### PR DESCRIPTION
Fixes #6648

/claim #6648

## Summary

- Return shallow array snapshots from the in-memory list services for jobs, messages, notifications, proposals, reviews, and users.
- Preserve the current record objects and API response shape while preventing callers from mutating backing stores through list results.
- Add focused service coverage proving that mutating a returned list does not change later reads.

## Red/green evidence

Before the fix, `node --test apps/api/src/tests/listSnapshots.test.js` failed for all six services because a pushed record was visible in the next list call.

After the fix, the same test passes for all six services.

## Validation

- `node --test apps/api/src/tests/listSnapshots.test.js` -> 6/6 pass
- `node --test apps/api/src/tests/*.test.js` -> 7/7 pass
- `node --check apps/api/src/services/jobService.js && node --check apps/api/src/services/messageService.js && node --check apps/api/src/services/notificationService.js && node --check apps/api/src/services/proposalService.js && node --check apps/api/src/services/reviewService.js && node --check apps/api/src/services/userService.js && node --check apps/api/src/tests/listSnapshots.test.js`
- `git diff --check HEAD~1..HEAD`

## Scope

This PR is limited to returning defensive list snapshots and focused regression coverage. It does not change auth, validation, persistence, record fields, or API route behavior.
