### PR TITLE
fix: avoid encoded skill separator mojibake

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { freelancers } from "../../../lib/mock";
 
+const SKILL_SEPARATOR = " \u00b7 ";
+
 export default function FreelancerSearchPage() {
   return (
     <section>
@@ -9,7 +11,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(SKILL_SEPARATOR)}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
## Summary
- Avoid a literal non-ASCII skill separator on the freelancer search page by centralizing it as an escaped `\u00b7` string.
- Preserve the rendered `Next.js · TypeScript` output while removing the source-encoding ambiguity that can surface as `Â·`.
- Keep the fix limited to freelancer search skill display.

Closes #6782
/claim #743

## Tests
- `npm run build -w apps/web`
- `git diff --check`