### PR TITLE
fix: reject inverted budget ranges in job creation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).default([])
+}).refine(data => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary

`createJobSchema` accepted payloads where `budgetMax` was lower than `budgetMin`, creating invalid job records like "USD 500-100".

## Changes

- Add `.refine()` to `createJobSchema` ensuring `budgetMax >= budgetMin`
- Add same validation to `updateJobSchema` when both budget fields are present
- `updateJobSchema` now uses explicit optional fields instead of `.partial()` to support the refine check
- Valid ordered ranges continue to parse successfully

Closes #2853

/claim #2853