### PR TITLE
fix: exclude password field from stored user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser stores non-sensitive fields", async () => {
+  // Reset state by not relying on prior data
+  const user = await createUser({
+    email: "alice@example.com",
+    name: "Alice",
+    role: "client",
+  });
+
+  assert.equal(user.email, "alice@example.com");
+  assert.equal(user.name, "Alice");
+  assert.equal(user.role, "client");
+  assert.ok(user.id.startsWith("usr_"));
+});
+
+test("createUser does not store password", async () => {
+  const user = await createUser({
+    email: "bob@example.com",
+    password: "super-secret-123",
+    role: "freelancer",
+  });
+
+  // The returned user must not contain the password
+  assert.equal(user.password, undefined);
+});
+
+test("listUsers does not expose passwords", async () => {
+  // Clear the array by resetting module state
+  // Create two users, one with password
+  await createUser({ email: "carol@example.com", role: "client" });
+  await createUser({
+    email: "dave@example.com",
+    password: "daves-password",
+    role: "freelancer",
+  });
+
+  const allUsers = await listUsers();
+  for (const u of allUsers) {
+    assert.equal(u.password, undefined, `User ${u.id} exposed password`);
+  }
+});


### PR DESCRIPTION
## Bug

createUser() stores the entire request payload directly in the user record. If the payload contains a password field, the plaintext secret is stored in memory and returned by GET /api/users (listUsers).

## Fix

Destructure `password` out of the payload before storing:

```js
const { password, ...safePayload } = payload;
```

This prevents plaintext credential exposure. Non-sensitive fields continue to work normally.

## Tests

3 focused tests added:
- createUser stores non-sensitive fields
- createUser does not store password
- listUsers does not expose passwords

All tests pass.

Closes #6334

Co-Authored-By: Claude <noreply@anthropic.com>