### PR TITLE
fix: reject invalid login credentials

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,22 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
   const result = await registerUser(payload);
+  if (!result) {
+    return fail(res, "Email already registered", 409);
+  }
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid credentials", 401);
+  }
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,53 @@
+import crypto from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
+const usersByEmail = new Map();
+
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}
+
+function hashPassword(password) {
+  return crypto.createHash("sha256").update(password).digest("hex");
+}
+
+export function resetAuthUsersForTest() {
+  usersByEmail.clear();
+}
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
+  const email = normalizeEmail(payload.email);
+  if (usersByEmail.has(email)) {
+    return null;
+  }
+
+  const user = {
+    id: crypto.randomUUID(),
+    email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  };
+
+  usersByEmail.set(email, user);
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const email = normalizeEmail(payload.email);
+  const user = usersByEmail.get(email);
+  if (!user || user.passwordHash !== hashPassword(payload.password)) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { resetAuthUsersForTest } from "../services/authService.js";
+
+async function withServer(fn) {
+  resetAuthUsersForTest();
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("login rejects unregistered credentials", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "missing@example.com",
+      password: "password123"
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("login rejects wrong password for a registered user", async () => {
+  await withServer(async (baseUrl) => {
+    await postJson(baseUrl, "/api/auth/register", {
+      email: "client@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password456"
+    });
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid credentials" });
+  });
+});
+
+test("successful login signs token for registered user id and role", async () => {
+  await withServer(async (baseUrl) => {
+    const { response: registerResponse, payload: registered } = await postJson(baseUrl, "/api/auth/register", {
+      email: "Client@Example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+
+    assert.equal(registerResponse.status, 201);
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "client@example.com");
+
+    const decoded = jwt.decode(payload.data.token);
+    assert.equal(decoded.sub, registered.data.id);
+    assert.equal(decoded.role, "freelancer");
+  });
+});
+
+test("registration rejects duplicate emails", async () => {
+  await withServer(async (baseUrl) => {
+    const registration = {
+      email: "duplicate@example.com",
+      password: "password123",
+      role: "client"
+    };
+
+    await postJson(baseUrl, "/api/auth/register", registration);
+    const { response, payload } = await postJson(baseUrl, "/api/auth/register", registration);
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(payload, { success: false, message: "Email already registered" });
+  });
+});


### PR DESCRIPTION
## Summary
- store mock registered users with hashed passwords
- reject unregistered and wrong-password login attempts with 401
- sign registration and login tokens for the registered user's actual id and role
- reject duplicate registrations and add auth regression tests
- fix the API test script glob so `npm test` runs the test files

Closes #6731
Closes #6733
/claim #6731
/claim #6733

## Test Plan
- npm test
