### PR TITLE
Omit submitted password material from user records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, passwordHash, ...profile } = payload;
+  const user = { id: `usr_${Date.now()}`, ...profile };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser omits submitted password material from stored users", async () => {
+  const user = await createUser({
+    email: "user@example.com",
+    fullName: "Example User",
+    password: "super-secret",
+    passwordHash: "already-secret"
+  });
+
+  assert.equal(user.password, undefined);
+  assert.equal(user.passwordHash, undefined);
+  assert.equal(user.email, "user@example.com");
+  assert.equal(user.fullName, "Example User");
+
+  const users = await listUsers();
+  const storedUser = users.find((candidate) => candidate.id === user.id);
+
+  assert.ok(storedUser);
+  assert.equal(storedUser.password, undefined);
+  assert.equal(storedUser.passwordHash, undefined);
+});


### PR DESCRIPTION
## Summary
- Strip password and passwordHash fields before storing user records.
- Preserve non-secret user profile fields.
- Add service coverage for returned and stored user records.

Closes #6988

## Validation
- node --test apps/api/src/tests/userService.test.js