### PR TITLE
fix: require fullName in registration and fix id/sub mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
## Summary

Two related bugs fixed in one PR:

### Bug 1: Registration missing fullName (#2770)
The Prisma User model requires `fullName`, but the registration schema only accepted `email`, `password`, and `role`. `registerUser()` also omitted `fullName` from the returned payload.

### Bug 2: JWT sub and user id mismatch (#2768)
`registerUser()` generated the user id twice with separate `Date.now()` calls — once for the response `id` and once for the JWT `sub` claim. If the two calls crossed a millisecond boundary, the token subject would not match the returned user id.

## Changes

- Add `fullName: z.string().min(1)` to `registerSchema`
- Generate user `id` once and reuse it for both the response and the JWT `sub` claim
- Include `fullName` in the returned user payload

Closes #2770
Closes #2768

/claim #2770
/claim #2768