### PR TITLE
Reject missing upload files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,6 +1,6 @@
 import { fail, ok } from "../utils/response.js";
 
-export async function uploadFile(req, res) {
+export function uploadFile(req, res) {
   if (!req.file) {
     return fail(res, "File is required", 400);
   }

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -3,18 +3,20 @@ import assert from "node:assert/strict";
 import { uploadFile } from "../controllers/uploadController.js";
 
 function createResponse() {
-  return {
+  const response = {
     statusCode: undefined,
     body: undefined,
     status(code) {
-      this.statusCode = code;
-      return this;
+      response.statusCode = code;
+      return response;
     },
     json(payload) {
-      this.body = payload;
-      return this;
+      response.body = payload;
+      return response;
     }
   };
+
+  return response;
 }
 
 test("upload controller rejects missing files", async () => {

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("upload controller rejects missing files", async () => {
+  const response = createResponse();
+
+  await uploadFile({}, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "File is required"
+  });
+});
+
+test("upload controller returns uploaded filename", async () => {
+  const response = createResponse();
+
+  await uploadFile({
+    file: {
+      originalname: "portfolio.pdf"
+    }
+  }, response);
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(response.body, {
+    success: true,
+    data: {
+      filename: "portfolio.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
Summary
- reject upload requests that do not include a file
- preserve 201 success responses for real uploaded files
- add focused controller regression tests for missing and valid files

Tests
- `node --test src/tests/uploadController.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`
- `npm test -w apps/api` currently fails on Windows because the existing script runs `node --test src/tests`, which Node resolves as a module path instead of discovering test files

Demo
![Upload validation demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/securebanana/securebanana-pr-6764-upload-demo.gif)

/claim #743
Closes #6764