### PR TITLE
Require auth for notification creation

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationRoutes.test.js
+++ b/apps/api/src/tests/notificationRoutes.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/notifications accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ message: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "hello");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
/claim #6623

Addresses #6623
Parent bounty: #743

## Summary
- require `authMiddleware` before notification creation reaches `postNotification`
- add API coverage for unauthenticated POST rejection and authenticated POST success

Payment details can be provided privately after maintainer acceptance.

## Validation
- RED: `node --test apps/api/src/tests/notificationRoutes.test.js` failed before the fix because unauthenticated `POST /api/notifications` returned 201 instead of 401
- GREEN: `node --test apps/api/src/tests/notificationRoutes.test.js`
- GREEN: `node --test apps/api/src/tests/*.test.js`
- `git diff --check HEAD~1..HEAD`
- staged diff scan for payment, billing, tax, identity, wallet, card, and bank terms

Note: `npm test` currently fails because the existing workspace script runs `node --test src/tests`, which Node 22 treats as a missing module path. That script issue is separate from this scoped fix and appears to be tracked by #6626.