### PR TITLE
fix: require authentication on payment endpoint

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -3,4 +3,6 @@ import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+import { authMiddleware } from "../middleware/auth.js";
+
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
## Fix

Adds `authMiddleware` to the payment creation route to ensure only authenticated users can initiate payments.

Closes #7028