### PR TITLE
fix(api): validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests/*.test.js"
+    "test": "node --test src/tests/**/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -5,21 +5,25 @@ const MAX_SEARCH_QUERY_LENGTH = 200;
 
 function normalizeSearchQuery(query) {
   if (query === undefined) {
-    return "";
+    return { value: "" };
+  }
+
+  if (Array.isArray(query)) {
+    return { error: "Search query must be a single value" };
   }
 
   if (typeof query !== "string") {
-    return null;
+    return { error: "Search query must be a string" };
   }
 
-  return query.trim().replace(/[\u0000-\u001f\u007f]/g, "");
+  return { value: query.trim().replace(/[\u0000-\u001f\u007f]/g, "") };
 }
 
 export async function search(req, res) {
-  const query = normalizeSearchQuery(req.query.q);
+  const { value: query, error } = normalizeSearchQuery(req.query.q);
 
-  if (query === null) {
-    return fail(res, "Search query must be a string", 400);
+  if (error) {
+    return fail(res, error, 400);
   }
 
   if (query.length > MAX_SEARCH_QUERY_LENGTH) {

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,30 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(query) {
+  if (query === undefined) {
+    return "";
+  }
+
+  if (typeof query !== "string") {
+    return null;
+  }
+
+  return query.trim().replace(/[\u0000-\u001f\u007f]/g, "");
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = normalizeSearchQuery(req.query.q);
+
+  if (query === null) {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query must be 200 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -39,7 +39,7 @@ test("GET /api/search rejects repeated query parameters", async () => {
 
     assert.equal(response.status, 400);
     assert.equal(payload.success, false);
-    assert.match(payload.message, /must be a string/i);
+    assert.match(payload.message, /single value/i);
   });
 });
 

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims and sanitizes string query input", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20hello%0Aworld%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "helloworld");
+  });
+});
+
+test("GET /api/search rejects repeated query parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /must be a string/i);
+  });
+});
+
+test("GET /api/search rejects queries longer than 200 characters after trimming", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=%20${longQuery}%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /200 characters or fewer/i);
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary
- validate `/api/search` `q` as a single string before calling the search service
- trim and strip control characters, and reject queries longer than 200 characters
- add API regression tests for sanitizing, repeated parameters, and length limits
- update API test script so Node runs the test files in `src/tests`

Fixes #7022

## Tests
- `npm test --workspace @freelanceflow/api`