### PR TITLE
fix(api): prevent cached health responses

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,6 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
/claim #743
Closes #6978

## Summary

- mark `GET /health` responses as non-cacheable with `Cache-Control: no-store`
- extend the health endpoint regression test to assert the cache directive
- keep the change limited to the health route and focused API coverage

## Why

Health checks should reflect current service status, not a cached intermediary copy. Adding an explicit `no-store` directive keeps `/health` safe for monitoring and readiness checks.

## Validation

- `node --test "src/tests/health.test.js"` (from `apps/api`)
- `git diff --check`
