### PR TITLE
fix(api): normalize payment currency

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = typeof payload.currency === "string" ? payload.currency.toLowerCase() : "usd";
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertion) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertion(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments normalizes submitted currency to lowercase", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 2500, currency: "EUR" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "eur");
+  });
+});
+
+test("POST /api/payments defaults missing currency to usd", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 1200 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.currency, "usd");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- normalize submitted payment currencies to lowercase before returning the payment intent
- keep missing currency defaulting to `usd`
- fix the API test script so the existing Node test runner discovers test files reliably
- add coverage for uppercase and missing currency payloads

Fixes #6953

## Test
- `npm test --workspace apps/api`