### PR TITLE
fix(api): validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q = "" } = req.query;
+
+  if (Array.isArray(q)) {
+    return fail(res, "q must be a single string");
+  }
+
+  if (typeof q !== "string") {
+    return fail(res, "q must be a string");
+  }
+
+  const query = q.trim();
+
+  if (query.length > 200) {
+    return fail(res, "q must be 200 characters or fewer");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims q before reaching the search payload", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=%20%20maya-dev%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "maya-dev");
+  });
+});
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /single string/i);
+  });
+});
+
+test("GET /api/search rejects queries longer than 200 characters", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /200 characters or fewer/i);
+  });
+});


### PR DESCRIPTION
/claim #743
Closes #7013

## Summary

- validate `q` as a single string before it reaches the search service
- trim the incoming query and reject values longer than 200 characters
- add API coverage for trimmed input, repeated query parameters, and overlong queries

## Why

The search controller should not pass unchecked query input straight through to the service layer. Trimming and basic shape/length validation keeps the endpoint predictable and avoids obvious misuse.

## Validation

- `node --test src/tests/health.test.js src/tests/search.test.js` (from `apps/api`)
- `git diff --check`
