### PR TITLE
fix(api): prevent caller-owned message id override

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-owned id and sentAt fields", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker_supplied",
+    sentAt: "2000-01-01T00:00:00.000Z",
+    senderId: "user_1",
+    recipientId: "user_2",
+    body: "hello",
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_attacker_supplied");
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(message.senderId, "user_1");
+  assert.equal(message.recipientId, "user_2");
+  assert.equal(message.body, "hello");
+});


### PR DESCRIPTION
## Summary
- Prevent caller-provided message payload fields from overriding the server-generated `id` and `sentAt` values.
- Add a service-level regression test covering a malicious caller-provided `id` and `sentAt`.

## Verification
- `node --test apps/api/src/tests/messageService.test.js`
- `node --check apps/api/src/services/messageService.js`
- `node --check apps/api/src/tests/messageService.test.js`
- `git diff --check`

Fixes #6671
Refs #743
/claim #743
