### PR TITLE
Fix ui package JavaScript entrypoint

### DIFF
--- a/packages/ui/dist/Button.d.ts
+++ b/packages/ui/dist/Button.d.ts
@@ -1,0 +1,5 @@
+﻿import type { ReactNode } from "react";
+
+export declare function Button(props: {
+  children: ReactNode;
+}): import("react").ReactElement;

--- a/packages/ui/dist/Button.js
+++ b/packages/ui/dist/Button.js
@@ -1,0 +1,5 @@
+﻿import React from "react";
+
+export function Button({ children }) {
+  return React.createElement("button", null, children);
+}

--- a/packages/ui/dist/Card.d.ts
+++ b/packages/ui/dist/Card.d.ts
@@ -1,0 +1,6 @@
+﻿import type { ReactNode } from "react";
+
+export declare function Card(props: {
+  title: string;
+  children: ReactNode;
+}): import("react").ReactElement;

--- a/packages/ui/dist/Card.js
+++ b/packages/ui/dist/Card.js
@@ -1,0 +1,10 @@
+﻿import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("h3", null, title),
+    children
+  );
+}

--- a/packages/ui/dist/index.d.ts
+++ b/packages/ui/dist/index.d.ts
@@ -1,0 +1,2 @@
+﻿export { Button } from "./Button.js";
+export { Card } from "./Card.js";

--- a/packages/ui/dist/index.js
+++ b/packages/ui/dist/index.js
@@ -1,0 +1,2 @@
+﻿export { Button } from "./Button.js";
+export { Card } from "./Card.js";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,21 @@
-{
+﻿{
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }


### PR DESCRIPTION
Fixes #2781

## Summary

This PR fixes the `@freelanceflow/ui` package entrypoint so it can be imported directly by a Node/ESM consumer.

Previously, the package pointed `main` to `src/index.ts`, which caused runtime imports to fail because Node could not resolve the TypeScript source entrypoint and component module exports as JavaScript.

## Changes

* Updated `packages/ui/package.json` to expose a real JavaScript entrypoint.
* Added `exports`, `types`, and `type: "module"` metadata.
* Added runtime JavaScript files under `packages/ui/dist`.
* Added TypeScript declaration files for consumers.

## Verification

The issue reproduction now succeeds:

```sh
node -e "import('@freelanceflow/ui').then(m => console.log(Object.keys(m)))"
```

Output:

```sh
[ 'Button', 'Card' ]
```

Note: `npm test` at the repository root currently fails in the unrelated `apps/api` workspace because `apps/api/src/tests` cannot be resolved. This appears unrelated to the UI package entrypoint change.
