### PR TITLE
fix: reject unsupported OAuth providers in callback

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+
+const SUPPORTED_PROVIDERS = ["github", "google", "microsoft"];
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,8 +17,12 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+  if (!SUPPORTED_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
   return ok(res, {
-    provider: req.params.provider,
+    provider: provider,
     status: "callback-received"
   });
 }


### PR DESCRIPTION
Closes #6692. Implementation of a whitelist for supported OAuth providers in the callback route.

### Changes:
- Added  whitelist (, , ).
- Modified  to validate the  parameter.
- Returns  with a clear error message for unsupported providers.
- Preserves the original response shape for supported providers.