### PR TITLE
fix(api): require auth for uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function uploadBody() {
+  const form = new FormData();
+  form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+  return form;
+}
+
+test("POST /api/uploads rejects unauthenticated upload requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: uploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/uploads accepts authenticated upload requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_upload_test", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      body: uploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Require the existing bearer-token auth middleware before `POST /api/uploads` reaches Multer.
- Reject missing bearer tokens with the existing `401 Unauthorized` response.
- Preserve the current successful upload response for authenticated callers.

## Bounty
- Parent bounty: #743
- Closes #6799

## Validation
- `node --test apps/api/src/tests/uploadAuth.test.js` - 2 passed
- `node --test apps/api/src/tests/*.test.js` - 3 passed
- `node --check apps/api/src/routes/uploadRoutes.js`
- `node --check apps/api/src/tests/uploadAuth.test.js`
- `git diff --check` - passed with Windows LF/CRLF working-copy warning only

## Demo
Before this change, `POST /api/uploads` was registered without `authMiddleware`, so unauthenticated multipart requests reached the upload handler. After this change, missing-token upload requests return `401`, while a request with a valid bearer token still returns `201` with the uploaded filename.

Payment details can be provided privately after maintainer acceptance.

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.