### PR TITLE
fix(api): return JSON for unmatched API routes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,10 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use("/api", (req, res) => {
+    res.status(404).json({ success: false, message: "Not found" });
+  });
+
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/tests/apiNotFound.test.js
+++ b/apps/api/src/tests/apiNotFound.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function assertJsonNotFound(url, init) {
+  const response = await fetch(url, init);
+  const payload = await response.json();
+
+  assert.equal(response.status, 404);
+  assert.match(response.headers.get("content-type"), /application\/json/);
+  assert.deepEqual(payload, { success: false, message: "Not found" });
+}
+
+test("unmatched API routes return the shared JSON 404 envelope", async () => {
+  await withServer(async (baseUrl) => {
+    await assertJsonNotFound(`${baseUrl}/api/not-real`);
+    await assertJsonNotFound(`${baseUrl}/api/not-real/deep/path`);
+    await assertJsonNotFound(`${baseUrl}/api/users/unknown`, { method: "POST" });
+    await assertJsonNotFound(`${baseUrl}/api/search`, { method: "DELETE" });
+  });
+});
+
+test("registered API routes still reach their real handlers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, []);
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #6974.

## Summary
- add an `/api` fallback after all registered routers so unmatched API requests return the shared JSON 404 envelope
- cover unmatched top-level, nested, and unsupported-method API requests
- verify a registered API route still reaches its real handler
- update the API test script to run checked-in test files on current Node

## Tests
- `npm test --workspace @freelanceflow/api`