### PR TITLE
fix(web): sync next-env route types import

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
﻿## Summary
Fixes the generated route type import in `apps/web/next-env.d.ts` so it matches the current Next.js route output.

## What changed
- Updated the checked-in bootstrap type import to `./.next/types/routes.d.ts`.

## Why this matters
- Keeps the app's type declarations aligned with the actual route surface.
- Prevents route type drift between generated Next.js output and the repository bootstrap file.

## Validation
- `cmd /c npm run build -w apps/web` completed successfully.

## Value
- Small, low-risk fix that improves build/type consistency.
