### PR TITLE
fix(api): require auth for notification creation

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("notification creation rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "message",
+        message: "New message",
+        recipientId: "user_1"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("notification creation keeps authenticated response behavior", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "user_1", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        type: "message",
+        message: "New message",
+        recipientId: "user_1"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_\d+$/);
+    assert.equal(payload.data.type, "message");
+    assert.equal(payload.data.message, "New message");
+    assert.equal(payload.data.recipientId, "user_1");
+  });
+});


### PR DESCRIPTION
## Summary
- require `authMiddleware` before notification creation
- keep notification listing unchanged
- add route coverage for unauthenticated rejection and authenticated success

Closes #6623
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/notificationAuth.test.js apps/api/src/tests/health.test.js`