### PR TITLE
fix(api): omit passwords from user records

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test \"src/tests/*.test.js\""
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const users = [];
 
 export async function listUsers() {
@@ -6,7 +8,7 @@ export async function listUsers() {
 
 export async function createUser(payload) {
   const { password, ...safePayload } = payload;
-  const user = { id: `usr_${Date.now()}`, ...safePayload };
+  const user = { id: `usr_${randomUUID()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -23,11 +23,13 @@ async function withServer(fn) {
 
 test("POST /api/users omits submitted password from stored user records", async () => {
   await withServer(async (baseUrl) => {
+    const email = `new-user-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+
     const createResponse = await fetch(`${baseUrl}/api/users`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        email: "new-user@example.com",
+        email,
         name: "New User",
         role: "freelancer",
         password: "super-secret-password"
@@ -38,14 +40,14 @@ test("POST /api/users omits submitted password from stored user records", async 
     const created = createPayload.data;
 
     assert.equal(createResponse.status, 201);
-    assert.equal(created.email, "new-user@example.com");
+    assert.equal(created.email, email);
     assert.equal(created.name, "New User");
     assert.equal(created.role, "freelancer");
     assert.equal("password" in created, false);
 
     const listResponse = await fetch(`${baseUrl}/api/users`);
     const listPayload = await listResponse.json();
-    const stored = listPayload.data.find((user) => user.email === "new-user@example.com");
+    const stored = listPayload.data.find((user) => user.email === email);
 
     assert.equal(listResponse.status, 200);
     assert.ok(stored);

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users omits submitted password from stored user records", async () => {
+  await withServer(async (baseUrl) => {
+    const createResponse = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "new-user@example.com",
+        name: "New User",
+        role: "freelancer",
+        password: "super-secret-password"
+      })
+    });
+
+    const createPayload = await createResponse.json();
+    const created = createPayload.data;
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(created.email, "new-user@example.com");
+    assert.equal(created.name, "New User");
+    assert.equal(created.role, "freelancer");
+    assert.equal("password" in created, false);
+
+    const listResponse = await fetch(`${baseUrl}/api/users`);
+    const listPayload = await listResponse.json();
+    const stored = listPayload.data.find((user) => user.email === "new-user@example.com");
+
+    assert.equal(listResponse.status, 200);
+    assert.ok(stored);
+    assert.equal(stored.name, "New User");
+    assert.equal(stored.role, "freelancer");
+    assert.equal("password" in stored, false);
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #6955.

## Summary
- omit submitted `password` before storing/returning user records
- add API coverage for POST/GET user records not exposing password material
- update API test script so Node runs the checked-in test files reliably

## Tests
- `npm test --workspace @freelanceflow/api`