### PR TITLE
fix(ui): forward native Card section props

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.ComponentPropsWithoutRef<"section"> & {
+  title: string;
+};
+
+export function Card({ title, children, style, ...sectionProps }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...sectionProps}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Fixes #6908

## Summary
- type Card as native <section> props plus its required 	itle
- spread remaining props onto the root <section>
- merge consumer style after default styles so overrides still work

## Validation
- No package-specific UI test script exists in this repository; change was validated by focused source inspection and TypeScript-compatible React prop typing.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.