### PR TITLE
ci: update leaderboard workflow for Node 24

### DIFF
--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout default branch (trusted code only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- update `actions/checkout` from `v4` to `v5` in the `update-pr-leaderboard` workflow
- proactively align the workflow with GitHub Actions' Node 24 transition

## Why
GitHub is close to switching JavaScript actions to Node 24 by default, and the current workflow emits a deprecation warning for `actions/checkout@v4`. Since the transition date is close, I decided to improve the workflow now and remove that warning path before it becomes operational noise or a future breakage point.

## Validation
- workflow change is limited to the checkout action version
- no behavior change intended beyond the runtime compatibility update
