### PR TITLE
fix: preserve generated proposal ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,11 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { ...payload, id: `prp_${Date.now()}` };
+  const proposal = { ...payload, id: `prp_${randomUUID()}` };
   proposals.push(proposal);
   return proposal;
+}
+
+export function resetProposalsForTest() {
+  proposals.length = 0;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("createProposal preserves the generated proposal id over payload id", async () => {
+  const proposal = await createProposal({
+    id: "prp_client_supplied",
+    jobId: "job_123",
+    freelancerId: "usr_123",
+    coverLetter: "Focused proposal",
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "prp_client_supplied");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_123");
+  assert.equal(proposal.coverLetter, "Focused proposal");
+
+  const stored = (await listProposals()).find((entry) => entry.jobId === "job_123");
+  assert.equal(stored?.id, proposal.id);
+});

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,21 +1,28 @@
-import test from "node:test";
+import { randomUUID } from "node:crypto";
+import { beforeEach, test } from "node:test";
 import assert from "node:assert/strict";
-import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposal, listProposals, resetProposalsForTest } from "../services/proposalService.js";
 
-test("createProposal preserves the generated proposal id over payload id", async () => {
+beforeEach(() => {
+  resetProposalsForTest();
+});
+
+test("createProposal ignores a client-provided id and stores the generated proposal id", async () => {
+  const jobId = `job_${randomUUID()}`;
+
   const proposal = await createProposal({
     id: "prp_client_supplied",
-    jobId: "job_123",
+    jobId,
     freelancerId: "usr_123",
     coverLetter: "Focused proposal",
   });
 
-  assert.match(proposal.id, /^prp_\d+$/);
-  assert.notEqual(proposal.id, "prp_client_supplied");
-  assert.equal(proposal.jobId, "job_123");
-  assert.equal(proposal.freelancerId, "usr_123");
-  assert.equal(proposal.coverLetter, "Focused proposal");
+  assert.match(proposal.id, /^prp_[0-9a-f-]+$/);
+  assert.notStrictEqual(proposal.id, "prp_client_supplied");
+  assert.strictEqual(proposal.jobId, jobId);
+  assert.strictEqual(proposal.freelancerId, "usr_123");
+  assert.strictEqual(proposal.coverLetter, "Focused proposal");
 
-  const stored = (await listProposals()).find((entry) => entry.jobId === "job_123");
-  assert.equal(stored?.id, proposal.id);
+  const stored = (await listProposals()).find((entry) => entry.jobId === jobId);
+  assert.strictEqual(stored?.id, proposal.id);
 });


### PR DESCRIPTION
## Summary
- preserves the server-generated proposal id when creating proposals
- adds focused service regression coverage for client-supplied ids

Fixes #6661
/claim #6661
/claim #743

## Test Plan
- `node --test apps/api/src/tests/proposalService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`