### PR TITLE
fix(api): enforce JSON body size limit

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,9 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  // Keep JSON request bodies bounded so write endpoints cannot consume
+  // unbounded memory before validation/rate limiting runs.
+  app.use(express.json({ limit: "1mb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "JSON request body exceeds the 1mb limit"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,31 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+
+test("JSON request bodies larger than 1mb are rejected", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ content: "x".repeat(1024 * 1024) })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 413);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "JSON request body exceeds the 1mb limit"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- configure the Express JSON parser with an explicit `1mb` request body limit
- return a clear 413 JSON response for oversized request bodies
- add regression coverage for oversized JSON payload rejection
- update the API test script to target test files explicitly on current Node versions

/claim #743

Fixes #6850

## Test Plan
- `npm test --workspace @freelanceflow/api`
