### PR TITLE
fix(api): normalize payment currency casing

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
+  const currency = typeof payload.currency === "string"
+    ? payload.currency.toLowerCase()
+    : "usd";
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments lowercases provided currency", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: 2500,
+        currency: "USD"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+  });
+});
+
+test("POST /api/payments defaults omitted currency to usd", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        amount: 4100
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
/claim #743
Closes #6980

## Summary

- normalize `payload.currency` to lowercase before returning the payment intent payload
- preserve the existing `"usd"` default when currency is omitted
- add focused API coverage for uppercase and omitted currency inputs

## Why

Payment processors typically expect lowercase currency codes. Normalizing at the service boundary avoids avoidable downstream failures while preserving the current mock payment flow.

## Validation

- `node --test "src/tests/payments.test.js"` (from `apps/api`)
- `git diff --check`
