### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a landing page",
+  description: "Create a polished landing page for a marketplace",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_web",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(result.error.issues[0].message, "budgetMax must be greater than or equal to budgetMin");
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,17 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const budgetRangeRule = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+function hasValidBudgetRange(job) {
+  return job.budgetMin === undefined
+    || job.budgetMax === undefined
+    || job.budgetMin <= job.budgetMax;
+}
+
+export const createJobSchema = jobSchema.refine(hasValidBudgetRange, budgetRangeRule);
+
+export const updateJobSchema = jobSchema.partial().refine(hasValidBudgetRange, budgetRangeRule);


### PR DESCRIPTION
## Summary
- Reject job payloads where budgetMin is greater than budgetMax.
- Preserve partial update schema behavior by refining create and update schemas from a shared base object.
- Add validator coverage for inverted and ordered budget ranges.

Closes #6995

## Validation
- node --test apps/api/src/tests/jobValidator.test.js