### PR TITLE
Expose @freelanceflow/db runtime package entrypoint

### DIFF
--- a/packages/db/import.test.mjs
+++ b/packages/db/import.test.mjs
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("@freelanceflow/db is importable by package name", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.equal(typeof db.PrismaClient, "function");
+  assert.equal(typeof db.Prisma, "object");
+});

--- a/packages/db/import.test.mjs
+++ b/packages/db/import.test.mjs
@@ -1,9 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 
 test("@freelanceflow/db is importable by package name", async () => {
   const db = await import("@freelanceflow/db");
+  const require = createRequire(import.meta.url);
+  const cjsDb = require("@freelanceflow/db");
+  const pkg = JSON.parse(
+    await readFile(new URL("./package.json", import.meta.url), "utf8"),
+  );
 
   assert.equal(typeof db.PrismaClient, "function");
   assert.equal(typeof db.Prisma, "object");
+  assert.equal(typeof cjsDb.PrismaClient, "function");
+  assert.equal(typeof cjsDb.Prisma, "object");
+  assert.equal(pkg.exports["."].default, "./index.js");
 });

--- a/packages/db/index.cjs
+++ b/packages/db/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,20 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "require": "./index.cjs"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test import.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,8 @@
     ".": {
       "types": "./index.d.ts",
       "import": "./index.js",
-      "require": "./index.cjs"
+      "require": "./index.cjs",
+      "default": "./index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- add explicit `main`, `types`, and conditional `exports` metadata for `@freelanceflow/db`
- add tiny ESM and CommonJS runtime entrypoints that re-export `@prisma/client`
- add a focused package-name import regression test for Prisma exports

## Validation
- RED first: `node --test packages/db/import.test.mjs` failed with missing `node_modules/@freelanceflow/db/index.js`
- `npm test -w @freelanceflow/db`
- `node --check packages/db/index.js`
- `node --check packages/db/index.cjs`
- `node -e "import('@freelanceflow/db').then((m)=>console.log(typeof m.PrismaClient, typeof m.Prisma))"`
- `node -e "const db=require('@freelanceflow/db'); console.log(typeof db.PrismaClient, typeof db.Prisma)"`
- `git diff --check`

Closes #6808
Related source issue: #2775

/claim #743