### PR TITLE
fix: expose @freelanceflow/ui as a directly importable ESM package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "files": ["dist"]
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./Button";
-export * from "./Card";
+export * from "./Button.js";
+export * from "./Card.js";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Fixes #2781

## Changes
- Add tsconfig.json with NodeNext module resolution for proper ESM output
- Update package.json to declare package as ESM and point main/exports to compiled dist/
- Update source imports to include .js extensions for Node ESM resolution
- Add build and clean scripts
- Package now successfully imports via: `import('@freelanceflow/ui')`

## Testing
✓ Package successfully imports via ESM: `import { Button, Card } from '@freelanceflow/ui'`
✓ Exported components are correct types (functions)
✓ TypeScript definitions are generated and available

This fixes the issue where the package was pointing to TypeScript source and failing on direct imports. The package now exposes a compiled JavaScript entrypoint while maintaining TypeScript type definitions.