### PR TITLE
Ensure sendMessage owns generated id and sentAt

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied server-owned fields", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker",
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "hello",
+    sentAt: "1999-01-01T00:00:00.000Z"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_attacker");
+  assert.notEqual(message.sentAt, "1999-01-01T00:00:00.000Z");
+  assert.equal(message.senderId, "usr_sender");
+  assert.equal(message.receiverId, "usr_receiver");
+  assert.equal(message.body, "hello");
+});


### PR DESCRIPTION
## Summary
- Ensure sendMessage() applies server-owned id and sentAt after caller payload so request data cannot override them.
- Add a focused service regression test that preserves normal payload fields while rejecting caller-supplied server-owned fields.

## Validation
- 
ode --test apps/api/src/tests/messageService.test.js passes.
- Full local API test run is blocked in this workspace because dependencies such as zod and cors are not installed and 
pm is unavailable in PATH.

Closes #6734