### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build landing page",
+  description: "Create a polished marketing landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["design", "react"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.parse(validJobPayload);
+
+  assert.equal(result.budgetMin, 100);
+  assert.equal(result.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMin must be less than or equal to budgetMax"
+  );
+});
+
+test("updateJobSchema rejects inverted ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema allows partial budget updates with one side omitted", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,17 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const orderedBudgetRange = ({ budgetMin, budgetMax }) =>
+  budgetMin === undefined || budgetMax === undefined || budgetMin <= budgetMax;
+
+const budgetRangeMessage = "budgetMin must be less than or equal to budgetMax";
+
+export const createJobSchema = jobSchema.refine(orderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(orderedBudgetRange, {
+  message: budgetRangeMessage,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
/claim #743

## Summary
- Add a shared budget range refinement to job validation so `budgetMin` cannot exceed `budgetMax`.
- Preserve partial update behavior while rejecting inverted ranges when both budget fields are present.
- Add focused validator regression coverage for ordered create payloads, inverted create payloads, inverted updates, and one-sided partial updates.

## Bounty
- Parent bounty: #743
- Addresses #6879

## Validation
- `node --test apps/api/src/tests/jobValidator.test.js apps/api/src/tests/authService.test.js apps/api/src/tests/health.test.js` - 5 passed
- `node --check apps/api/src/validators/job.js`
- `node --check apps/api/src/tests/jobValidator.test.js`
- `git diff --check` - passed with Windows line-ending warnings only

AI assistance disclosure: this PR was prepared with OpenAI Codex assistance and locally verified with the commands above.