### PR TITLE
Require authentication on upload endpoint

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/uploads rejects unauthenticated requests", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const body = new FormData();
+  body.append("file", new Blob(["test"]), "test.txt");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body,
+  });
+
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads accepts authenticated requests with a file", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const token = signAccessToken({ sub: "user-1" });
+
+  const body = new FormData();
+  body.append("file", new Blob(["hello world"]), "doc.txt");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body,
+  });
+
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.filename, "doc.txt");
+  assert.equal(payload.data.status, "uploaded");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads rejects expired or invalid tokens", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const body = new FormData();
+  body.append("file", new Blob(["test"]), "test.txt");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { Authorization: "Bearer invalid-token" },
+    body,
+  });
+
+  assert.equal(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #6812

The `POST /api/uploads` endpoint was accepting file uploads without authentication. The upload route in `uploadRoutes.js` did not apply `authMiddleware`, so anyone could upload files.

## Changes

- Applied `authMiddleware` to the upload routes so all requests are authenticated before reaching multer
- Added `uploadAuth.test.js` with regression coverage:
  - Unauthenticated upload returns 401
  - Authenticated upload with valid token succeeds (201)
  - Invalid token returns 401

## Testing

```bash
node --test apps/api/src/tests/uploadAuth.test.js
node --test apps/api/src/tests/*.test.js
node --check apps/api/src/routes/uploadRoutes.js
```

/claim #743