### PR TITLE
fix: preserve generated message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied id", async () => {
+  const message = await sendMessage({
+    id: "attacker-controlled-id",
+    body: "hello",
+    senderId: "usr_1",
+    recipientId: "usr_2"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "attacker-controlled-id");
+  assert.equal(message.body, "hello");
+  assert.equal(message.senderId, "usr_1");
+  assert.equal(message.recipientId, "usr_2");
+  assert.equal(typeof message.sentAt, "string");
+});


### PR DESCRIPTION
## Summary
- ensure sendMessage keeps the server-generated message id even when callers include id in payload
- add focused service regression coverage for caller-supplied id override attempts

Closes #6727

/claim #743

## Test Plan
- node --test apps/api/src/tests/messageService.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check