### PR TITLE
Normalize payment currency before processing

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = typeof payload.currency === "string"
+    ? payload.currency.toLowerCase()
+    : "usd";
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes explicit currency to lowercase", async () => {
+  const payment = await createPaymentIntent({ amount: 5000, currency: "USD" });
+
+  assert.equal(payment.currency, "usd");
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const payment = await createPaymentIntent({ amount: 5000 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
## Summary
- Normalize explicit payment currency codes to lowercase in createPaymentIntent.
- Keep the missing-currency default as usd.
- Add service coverage for uppercase currency and default currency behavior.

Closes #6986

## Validation
- node --test apps/api/src/tests/paymentService.test.js