### PR TITLE
fix(api): return json for unknown api routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { fail } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +39,7 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+  app.use("/api", (req, res) => fail(res, "Not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/apiNotFound.test.js
+++ b/apps/api/src/tests/apiNotFound.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("unknown API routes return JSON 404 responses", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type"), /^application\/json/);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- return the shared JSON failure envelope for unmatched `/api/*` routes
- keep existing successful routes unchanged
- add regression coverage for status, content type, and payload

Closes #6949
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/apiNotFound.test.js apps/api/src/tests/health.test.js`