### PR TITLE
[BOUNTY] Fix issue #2835 - Automated AI Solution

### DIFF
--- a/src/validation/job.validation.ts
+++ b/src/validation/job.validation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const createJobSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  budgetMin: z.number().positive(),
+  budgetMax: z.number().positive()
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: 'budgetMax must be greater than or equal to budgetMin',
+  path: ['budgetMax']
+});
+
+export const updateJobSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  budgetMin: z.number().positive().optional(),
+  budgetMax: z.number().positive().optional()
+}).refine(data => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+}, {
+  message: 'budgetMax must be greater than or equal to budgetMin',
+  path: ['budgetMax']
+});
+
+export type CreateJobInput = z.infer<typeof createJobSchema>;
+export type UpdateJobInput = z.infer<typeof updateJobSchema>;


### PR DESCRIPTION
### 🤖 Automated AI Solution Proposal

Fixes #2835.

#### Proposal:
I propose to fix the bug in job validation where inverted budget ranges (budgetMax < budgetMin) are accepted. The fix will add a validation check in the job schema to reject such payloads for both creation and update operations, ensuring data integrity and preventing client-side issues.

#### Solution Summary:
Add custom validation to the job schema (likely using Zod or Joi) that checks if budgetMax >= budgetMin when both fields are present. This will be applied to the create and update schemas.

---
*Created automatically by Auto-Job-Agent.*