### PR TITLE
Handle server bootstrap failures

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -1,13 +1,36 @@
 import { connectDb } from "./config/db.js";
 import { env } from "./config/env.js";
 import { createApp } from "./app.js";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-async function bootstrap() {
-  await connectDb();
-  const app = createApp();
-  app.listen(env.port, () => {
-    console.log(`API listening on http://localhost:${env.port}`);
+export async function bootstrap({
+  connectDb: connect = connectDb,
+  createApp: makeApp = createApp,
+  port = env.port
+} = {}) {
+  await connect();
+  const app = makeApp();
+  const server = app.listen(port);
+
+  await new Promise((resolveStartup, rejectStartup) => {
+    server.once("listening", () => {
+      console.log(`API listening on http://localhost:${port}`);
+      resolveStartup();
+    });
+    server.once("error", rejectStartup);
   });
+
+  return server;
 }
 
-bootstrap();
+function isEntrypoint() {
+  return Boolean(process.argv[1]) && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isEntrypoint()) {
+  bootstrap().catch((error) => {
+    console.error("API startup failed:", error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/api/src/tests/serverBootstrap.test.js
+++ b/apps/api/src/tests/serverBootstrap.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+test("importing the server module does not start the listener", async () => {
+  const child = spawn(process.execPath, [
+    "--input-type=module",
+    "-e",
+    "await import('./apps/api/src/server.js'); console.log('imported');"
+  ], {
+    cwd: process.cwd(),
+    env: { ...process.env, PORT: "0" },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  const timeout = setTimeout(() => child.kill("SIGTERM"), 1000);
+  const [code] = await once(child, "exit");
+  clearTimeout(timeout);
+
+  assert.equal(code, 0);
+});
+
+test("bootstrap surfaces startup dependency failures", async () => {
+  const { bootstrap } = await import("../server.js");
+
+  await assert.rejects(
+    () => bootstrap({
+      connectDb: async () => {
+        throw new Error("database unavailable");
+      },
+      createApp: () => ({
+        listen() {
+          throw new Error("listen should not run");
+        }
+      }),
+      port: 0
+    }),
+    /database unavailable/
+  );
+});


### PR DESCRIPTION
Closes #6721

/claim #743

## Summary
- export a testable API bootstrap() helper
- keep importing server.js side-effect free by only auto-starting when executed as the entrypoint
- wait for listener startup and surface dependency/listener failures through bootstrap()
- catch entrypoint startup failures with a clear log message and non-zero exit code

## Validation
- node --test apps/api/src/tests/serverBootstrap.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/server.js
- node --check apps/api/src/tests/serverBootstrap.test.js
- node child-process startup smoke check with PORT=0 node apps/api/src/server.js
- git diff --check
- git diff --cached --check

Payment details can be provided privately after maintainer acceptance.