### PR TITLE
fix(api): omit user passwords

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userPassword.test.js
+++ b/apps/api/src/tests/userPassword.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser does not store submitted passwords", async () => {
+  const user = await createUser({
+    email: "user@example.com",
+    fullName: "Test User",
+    role: "client",
+    password: "super-secret"
+  });
+  const users = await listUsers();
+  const storedUser = users.find((candidate) => candidate.id === user.id);
+
+  assert.equal(user.password, undefined);
+  assert.equal(storedUser.password, undefined);
+  assert.equal(user.email, "user@example.com");
+  assert.equal(user.fullName, "Test User");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
## Summary
- omit submitted password fields before storing in-memory users
- preserve non-secret user profile fields
- add service coverage proving returned and stored users do not expose passwords

Closes #6955
Refs #743

## Tests
- `node.exe --test apps/api/src/tests/userPassword.test.js apps/api/src/tests/health.test.js`