### PR TITLE
fix: sendMessage should ignore caller-supplied id

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _callerId, ...safePayload } = payload;
+  const message = { id: `msg_${Date.now()}`, ...safePayload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
## Summary

Fix the `sendMessage` function to ignore caller-supplied `id` field. The function now destructures and excludes `id` from the payload, ensuring the server always controls message identity.

## Changes

- **`apps/api/src/services/messageService.js`**: Destructure `id` from caller payload before spreading, so the server-generated `id` is never overridden.

## Test Plan

- Verify that `sendMessage({ id: 'injected', text: 'hello' })` still generates a server-owned `msg_...` id
- Verify other payload fields (text, sender, etc.) are preserved

Closes #6750

/claim #6750
/claim #743