### PR TITLE
fix: reuse Date.now() to prevent JWT subject ID mismatch on registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
/claim #743\n\nCloses #6664\n\n## Problem\n\nIn \`apps/api/src/services/authService.js\`, the \`registerUser\` function called \`Date.now()\` twice — once for the user \`id\` and once for the JWT \`sub\`. When the system clock advances between the two calls, the JWT subject does not match the user record ID.\n\n## Fix\n\nCall \`Date.now()\` once, store the result, and reuse it for both the user ID and JWT subject.\n\n## Diff\n\n\`\`\`diff\n-    id: \`usr_\${Date.now()}\`,\n-    token: signAccessToken({ sub: \`usr_\${Date.now()}\`, role: payload.role })\n+  const id = \`usr_\${Date.now()}\`;\n+    id,\n+    token: signAccessToken({ sub: id, role: payload.role })\n\`\`\`