### PR TITLE
fix(api): reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/job-validation.test.js
+++ b/apps/api/src/tests/job-validation.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { updateJobSchema } from "../validators/job.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a focused landing page for a product launch.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...validJobPayload,
+        budgetMin: 500,
+        budgetMax: 100
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid job payload"
+    });
+  });
+});
+
+test("POST /api/jobs accepts ordered budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, 100);
+    assert.equal(payload.data.budgetMax, 500);
+  });
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 500, budgetMax: 100 }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+
+  assert.doesNotThrow(() => updateJobSchema.parse({ budgetMin: 100 }));
+  assert.doesNotThrow(() => updateJobSchema.parse({ budgetMin: 100, budgetMax: 500 }));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,22 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function hasValidBudgetRange(payload) {
+  return (
+    payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMax >= payload.budgetMin
+  );
+}
+
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+export const createJobSchema = jobSchema.refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(hasValidBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary

- Reject job payloads where `budgetMax` is lower than `budgetMin`
- Return HTTP 400 for invalid job creation payloads instead of creating bad records or falling through to a generic server error
- Add regression tests for invalid create payloads, valid ordered ranges, and partial update schema validation

## Demo / Verification

```text
node --test apps/api/src/tests/*.test.js
pass 4
fail 0
```

Fixes #6708

/claim #743