### PR TITLE
fix: restrict CORS to configured origin whitelist

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -2,6 +2,7 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
+import { env } from "./config/env.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -19,7 +20,20 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  const allowedOrigins = env.corsOrigins
+    ? env.corsOrigins.split(",").map(o => o.trim())
+    : [];
+
+  app.use(cors({
+    origin(origin, callback) {
+      // allow requests with no origin (mobile apps, curl, server-to-server)
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.length === 0) return callback(null, true);
+      if (allowedOrigins.includes(origin)) return callback(null, true);
+      callback(new Error("CORS origin not allowed"));
+    },
+    credentials: true
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,6 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: process.env.CORS_ORIGINS ?? ""
 };


### PR DESCRIPTION
## Problem

The API applies `cors()` with zero configuration, accepting requests from any origin. A malicious site could make authenticated cross-origin API calls (file upload, payment, job creation) using browser credentials.

## Fix

- Read `CORS_ORIGINS` from env (comma-separated origin list, e.g. `https://app.example.com,https://admin.example.com`)
- Only origins in the whitelist are allowed; everything else gets rejected
- Requests without an `Origin` header (curl, server-to-server, mobile) pass through
- When `CORS_ORIGINS` is empty/unset the middleware stays permissive, so existing dev setups keep working
- Added `credentials: true` so the CORS handshake covers cookie/auth headers

## Files changed

- `apps/api/src/app.js` — replace bare `cors()` with configured middleware
- `apps/api/src/config/env.js` — add `corsOrigins` config entry

## Testing

```sh
# With no CORS_ORIGINS set — should allow all (backwards compat)
curl -H "Origin: https://evil.example" http://localhost:4000/health
# → 200

# With CORS_ORIGINS=https://app.example.com
curl -H "Origin: https://evil.example" http://localhost:4000/health
# → 500 CORS error

curl -H "Origin: https://app.example.com" http://localhost:4000/health
# → 200, Access-Control-Allow-Origin: https://app.example.com
```

Closes #6896