### PR TITLE
Validate OAuth callback providers

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const SUPPORTED_OAUTH_PROVIDERS = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +17,10 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  if (!SUPPORTED_OAUTH_PROVIDERS.has(req.params.provider)) {
+    return fail(res, "Unsupported OAuth provider");
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/authOauth.test.js
+++ b/apps/api/src/tests/authOauth.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("OAuth callback rejects unsupported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/evil_provider/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});
+
+test("OAuth callback accepts supported providers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add OAuth callback provider validation so unsupported provider names return the existing structured 400 response.
- Preserve the current successful callback response for supported providers (`github`, `google`).
- Add route-level regression coverage for rejected and accepted OAuth provider callbacks.

## Linked issue
- Fixes #6681

## TDD evidence
- Red: `node --test apps/api/src/tests/authOauth.test.js` failed before the fix because `evil_provider` returned 200 instead of 400.
- Green: focused OAuth route test passes after the controller whitelist fix.

## Validation
- `node --test apps/api/src/tests/authOauth.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

/claim #743