### PR TITLE
Return 400 for malformed JSON request bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,15 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.parse.failed") {
+    return fail(res, "Malformed JSON request body", 400);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"title\":"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Handle Express JSON parse failures as client errors.
- Return the shared JSON failure envelope with 400 for malformed JSON bodies.
- Add regression coverage for invalid application/json input.

Closes #6990

## Validation
- node --test apps/api/src/tests/malformedJson.test.js