### PR TITLE
Require authentication on proposal creation endpoint

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposalAuth.test.js
+++ b/apps/api/src/tests/proposalAuth.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/proposals rejects unauthenticated requests", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ bid: 100 }),
+  });
+
+  assert.equal(response.status, 401);
+  const payload = await response.json();
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/proposals accepts authenticated requests", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const token = signAccessToken({ sub: "user-1" });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ bid: 100 }),
+  });
+
+  assert.notEqual(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/proposals remains public without auth", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`);
+
+  assert.notEqual(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #6822

The `POST /api/proposals` endpoint was allowing unauthenticated proposal creation. The route did not apply `authMiddleware`, so anyone could submit proposals without logging in.

## Changes

- Applied `authMiddleware` to the POST route only (GET remains public)
- Added `proposalAuth.test.js` with regression coverage:
  - Unauthenticated POST returns 401
  - Authenticated POST passes auth middleware
  - GET /api/proposals remains publicly accessible

## Testing

```bash
node --test apps/api/src/tests/proposalAuth.test.js
node --test apps/api/src/tests/*.test.js
node --check apps/api/src/routes/proposalRoutes.js
```

/claim #743