### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,18 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import request from "supertest";
+import { createApp } from "../app.js";
+
+describe("POST /api/auth/register", () => {
+  test("returns 400 when trying to register with admin role", async () => {
+    const app = createApp();
+    const res = await request(app).post(`/api/auth/register`).send({
+      email: "test@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    
+    assert.equal(res.status, 400);
+    assert.equal(res.body.success, false);
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Resolves #6877

This PR hardens the registration flow by strictly preventing the `admin` role from being self-assigned during sign-up. The Zod `registerSchema` is updated to only permit `client` and `freelancer` public roles.

Includes a test to explicitly verify that `role: "admin"` returns a 400 Bad Request.