### PR TITLE
Implement Stripe PaymentIntent creation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.2.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
-import { ok } from "../utils/response.js";
-import { createPaymentIntent } from "../services/paymentService.js";
+import { fail, ok } from "../utils/response.js";
+import { createPaymentIntent, PaymentServiceError } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    if (error instanceof PaymentServiceError) {
+      return fail(res, error.message, error.status);
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,94 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
+import Stripe from "stripe";
+
+export class PaymentServiceError extends Error {
+  constructor(message, status = 400, cause) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.status = status;
+    this.cause = cause;
+  }
+}
+
+let stripeClient;
+
+function getStripeClient() {
+  if (stripeClient) {
+    return stripeClient;
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY is required to create payment intents", 500);
+  }
+
+  stripeClient = new Stripe(secretKey);
+  return stripeClient;
+}
+
+function normalizeMetadata(metadata) {
+  if (metadata === undefined) {
+    return undefined;
+  }
+
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new PaymentServiceError("metadata must be an object when provided");
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => {
+      if (value === null || value === undefined || typeof value === "object" || typeof value === "function") {
+        throw new PaymentServiceError("metadata values must be primitive values");
+      }
+
+      return [key, String(value)];
+    })
+  );
+}
+
+function normalizePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PaymentServiceError("payment payload must be an object");
+  }
+
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new PaymentServiceError("amount is required and must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new PaymentServiceError("currency must be a three-letter ISO currency code");
+  }
+
   return {
-    paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+    currency: currency.toLowerCase(),
+    metadata: normalizeMetadata(payload.metadata)
   };
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const request = normalizePaymentPayload(payload);
+  const client = options.stripeClient ?? getStripeClient();
+  const paymentIntentParams = {
+    amount: request.amount,
+    currency: request.currency
+  };
+
+  if (request.metadata) {
+    paymentIntentParams.metadata = request.metadata;
+  }
+
+  try {
+    const paymentIntent = await client.paymentIntents.create(paymentIntentParams);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? request.amount,
+      currency: paymentIntent.currency ?? request.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw new PaymentServiceError(error.message ?? "Stripe PaymentIntent creation failed", error.statusCode ?? 502, error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent, PaymentServiceError } from "../services/paymentService.js";
+
+function createMockStripeClient({ response, error } = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+        if (error) {
+          throw error;
+        }
+
+        return response ?? {
+          id: "pi_test_123",
+          client_secret: "pi_test_123_secret_test",
+          amount: params.amount,
+          currency: params.currency
+        };
+      }
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent and maps the response", async () => {
+  const stripeClient = createMockStripeClient();
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "EUR",
+      metadata: { jobId: "job_123", retry: 1 }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(stripeClient.calls, [
+    {
+      amount: 2500,
+      currency: "eur",
+      metadata: {
+        jobId: "job_123",
+        retry: "1"
+      }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_123_secret_test",
+    amount: 2500,
+    currency: "eur",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const stripeClient = createMockStripeClient();
+
+  await createPaymentIntent({ amount: 1200 }, { stripeClient });
+
+  assert.deepEqual(stripeClient.calls, [{ amount: 1200, currency: "usd" }]);
+});
+
+test("createPaymentIntent rejects missing or invalid amounts", async () => {
+  const stripeClient = createMockStripeClient();
+
+  await assert.rejects(
+    () => createPaymentIntent({ currency: "usd" }, { stripeClient }),
+    (error) => error instanceof PaymentServiceError && error.status === 400 && error.message.includes("amount is required")
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    (error) => error instanceof PaymentServiceError && error.status === 400 && error.message.includes("amount is required")
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 10.5 }, { stripeClient }),
+    (error) => error instanceof PaymentServiceError && error.status === 400 && error.message.includes("amount is required")
+  );
+
+  assert.deepEqual(stripeClient.calls, []);
+});
+
+test("createPaymentIntent rejects invalid currency and metadata values", async () => {
+  const stripeClient = createMockStripeClient();
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, currency: "usdollar" }, { stripeClient }),
+    (error) => error instanceof PaymentServiceError && error.message.includes("currency")
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1000, metadata: { nested: { bad: true } } }, { stripeClient }),
+    (error) => error instanceof PaymentServiceError && error.message.includes("metadata values")
+  );
+
+  assert.deepEqual(stripeClient.calls, []);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = Object.assign(new Error("Your card was declined."), { statusCode: 402 });
+  const stripeClient = createMockStripeClient({ error: stripeError });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 2500 }, { stripeClient }),
+    (error) =>
+      error instanceof PaymentServiceError &&
+      error.status === 402 &&
+      error.message === "Your card was declined." &&
+      error.cause === stripeError
+  );
+});
+
+test(
+  "createPaymentIntent can create a live Stripe test-mode PaymentIntent",
+  { skip: !process.env.RUN_STRIPE_SMOKE_TEST || !process.env.STRIPE_SECRET_KEY?.startsWith("sk_test_") },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { source: "node-test" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_.*_secret_/);
+    assert.equal(result.provider, "stripe");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.2.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.0.tgz",
+      "integrity": "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
/claim #1

## Summary

- Added Stripe SDK integration for `createPaymentIntent`.
- Validates `amount` as a positive integer in the smallest currency unit.
- Defaults `currency` to `usd` and normalizes valid currency codes.
- Returns Stripe `id` and `client_secret` as `paymentId` and `clientSecret`.
- Preserves Stripe/provider error messages through the API controller.
- Added mocked unit coverage plus an env-gated live Stripe test-mode smoke test.

## Validation

```text
npm test -w apps/api

tests 7
pass 6
fail 0
skipped 1
```

The skipped test is an optional live Stripe smoke test. It only runs when both `RUN_STRIPE_SMOKE_TEST=1` and a test-mode `STRIPE_SECRET_KEY` are provided.

## Notes

No Stripe secrets are committed. The implementation reads `STRIPE_SECRET_KEY` from the runtime environment and rejects missing/invalid payment payloads before calling Stripe.
