### PR TITLE
fix(web): resolve seeded freelancer profiles

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,34 @@
+import Link from "next/link";
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((entry) => entry.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer matches <strong>{params.username}</strong>.</p>
+        <p>Use the seeded search results to open an available profile.</p>
+        <Link href="/freelancers/search">Back to freelancer search</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.name}</h2>
+      <p><strong>Username:</strong> {freelancer.username}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p>{freelancer.headline}</p>
+      <div>
+        <h3>Skills</h3>
+        <ul>
+          {freelancer.skills.map((skill) => (
+            <li key={skill}>{skill}</li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,18 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    headline: "Frontend engineer focused on marketplace flows"
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Ellis",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    headline: "Product designer for onboarding and conversion work"
+  }
 ];


### PR DESCRIPTION
/claim #743
Closes #7012

## Summary

- resolve `/freelancers/[username]` against the seeded mock profiles instead of echoing the raw username
- show the matching freelancer name, hourly rate, headline, and skills for known usernames
- render a clear not-found fallback for unknown usernames with a link back to search

## Why

The search results already point to seeded usernames, so the profile route should display the matching mock profile instead of placeholder text. That keeps the demo flow coherent and avoids pretending missing usernames are valid records.

## Validation

- `npm.cmd run build -w apps/web`
- `git diff --check`
