### PR TITLE
Require authentication for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobAuth.test.js
+++ b/apps/api/src/tests/jobAuth.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+const validJob = {
+  title: "Build a landing page",
+  description: "Create a polished landing page for a marketplace",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_web",
+  skills: ["react"]
+};
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/jobs requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/jobs accepts authenticated job creation", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, validJob.title);
+  });
+});


### PR DESCRIPTION
## Summary
- Add authMiddleware to POST /api/jobs.
- Keep public GET /api/jobs unchanged.
- Add route coverage for unauthenticated rejection and authenticated creation.

Closes #6991

## Validation
- node --test apps/api/src/tests/jobAuth.test.js