### PR TITLE
fix: require authentication for payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
## Problem

POST /api/payments allowed anonymous callers to create payment intents.

## Fix

Add authMiddleware to POST /api/payments.

Closes #6340

Co-Authored-By: Claude <noreply@anthropic.com>