### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createJobSchema, updateJobSchema } from "../validators/job.js";
+import { createJobSchema, jobSchemaBase, updateJobSchema } from "../validators/job.js";
 
 const validJob = {
   title: "Build landing page",
@@ -48,4 +48,11 @@ test("updateJobSchema allows partial budget updates with one side omitted", () =
 
   assert.equal(minOnly.success, true);
   assert.equal(maxOnly.success, true);
+});
+
+test("jobSchemaBase remains available for object-schema composition", () => {
+  const titleOnlySchema = jobSchemaBase.pick({ title: true });
+  const result = titleOnlySchema.safeParse({ title: "Build landing page" });
+
+  assert.equal(result.success, true);
 });

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for launch",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_design",
+  skills: ["design"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMax must be greater than or equal to budgetMin"
+  );
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 300,
+    budgetMax: 200
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema allows partial budget updates with one side omitted", () => {
+  const minOnly = updateJobSchema.safeParse({ budgetMin: 300 });
+  const maxOnly = updateJobSchema.safeParse({ budgetMax: 200 });
+
+  assert.equal(minOnly.success, true);
+  assert.equal(maxOnly.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, ctx) {
+  if (
+    payload.budgetMin !== undefined &&
+    payload.budgetMax !== undefined &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+export const createJobSchema = jobFields.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobFields.partial().superRefine(validateBudgetRange);

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const jobFields = z.object({
+export const jobSchemaBase = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -23,6 +23,6 @@ function validateBudgetRange(payload, ctx) {
   }
 }
 
-export const createJobSchema = jobFields.superRefine(validateBudgetRange);
+export const createJobSchema = jobSchemaBase.superRefine(validateBudgetRange);
 
-export const updateJobSchema = jobFields.partial().superRefine(validateBudgetRange);
+export const updateJobSchema = jobSchemaBase.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary
- add shared budget range validation for job create and partial update schemas
- reject payloads where `budgetMax` is lower than `budgetMin`
- keep valid ordered ranges and one-sided partial budget updates working

## Tests
- `node --test src/tests/jobValidator.test.js`
- `node --test src/tests/*.test.js`
- `npm test -w apps/api` currently fails on Windows because the existing script runs `node --test src/tests`, which Node resolves as a module path instead of discovering test files

Closes #6724