### PR TITLE
fix(api): require admin role for metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return (req, res, next) => {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuth.test.js
+++ b/apps/api/src/tests/adminAuth.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects missing bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("GET /api/admin/metrics rejects invalid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: "Bearer not-a-real-token" }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Invalid token");
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.message, "Forbidden");
+  });
+});
+
+test("GET /api/admin/metrics allows admin bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.openJobs, "number");
+    assert.equal(typeof payload.data.activeFreelancers, "number");
+    assert.equal(typeof payload.data.flaggedAccounts, "number");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- Add a reusable role guard for authenticated API routes.
- Require `role: "admin"` after bearer-token auth on `/api/admin/metrics`.
- Cover missing token, invalid token, non-admin token, and admin token behavior.

## Bounty
- Parent bounty: #743
- Closes #6809

## Validation
- `node --test apps/api/src/tests/adminAuth.test.js` - 4 passed
- `node --test apps/api/src/tests/health.test.js` - 1 passed
- `node --check apps/api/src/middleware/auth.js`
- `node --check apps/api/src/routes/adminRoutes.js`
- `node --check apps/api/src/tests/adminAuth.test.js`
- `git diff --check`

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.