### PR TITLE
Add clear ledger poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Clear Ledger
+
+The brief arrives with measured light,
+a title, scope, and promised lane;
+we name the work before the night,
+then leave no hidden debt or stain.
+
+The proof is small, but made to hold,
+a test, a note, a trace in view;
+each line records what can be told,
+and keeps the handoff clean and true.
+
+The review comes in a steady frame,
+not noise, not guess, not hurried claim;
+it weighs the change against the need,
+then signs the path from plan to deed.
+
+When merge and payout share one page,
+the ledger quiets into trust;
+good work survives the market's gauge,
+because its evidence is just.


### PR DESCRIPTION
## Summary
- Add `POEM.md` at the project root with an original four-stanza poem written for FreelanceFlow.
- Creative note: I used a clear-ledger form so scope, proof, review, and payout read like accountable marketplace checkpoints.

## Validation
- Confirmed `POEM.md` exists at the repository root.
- Confirmed stanza count: 4.
- Ran `git diff --check`.

/claim #76