### PR TITLE
Reject invalid auth login credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,24 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
   const result = await registerUser(payload);
+  if (!result) {
+    return fail(res, "Email already registered", 409);
+  }
+
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
+  if (!result) {
+    return fail(res, "Invalid email or password", 401);
+  }
+
   return ok(res, result);
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,50 @@
+import crypto from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
+
+const users = [];
+
+const normalizeEmail = (email) => email.toLowerCase();
+
+const hashPassword = (password) =>
+  crypto.createHash("sha256").update(password).digest("hex");
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
+  const email = normalizeEmail(payload.email);
+  const existingUser = users.find((user) => user.email === email);
+
+  if (existingUser) {
+    return null;
+  }
+
+  const user = {
     id: `usr_${Date.now()}`,
-    email: payload.email,
+    email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  };
+  users.push(user);
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const email = normalizeEmail(payload.email);
+  const user = users.find((candidate) => candidate.email === email);
+
+  if (!user || user.passwordHash !== hashPassword(payload.password)) {
+    return null;
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 

--- a/apps/api/src/tests/authLogin.test.js
+++ b/apps/api/src/tests/authLogin.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+  const payload = await response.json();
+
+  return { response, payload };
+}
+
+test("login rejects unregistered credentials", async () => {
+  await withTestServer(async (baseUrl) => {
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email: "missing@example.com",
+      password: "password123"
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("login rejects a registered user with the wrong password", async () => {
+  await withTestServer(async (baseUrl) => {
+    const email = `wrong-password-${Date.now()}@example.com`;
+    await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password: "password123",
+      role: "freelancer"
+    });
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password: "password456"
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("login signs tokens for the registered user's id and role", async () => {
+  await withTestServer(async (baseUrl) => {
+    const email = `valid-login-${Date.now()}@example.com`;
+    const password = "password123";
+    const role = "freelancer";
+    const registration = await postJson(baseUrl, "/api/auth/register", {
+      email,
+      password,
+      role
+    });
+
+    const { response, payload } = await postJson(baseUrl, "/api/auth/login", {
+      email,
+      password
+    });
+    const claims = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(claims.sub, registration.payload.data.id);
+    assert.equal(claims.role, role);
+  });
+});


### PR DESCRIPTION
Closes #6731

## Summary
- keep registered users in the auth service in-memory source of truth with hashed passwords
- reject duplicate registration and invalid login credentials with explicit error responses
- sign login tokens with the registered user id and role
- add focused API regression coverage for unknown users, wrong passwords, and successful token claims

## Validation
- `node --test apps/api/src/tests/authLogin.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm test -w apps/api` still fails on current main because the package script runs `node --test src/tests`, which Node 22 treats as a missing file path rather than expanding test files.