### PR TITLE
Render dynamic detail records and 404 missing slugs

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,35 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { freelancers, getFreelancerByUsername } from "../../../lib/mock";
+
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export function generateStaticParams() {
+  return freelancers.map((freelancer) => ({ username: freelancer.username }));
+}
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+  const freelancer = getFreelancerByUsername(username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.displayName}</h2>
+      <p>
+        Profile: <strong>{freelancer.username}</strong>
+      </p>
+      <p>{freelancer.bio}</p>
+      <p>
+        <strong>Skills:</strong> {freelancer.skills.join(", ")}
+      </p>
+      <p>
+        <strong>Rate:</strong> {freelancer.rate}
+      </p>
     </section>
   );
 }

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,35 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import { notFound } from "next/navigation";
+import { getJobById, jobs } from "../../../lib/mock";
+
+type JobDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export function generateStaticParams() {
+  return jobs.map((job) => ({ id: job.id }));
+}
+
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const { id } = await params;
+  const job = getJobById(id);
+
+  if (!job) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>{job.summary}</p>
+      <p>
+        <strong>Budget:</strong> {job.budget}
+      </p>
+      <h3>Milestones</h3>
+      <ul>
+        {job.milestones.map((milestone) => (
+          <li key={milestone}>{milestone}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,10 +1,48 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create an embeddable support widget with AI-assisted replies.",
+    milestones: ["Conversation capture", "AI response draft", "Admin handoff"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Move an existing REST API to a maintainable Node.js service.",
+    milestones: ["Route parity", "Data migration", "Production rollout"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Design onboarding screens that guide new SaaS users to activation.",
+    milestones: ["Journey audit", "Wireframes", "Prototype review"]
+  }
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    displayName: "Maya Chen",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    bio: "Frontend engineer focused on polished marketplace experiences."
+  },
+  {
+    username: "jordan-ux",
+    displayName: "Jordan Rivera",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    bio: "Product designer who turns ambiguous flows into clear interfaces."
+  }
 ];
+
+export function getJobById(id: string) {
+  return jobs.find((job) => job.id === id);
+}
+
+export function getFreelancerByUsername(username: string) {
+  return freelancers.find((freelancer) => freelancer.username === username);
+}

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,4 +1,20 @@
-export const jobs = [
+export type Job = {
+  id: string;
+  title: string;
+  budget: string;
+  summary: string;
+  milestones: string[];
+};
+
+export type Freelancer = {
+  username: string;
+  displayName: string;
+  skills: string[];
+  rate: string;
+  bio: string;
+};
+
+export const jobs: Job[] = [
   {
     id: "job-101",
     title: "Build an AI customer support widget",
@@ -22,7 +38,7 @@ export const jobs = [
   }
 ];
 
-export const freelancers = [
+export const freelancers: Freelancer[] = [
   {
     username: "maya-dev",
     displayName: "Maya Chen",
@@ -39,10 +55,10 @@ export const freelancers = [
   }
 ];
 
-export function getJobById(id: string) {
+export function getJobById(id: string): Job | undefined {
   return jobs.find((job) => job.id === id);
 }
 
-export function getFreelancerByUsername(username: string) {
+export function getFreelancerByUsername(username: string): Freelancer | undefined {
   return freelancers.find((freelancer) => freelancer.username === username);
 }


### PR DESCRIPTION
## Summary
- Resolve job and freelancer dynamic routes against existing mock data instead of rendering placeholders for every slug.
- Add richer mock fields plus shared lookup helpers used by detail pages.
- Return the app 404 for unknown job ids or freelancer usernames and prebuild known mock routes with generateStaticParams.

## Demo
![Dynamic detail demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/securebanana/securebanana-pr-6771-dynamic-detail-demo.gif)

## Validation
- `npm run build -w apps/web`
- Runtime check against built app: `/jobs/job-101` returned 200 with the job title, `/freelancers/maya-dev` returned 200 with the freelancer name, and `/jobs/nope` returned 404.
- `git diff --check`

Closes #6771

/claim #743