### PR TITLE
fix: add input validation and length limit to search query

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let q = req.query.q;
+
+  if (q === undefined) {
+    q = "";
+  }
+
+  if (typeof q !== "string") {
+    return fail(res, "Invalid search query parameter: must be a string", 400);
+  }
+
+  q = q.trim();
+
+  if (q.length > 200) {
+    return fail(res, "Search query is too long (maximum 200 characters)", 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,33 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import request from "supertest";
+import { createApp } from "../app.js";
+
+describe("GET /api/search", () => {
+  test("returns 400 for overly long query", async () => {
+    const app = createApp();
+    const longQuery = "a".repeat(201);
+    const res = await request(app).get(`/api/search?q=${longQuery}`);
+    
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.match(res.body.message, /too long/i);
+  });
+
+  test("returns 400 for non-string array query", async () => {
+    const app = createApp();
+    const res = await request(app).get(`/api/search?q=1&q=2`);
+    
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+    assert.match(res.body.message, /string/i);
+  });
+
+  test("trims and accepts valid query", async () => {
+    const app = createApp();
+    const res = await request(app).get(`/api/search?q=  valid  `);
+    
+    assert.equal(res.status, 200);
+    assert.equal(res.body.success, true);
+  });
+});


### PR DESCRIPTION
Resolves #6875

This PR introduces necessary input validation and length limits for the search query to prevent potential DoS and unhandled errors when non-string inputs are passed to `globalSearch`.

- Validates that `req.query.q` is a string (rejects arrays from repeated `q` parameters).
- Defaults `undefined` to empty string.
- Trims the query string.
- Rejects queries exceeding 200 characters with a 400 Bad Request.
- Includes a test suite verifying these constraints using supertest.