### PR TITLE
fix(api): reject non-positive payment amounts

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
+  const { amount, currency } = req.body ?? {};
+
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return fail(res, "Payment amount must be a positive number", 400);
+  }
+
+  if (currency !== undefined) {
+    if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency.trim())) {
+      return fail(res, "Payment currency must be a 3-letter code", 400);
+    }
+  }
+
   return ok(res, await createPaymentIntent(req.body), 201);
 }

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const invalidPayloads = [
+      { amount: -100, currency: "usd" },
+      { amount: 0, currency: "usd" },
+      { amount: "free", currency: "usd" }
+    ];
+
+    for (const invalidPayload of invalidPayloads) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(invalidPayload)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 400);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Payment amount must be a positive number"
+      });
+    }
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("POST /api/payments still accepts valid payment payloads", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ amount: 125, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #6917

## Summary
- validate `POST /api/payments` request bodies before creating a payment intent
- reject non-positive or non-numeric `amount` values with the existing JSON failure shape
- add route-level regression coverage for invalid and valid payment payloads

## Why
The payments endpoint forwarded request bodies directly into the service layer, which allowed invalid amounts to be accepted. This keeps the fix scoped to request validation while preserving the existing success response for valid payments.

## Validation
- `node --test apps/api/src/tests/payments.test.js apps/api/src/tests/health.test.js apps/api/src/tests/uploads.test.js`
- `git diff --check`
