### PR TITLE
Fix sendMessage caller-supplied id override

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,11 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied id", async () => {
+  const message = await sendMessage({ id: "attacker-controlled", body: "hello" });
+
+  assert.notEqual(message.id, "attacker-controlled");
+  assert.match(message.id, /^msg_\d+$/);
+  assert.equal(message.body, "hello");
+});


### PR DESCRIPTION
Fixes #6834
/claim #6834

Summary:
- Ensure `sendMessage` always uses service-owned `id` and `sentAt` values after spreading allowed payload fields.
- Add a Node test proving caller-supplied `id` is ignored while other payload data is preserved.

Validation:
- `node --test src/tests/*.test.js` passes locally in `apps/api`.