### PR TITLE
fix(api): require auth for token refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -1,8 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 test("GET /health returns ok payload", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});
+
+async function withTestServer(run) {
   const app = createApp();
   const server = app.listen(0);
 
@@ -11,14 +22,55 @@ test("GET /health returns ok payload", async () => {
     server.once("error", reject);
   });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+test("POST /api/auth/refresh rejects missing bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST"
+    });
+    const payload = await response.json();
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: "Bearer invalid-token" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/auth/refresh preserves authenticated token claims", async () => {
+  await withTestServer(async (baseUrl) => {
+    const originalToken = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${originalToken}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const refreshedClaims = verifyAccessToken(payload.data.token);
+    assert.equal(refreshedClaims.sub, "usr_refresh");
+    assert.equal(refreshedClaims.role, "freelancer");
   });
 });


### PR DESCRIPTION
/claim #743

## Summary
- Protect `POST /api/auth/refresh` with the existing bearer-token auth middleware.
- Reject missing and invalid bearer tokens with 401 responses instead of minting a new token.
- Preserve the authenticated user's `sub` and `role` claims when issuing the refreshed access token.

## Bounty
- Parent bounty: #743
- Closes #6790

## Validation
- `node --test apps/api/src/tests/health.test.js` - 4 passed
- `node --check apps/api/src/routes/authRoutes.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/health.test.js`
- `git diff --check` - passed

## Demo
![Auth refresh demo](https://gist.githubusercontent.com/lcwLcw123/387f9de1c0fc870408b1c77208953a4b/raw/auth-refresh-demo.svg)

Before this change, the new regression tests failed because unauthenticated and invalid-token refresh requests returned 200, and valid-token refresh changed the user subject to the hardcoded `usr_existing`. After this change, the same test file passes and verifies the endpoint only refreshes an authenticated user's own claims.

Note: `npm test -w apps/api` currently fails before running tests because the workspace script invokes `node --test src/tests`, which this Node version treats as a missing module path. Direct file-level `node --test` was used for validation.

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.
