### PR TITLE
fix(web): resolve seeded jobs on detail route

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,33 @@
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((entry) => entry.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job matches <strong>{params.id}</strong>.</p>
+        <p>Return to the listings to choose one of the seeded demo jobs.</p>
+        <Link href="/jobs">Back to job listings</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.summary}</p>
+      <div>
+        <h3>Milestones</h3>
+        <ul>
+          {job.milestones.map((milestone) => (
+            <li key={milestone}>{milestone}</li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,25 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    summary: "Create a support assistant for account and billing questions.",
+    milestones: ["Conversation flow", "Provider wiring", "Launch checklist"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    summary: "Port a customer-facing API from a legacy stack to Node.js.",
+    milestones: ["Route parity", "Auth migration", "Deployment handoff"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    summary: "Improve activation and first-run guidance for new workspace admins.",
+    milestones: ["User journey", "Wireframes", "Copy review"]
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
/claim #743
Closes #7010

## Summary

- resolve `/jobs/[id]` against the seeded mock jobs instead of echoing the raw route id
- show the matching title, budget, summary, and milestone context for known job ids
- render a clear not-found fallback for unknown ids with a link back to the job listings

## Why

The job list already links to concrete seeded ids, so the detail route should present the matching mock record instead of placeholder copy. That keeps the demo flow coherent and avoids pretending unknown ids are valid jobs.

## Validation

- `npm.cmd run build -w apps/web`
- `git diff --check`
