### PR TITLE
fix(api): validate review ratings and server ids

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  if (!Number.isInteger(payload.rating) || payload.rating < 1 || payload.rating > 5) {
+    throw new Error("Review rating must be an integer between 1 and 5");
+  }
+
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller-supplied ids", async () => {
+  const review = await createReview({
+    id: "rev_attacker",
+    freelancerId: "user_1",
+    clientId: "user_2",
+    rating: 5,
+    comment: "great work"
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "rev_attacker");
+  assert.equal(review.rating, 5);
+});
+
+test("createReview rejects out-of-range ratings", async () => {
+  await assert.rejects(
+    () =>
+      createReview({
+        freelancerId: "user_1",
+        clientId: "user_2",
+        rating: 6,
+        comment: "inflated rating"
+      }),
+    /between 1 and 5/
+  );
+});
+
+test("createReview rejects non-integer ratings", async () => {
+  await assert.rejects(
+    () =>
+      createReview({
+        freelancerId: "user_1",
+        clientId: "user_2",
+        rating: 4.5,
+        comment: "fractional rating"
+      }),
+    /between 1 and 5/
+  );
+});


### PR DESCRIPTION
## Summary
- validate review ratings as integers from 1 to 5 before storing reviews
- preserve server-generated `rev_*` ids by assigning the id after spreading client payload data
- add regression coverage for forged ids and invalid ratings
- update the API test script to target test files explicitly on current Node versions

/claim #743

Fixes #6846

## Test Plan
- `npm test --workspace apps/api`
