### PR TITLE
fix: 6 small API hardening fixes (404, cache, password, currency, job auth, malformed JSON)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,11 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  // Catch-all 404 for unmatched API routes
+  app.use((req, res, next) => {
+    return fail(res, "Not Found", 404);
+  });
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -25,6 +25,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { jsonBodyErrorHandler } from "./middleware/jsonBodyError.js";
 import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -22,6 +23,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
+  app.use(jsonBodyErrorHandler);
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/jsonBodyError.js
+++ b/apps/api/src/middleware/jsonBodyError.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function jsonBodyErrorHandler(err, req, res, next) {
+  if (err && err.type === "entity.parse.failed") {
+    return fail(res, "Invalid JSON body", 400);
+  }
+  return next(err);
+}

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const rawCurrency = payload.currency ?? "usd";
+  const currency = typeof rawCurrency === "string" ? rawCurrency.toLowerCase() : "usd";
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -4,8 +4,21 @@ export async function listUsers() {
   return users;
 }
 
+const SECRET_USER_FIELDS = ["password", "passwordHash", "password_hash"];
+
+function stripSecrets(payload) {
+  const safe = { ...payload };
+  for (const key of SECRET_USER_FIELDS) {
+    if (key in safe) {
+      delete safe[key];
+    }
+  }
+  return safe;
+}
+
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const safePayload = stripSecrets(payload || {});
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/apiNotFound.test.js
+++ b/apps/api/src/tests/apiNotFound.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/does-not-exist returns 404 JSON failure envelope", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.equal(response.headers.get("content-type")?.includes("application/json"), true);
+  assert.equal(payload.success, false);
+  assert.equal(typeof payload.message, "string");
+  assert.ok(payload.message.length > 0);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /health still returns 200 after catch-all 404", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/health`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload, { ok: true, service: "api" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,6 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {

--- a/apps/api/src/tests/jobAuth.test.js
+++ b/apps/api/src/tests/jobAuth.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs requires authentication", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    const noAuth = await fetch(`${base}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "No-auth job", budget: 100 }),
+    });
+    const noAuthPayload = await noAuth.json();
+    assert.equal(noAuth.status, 401);
+    assert.equal(noAuthPayload.success, false);
+    assert.equal(typeof noAuthPayload.message, "string");
+
+    const badToken = await fetch(`${base}/api/jobs`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer not.a.real.jwt",
+      },
+      body: JSON.stringify({ title: "Bad-token job", budget: 100 }),
+    });
+    const badTokenPayload = await badToken.json();
+    assert.equal(badToken.status, 401);
+    assert.equal(badTokenPayload.success, false);
+  } finally {
+    await new Promise((r) => server.close(() => r()));
+  }
+});
+
+test("GET /api/jobs still works without authentication", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    const list = await fetch(`http://127.0.0.1:${port}/api/jobs`);
+    assert.equal(list.status, 200);
+  } finally {
+    await new Promise((r) => server.close(() => r()));
+  }
+});

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST with invalid JSON returns 400 with the shared failure envelope", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ this is not valid JSON",
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(typeof payload.message, "string");
+    assert.ok(payload.message.length > 0);
+  } finally {
+    await new Promise((r) => server.close(() => r()));
+  }
+});
+
+test("POST with valid JSON to /api/users still succeeds (201)", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "ok@example.com", name: "Ok User" }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "ok@example.com");
+  } finally {
+    await new Promise((r) => server.close(() => r()));
+  }
+});

--- a/apps/api/src/tests/paymentCurrencyLowercase.test.js
+++ b/apps/api/src/tests/paymentCurrencyLowercase.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent lowercases uppercase currency codes", async () => {
+  const intent = await createPaymentIntent({ amount: 1000, currency: "USD" });
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent lowercases mixed-case currency codes", async () => {
+  const intent = await createPaymentIntent({ amount: 1000, currency: "Gbp" });
+  assert.equal(intent.currency, "gbp");
+});
+
+test("createPaymentIntent defaults to usd when currency is missing", async () => {
+  const intent = await createPaymentIntent({ amount: 1000 });
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent keeps already-lowercase currency codes unchanged", async () => {
+  const intent = await createPaymentIntent({ amount: 1000, currency: "eur" });
+  assert.equal(intent.currency, "eur");
+});

--- a/apps/api/src/tests/userPasswordStrip.test.js
+++ b/apps/api/src/tests/userPasswordStrip.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users strips secret fields from the persisted record", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  try {
+    const create = await fetch(`${base}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "test@example.com",
+        name: "Tester",
+        password: "supersecret123",
+      }),
+    });
+    const created = await create.json();
+    assert.equal(create.status, 201);
+    assert.equal(created.success, true);
+    assert.equal(created.data.password, undefined, "password should be stripped");
+    assert.equal(created.data.email, "test@example.com");
+    assert.equal(created.data.name, "Tester");
+
+    const list = await fetch(`${base}/api/users`);
+    const listed = await list.json();
+    assert.equal(list.status, 200);
+    assert.equal(listed.success, true);
+    assert.equal(listed.data.length, 1);
+    assert.equal(listed.data[0].password, undefined, "password should not be returned by list");
+  } finally {
+    await new Promise((r) => server.close(() => r()));
+  }
+});


### PR DESCRIPTION
## What

Closes six child issues under the #743 workflow:

- #6962: Unknown API routes should return JSON 404 responses (mirror of #6943 / #6949)
- #6964: Health endpoint responses should not be cacheable (mirror of #6921 / #6957)
- #6965: User service should not store submitted passwords (mirror of #6935 / #6955)
- #6966: Payment currency should normalize to lowercase before processing (mirror of #6936 / #6953)
- #6967: Enforce authentication on job creation endpoint (mirror of #6942 / #6951)
- #6968: Malformed JSON request bodies should return 400 (mirror of #6960)

## Changes

- `apps/api/src/app.js`:
  - Catch-all 404 handler that returns `{ success: false, message: "Not Found" }` with status 404.
  - `Cache-Control: no-store` on `/health`.
  - Registers `jsonBodyErrorHandler` right after `express.json()` so parse errors become 400.
- `apps/api/src/middleware/jsonBodyError.js` (new): Maps `entity.parse.failed` errors to a 400 with the shared `fail()` envelope.
- `apps/api/src/services/userService.js`: Strip `password`, `passwordHash`, and `password_hash` from the user payload before persisting.
- `apps/api/src/services/paymentService.js`: Normalize `payload.currency` to lowercase (defaulting to `"usd"` when missing or non-string).
- `apps/api/src/routes/jobRoutes.js`: `POST /` now goes through `authMiddleware`. Public `GET /` is unchanged.
- `apps/api/src/tests/apiNotFound.test.js`: 404 envelope + `/health` unchanged.
- `apps/api/src/tests/health.test.js`: `Cache-Control` header assertion.
- `apps/api/src/tests/userPasswordStrip.test.js`: `POST /api/users` strips password fields.
- `apps/api/src/tests/paymentCurrencyLowercase.test.js`: 4 cases for the currency normalizer.
- `apps/api/src/tests/jobAuth.test.js`: `POST /api/jobs` requires Bearer; `GET /api/jobs` still public.
- `apps/api/src/tests/malformedJson.test.js`: Invalid JSON returns 400, valid JSON still creates a user.

## Tests

```
$ node --test src/tests/*.test.js
✔ GET /api/does-not-exist returns 404 JSON failure envelope
✔ GET /health still returns 200 after catch-all 404
✔ GET /health returns ok payload
✔ POST /api/jobs requires authentication
✔ GET /api/jobs still works without authentication
✔ POST with invalid JSON returns 400 with the shared failure envelope
✔ POST with valid JSON to /api/users still succeeds (201)
✔ createPaymentIntent lowercases uppercase currency codes
✔ createPaymentIntent lowercases mixed-case currency codes
✔ createPaymentIntent defaults to usd when currency is missing
✔ createPaymentIntent keeps already-lowercase currency codes unchanged
✔ POST /api/users strips secret fields from the persisted record
ℹ tests 12
ℹ pass 12
ℹ fail 0
```

## Scope

Each fix is limited to its own surface and focused tests, as specified in the issues. No unrelated refactors.

## Eligibility

- Repo starred by `Robert0303-C` ✓
- Author of all six child issues (#6962, #6964, #6965, #6966, #6967, #6968) ✓