### PR TITLE
Return validation errors as bad requests

### DIFF
--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
+import { ZodError } from "zod";
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return fail(res, "Validation error", 400, err.issues);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,13 +1,21 @@
 import { ZodError } from "zod";
 import { fail } from "../utils/response.js";
 
+function publicZodIssues(issues) {
+  return issues.map((issue) => ({
+    path: issue.path,
+    message: issue.message,
+    code: issue.code
+  }));
+}
+
 export function errorHandler(err, req, res, next) {
   if (res.headersSent) {
     return next(err);
   }
 
   if (err instanceof ZodError) {
-    return fail(res, "Validation error", 400, err.issues);
+    return fail(res, "Validation error", 400, publicZodIssues(err.issues));
   }
 
   console.error("Unhandled API error:", err);

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/validationErrors.test.js
+++ b/apps/api/src/tests/validationErrors.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register returns 400 for invalid payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", password: "short" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation error");
+    assert.ok(payload.errors.some((issue) => issue.path.includes("email")));
+    assert.ok(payload.errors.some((issue) => issue.path.includes("password")));
+  });
+});
+
+test("POST /api/jobs returns 400 for invalid job payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Bug",
+        description: "too short",
+        budgetMin: -1,
+        budgetMax: 100,
+        categoryId: "",
+        skills: [""]
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation error");
+    assert.ok(payload.errors.some((issue) => issue.path.includes("title")));
+    assert.ok(payload.errors.some((issue) => issue.path.includes("budgetMin")));
+    assert.ok(payload.errors.some((issue) => issue.path.includes("categoryId")));
+  });
+});

--- a/apps/api/src/tests/validationErrors.test.js
+++ b/apps/api/src/tests/validationErrors.test.js
@@ -1,65 +1,63 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createApp } from "../app.js";
+import { errorHandler } from "../middleware/errorHandler.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
+import { registerSchema } from "../validators/auth.js";
+import { createJobSchema } from "../validators/job.js";
 
-async function withServer(run) {
-  const app = createApp();
-  const server = app.listen(0);
-
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
-
-  const { port } = server.address();
-
-  try {
-    await run(`http://127.0.0.1:${port}`);
-  } finally {
-    await new Promise((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
+function createResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.headersSent = true;
+      return this;
+    }
+  };
 }
 
-test("POST /api/auth/register returns 400 for invalid payload", async () => {
-  await withServer(async (baseUrl) => {
-    const response = await fetch(`${baseUrl}/api/auth/register`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ email: "not-an-email", password: "short" })
-    });
-    const payload = await response.json();
+async function runValidation(handler) {
+  const res = createResponse();
+  const wrapped = asyncHandler(handler);
+  await wrapped({}, res, (error) => errorHandler(error, {}, res, assert.fail));
+  return res;
+}
 
-    assert.equal(response.status, 400);
-    assert.equal(payload.success, false);
-    assert.equal(payload.message, "Validation error");
-    assert.ok(payload.errors.some((issue) => issue.path.includes("email")));
-    assert.ok(payload.errors.some((issue) => issue.path.includes("password")));
+test("validation errors return sanitized 400 responses", async () => {
+  const response = await runValidation(async () => {
+    registerSchema.parse({ email: "not-an-email", password: "short" });
   });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.success, false);
+  assert.equal(response.body.message, "Validation error");
+  assert.ok(response.body.errors.some((issue) => issue.path.includes("email")));
+  assert.ok(response.body.errors.some((issue) => issue.path.includes("password")));
+  assert.deepEqual(Object.keys(response.body.errors[0]).sort(), ["code", "message", "path"]);
 });
 
-test("POST /api/jobs returns 400 for invalid job payload", async () => {
-  await withServer(async (baseUrl) => {
-    const response = await fetch(`${baseUrl}/api/jobs`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        title: "Bug",
-        description: "too short",
-        budgetMin: -1,
-        budgetMax: 100,
-        categoryId: "",
-        skills: [""]
-      })
+test("job validation errors keep field paths in 400 responses", async () => {
+  const response = await runValidation(async () => {
+    createJobSchema.parse({
+      title: "Bug",
+      description: "too short",
+      budgetMin: -1,
+      budgetMax: 100,
+      categoryId: "",
+      skills: [""]
     });
-    const payload = await response.json();
-
-    assert.equal(response.status, 400);
-    assert.equal(payload.success, false);
-    assert.equal(payload.message, "Validation error");
-    assert.ok(payload.errors.some((issue) => issue.path.includes("title")));
-    assert.ok(payload.errors.some((issue) => issue.path.includes("budgetMin")));
-    assert.ok(payload.errors.some((issue) => issue.path.includes("categoryId")));
   });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.success, false);
+  assert.equal(response.body.message, "Validation error");
+  assert.ok(response.body.errors.some((issue) => issue.path.includes("title")));
+  assert.ok(response.body.errors.some((issue) => issue.path.includes("budgetMin")));
+  assert.ok(response.body.errors.some((issue) => issue.path.includes("categoryId")));
 });

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -5,7 +5,7 @@ export function ok(res, data, status = 200) {
 export function fail(res, message, status = 400, errors) {
   const payload = { success: false, message };
 
-  if (errors !== undefined) {
+  if (Array.isArray(errors)) {
     payload.errors = errors;
   }
 

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,12 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, errors) {
+  const payload = { success: false, message };
+
+  if (errors !== undefined) {
+    payload.errors = errors;
+  }
+
+  return res.status(status).json(payload);
 }


### PR DESCRIPTION
Summary
- route async auth/job controller rejections through the error middleware
- return Zod validation failures as 400 responses with sanitized issue details
- add direct regression coverage for invalid auth and job payload validation

Tests
- `node --test src/tests/validationErrors.test.js`
- `node --test src/tests/*.test.js`
- `npm test -w apps/api` currently fails on Windows because the existing script runs `node --test src/tests`, which Node resolves as a module path instead of discovering test files

Demo
![Validation errors return 400](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/securebanana/securebanana-pr-6760-demo.gif)

/claim #743
Closes #6759