### PR TITLE
Keep registration JWT subject aligned with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token with the returned user id", async () => {
+  const originalNow = Date.now;
+  const firstTimestamp = originalNow();
+  const timestamps = [firstTimestamp, firstTimestamp + 1];
+
+  Date.now = () => timestamps.shift() ?? originalNow();
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      role: "client"
+    });
+    const tokenPayload = verifyAccessToken(result.token);
+
+    assert.equal(result.id, `usr_${firstTimestamp}`);
+    assert.equal(tokenPayload.sub, result.id);
+    assert.equal(tokenPayload.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once before building the response
- reuse that id as the JWT `sub` claim so the returned user id and token identity cannot drift
- add service coverage that simulates adjacent `Date.now()` values and verifies the signed subject matches the returned id

## Validation
- `node --test src/tests/authService.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`

/claim #6679