### PR TITLE
fix: require authentication for message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);


### PR DESCRIPTION
## Problem

/api/messages allowed unauthenticated callers to list and send messages.

## Fix

Add authMiddleware to all /api/messages routes via .use().

Closes #6362

Co-Authored-By: Claude <noreply@anthropic.com>