### PR TITLE
fix(api): validate auth login credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,37 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+function handleAuthServiceError(error, res) {
+  if (error?.code === "EMAIL_ALREADY_REGISTERED") {
+    return fail(res, "Email already registered", 409);
+  }
+
+  if (error?.code === "INVALID_CREDENTIALS") {
+    return fail(res, "Invalid email or password", 401);
+  }
+
+  throw error;
+}
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return handleAuthServiceError(error, res);
+  }
 }
 
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    return handleAuthServiceError(error, res);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,69 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { randomBytes, randomUUID, scryptSync, timingSafeEqual } from "node:crypto";
+
+const usersByEmail = new Map();
+
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}
+
+function createServiceError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function hashPassword(password) {
+  const salt = randomBytes(16).toString("hex");
+  const hash = scryptSync(password, salt, 32).toString("hex");
+  return `${salt}:${hash}`;
+}
+
+function verifyPassword(password, storedHash) {
+  const [salt, hash] = storedHash.split(":");
+  if (!salt || !hash) {
+    return false;
+  }
+
+  const expected = Buffer.from(hash, "hex");
+  const actual = scryptSync(password, salt, 32);
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
+  const email = normalizeEmail(payload.email);
+  if (usersByEmail.has(email)) {
+    throw createServiceError("EMAIL_ALREADY_REGISTERED", "Email already registered");
+  }
+
+  const user = {
+    id: `usr_${randomUUID()}`,
+    email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  };
+  usersByEmail.set(email, user);
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  // TODO: replace in-memory lookup with Prisma-backed user records.
+  const email = normalizeEmail(payload.email);
+  const user = usersByEmail.get(email);
+  if (!user || !verifyPassword(payload.password, user.passwordHash)) {
+    throw createServiceError("INVALID_CREDENTIALS", "Invalid email or password");
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/login rejects unregistered credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email: "missing@example.com",
+      password: "password123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid email or password"
+    });
+  });
+});
+
+test("POST /api/auth/login rejects a wrong password for a registered user", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/auth/register", {
+      email: "wrong-password@example.com",
+      password: "correct-password",
+      role: "client"
+    });
+
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email: "wrong-password@example.com",
+      password: "incorrect-password"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid email or password"
+    });
+  });
+});
+
+test("POST /api/auth/login signs tokens for the registered user id", async () => {
+  await withServer(async (baseUrl) => {
+    const registerResponse = await postJson(baseUrl, "/api/auth/register", {
+      email: "login-success@example.com",
+      password: "correct-password",
+      role: "freelancer"
+    });
+    const registered = await registerResponse.json();
+
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", {
+      email: "LOGIN-SUCCESS@example.com",
+      password: "correct-password"
+    });
+    const loggedIn = await loginResponse.json();
+    const decoded = verifyAccessToken(loggedIn.data.token);
+
+    assert.equal(loginResponse.status, 200);
+    assert.equal(loggedIn.data.email, "login-success@example.com");
+    assert.equal(decoded.sub, registered.data.id);
+    assert.equal(decoded.role, "freelancer");
+  });
+});


### PR DESCRIPTION
Fixes #6729
/claim #743

## Summary

- store registered users in the existing mock auth service with scrypt password hashes
- reject unknown users and wrong passwords with 401 responses
- sign successful login tokens with the registered user id and role
- add regression coverage for unregistered login, wrong password, and successful login token claims

## Verification

- node --test apps/api/src/tests/*.test.js

Local result: 4 tests passed.