### PR TITLE
fix(api): require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,20 @@
+function resolveJwtSecret() {
+  if (process.env.JWT_SECRET) {
+    return process.env.JWT_SECRET;
+  }
+
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+  if (nodeEnv !== "development") {
+    throw new Error("JWT_SECRET is required outside development");
+  }
+
+  return "development-secret";
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_JWT_SECRET = process.env.JWT_SECRET;
+
+async function loadEnvForCase(name) {
+  return import(`../config/env.js?case=${name}-${Date.now()}-${Math.random()}`);
+}
+
+test.afterEach(() => {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  }
+
+  if (ORIGINAL_JWT_SECRET === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = ORIGINAL_JWT_SECRET;
+  }
+});
+
+test("uses development JWT secret fallback only in development", async () => {
+  process.env.NODE_ENV = "development";
+  delete process.env.JWT_SECRET;
+
+  const { env } = await loadEnvForCase("development-fallback");
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("requires JWT_SECRET outside development", async () => {
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  await assert.rejects(
+    loadEnvForCase("production-missing-secret"),
+    /JWT_SECRET is required outside development/
+  );
+});
+
+test("uses supplied JWT_SECRET outside development", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.JWT_SECRET = "production-secret";
+
+  const { env } = await loadEnvForCase("production-secret");
+
+  assert.equal(env.jwtSecret, "production-secret");
+});


### PR DESCRIPTION
## Summary

- Keeps the existing `development-secret` JWT fallback only for local development.
- Throws during config loading when `JWT_SECRET` is missing outside development.
- Adds regression coverage for development fallback, production failure, and production success with an explicit secret.

Closes #6743

Parent bounty: #743

## Verification

- `node --test apps\api\src\tests\env.test.js`
- `node --test apps\api\src\tests\*.test.js`
- `git diff --check`

Note: `npm.cmd test -w apps/api` still fails on current main because the existing package script runs `node --test src/tests`, which Node treats as a missing file path. I did not change that unrelated script in this PR.