### PR TITLE
Validate auth token identity claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,20 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
+function hasValidIdentityClaims(payload) {
+  return (
+    payload !== null &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    typeof payload.sub === "string" &&
+    payload.sub.trim() !== "" &&
+    typeof payload.role === "string" &&
+    allowedRoles.has(payload.role)
+  );
+}
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +22,12 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!hasValidIdentityClaims(payload)) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authMiddleware.test.js
+++ b/apps/api/src/tests/authMiddleware.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function signedToken(payload) {
+  return jwt.sign(payload, env.jwtSecret);
+}
+
+async function getAdminMetrics(baseUrl, token) {
+  return fetch(`${baseUrl}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function assertUnauthorized(baseUrl, token) {
+  const response = await getAdminMetrics(baseUrl, token);
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(payload, { success: false, message: "Invalid token" });
+}
+
+test("auth middleware rejects signed tokens with string payloads", async () => {
+  await withServer(async (baseUrl) => {
+    await assertUnauthorized(baseUrl, signedToken("usr_1"));
+  });
+});
+
+test("auth middleware rejects signed tokens missing sub", async () => {
+  await withServer(async (baseUrl) => {
+    await assertUnauthorized(baseUrl, signedToken({ role: "client" }));
+  });
+});
+
+test("auth middleware rejects signed tokens with blank sub", async () => {
+  await withServer(async (baseUrl) => {
+    await assertUnauthorized(baseUrl, signedToken({ sub: "   ", role: "client" }));
+  });
+});
+
+test("auth middleware rejects signed tokens with unsupported role", async () => {
+  await withServer(async (baseUrl) => {
+    await assertUnauthorized(baseUrl, signedToken({ sub: "usr_1", role: "owner" }));
+  });
+});
+
+test("auth middleware accepts valid app-issued access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const response = await getAdminMetrics(baseUrl, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.openJobs, "number");
+  });
+});


### PR DESCRIPTION
## Summary
- reject signed JWTs whose decoded payload is not an object
- require a non-empty string `sub` and an allowed `role` before setting `req.user`
- preserve valid app-issued access tokens for protected routes
- add focused API coverage through `/api/admin/metrics`

Fixes #6699
Parent bounty: #743
/claim #743

## Validation
- `node --test apps/api/src/tests/authMiddleware.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
- `git diff --cached --check`

Note: `npm test -w apps/api` still fails on current main because the script runs `node --test src/tests`, which Node 22 treats as a missing directory entrypoint. The concrete test-file command above passes.