### PR TITLE
Require JWT secret outside development

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,15 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET
+  ?? (nodeEnv === "development" ? "development-secret" : undefined);
+
+if (!jwtSecret) {
+  throw new Error("JWT_SECRET is required outside development");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importFreshEnv() {
+  return import(`../config/env.js?case=${Date.now()}-${Math.random()}`);
+}
+
+function snapshotEnv() {
+  return {
+    NODE_ENV: process.env.NODE_ENV,
+    JWT_SECRET: process.env.JWT_SECRET
+  };
+}
+
+function restoreEnv(snapshot) {
+  for (const key of Object.keys(snapshot)) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+}
+
+test("env uses a development JWT fallback only in development", async () => {
+  const original = snapshotEnv();
+  try {
+    process.env.NODE_ENV = "development";
+    delete process.env.JWT_SECRET;
+
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.nodeEnv, "development");
+    assert.equal(env.jwtSecret, "development-secret");
+  } finally {
+    restoreEnv(original);
+  }
+});
+
+test("env requires JWT_SECRET outside development", async () => {
+  const original = snapshotEnv();
+  try {
+    process.env.NODE_ENV = "production";
+    delete process.env.JWT_SECRET;
+
+    await assert.rejects(importFreshEnv(), /JWT_SECRET is required outside development/);
+  } finally {
+    restoreEnv(original);
+  }
+});
+
+test("env accepts explicit JWT_SECRET outside development", async () => {
+  const original = snapshotEnv();
+  try {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "production-secret";
+
+    const { env } = await importFreshEnv();
+
+    assert.equal(env.nodeEnv, "production");
+    assert.equal(env.jwtSecret, "production-secret");
+  } finally {
+    restoreEnv(original);
+  }
+});


### PR DESCRIPTION
## Summary
- Keep the development JWT fallback only for NODE_ENV=development.
- Fail fast outside development when JWT_SECRET is missing.
- Add config coverage for development fallback, missing production secret, and explicit production secret.

Closes #6993

## Validation
- node --test apps/api/src/tests/env.test.js