### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,23 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
Closes #2853

## Problem
createJobSchema does not validate that budgetMax >= budgetMin, allowing inverted budget ranges.

## Fix
Added .refine() to both schemas to reject budgetMax < budgetMin:
- createJobSchema: always validates
- updateJobSchema: validates only when both fields present in partial update

## Test Cases
| Input | Expected |
|---|---|
| budgetMin:100, budgetMax:500 | Pass |
| budgetMin:500, budgetMax:500 | Pass |
| budgetMin:500, budgetMax:100 | Reject |
| Partial {budgetMax:200} | Pass |