### PR TITLE
fix: preserve generated review ids

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { ...payload, id: `rev_${Date.now()}` };
+  const review = { ...payload, id: `rev_${randomUUID()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { createReview } from "../services/reviewService.js";
 
-test("createReview preserves the server-generated id", async () => {
+test("createReview ignores a client-provided id", async () => {
   const review = await createReview({
     id: "client-controlled-id",
     jobId: "job_123",
@@ -12,10 +12,10 @@ test("createReview preserves the server-generated id", async () => {
     comment: "Clear communication"
   });
 
-  assert.match(review.id, /^rev_\d+$/);
-  assert.notEqual(review.id, "client-controlled-id");
-  assert.equal(review.jobId, "job_123");
-  assert.equal(review.reviewerId, "usr_456");
-  assert.equal(review.rating, 5);
-  assert.equal(review.comment, "Clear communication");
+  assert.match(review.id, /^rev_[0-9a-f-]+$/);
+  assert.notStrictEqual(review.id, "client-controlled-id");
+  assert.strictEqual(review.jobId, "job_123");
+  assert.strictEqual(review.reviewerId, "usr_456");
+  assert.strictEqual(review.rating, 5);
+  assert.strictEqual(review.comment, "Clear communication");
 });

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createReview } from "../services/reviewService.js";
+
+test("createReview preserves the server-generated id", async () => {
+  const review = await createReview({
+    id: "client-controlled-id",
+    jobId: "job_123",
+    reviewerId: "usr_456",
+    rating: 5,
+    comment: "Clear communication"
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "client-controlled-id");
+  assert.equal(review.jobId, "job_123");
+  assert.equal(review.reviewerId, "usr_456");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Clear communication");
+});


### PR DESCRIPTION
## Summary
- preserves the server-generated review id when creating reviews
- adds focused service regression coverage for client-supplied ids

Fixes #6651
/claim #6651
/claim #743

## Test Plan
- `node --test apps/api/src/tests/reviewService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
