### PR TITLE
fix: store Date.now() once in registerUser to keep JWT subject consistent with returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Closes #6669

Parent bounty: #743

### Problem

`registerUser()` in `apps/api/src/services/authService.js` calls `Date.now()` twice — once for the returned user `id` and once for the JWT `sub` claim. If the two calls land on different milliseconds, the token subject drifts from the user id returned at registration.

### Fix

Store `Date.now()` in a `userId` variable and reuse it for both fields, keeping the subject consistent.