### PR TITLE
fix(api): reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ZodError } from "zod";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +8,17 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  let payload;
+
+  try {
+    payload = createJobSchema.parse(req.body);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, error.issues[0]?.message ?? "Invalid job payload");
+    }
+
+    throw error;
+  }
+
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      title: "Build pricing page",
+      description: "Create a refreshed pricing page for a B2B product.",
+      budgetMin: 500,
+      budgetMax: 100,
+      categoryId: "design",
+      skills: ["copywriting"]
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.match(payload.message, /budgetMax/i);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/jobs accepts valid ordered budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      title: "Build pricing page",
+      description: "Create a refreshed pricing page for a B2B product.",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "design",
+      skills: ["copywriting"]
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.budgetMin, 100);
+  assert.equal(payload.data.budgetMax, 500);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,22 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function addBudgetRangeValidation(schema) {
+  return schema.superRefine((payload, ctx) => {
+    if (
+      payload.budgetMin !== undefined &&
+      payload.budgetMax !== undefined &&
+      payload.budgetMax < payload.budgetMin
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "budgetMax must be greater than or equal to budgetMin",
+        path: ["budgetMax"]
+      });
+    }
+  });
+}
+
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +25,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = addBudgetRangeValidation(jobFieldsSchema);
+
+export const updateJobSchema = addBudgetRangeValidation(jobFieldsSchema.partial());


### PR DESCRIPTION
/claim #743
Closes #7011

## Summary

- reject job payloads where `budgetMax` is lower than `budgetMin`
- return a focused 400 response for invalid budget ranges instead of creating a broken job record
- add API coverage for both rejected inverted ranges and accepted ordered ranges

## Why

An inverted budget range creates impossible job data and leaks bad assumptions into listing, filtering, and display flows. The API should stop that at validation time.

## Validation

- `node --test src/tests/health.test.js src/tests/jobValidation.test.js` (from `apps/api`)
- `git diff --check`
