### PR TITLE
[OpenAI Codex] Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a small API endpoint",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_backend",
+  skills: ["node"]
+};
+
+describe("job validation", () => {
+  it("accepts ordered budget ranges on job creation", () => {
+    const result = createJobSchema.safeParse(validJob);
+
+    assert.equal(result.success, true);
+  });
+
+  it("rejects inverted budget ranges on job creation", () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 500,
+      budgetMax: 100
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+  });
+
+  it("rejects inverted budget ranges on partial updates when both fields are present", () => {
+    const result = updateJobSchema.safeParse({
+      budgetMin: 500,
+      budgetMax: 100
+    });
+
+    assert.equal(result.success, false);
+    assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+  });
+
+  it("allows partial updates with only one budget field", () => {
+    assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+    assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function hasOrderedBudgetRange(payload) {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+
+  return payload.budgetMax >= payload.budgetMin;
+}
+
+const budgetRangeMessage = "budgetMax must be greater than or equal to budgetMin";
+
+const jobPayloadSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobPayloadSchema.refine(hasOrderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobPayloadSchema.partial().refine(hasOrderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
Closes #6737

## Summary

- Add shared budget range validation for job create and partial update schemas.
- Reject payloads where `budgetMax` is lower than `budgetMin`.
- Preserve partial update behavior when only one budget field is supplied.
- Add focused regression coverage for valid create ranges, invalid create ranges, invalid partial update ranges, and single-field partial updates.

## Testing

- `node --test src/tests/jobValidator.test.js`
- `node --test "src/tests/*.test.js"`

Note: `npm test` currently invokes `node --test src/tests`; on this Windows/Node 24 environment that treats the directory as an entrypoint and fails before test discovery. Running the test files through a glob passes.

/claim #743
