### PR TITLE
fix(api): require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobAuth.test.js
+++ b/apps/api/src/tests/jobAuth.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a polished landing page for a marketplace launch.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "cat_web",
+  skills: ["react"]
+};
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs rejects missing bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/jobs rejects invalid bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer invalid-token"
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/jobs creates a job with a valid bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(validJobPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJobPayload.title);
+    assert.equal(payload.data.status, "open");
+    assert.match(payload.data.id, /^job_/);
+  });
+});
+


### PR DESCRIPTION
/claim #743

## Summary
- Protect `POST /api/jobs` with the existing bearer-token auth middleware.
- Reject missing and invalid bearer tokens with 401 responses instead of creating anonymous job listings.
- Keep `GET /api/jobs` public so job browsing remains unchanged.

## Bounty
- Parent bounty: #743
- Closes #6792

## Validation
- `node --test apps/api/src/tests/jobAuth.test.js` - 3 passed
- `node --test apps/api/src/tests/health.test.js` - 1 passed
- `node --check apps/api/src/routes/jobRoutes.js`
- `node --check apps/api/src/tests/jobAuth.test.js`
- `git diff --check` - passed

## Demo
Before this change, the new regression tests failed because missing-token and invalid-token job creation requests returned 201. After this change, those requests return 401 while a valid bearer token can still create a job.

Note: `npm test -w apps/api` currently fails before running tests because the workspace script invokes `node --test src/tests`, which this Node version treats as a missing module path. Direct file-level `node --test` was used for validation.

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.
