### PR TITLE
Preserve server-owned message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id, ...messagePayload } = payload;
+  const message = { ...messagePayload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied ids", async () => {
+  const message = await sendMessage({
+    id: "attacker-controlled-id",
+    senderId: "user_1",
+    recipientId: "user_2",
+    body: "hello"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "attacker-controlled-id");
+  assert.equal(message.senderId, "user_1");
+  assert.equal(message.recipientId, "user_2");
+  assert.equal(message.body, "hello");
+  assert.equal(typeof message.sentAt, "string");
+});


### PR DESCRIPTION
Closes #6858

/claim #6858

## Summary
- strip caller-supplied `id` from message payloads before constructing stored messages
- assign the generated `msg_*` id after spreading allowed message fields
- preserve all other message fields and the generated `sentAt` timestamp
- add a focused regression test for `sendMessage`

## Validation
- `node --test apps/api/src/tests/message-service.test.js` -> 1 passed
- `git diff --check` -> passed

No payout address, private token, cookie, seed phrase, API key, or payment details are included.