### PR TITLE
fix(api): align registration token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,25 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+    // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+        id,
+        email: payload.email,
+        role: payload.role,
+        token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+    // TODO: verify password hash against stored user record
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+        email: payload.email,
+        token: signAccessToken({ sub: "usr_existing", role: "client" })
   };
 }
 
 export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+    return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -1,24 +1,39 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
 
 test("GET /health returns ok payload", async () => {
-  const app = createApp();
-  const server = app.listen(0);
+    const app = createApp();
+    const server = app.listen(0);
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
+       await new Promise((resolve, reject) => {
+             server.once("listening", resolve);
+             server.once("error", reject);
+       });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+       const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+       assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
+       await new Promise((resolve, reject) => {
+             server.close((error) => (error ? reject(error) : resolve()));
+       });
+});
+
+test("registerUser signs access token for the returned user id", async () => {
+    const result = await registerUser({
+          email: "new-user@example.com",
+          password: "password123",
+          role: "freelancer"
+    });
+
+       const decoded = verifyAccessToken(result.token);
+
+       assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, result.role);
 });


### PR DESCRIPTION
Fixes #6781
/claim #743

## Summary

- generate the registration user id once
- sign the registration token with that same id as `sub`
- add regression coverage for returned id/token subject alignment

## Verification

- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
