### PR TITLE
fix: keep registration token subject aligned with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const result = await registerUser({
+    email: "new.user@example.com",
+    role: "freelancer"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, "freelancer");
+});


### PR DESCRIPTION
/claim #743

## Summary
- Generate the registration user id once inside `registerUser()`.
- Reuse that id as the JWT `sub` claim so the returned user id and signed token subject cannot drift apart.
- Add focused regression coverage that decodes the access token and verifies both `sub` and role.

## Bounty
- Parent bounty: #743
- Addresses #6781

## Validation
- `node --test apps/api/src/tests/authService.test.js apps/api/src/tests/health.test.js` - 2 passed
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authService.test.js`
- `git diff --check` - passed with Windows line-ending warnings only

Note: `npm test` currently fails before running tests on this machine because the workspace script invokes `node --test src/tests`, which Node 25 treats as a missing module path. The direct file-level `node --test` command above was used for validation.

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.