### PR TITLE
Prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const validRegistration = {
+  email: "client@example.com",
+  password: "password123"
+};
+
+test("registerSchema defaults omitted role to client", () => {
+  const result = registerSchema.parse(validRegistration);
+
+  assert.equal(result.role, "client");
+});
+
+test("registerSchema accepts public freelancer role", () => {
+  const result = registerSchema.safeParse({
+    ...validRegistration,
+    role: "freelancer"
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("registerSchema rejects public admin role assignment", () => {
+  const result = registerSchema.safeParse({
+    ...validRegistration,
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "role");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

- Remove `admin` from the public registration role enum.
- Preserve the existing `client` default for omitted registration roles.
- Add focused validator coverage for default, freelancer, and rejected admin roles.

Fixes #3606
Parent bounty: #743
Source issue: #2832

## Tests

- `node --test apps/api/src/tests/authValidator.test.js`
  - pass: 3
- `node --test apps/api/src/tests/*.test.js`
  - pass: 8
- `npm test`
  - currently fails before executing tests because `apps/api/package.json` passes `src/tests` as a module path under Node v26; left out of this PR because a separate open PR appears to cover the test-script glob.
