### PR TITLE
fix(api): require auth for proposal creation

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposalAuth.test.js
+++ b/apps/api/src/tests/proposalAuth.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const validProposalPayload = {
+  jobId: "job_123",
+  freelancerId: "usr_freelancer",
+  bidAmount: 750,
+  durationDays: 14,
+  coverLetter: "I can deliver this project with a focused implementation plan."
+};
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validProposalPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/proposals rejects invalid bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer invalid-token"
+      },
+      body: JSON.stringify(validProposalPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/proposals creates a proposal with a valid bearer token", async () => {
+  await withTestServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_freelancer", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(validProposalPayload)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, validProposalPayload.jobId);
+    assert.equal(payload.data.bidAmount, validProposalPayload.bidAmount);
+    assert.match(payload.data.id, /^prp_/);
+  });
+});
+


### PR DESCRIPTION
/claim #743

## Summary
- Protect `POST /api/proposals` with the existing bearer-token auth middleware.
- Reject missing and invalid bearer tokens with 401 responses instead of creating anonymous proposal records.
- Keep `GET /api/proposals` unchanged for this scoped fix.

## Bounty
- Parent bounty: #743
- Closes #6794

## Validation
- `node --test apps/api/src/tests/proposalAuth.test.js` - 3 passed
- `node --test apps/api/src/tests/health.test.js` - 1 passed
- `node --check apps/api/src/routes/proposalRoutes.js`
- `node --check apps/api/src/tests/proposalAuth.test.js`
- `git diff --check` - passed

## Demo
Before this change, the new regression tests failed because missing-token and invalid-token proposal creation requests returned 201. After this change, those requests return 401 while a valid bearer token can still create a proposal.

Note: `npm test -w apps/api` currently fails before running tests because the workspace script invokes `node --test src/tests`, which this Node version treats as a missing module path. Direct file-level `node --test` was used for validation.

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.
