### PR TITLE
Document environment variables template

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,18 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+Use this template for local development:
+
+```bash
+# apps/api/.env
+NODE_ENV=development
+PORT=4000
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/freelanceflow"
+JWT_SECRET="replace-with-a-local-development-secret"
+STRIPE_SECRET_KEY="sk_test_replace_me"
+```
+
+`DATABASE_URL` is consumed by Prisma in `packages/db`, while the API reads
+`PORT`, `JWT_SECRET`, `STRIPE_SECRET_KEY`, and `NODE_ENV` from `apps/api/.env`.
+Use production-specific values in deployed environments.


### PR DESCRIPTION
Closes #6860

/claim #6860

## Summary
- add a local development `.env` template to the README
- document `NODE_ENV`, `PORT`, `DATABASE_URL`, `JWT_SECRET`, and `STRIPE_SECRET_KEY`
- call out that `DATABASE_URL` is used by Prisma in `packages/db` and API values are read from `apps/api/.env`
- clarify that deployed environments should use production-specific values

## Validation
- `git diff --check` -> passed
- README source scan confirmed the template includes `NODE_ENV`, `PORT`, `DATABASE_URL`, `JWT_SECRET`, `STRIPE_SECRET_KEY`, `apps/api/.env`, and `packages/db`

No payout address, private token, cookie, seed phrase, API key, or payment details are included.