### PR TITLE
fix: sendMessage should ignore caller-supplied id via spread-order fix

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
Fixes #6667

## What

Fixed the spread order in `sendMessage()` so that server-generated `id` (and `sentAt`) cannot be overridden by caller-supplied payload fields.

## Before
```js
const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
```
A caller could submit `{ id: "injected" }` and replace the server-owned message id.

## After
```js
const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
```
Server-generated `id` and `sentAt` always take precedence.

## Scope
Only `apps/api/src/services/messageService.js` — no changes to routes, auth, persistence, or other services.

/attempt #743