### PR TITLE
fix(api): normalize payment currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = (payload.currency ?? "usd").toLowerCase();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes supplied currency to lowercase", async () => {
+  const payment = await createPaymentIntent({ amount: 1000, currency: "USD" });
+
+  assert.equal(payment.amount, 1000);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+  assert.match(payment.paymentId, /^pay_\d+$/);
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const payment = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(payment.amount, 2500);
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- normalize supplied payment currency codes to lowercase
- keep missing currency defaulting to `usd`
- add focused service coverage for both paths

Closes #6953
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/paymentService.test.js apps/api/src/tests/health.test.js`