### PR TITLE
fix(api): return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,11 @@
 export function errorHandler(err, req, res, next) {
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("malformed JSON request bodies return 400 instead of 500", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: '{"amount":'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #6916

## Summary
- return `400` for body-parser `entity.parse.failed` errors instead of the generic `500`
- preserve the existing unexpected-server-error behavior for real unhandled failures
- add focused regression coverage for malformed JSON request bodies

## Why
Malformed JSON is a client error, not a server fault. Mapping it to a structured `400` response avoids misleading `500` errors and keeps the API behavior consistent.

## Validation
- `node --test apps/api/src/tests/errorHandler.test.js apps/api/src/tests/health.test.js apps/api/src/tests/uploads.test.js`
- `git diff --check`
