### PR TITLE
[OpenAI Codex] Validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid user payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/userRoutes.test.js
+++ b/apps/api/src/tests/userRoutes.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects empty payloads", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid user payload");
+  });
+});
+
+test("POST /api/users rejects client-controlled ids", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "usr_attacker",
+        email: "client@example.com",
+        fullName: "Client User"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "usr_attacker");
+    assert.equal(payload.data.email, "client@example.com");
+    assert.equal(payload.data.fullName, "Client User");
+    assert.equal(payload.data.role, "client");
+  });
+});
+
+test("POST /api/users preserves valid freelancer payloads", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "freelancer@example.com",
+        fullName: "Freelancer User",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(payload.data.email, "freelancer@example.com");
+    assert.equal(payload.data.fullName, "Freelancer User");
+    assert.equal(payload.data.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
Closes #6747

## Summary

- Add a Zod schema for user creation payloads.
- Reject empty or malformed user creation requests with `400`.
- Strip client-controlled ids before the service creates the server-owned user id.
- Add API coverage for invalid payloads, id stripping, and valid freelancer creation.

## Testing

- `node --test src/tests/userRoutes.test.js`
- `node --test "src/tests/*.test.js"`

/claim #743
