### PR TITLE
fix(ui): forward native button props

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+const defaultStyle: React.CSSProperties = {
+  background: "#5468ff",
+  color: "white",
+  border: "none",
+  borderRadius: 8,
+  padding: "0.6rem 0.9rem",
+  cursor: "pointer"
+};
+
+export function Button({ children, style, ...props }: ButtonProps) {
   return (
     <button
-      style={{
-        background: "#5468ff",
-        color: "white",
-        border: "none",
-        borderRadius: 8,
-        padding: "0.6rem 0.9rem",
-        cursor: "pointer"
-      }}
+      style={{ ...defaultStyle, ...style }}
+      {...props}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary
- update `Button` to accept native `button` props via `React.ButtonHTMLAttributes<HTMLButtonElement>`
- forward attributes/events to the rendered `<button>`
- preserve the default visual styles while allowing consumer `style` overrides

Fixes #6928
/claim #743

## Demo / proof
A typed callsite using `type`, `disabled`, `aria-label`, `data-testid`, `onClick`, and `style` now compiles against `Button`. This demonstrates the native-prop forwarding path without adding test-only files.

## Validation
- `npm run build -w apps/web`
- `npx tsc --jsx react-jsx --module esnext --moduleResolution bundler --target ES2022 --lib dom,dom.iterable,esnext --strict false --noEmit packages/ui/src/Button.tsx`
- `npx tsc --jsx react-jsx --module esnext --moduleResolution bundler --target ES2022 --lib dom,dom.iterable,esnext --strict false --esModuleInterop --noEmit .button-props-smoke.tsx` with temporary smoke file removed after pass
- `git diff --check`
