### PR TITLE
fix: forward native button props

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const defaultStyle: React.CSSProperties = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children, style, type = "button", ...props }: ButtonProps) {
   return (
-    <button
-      style={{
-        background: "#5468ff",
-        color: "white",
-        border: "none",
-        borderRadius: 8,
-        padding: "0.6rem 0.9rem",
-        cursor: "pointer"
-      }}
-    >
+    <button {...props} type={type} style={{ ...defaultStyle, ...style }}>
       {children}
     </button>
   );


### PR DESCRIPTION
## Summary
- fixes #6787 by typing the shared Button with native button attributes
- forwards standard button props and defaults `type` to `button`
- merges caller style overrides with the default visual style

/claim #743

## Test Plan
- `npm run build -w apps/web`