### PR TITLE
docs: add environment template setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NODE_ENV=development
+PORT=4000
+JWT_SECRET=replace-with-a-local-development-secret
+DATABASE_URL=postgresql://freelanceflow:freelanceflow@localhost:5432/freelanceflow?schema=public
+STRIPE_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 dist
 .env
 .env.*
+!.env.example
 coverage
 *.log

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Backend architecture follows:
 
 ```bash
 npm install
+cp .env.example .env
 npm run test
 ```
 
@@ -86,3 +87,19 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+Use the checked-in template as the starting point for local development:
+
+```bash
+cp .env.example .env
+```
+
+The template covers the variables read by the API config and Prisma schema:
+
+| Variable | Used by | Default or example | Notes |
+| --- | --- | --- | --- |
+| `NODE_ENV` | `apps/api/src/config/env.js` | `development` | Controls the API runtime mode. |
+| `PORT` | `apps/api/src/config/env.js` | `4000` | API server port. |
+| `JWT_SECRET` | `apps/api/src/config/env.js` | `replace-with-a-local-development-secret` | Replace this for shared or deployed environments. |
+| `DATABASE_URL` | `apps/api/src/config/env.js`, `packages/db/prisma/schema.prisma` | `postgresql://freelanceflow:freelanceflow@localhost:5432/freelanceflow?schema=public` | Prisma connection string for the local database. |
+| `STRIPE_SECRET_KEY` | `apps/api/src/config/env.js` | empty | Optional while using the payment placeholder locally. |


### PR DESCRIPTION
/claim #743

Related scoped issue: #6839
Related source issue: #6768

## Summary
- add a safe checked-in `.env.example` for the API/Prisma environment variables
- keep local `.env` files ignored while allowing `.env.example` to be tracked
- document the setup copy command and variable table in the README

## Validation
- `git diff --check`
- `node --check apps/api/src/config/env.js`
- `node --test apps/api/src/tests/*.test.js` -> 1 passed
- `npm test -w apps/api` -> fails on the existing script because it runs `node --test src/tests`, which Node resolves as a missing module path on this checkout

This PR is a scoped docs/setup change and does not include payout details, secrets, tokens, cookies, or API keys. Prepared with AI assistance and manually validated with the commands above.
