### PR TITLE
Fix review id and rating handling

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  if (!Number.isInteger(payload.rating) || payload.rating < 1 || payload.rating > 5) {
+    throw new Error("Review rating must be an integer from 1 to 5");
+  }
+
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller-supplied id", async () => {
+  const review = await createReview({
+    id: "attacker-controlled",
+    rating: 5,
+    comment: "great work"
+  });
+
+  assert.notEqual(review.id, "attacker-controlled");
+  assert.match(review.id, /^rev_\d+$/);
+  assert.equal(review.rating, 5);
+});
+
+test("createReview rejects out-of-range ratings", async () => {
+  await assert.rejects(
+    () => createReview({ rating: 6, comment: "inflated rating" }),
+    /Review rating must be an integer from 1 to 5/
+  );
+});


### PR DESCRIPTION
Fixes #6843
/claim #6843

## Summary
- Validate review ratings as 1-5 integers.
- Apply payload before the server-generated review id so callers cannot override it.
- Add service tests for caller-supplied ids and out-of-range ratings.

## Tests
- node --test src/tests/*.test.js