### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,27 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+
+function isValidProposal(payload) {
+  return (
+    typeof payload?.bidAmount === "number" &&
+    Number.isFinite(payload.bidAmount) &&
+    payload.bidAmount >= 0 &&
+    typeof payload.estimatedDays === "number" &&
+    Number.isFinite(payload.estimatedDays) &&
+    payload.estimatedDays >= 0 &&
+    typeof payload.coverLetter === "string" &&
+    payload.coverLetter.trim() !== ""
+  );
+}
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
+  if (!isValidProposal(req.body)) {
+    return fail(res, "Invalid proposal payload");
+  }
+
   return ok(res, await createProposal(req.body), 201);
 }

--- a/apps/api/src/tests/proposalController.test.js
+++ b/apps/api/src/tests/proposalController.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function validProposal(overrides = {}) {
+  return {
+    jobId: "job_1",
+    freelancerId: "usr_1",
+    bidAmount: 250,
+    estimatedDays: 7,
+    coverLetter: "I can complete this work with tests and documentation.",
+    ...overrides,
+  };
+}
+
+async function assertBadProposal(baseUrl, body) {
+  const response = await postProposal(baseUrl, body);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, { success: false, message: "Invalid proposal payload" });
+}
+
+test("POST /api/proposals rejects negative bidAmount", async () => {
+  await withServer(async (baseUrl) => {
+    await assertBadProposal(baseUrl, validProposal({ bidAmount: -1 }));
+  });
+});
+
+test("POST /api/proposals rejects negative estimatedDays", async () => {
+  await withServer(async (baseUrl) => {
+    await assertBadProposal(baseUrl, validProposal({ estimatedDays: -1 }));
+  });
+});
+
+test("POST /api/proposals rejects blank coverLetter", async () => {
+  await withServer(async (baseUrl) => {
+    await assertBadProposal(baseUrl, validProposal({ coverLetter: "   " }));
+  });
+});
+
+test("POST /api/proposals creates proposals for valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const proposal = validProposal();
+    const response = await postProposal(baseUrl, proposal);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^prp_\d+$/);
+    assert.equal(payload.data.bidAmount, proposal.bidAmount);
+    assert.equal(payload.data.estimatedDays, proposal.estimatedDays);
+    assert.equal(payload.data.coverLetter, proposal.coverLetter);
+  });
+});


### PR DESCRIPTION
## Summary
- reject proposal creation payloads with negative `bidAmount`
- reject negative `estimatedDays` and blank `coverLetter`
- preserve valid proposal creation behavior and response shape
- add focused API coverage for invalid and valid proposal payloads

Fixes #6702
Parent bounty: #743
/claim #743

## Validation
- `node --test apps/api/src/tests/proposalController.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
- `git diff --cached --check`

Note: `npm test -w apps/api` still fails on current main because the script runs `node --test src/tests`, which Node 22 treats as a missing directory entrypoint. The concrete test-file command above passes.