### PR TITLE
Reject blank notification messages

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +6,9 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
+  if (typeof req.body?.message !== "string" || req.body.message.trim() === "") {
+    return fail(res, "Notification message is required");
+  }
+
   return ok(res, await createNotification(req.body), 201);
 }

--- a/apps/api/src/tests/notificationController.test.js
+++ b/apps/api/src/tests/notificationController.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postNotification(baseUrl, body) {
+  return fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("POST /api/notifications rejects missing message", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Notification message is required" });
+  });
+});
+
+test("POST /api/notifications rejects non-string message", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, { message: 42 });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Notification message is required" });
+  });
+});
+
+test("POST /api/notifications rejects blank message", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, { message: "   " });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Notification message is required" });
+  });
+});
+
+test("POST /api/notifications creates notification for valid message", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, { message: "Proposal accepted" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "Proposal accepted");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_\d+$/);
+  });
+});


### PR DESCRIPTION
## Summary
- reject notification creation requests when `message` is missing, non-string, or blank
- keep valid notification creation returning 201 with the existing response shape
- add focused API coverage for invalid and valid notification payloads

Fixes #6696
Parent bounty: #743
/claim #743

## Validation
- `node --test apps/api/src/tests/notificationController.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
- `git diff --cached --check`

Note: `npm test -w apps/api` still fails on current main because the script runs `node --test src/tests`, which Node 22 treats as a missing directory entrypoint. The concrete test-file command above passes.