### PR TITLE
fix(api): return JSON for rate limit errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests/*.js"
+    "test": "node --test src/tests/health.test.js src/tests/rateLimit.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { apiLimiter, createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -15,13 +15,14 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp(options = {}) {
   const app = express();
+  const limiter = options.rateLimit ? createApiLimiter(options.rateLimit) : apiLimiter;
 
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(limiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,10 +1,15 @@
 import rateLimit from "express-rate-limit";
 import { fail } from "../utils/response.js";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false,
-  handler: (req, res) => fail(res, "Too many requests", 429)
-});
+export function createApiLimiter(options = {}) {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    handler: (req, res) => fail(res, "Too many requests", 429),
+    ...options
+  });
+}
+
+export const apiLimiter = createApiLimiter();

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("global rate limiter returns API JSON error payload", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    let response;
+
+    for (let i = 0; i < 201; i += 1) {
+      response = await fetch(`http://127.0.0.1:${port}/health`);
+    }
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many requests"
+    });
+  } finally {
+    await closeServer(server);
+  }
+});

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -9,7 +9,7 @@ async function closeServer(server) {
 }
 
 test("global rate limiter returns API JSON error payload", async () => {
-  const app = createApp();
+  const app = createApp({ rateLimit: { limit: 2 } });
   const server = app.listen(0);
 
   await new Promise((resolve, reject) => {
@@ -21,14 +21,14 @@ test("global rate limiter returns API JSON error payload", async () => {
     const { port } = server.address();
     let response;
 
-    for (let i = 0; i < 201; i += 1) {
+    for (let i = 0; i < 3; i += 1) {
       response = await fetch(`http://127.0.0.1:${port}/health`);
     }
 
     const payload = await response.json();
 
     assert.equal(response.status, 429);
-    assert.match(response.headers.get("content-type"), /application\/json/);
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
     assert.deepEqual(payload, {
       success: false,
       message: "Too many requests"


### PR DESCRIPTION
## Summary
- Return the shared API failure payload from the global rate-limit handler.
- Add regression coverage for the 429 JSON response shape and content type.
- Update the API test script so the checked-in tests are discovered by Node's test runner.

/claim #6890

## Test Plan
- npm test
