### PR TITLE
[JARVIS] Solve issue #2781: @freelanceflow/ui package entrypoint should be directly importable

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
-  "private": true,
-  "main": "src/index.ts"
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc --outDir dist"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
 }


### PR DESCRIPTION
Automated solution generated by JARVIS Mark XL.

**Issue:** https://github.com/SecureBananaLabs/bug-bounty/issues/2781

Fixing package entrypoint configuration in package.json and ensuring proper transpilation to expose direct importable JavaScript entrypoints for @freelanceflow/ui package.