### PR TITLE
Protect server-owned fields during record creation

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id, sentAt, ...messagePayload } = payload;
+  const message = { ...messagePayload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const messages = [];
 
 export async function listMessages() {
@@ -6,7 +8,11 @@ export async function listMessages() {
 
 export async function sendMessage(payload) {
   const { id, sentAt, ...messagePayload } = payload;
-  const message = { ...messagePayload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
+  const message = { ...messagePayload, id: createId("msg"), sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
+}
+
+export function resetMessages() {
+  messages.length = 0;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -6,7 +8,11 @@ export async function listNotifications() {
 
 export async function createNotification(payload) {
   const { id, read, ...notificationPayload } = payload;
-  const notification = { ...notificationPayload, id: `ntf_${Date.now()}`, read: false };
+  const notification = { ...notificationPayload, id: createId("ntf"), read: false };
   notifications.push(notification);
   return notification;
+}
+
+export function resetNotifications() {
+  notifications.length = 0;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id, read, ...notificationPayload } = payload;
+  const notification = { ...notificationPayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -6,7 +8,11 @@ export async function listProposals() {
 
 export async function createProposal(payload) {
   const { id, ...proposalPayload } = payload;
-  const proposal = { ...proposalPayload, id: `prp_${Date.now()}` };
+  const proposal = { ...proposalPayload, id: createId("prp") };
   proposals.push(proposal);
   return proposal;
+}
+
+export function resetProposals() {
+  proposals.length = 0;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...proposalPayload } = payload;
+  const proposal = { ...proposalPayload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -6,7 +8,11 @@ export async function listReviews() {
 
 export async function createReview(payload) {
   const { id, ...reviewPayload } = payload;
-  const review = { ...reviewPayload, id: `rev_${Date.now()}` };
+  const review = { ...reviewPayload, id: createId("rev") };
   reviews.push(review);
   return review;
+}
+
+export function resetReviews() {
+  reviews.length = 0;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id, ...reviewPayload } = payload;
+  const review = { ...reviewPayload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { createId } from "../utils/ids.js";
+
 const users = [];
 
 export async function listUsers() {
@@ -6,7 +8,11 @@ export async function listUsers() {
 
 export async function createUser(payload) {
   const { id, ...userPayload } = payload;
-  const user = { ...userPayload, id: `usr_${Date.now()}` };
+  const user = { ...userPayload, id: createId("usr") };
   users.push(user);
   return user;
+}
+
+export function resetUsers() {
+  users.length = 0;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id, ...userPayload } = payload;
+  const user = { ...userPayload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/serverOwnedFields.test.js
+++ b/apps/api/src/tests/serverOwnedFields.test.js
@@ -1,10 +1,23 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import { sendMessage } from "../services/messageService.js";
-import { createNotification } from "../services/notificationService.js";
-import { createProposal } from "../services/proposalService.js";
-import { createReview } from "../services/reviewService.js";
-import { createUser } from "../services/userService.js";
+import { afterEach, test } from "node:test";
+import { resetMessages, sendMessage } from "../services/messageService.js";
+import { createNotification, resetNotifications } from "../services/notificationService.js";
+import { createProposal, resetProposals } from "../services/proposalService.js";
+import { createReview, resetReviews } from "../services/reviewService.js";
+import { createUser, resetUsers } from "../services/userService.js";
+
+afterEach(() => {
+  resetUsers();
+  resetProposals();
+  resetReviews();
+  resetMessages();
+  resetNotifications();
+});
+
+function assertServerId(actual, prefix, attackerId) {
+  assert.match(actual, new RegExp(`^${prefix}_[0-9a-f-]+$`));
+  assert.notEqual(actual, attackerId);
+}
 
 test("createUser keeps the generated id server-owned", async () => {
   const user = await createUser({
@@ -13,8 +26,7 @@ test("createUser keeps the generated id server-owned", async () => {
     role: "freelancer"
   });
 
-  assert.match(user.id, /^usr_\d+$/);
-  assert.notEqual(user.id, "usr_attacker");
+  assertServerId(user.id, "usr", "usr_attacker");
   assert.equal(user.email, "freelancer@example.com");
   assert.equal(user.role, "freelancer");
 });
@@ -27,8 +39,7 @@ test("createProposal keeps the generated id server-owned", async () => {
     bidAmount: 500
   });
 
-  assert.match(proposal.id, /^prp_\d+$/);
-  assert.notEqual(proposal.id, "prp_attacker");
+  assertServerId(proposal.id, "prp", "prp_attacker");
   assert.equal(proposal.jobId, "job_123");
   assert.equal(proposal.freelancerId, "usr_456");
   assert.equal(proposal.bidAmount, 500);
@@ -42,8 +53,7 @@ test("createReview keeps the generated id server-owned", async () => {
     rating: 5
   });
 
-  assert.match(review.id, /^rev_\d+$/);
-  assert.notEqual(review.id, "rev_attacker");
+  assertServerId(review.id, "rev", "rev_attacker");
   assert.equal(review.reviewerId, "usr_reviewer");
   assert.equal(review.revieweeId, "usr_reviewee");
   assert.equal(review.rating, 5);
@@ -58,8 +68,7 @@ test("sendMessage keeps id and sentAt server-owned", async () => {
     body: "Hello"
   });
 
-  assert.match(message.id, /^msg_\d+$/);
-  assert.notEqual(message.id, "msg_attacker");
+  assertServerId(message.id, "msg", "msg_attacker");
   assert.notEqual(message.sentAt, "1999-01-01T00:00:00.000Z");
   assert.doesNotThrow(() => new Date(message.sentAt).toISOString());
   assert.equal(message.body, "Hello");
@@ -74,8 +83,7 @@ test("createNotification keeps id and read server-owned", async () => {
     body: "A freelancer responded"
   });
 
-  assert.match(notification.id, /^ntf_\d+$/);
-  assert.notEqual(notification.id, "ntf_attacker");
+  assertServerId(notification.id, "ntf", "ntf_attacker");
   assert.equal(notification.read, false);
   assert.equal(notification.title, "Proposal update");
   assert.equal(notification.body, "A freelancer responded");

--- a/apps/api/src/tests/serverOwnedFields.test.js
+++ b/apps/api/src/tests/serverOwnedFields.test.js
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sendMessage } from "../services/messageService.js";
+import { createNotification } from "../services/notificationService.js";
+import { createProposal } from "../services/proposalService.js";
+import { createReview } from "../services/reviewService.js";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps the generated id server-owned", async () => {
+  const user = await createUser({
+    id: "usr_attacker",
+    email: "freelancer@example.com",
+    role: "freelancer"
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.email, "freelancer@example.com");
+  assert.equal(user.role, "freelancer");
+});
+
+test("createProposal keeps the generated id server-owned", async () => {
+  const proposal = await createProposal({
+    id: "prp_attacker",
+    jobId: "job_123",
+    freelancerId: "usr_456",
+    bidAmount: 500
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "prp_attacker");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_456");
+  assert.equal(proposal.bidAmount, 500);
+});
+
+test("createReview keeps the generated id server-owned", async () => {
+  const review = await createReview({
+    id: "rev_attacker",
+    reviewerId: "usr_reviewer",
+    revieweeId: "usr_reviewee",
+    rating: 5
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "rev_attacker");
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.revieweeId, "usr_reviewee");
+  assert.equal(review.rating, 5);
+});
+
+test("sendMessage keeps id and sentAt server-owned", async () => {
+  const message = await sendMessage({
+    id: "msg_attacker",
+    sentAt: "1999-01-01T00:00:00.000Z",
+    senderId: "usr_sender",
+    receiverId: "usr_receiver",
+    body: "Hello"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "msg_attacker");
+  assert.notEqual(message.sentAt, "1999-01-01T00:00:00.000Z");
+  assert.doesNotThrow(() => new Date(message.sentAt).toISOString());
+  assert.equal(message.body, "Hello");
+});
+
+test("createNotification keeps id and read server-owned", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    read: true,
+    userId: "usr_123",
+    title: "Proposal update",
+    body: "A freelancer responded"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "ntf_attacker");
+  assert.equal(notification.read, false);
+  assert.equal(notification.title, "Proposal update");
+  assert.equal(notification.body, "A freelancer responded");
+});

--- a/apps/api/src/utils/ids.js
+++ b/apps/api/src/utils/ids.js
@@ -1,0 +1,5 @@
+import { randomUUID } from "node:crypto";
+
+export function createId(prefix) {
+  return `${prefix}_${randomUUID()}`;
+}


### PR DESCRIPTION
## Summary
- Keep generated ids server-owned for users, proposals, reviews, messages, and notifications.
- Keep message `sentAt` and notification `read` server-owned instead of accepting caller overrides.
- Add direct service regressions that prove attacker-supplied server fields are ignored while domain payload fields survive.

## Demo
![Server-owned fields demo](https://raw.githubusercontent.com/KaisAbiyyi/bounty-demo-assets/main/securebanana/securebanana-pr-6777-server-fields-demo.gif)

## Validation
- `node --test src/tests/serverOwnedFields.test.js`
- `node --test src/tests/*.test.js`
- `git diff --check`
- `npm test -w apps/api` still fails because the existing package script runs `node --test src/tests`, which Node cannot resolve as a test entry point on this checkout.

Closes #6777

/claim #743