### PR TITLE
fix(api): omit submitted passwords from user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password: _password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return server;
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("POST /api/users omits submitted password from stored user records", async () => {
+  const server = await startServer();
+
+  try {
+    const { port } = server.address();
+    const createResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        email: "alice@example.com",
+        password: "super-secret",
+        name: "Alice"
+      })
+    });
+    const createPayload = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.success, true);
+    assert.equal(createPayload.data.email, "alice@example.com");
+    assert.equal(createPayload.data.name, "Alice");
+    assert.equal("password" in createPayload.data, false);
+
+    const listResponse = await fetch(`http://127.0.0.1:${port}/api/users`);
+    const listPayload = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.deepEqual(listPayload, {
+      success: true,
+      data: [
+        {
+          id: createPayload.data.id,
+          email: "alice@example.com",
+          name: "Alice"
+        }
+      ]
+    });
+  } finally {
+    await stopServer(server);
+  }
+});


### PR DESCRIPTION
/claim #743
Closes #6976

Summary
- omit caller-supplied password fields from persisted and returned user records
- preserve non-secret profile fields during user creation
- add focused API coverage proving POST and GET /api/users never expose submitted passwords

Why
User creation currently stores the request payload directly in memory. If a caller submits a password, that secret is persisted and then exposed by GET /api/users.

Validation
- node --test "src/tests/*.test.js" (from apps/api)
- git diff --check

Notes
- API-only change; no UI demo was needed for verification
