### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build API",
+  description: "Build a secure API endpoint",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "backend",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJobPayload);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema accepts partial budget updates", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const validateBudgetRange = (job, context) => {
+  if (
+    typeof job.budgetMin === "number" &&
+    typeof job.budgetMax === "number" &&
+    job.budgetMax < job.budgetMin
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+};
+
+export const createJobSchema = jobFieldsSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobFieldsSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
Closes #6737

## Summary
- add shared cross-field validation for job budget ranges
- reject create and partial update payloads where `budgetMax` is lower than `budgetMin`
- add focused validator regression coverage

## Validation
- `node --test apps/api/src/tests/jobValidator.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm test -w apps/api` still fails on current main because the package script runs `node --test src/tests`, which Node 22 treats as a missing file path rather than expanding test files.