### PR TITLE
fix(security): enforce request body size limit for JSON payloads

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "10kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
This PR implements a request body size limit for the Express JSON parser to prevent potential Denial of Service (DoS) attacks using excessively large payloads.

**Changes:**
- Updated `app.use(express.json())` to `app.use(express.json({ limit: '10kb' }))` in `apps/api/src/app.js`.

Closes #6872