### PR TITLE
fix: validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,10 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid request body", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposal.test.js
+++ b/apps/api/src/tests/proposal.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createProposalSchema } from "../validators/proposal.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can complete this safely.",
+  bidAmount: 250,
+  estDuration: "2 weeks"
+};
+
+test("createProposalSchema accepts a valid proposal", () => {
+  assert.deepEqual(createProposalSchema.parse(validProposal), validProposal);
+});
+
+test("createProposalSchema rejects a missing estimated duration", () => {
+  assert.throws(() => {
+    createProposalSchema.parse({
+      ...validProposal,
+      estDuration: undefined
+    });
+  });
+});
+
+test("createProposalSchema rejects a blank estimated duration", () => {
+  assert.throws(() => {
+    createProposalSchema.parse({
+      ...validProposal,
+      estDuration: ""
+    });
+  });
+});
+
+test("createProposalSchema rejects non-positive bids", () => {
+  assert.throws(() => {
+    createProposalSchema.parse({
+      ...validProposal,
+      bidAmount: 0
+    });
+  });
+});
+
+test("POST /api/proposals rejects missing estimated duration", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      coverLetter: "I can complete this safely.",
+      bidAmount: 250
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Invalid request body"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1),
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

This adds request validation before creating proposals. It now requires the fields the proposal model expects, including `estDuration`, and returns a 400 for invalid proposal payloads instead of storing incomplete records.

Fixes #6932.

## Tests

`npm exec -w apps/api -- node --test src/tests/health.test.js src/tests/proposal.test.js`