### PR TITLE
fix: preserve generated user ids

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,11 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { ...payload, id: `usr_${Date.now()}` };
+  const user = { ...payload, id: `usr_${randomUUID()}` };
   users.push(user);
   return user;
+}
+
+export function resetUsersForTest() {
+  users.length = 0;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,19 +1,26 @@
-import test from "node:test";
+import { randomUUID } from "node:crypto";
+import { beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
-import { createUser, listUsers } from "../services/userService.js";
+import { createUser, listUsers, resetUsersForTest } from "../services/userService.js";
 
-test("createUser preserves the generated user id over payload id", async () => {
+beforeEach(() => {
+  resetUsersForTest();
+});
+
+test("createUser ignores a client-provided id and stores the generated user id", async () => {
+  const email = `payload-${randomUUID()}@example.com`;
+
   const user = await createUser({
     id: "usr_client_supplied",
     name: "Payload Name",
-    email: "payload@example.com",
+    email,
   });
 
-  assert.match(user.id, /^usr_\d+$/);
-  assert.notEqual(user.id, "usr_client_supplied");
-  assert.equal(user.name, "Payload Name");
-  assert.equal(user.email, "payload@example.com");
+  assert.match(user.id, /^usr_[0-9a-f-]+$/);
+  assert.notStrictEqual(user.id, "usr_client_supplied");
+  assert.strictEqual(user.name, "Payload Name");
+  assert.strictEqual(user.email, email);
 
-  const stored = (await listUsers()).find((entry) => entry.email === "payload@example.com");
-  assert.equal(stored?.id, user.id);
+  const stored = (await listUsers()).find((entry) => entry.email === email);
+  assert.strictEqual(stored?.id, user.id);
 });

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser preserves the generated user id over payload id", async () => {
+  const user = await createUser({
+    id: "usr_client_supplied",
+    name: "Payload Name",
+    email: "payload@example.com",
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_client_supplied");
+  assert.equal(user.name, "Payload Name");
+  assert.equal(user.email, "payload@example.com");
+
+  const stored = (await listUsers()).find((entry) => entry.email === "payload@example.com");
+  assert.equal(stored?.id, user.id);
+});


### PR DESCRIPTION
## Summary
- preserves the server-generated user id when creating users
- adds focused service regression coverage for client-supplied ids

Fixes #6658
/claim #6658
/claim #743

## Test Plan
- `node --test apps/api/src/tests/userService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`