### PR TITLE
fix(api): require proposal estDuration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +6,9 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
+  if (!req.body?.estimatedDuration) {
+    return fail(res, "Estimated duration is required", 400);
+  }
+
   return ok(res, await createProposal(req.body), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -11,5 +11,12 @@ export async function postProposal(req, res) {
     return fail(res, "Estimated duration is required", 400);
   }
 
-  return ok(res, await createProposal(req.body), 201);
+  return ok(
+    res,
+    await createProposal({
+      ...req.body,
+      estDuration: estDuration.trim()
+    }),
+    201
+  );
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -6,7 +6,8 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  if (!req.body?.estimatedDuration) {
+  const { estDuration } = req.body ?? {};
+  if (typeof estDuration !== "string" || estDuration.trim().length === 0) {
     return fail(res, "Estimated duration is required", 400);
   }
 

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -4,7 +4,7 @@ import { createApp } from "../app.js";
 
 async function withServer(fn) {
   const app = createApp();
-  const server = app.listen(0);
+  const server = app.listen(0, "127.0.0.1");
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);
@@ -31,10 +31,8 @@ test("POST /api/proposals rejects missing estDuration", async () => {
     const payload = await response.json();
 
     assert.equal(response.status, 400);
-    assert.deepEqual(payload, {
-      success: false,
-      message: "Estimated duration is required"
-    });
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Estimated duration is required");
   });
 });
 
@@ -52,10 +50,8 @@ test("POST /api/proposals rejects blank estDuration", async () => {
     const payload = await response.json();
 
     assert.equal(response.status, 400);
-    assert.deepEqual(payload, {
-      success: false,
-      message: "Estimated duration is required"
-    });
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Estimated duration is required");
   });
 });
 
@@ -75,6 +71,25 @@ test("POST /api/proposals accepts provided estDuration", async () => {
     assert.equal(response.status, 201);
     assert.equal(payload.success, true);
     assert.equal(payload.data.jobId, "job_123");
+    assert.equal(payload.data.estDuration, "3 days");
+  });
+});
+
+test("POST /api/proposals trims provided estDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_123",
+        coverLetter: "I can help with this.",
+        estDuration: "  3 days  "
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
     assert.equal(payload.data.estDuration, "3 days");
   });
 });

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jobId: "job_123", coverLetter: "I can help with this." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Estimated duration is required"
+    });
+  });
+});
+
+test("POST /api/proposals accepts provided estimated duration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_123",
+        coverLetter: "I can help with this.",
+        estimatedDuration: "3 days"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, "job_123");
+    assert.equal(payload.data.estimatedDuration, "3 days");
+  });
+});

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -21,7 +21,7 @@ async function withServer(fn) {
   }
 }
 
-test("POST /api/proposals rejects missing estimated duration", async () => {
+test("POST /api/proposals rejects missing estDuration", async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/proposals`, {
       method: "POST",
@@ -38,7 +38,7 @@ test("POST /api/proposals rejects missing estimated duration", async () => {
   });
 });
 
-test("POST /api/proposals accepts provided estimated duration", async () => {
+test("POST /api/proposals rejects blank estDuration", async () => {
   await withServer(async (baseUrl) => {
     const response = await fetch(`${baseUrl}/api/proposals`, {
       method: "POST",
@@ -46,7 +46,28 @@ test("POST /api/proposals accepts provided estimated duration", async () => {
       body: JSON.stringify({
         jobId: "job_123",
         coverLetter: "I can help with this.",
-        estimatedDuration: "3 days"
+        estDuration: "   "
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Estimated duration is required"
+    });
+  });
+});
+
+test("POST /api/proposals accepts provided estDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_123",
+        coverLetter: "I can help with this.",
+        estDuration: "3 days"
       })
     });
     const payload = await response.json();
@@ -54,6 +75,6 @@ test("POST /api/proposals accepts provided estimated duration", async () => {
     assert.equal(response.status, 201);
     assert.equal(payload.success, true);
     assert.equal(payload.data.jobId, "job_123");
-    assert.equal(payload.data.estimatedDuration, "3 days");
+    assert.equal(payload.data.estDuration, "3 days");
   });
 });


### PR DESCRIPTION
/claim #743

Fixes #7007.\n\n## Summary\n- reject proposal creation when estDuration is missing, non-string, or blank\n- keep the existing JSON failure envelope\n- add route coverage for missing, blank, and valid estDuration cases\n\n## Verification\n- cd apps/api && node --test src/tests/*.test.js (4 passed)