### PR TITLE
fix(api): require jwt secret outside development

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET ?? (nodeEnv === "development" ? "development-secret" : undefined);
+
+if (!jwtSecret) {
+  throw new Error("JWT_SECRET is required when NODE_ENV is not development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function loadEnvWith(overrides) {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  if (Object.prototype.hasOwnProperty.call(overrides, "NODE_ENV")) {
+    process.env.NODE_ENV = overrides.NODE_ENV;
+  } else {
+    delete process.env.NODE_ENV;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(overrides, "JWT_SECRET")) {
+    process.env.JWT_SECRET = overrides.JWT_SECRET;
+  } else {
+    delete process.env.JWT_SECRET;
+  }
+
+  try {
+    return await import(`../config/env.js?test=${Date.now()}-${Math.random()}`);
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+  }
+}
+
+test("development uses the local JWT secret fallback", async () => {
+  const { env } = await loadEnvWith({ NODE_ENV: "development" });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("non-development requires JWT_SECRET", async () => {
+  await assert.rejects(
+    loadEnvWith({ NODE_ENV: "production" }),
+    /JWT_SECRET is required when NODE_ENV is not development/
+  );
+});
+
+test("non-development accepts an explicit JWT_SECRET", async () => {
+  const { env } = await loadEnvWith({ NODE_ENV: "production", JWT_SECRET: "test-secret" });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.jwtSecret, "test-secret");
+});


### PR DESCRIPTION
## Summary
- keep the `development-secret` fallback only for development
- fail fast in non-development when `JWT_SECRET` is missing
- cover development fallback, missing production secret, and explicit production secret
- update the API test script to run the checked-in test files directly

Fixes #6926
/claim #743

## Test Plan
- `cd apps/api && npm test`