### PR TITLE
fix(api): ignore caller supplied message ids

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignoredId, ...messagePayload } = payload;
+  const message = { id: `msg_${Date.now()}`, ...messagePayload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied ids", async () => {
+  const message = await sendMessage({
+    id: "client-controlled-id",
+    body: "Hello",
+    conversationId: "conv_1"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "client-controlled-id");
+  assert.equal(message.body, "Hello");
+  assert.equal(message.conversationId, "conv_1");
+  assert.match(message.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary
- ignore caller-supplied `id` values when creating messages
- preserve the generated `msg_*` server id and other message payload fields
- add a regression test for the message service behavior
- make the API test script target test files explicitly for current Node versions

/claim #743

Fixes #6841

## Test Plan
- `npm test`