### PR TITLE
Fix registration token subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,15 +1,18 @@
+import { randomUUID } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
-export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  const id = `usr_${Date.now()}`;
-
+export function createRegisteredUser(payload, id = `usr_${randomUUID()}`) {
   return {
     id,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: id, role: payload.role })
   };
+}
+
+export async function registerUser(payload) {
+  // TODO: persist new user via Prisma
+  return createRegisteredUser(payload);
 }
 
 export async function loginUser(payload) {

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,17 +1,40 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { registerUser } from "../services/authService.js";
+import { createRegisteredUser, registerUser } from "../services/authService.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
-test("registerUser signs the returned user id as the token subject", async () => {
-  const result = await registerUser({
+test("createRegisteredUser signs the supplied user id as the token subject", () => {
+  const result = createRegisteredUser(
+    {
+      email: "person@example.com",
+      password: "correct horse battery staple",
+      role: "client"
+    },
+    "usr_test_id"
+  );
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(result.id, "usr_test_id");
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});
+
+test("registerUser returns a collision-resistant prefixed user id", async () => {
+  const first = await registerUser({
     email: "person@example.com",
     password: "correct horse battery staple",
     role: "client"
   });
+  const second = await registerUser({
+    email: "another@example.com",
+    password: "correct horse battery staple",
+    role: "client"
+  });
 
-  const decoded = verifyAccessToken(result.token);
+  const decoded = verifyAccessToken(first.token);
 
-  assert.equal(decoded.sub, result.id);
-  assert.equal(decoded.role, result.role);
+  assert.match(first.id, /^usr_[0-9a-f-]{36}$/);
+  assert.notEqual(first.id, second.id);
+  assert.equal(decoded.sub, first.id);
 });

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the returned user id as the token subject", async () => {
+  const result = await registerUser({
+    email: "person@example.com",
+    password: "correct horse battery staple",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once
- use that same id for the returned payload and JWT subject
- add a service regression test that decodes the issued token

## Tests
- `node --test src/tests/authService.test.js`
- `node --test src/tests/*.test.js`
- `npm test -w apps/api` currently fails on Windows because the existing script runs `node --test src/tests`, which Node resolves as a module path instead of discovering test files

Closes #6723