### PR TITLE
fix: require authentication for uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function fileFormData() {
+  const form = new FormData();
+  form.append("file", new Blob(["test upload"], { type: "text/plain" }), "sample.txt");
+  return form;
+}
+
+function authorizationHeader() {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  return `Bearer ${token}`;
+}
+
+test("POST /api/uploads rejects unauthenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: fileFormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/uploads rejects uploads with an invalid token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: "Bearer invalid-token" },
+      body: fileFormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/uploads accepts authenticated uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: authorizationHeader() },
+      body: fileFormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "sample.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});
+
+test("POST /api/uploads preserves authenticated no-file behavior", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: authorizationHeader() }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: null,
+        status: "no-file"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR requires authentication before requests can reach the upload endpoint.

The upload route previously registered the upload middleware/controller without applying the existing authentication middleware.

## Root cause

`POST /api/uploads` was registered without `authMiddleware`, so unauthenticated callers could reach upload processing.

## Fix

- Applied the existing authentication middleware to the upload route before Multer
- Preserved authenticated upload behavior
- Added regression coverage for unauthenticated and invalid-token upload rejection
- Added coverage showing authenticated upload and no-file behavior still work

## Security impact

Unauthenticated users can no longer access the upload endpoint. This reduces storage abuse risk and prevents unauthenticated callers from triggering upload processing.

## Tests

Commands run:

```bash
node --test src/tests/upload.test.js
# pass: 4 tests

node --test "src/tests/*.test.js"
# pass: 5 tests

npm run lint
# pass: root script reports "No root lint configured"

git diff --cached --check
# pass
```

## References

Closes #6798
References #1771
References #743

/claim #743
