### PR TITLE
fix(api): require jwt secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? (nodeEnv === "development" ? "development-secret" : undefined);
+
+if (!jwtSecret) {
+    throw new Error("JWT_SECRET is required outside development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+    nodeEnv,
+    port: Number(process.env.PORT ?? 4000),
+    jwtSecret,
+    stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importEnv() {
+    return import(`../config/env.js?test=${Date.now()}-${Math.random()}`);
+}
+
+async function withEnv(values, callback) {
+    const previous = {
+          NODE_ENV: process.env.NODE_ENV,
+          JWT_SECRET: process.env.JWT_SECRET
+    };
+
+  for (const [key, value] of Object.entries(values)) {
+        if (value === undefined) {
+                delete process.env[key];
+        } else {
+                process.env[key] = value;
+        }
+  }
+
+  try {
+        return await callback();
+  } finally {
+        for (const [key, value] of Object.entries(previous)) {
+                if (value === undefined) {
+                          delete process.env[key];
+                } else {
+                          process.env[key] = value;
+                }
+        }
+  }
+}
+
+test("development uses the local JWT secret fallback", async () => {
+    await withEnv({ NODE_ENV: undefined, JWT_SECRET: undefined }, async () => {
+          const { env } = await importEnv();
+
+                      assert.equal(env.nodeEnv, "development");
+          assert.equal(env.jwtSecret, "development-secret");
+    });
+});
+
+test("non-development environments require JWT_SECRET", async () => {
+    await withEnv({ NODE_ENV: "production", JWT_SECRET: undefined }, async () => {
+          await assert.rejects(importEnv, /JWT_SECRET is required outside development/);
+    });
+});
+
+test("non-development environments accept configured JWT_SECRET", async () => {
+    await withEnv({ NODE_ENV: "production", JWT_SECRET: "configured-secret" }, async () => {
+          const { env } = await importEnv();
+
+                      assert.equal(env.nodeEnv, "production");
+          assert.equal(env.jwtSecret, "configured-secret");
+    });
+});


### PR DESCRIPTION
Fixes #6776
/claim #743

## Summary

- keep the `development-secret` JWT fallback only for local development
- fail fast outside development when `JWT_SECRET` is missing
- cover development fallback, production missing-secret failure, and production configured-secret success

## Verification

- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
