### PR TITLE
Forward native Button props

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, style, type = "button", ...props }: ButtonProps) {
   return (
     <button
+      type={type}
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

- Let the shared `Button` accept standard native button attributes.
- Forward props such as `onClick`, `disabled`, `aria-*`, `className`, and `type` to the rendered button.
- Default `type` to `button` and merge caller styles after the default visual styles.

## Validation

- `node_modules/.bin/tsc --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --esModuleInterop --skipLibCheck --noEmit packages/ui/src/Button.tsx`
- `git diff --check`

Demo: this is a type-level shared component fix with no visual behavior to record; the TypeScript check verifies the component contract.

Closes #6770

/claim #743