### PR TITLE
fix(api): return JSON for unknown routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,8 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use((req, res) => fail(res, "Not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/not-found.test.js
+++ b/apps/api/src/tests/not-found.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown API routes return structured JSON 404 responses", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type"), /^application\/json\b/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  });
+});


### PR DESCRIPTION
﻿/claim #743

Closes #6943

## Summary
- Added a final unknown-route fallback before the API error handler.
- Reused the shared `fail` helper so missing endpoints return the same JSON envelope as other API failures.
- Added regression coverage for `GET /api/does-not-exist` asserting status `404`, JSON content type, and `{ success: false, message: "Not found" }`.

## Validation
- `node --test src/tests/*.test.js`
- `git diff --check`

## Demo / proof
- https://gist.github.com/Asti1982/c165f4abfb734fb592419b2abed6ea04

Disclosure: this focused patch was prepared with AI assistance and validated locally before submission.
