### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API endpoint",
+  description: "Implement the API endpoint for the bounty board.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const parsed = createJobSchema.parse(validJob);
+
+  assert.equal(parsed.budgetMin, 100);
+  assert.equal(parsed.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+  assert.match(result.error.issues[0].message, /budgetMax/);
+});
+
+test("updateJobSchema rejects inverted ranges when both budgets are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema still accepts partial single-budget updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const validateBudgetRange = (job, context) => {
+  if (
+    typeof job.budgetMin === "number" &&
+    typeof job.budgetMax === "number" &&
+    job.budgetMax < job.budgetMin
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+};
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Closes #6710

/claim #6710

## Summary
- reject job payloads where budgetMax is lower than budgetMin
- apply the same cross-field validation to partial job updates when both budget fields are present
- add focused validator regression coverage

## Test Plan
- node --test src/tests/jobValidator.test.js
- node --test src/tests/*.test.js