### PR TITLE
fix: expose db package entrypoint

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/db-package.test.js
+++ b/apps/api/src/tests/db-package.test.js
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+
+test("@freelanceflow/db can be imported by workspace package name", async () => {
+  const esm = await import("@freelanceflow/db");
+  const cjs = require("@freelanceflow/db");
+
+  assert.equal(typeof esm.PrismaClient, "function");
+  assert.equal(typeof cjs.PrismaClient, "function");
+});

--- a/packages/db/index.cjs
+++ b/packages/db/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.cjs",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./index.js",
+      "require": "./index.cjs"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Fixes #6832
/claim #743

## Summary
- add explicit @freelanceflow/db package exports for ESM and CommonJS consumers
- add root JS/CJS entrypoints that re-export Prisma client APIs
- add a package-name import regression test and make the API test script glob test files reliably

## Test Plan
- npm test