### PR TITLE
Use ASCII-safe freelancer skill separator

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { freelancers } from "../../../lib/mock";
 
+const skillSeparator = " \u00b7 ";
+
 export default function FreelancerSearchPage() {
   return (
     <section>
@@ -9,7 +11,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(skillSeparator)}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
Closes #6856

/claim #6856

## Summary
- replace the literal freelancer skills separator with an ASCII-source `\u00b7` separator constant
- keep the change limited to `/freelancers/search`
- preserve existing freelancer data, profile routing, and layout

## Validation
- `npx tsc --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --skipLibCheck --noEmit --esModuleInterop --allowJs false apps/web/app/freelancers/search/page.tsx apps/web/lib/mock.ts` -> passed
- source scan confirmed no literal middle dot, `Â·`, or `路` remains in `apps/web/app/freelancers/search/page.tsx`; only the ASCII `\u00b7` escape remains
- `git diff --check` -> passed

No payout address, private token, cookie, seed phrase, API key, or payment details are included.