### PR TITLE
fix: validate and limit search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchQuerySchema.parse(req.query);
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().max(200).default("")
+});


### PR DESCRIPTION
## Summary

`GET /api/search` passed `req.query.q` directly to the search service without validation. An attacker could send extremely long query strings or non-string input.

## Changes

- Add `searchQuerySchema` in `apps/api/src/validators/search.js` using Zod
- Query string is trimmed, length-limited to 200 characters, defaults to empty string
- Non-string input (e.g. repeated `q` parameters as array) is rejected
- Apply `schema.parse()` in `searchController.js`

Closes #2833

/claim #2833