### PR TITLE
Forward native props from shared Button

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const defaultStyle: React.CSSProperties = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children, style, type = "button", ...props }: ButtonProps) {
   return (
     <button
-      style={{
-        background: "#5468ff",
-        color: "white",
-        border: "none",
-        borderRadius: 8,
-        padding: "0.6rem 0.9rem",
-        cursor: "pointer"
-      }}
+      type={type}
+      style={{ ...defaultStyle, ...style }}
+      {...props}
     >
       {children}
     </button>


### PR DESCRIPTION
Closes #6854

/claim #6854

## Summary
- changed the shared `Button` props to `React.ButtonHTMLAttributes<HTMLButtonElement>`
- forward native button props such as `onClick`, `disabled`, `aria-*`, `className`, `type`, and `style`
- default the rendered button to `type="button"` while still allowing callers to override it
- merge caller style with the default visual style

## Validation
- `npx tsc --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --skipLibCheck --noEmit --esModuleInterop packages/ui/src/Button.tsx` -> passed
- `git diff --check` -> passed

Note: `npm run build -w apps/web` and `npx next build --webpack` were attempted on this Windows host, but Next failed while loading the local `@next/swc-win32-x64-msvc` native binding; the direct TypeScript check above validates the scoped component change.

No payout address, private token, cookie, seed phrase, API key, or payment details are included.