### PR TITLE
Reject oversized job metadata

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid job payload", 400);
+  }
+
+  const payload = result.data;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/jobMetadata.test.js
+++ b/apps/api/src/tests/jobMetadata.test.js
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+function validJob(overrides = {}) {
+  return {
+    title: "Build dashboard",
+    description: "Create a hiring dashboard for clients",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "cat_web",
+    skills: ["react", "node"],
+    ...overrides
+  };
+}
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJob(baseUrl, body) {
+  return fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/jobs preserves normal job creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJob(baseUrl, validJob());
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, "Build dashboard");
+  });
+});
+
+test("POST /api/jobs rejects oversized metadata", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedPayloads = [
+      validJob({ title: "x".repeat(121) }),
+      validJob({ description: "x".repeat(5001) }),
+      validJob({ categoryId: "x".repeat(101) }),
+      validJob({ skills: ["x".repeat(81)] }),
+      validJob({ skills: Array.from({ length: 26 }, (_, index) => `skill-${index}`) })
+    ];
+
+    for (const body of oversizedPayloads) {
+      const response = await postJob(baseUrl, body);
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.equal(payload.success, false);
+    }
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().min(4).max(120),
+  description: z.string().min(10).max(5000),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: z.string().min(1).max(100),
+  skills: z.array(z.string().min(1).max(80)).max(25).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Closes #6719

/claim #743

## Summary
- cap job title, description, category id, skill name, and skill array sizes in the job creation schema
- return 400 Bad Request for invalid job creation payloads in the job controller
- add route coverage proving normal job creation still succeeds and oversized metadata is rejected

## Validation
- node --test apps/api/src/tests/jobMetadata.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/controllers/jobController.js
- node --check apps/api/src/validators/job.js
- git diff --check
- git diff --cached --check

Payment details can be provided privately after maintainer acceptance.