### PR TITLE
Return JSON rate-limit errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("rate limiter returns API JSON error payload", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const { port } = server.address();
+    const url = `http://127.0.0.1:${port}/api/search?q=rate-limit`;
+    let response;
+
+    for (let requestNumber = 0; requestNumber <= 200; requestNumber += 1) {
+      response = await fetch(url);
+    }
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type") ?? "", /^application\/json/);
+    assert.deepEqual(await response.json(), {
+      success: false,
+      message: "Too many requests"
+    });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #6884

## Summary

- Configure the global API rate limiter to return the shared JSON failure shape for `429` responses.
- Add a regression test that exhausts the limiter and asserts status, JSON content type, and payload.
- Update the API test script glob so `npm test -w apps/api` runs the checked-in test files on the current Node runtime.

## Validation

- `npm test`
- `git diff --check`

## Demo

The regression test exercises the full HTTP path by making 201 requests to a limited route and asserting:

- HTTP status `429`
- `application/json` content type
- `{ "success": false, "message": "Too many requests" }`

Disclosure: this focused patch was prepared with AI assistance and validated locally before submission.
