### PR TITLE
[codex] Prevent health response caching

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -6,19 +6,27 @@ test("GET /health returns ok payload", async () => {
   const app = createApp();
   const server = app.listen(0);
 
-  await new Promise((resolve, reject) => {
-    server.once("listening", resolve);
-    server.once("error", reject);
-  });
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
 
-  const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
-  const payload = await response.json();
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
+    const cacheDirectives = response.headers
+      .get("cache-control")
+      ?.split(",")
+      .map((directive) => directive.trim().toLowerCase());
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
-
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /^application\/json\b/);
+    assert.ok(cacheDirectives?.includes("no-store"));
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
 });

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -25,8 +25,10 @@ test("GET /health returns ok payload", async () => {
     assert.ok(cacheDirectives?.includes("no-store"));
     assert.deepEqual(payload, { ok: true, service: "api" });
   } finally {
-    await new Promise((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
+    if (server.listening) {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   }
 });


### PR DESCRIPTION
## Summary

- add `Cache-Control: no-store` to `GET /health`
- preserve the existing status code and JSON payload
- verify JSON content type and parse cache directives token-by-token so valid combined directives remain supported
- guarantee server cleanup even when an assertion fails

## Root cause

The health endpoint returned live readiness data without an explicit cache policy, allowing clients or intermediaries to reuse stale responses.

## Validation

- `node --test apps/api/src/tests/health.test.js`
- explicit enumeration of all API `*.test.js` files
- `git diff --check`

All tests pass. The repository's `npm test` directory invocation is not supported by Node 22 on Windows, so the same suite was executed by enumerating its test files explicitly.

Closes #6969
Refs #743