### PR TITLE
fix(api): require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,18 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+export function loadEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret = source.JWT_SECRET ?? (nodeEnv === "development" ? "development-secret" : undefined);
+
+  if (!jwtSecret) {
+    throw new Error("JWT_SECRET is required outside development");
+  }
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret,
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: source.DATABASE_URL ?? ""
+  };
+}
+
+export const env = loadEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadEnv } from "../config/env.js";
+
+test("loadEnv keeps the development JWT fallback", () => {
+  const env = loadEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("loadEnv requires JWT_SECRET outside development", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production" }),
+    /JWT_SECRET is required outside development/
+  );
+});
+
+test("loadEnv accepts JWT_SECRET outside development", () => {
+  const env = loadEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "replace-me-with-a-real-secret"
+  });
+
+  assert.equal(env.jwtSecret, "replace-me-with-a-real-secret");
+});


### PR DESCRIPTION
Fixes #6912

## Summary
- keeps the development-secret fallback only for NODE_ENV=development
- fails fast outside development when JWT_SECRET is missing
- adds focused coverage for development fallback, production failure, and production success

## Validation
- 
ode --test apps/api/src/tests/env.test.js

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.