### PR TITLE
Preserve login token roles

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -12,9 +12,11 @@ export async function registerUser(payload) {
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const role = payload.role ?? "client";
+
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loginUser } from "../services/authService.js";
+import { loginSchema } from "../validators/auth.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("login schema preserves supplied user roles", () => {
+  const payload = loginSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(payload.role, "freelancer");
+});
+
+test("login tokens use the supplied user role", async () => {
+  const result = await loginUser({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(claims.role, "freelancer");
+});
+
+test("login tokens default to client when no role is available", async () => {
+  const result = await loginUser({
+    email: "client@example.com",
+    password: "password123"
+  });
+  const claims = verifyAccessToken(result.token);
+
+  assert.equal(claims.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -8,5 +8,6 @@ export const registerSchema = z.object({
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: z.string().min(8),
+  role: z.enum(["client", "freelancer", "admin"]).optional()
 });


### PR DESCRIPTION
Closes #6715

/claim #743

## Summary
- preserve optional login roles through auth login validation
- sign login access tokens with the supplied role when available
- keep the existing client role default for mock logins without a role
- add focused service coverage for supplied roles and default behavior

## Validation
- node --test apps/api/src/tests/authService.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/validators/auth.js
- git diff --check
- git diff --cached --check

Payment details can be provided privately after maintainer acceptance.