### PR TITLE
fix(api): prevent health response caching

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,7 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+    res.set("Cache-Control", "no-store");`n    res.status(200).json({ ok: true, service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -15,7 +15,7 @@ test("GET /health returns ok payload", async () => {
   const response = await fetch(`http://127.0.0.1:${port}/health`);
   const payload = await response.json();
 
-  assert.equal(response.status, 200);
+  assert.equal(response.status, 200);`n  assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #6905

## Summary
- set Cache-Control: no-store on GET /health
- extend the existing health endpoint test to assert the cache policy

## Testing
- 
ode --test apps/api/src/tests/health.test.js *(blocked locally: dependencies are not installed in this workspace; Node failed before running the test because package cors is missing)*

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.