### PR TITLE
Preserve job server-owned fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps id and status server-owned", async () => {
+  const job = await createJob({
+    id: "job_attacker",
+    title: "Build dashboard",
+    description: "Create a hiring dashboard",
+    budgetMin: 100,
+    budgetMax: 200,
+    status: "closed"
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "job_attacker");
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
Closes #6717

/claim #743

## Summary
- keep job id and status server-owned during job creation
- prevent caller-provided id or status from overriding generated values
- add focused service coverage for malicious payload fields

## Validation
- node --test apps/api/src/tests/jobService.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/services/jobService.js
- node --check apps/api/src/tests/jobService.test.js
- git diff --check
- git diff --cached --check

Payment details can be provided privately after maintainer acceptance.