### PR TITLE
Add 1mb JSON body size limit to Express app

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "1mb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/tests/body-size-limit.test.js
+++ b/apps/api/src/tests/body-size-limit.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST with body exceeding 1mb limit returns 413", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Build a JSON payload larger than 1mb
+  const bigPayload = JSON.stringify({ title: "x".repeat(1024 * 1024 + 100) });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: bigPayload
+  });
+
+  assert.ok(
+    response.status === 413,
+    `Expected 413 but got ${response.status}`
+  );
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST with normal-sized body still works", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body: "hello world" })
+  });
+
+  assert.equal(response.status, 201);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## What

The Express app uses `express.json()` without specifying a body size limit. A client can send an arbitrarily large JSON payload to any POST endpoint, potentially causing memory exhaustion and denial-of-service.

This PR adds an explicit `limit: "1mb"` option to `express.json()` so oversized payloads are rejected with a 413 status.

## Why

Without an explicit ceiling, the default behavior depends on the version of `body-parser` bundled with Express. Setting a clear 1mb limit:

- Prevents memory exhaustion attacks on `/api/messages`, `/api/proposals`, `/api/reviews`, etc.
- Leaves room for legitimate requests (no normal review, message, or proposal will be 1mb)
- Express returns a clear 413 Payload Too Large automatically when the limit is hit

## Changes

- `apps/api/src/app.js` — `express.json({ limit: "1mb" })`
- `apps/api/src/tests/body-size-limit.test.js` — new test verifying 413 on oversized body and 201 on normal body

## How to test

```bash
npm test --workspace apps/api
```

Closes #6848