### PR TITLE
fix(web): hide admin link for public navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,16 +1,22 @@
 import Link from "next/link";
 
-const links = [
+const publicLinks = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
-export function Navigation() {
+type NavigationProps = {
+  currentUserRole?: string;
+};
+
+export function Navigation({ currentUserRole }: NavigationProps) {
+  const links =
+    currentUserRole === "admin" ? [...publicLinks, ["/admin", "Admin"]] : publicLinks;
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
       {links.map(([href, label]) => (


### PR DESCRIPTION
/claim #743

Closes #6915

## Summary
- hide the `/admin` navigation link for visitors and non-admin users
- keep the public route list unchanged for normal marketplace navigation
- allow the admin link only when `Navigation` receives `currentUserRole="admin"`

## Why
The shared navigation exposed a protected admin destination in the default public layout. This keeps the public path clean while preserving a simple explicit gate for admin-only navigation.

## Validation
- `npm run build -w apps/web`
- `git diff --check`
