### PR TITLE
docs: add environment variable template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NODE_ENV=development
+PORT=4000
+JWT_SECRET=change-me-in-local-development
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/freelanceflow
+STRIPE_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 dist
 .env
 .env.*
+!.env.example
 coverage
 *.log

--- a/README.md
+++ b/README.md
@@ -86,3 +86,16 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+Use the checked-in template as a safe starting point:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `NODE_ENV` | `apps/api/src/config/env.js` | Runtime environment name. Defaults to `development`. |
+| `PORT` | `apps/api/src/config/env.js` | Express API port. Defaults to `4000`. |
+| `JWT_SECRET` | `apps/api/src/config/env.js` | Secret used to sign and verify JWT access tokens. Replace the template value for any shared environment. |
+| `DATABASE_URL` | `apps/api/src/config/env.js`, `packages/db/prisma/schema.prisma` | PostgreSQL connection string used by the API config and Prisma datasource. |
+| `STRIPE_SECRET_KEY` | `apps/api/src/config/env.js` | Stripe secret key placeholder for payment integration work. Leave empty unless payments are being configured locally. |


### PR DESCRIPTION
Fixes #6910

## Summary
- adds a safe checked-in .env.example template for the variables read by the API and Prisma
- keeps local .env files ignored while allowing .env.example
- expands README environment setup with a copy command and variable table

## Validation
- Documentation/config-only change; verified against pps/api/src/config/env.js and packages/db/prisma/schema.prisma.

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.