### PR TITLE
fix(api): require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job-auth.test.js
+++ b/apps/api/src/tests/job-auth.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const payload = {
+  title: "Backend engineer",
+  description: "Build and maintain secure job posting flows.",
+  budgetMin: 100,
+  budgetMax: 250,
+  categoryId: "cat_dev",
+  skills: ["node", "security"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs rejects missing bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/jobs rejects invalid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer invalid-token"
+      },
+      body: JSON.stringify(payload)
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(body, { success: false, message: "Invalid token" });
+  });
+});
+
+test("POST /api/jobs accepts valid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.data.title, payload.title);
+    assert.equal(body.data.status, "open");
+  });
+});


### PR DESCRIPTION
/claim #743

Summary
- require authentication on POST /api/jobs while leaving GET /api/jobs public
- reject missing and invalid bearer tokens with 401 before job creation
- add focused regression coverage for unauthorized and authorized job creation

Closes #6814
References #6792
References #743

Validation
- node --test src/tests/health.test.js src/tests/job-auth.test.js
