### PR TITLE
Expose UI package entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,17 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "scripts": {
+    "test": "node --test src/*.test.mjs"
+  }
 }

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,0 +1,11 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Button({ children }: { children: ReactNode }): ReactElement;
+
+export declare function Card({
+  title,
+  children
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement;

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/package-entrypoint.test.mjs
+++ b/packages/ui/src/package-entrypoint.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("workspace package name exposes UI components", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});


### PR DESCRIPTION
Closes #6713

/claim #743

## Summary
- add explicit main, types, and exports metadata for @freelanceflow/ui
- add a runtime JavaScript entrypoint that exposes the existing Button and Card components through the package name
- add type declarations and focused workspace import coverage

## Validation
- npm test -w @freelanceflow/ui
- npm run build -w apps/web
- git diff --check
- git diff --cached --check

Payment details can be provided privately after maintainer acceptance.