### PR TITLE
Return 400 for malformed JSON request bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,11 @@
 export function errorHandler(err, req, res, next) {
+  if (isMalformedJsonError(err)) {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
@@ -8,4 +15,8 @@ export function errorHandler(err, req, res, next) {
     success: false,
     message: "Unexpected server error"
   });
+}
+
+function isMalformedJsonError(err) {
+  return err instanceof SyntaxError && err.status === 400 && err.type === "entity.parse.failed";
 }

--- a/apps/api/src/tests/json-errors.test.js
+++ b/apps/api/src/tests/json-errors.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST with malformed JSON returns a 400 response", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"email":'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- return HTTP 400 for malformed JSON parse errors instead of the generic 500 response
- keep the API error response in the existing `{ success: false, message }` shape
- add regression coverage for invalid JSON request bodies
- update the API test script so `npm test` discovers the test files on the current Node runtime

## Proof
```
$ npm test

> test
> npm run test -w apps/api

> test
> node --test src/tests/*.test.js

✔ GET /health returns ok payload
✔ POST with malformed JSON returns a 400 response
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

```
$ git diff --check HEAD~1..HEAD
# no output
```

Fixes #6960
/claim #743