### PR TITLE
fix: add DB workspace entrypoint

### DIFF
--- a/apps/api/src/tests/db-package-import.test.js
+++ b/apps/api/src/tests/db-package-import.test.js
@@ -1,0 +1,7 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PrismaClient } from "@freelanceflow/db";
+
+test("@freelanceflow/db resolves through the workspace package entrypoint", () => {
+  assert.equal(typeof PrismaClient, "function");
+});

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Closes #2775

## Summary
- add an explicit runtime entrypoint for `@freelanceflow/db`
- declare `main`, `types`, and `exports` in the DB package metadata
- add a focused API-side test that imports the workspace package name

## Validation
- node --test "apps/api/src/tests/*.test.js"
- node -e "import('@freelanceflow/db').then((mod) => { console.log(typeof mod.PrismaClient) })"
