### PR TITLE
Normalize payment currency before intent creation

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,18 @@
+function normalizeCurrency(currency) {
+  if (typeof currency !== "string") {
+    return "usd";
+  }
+
+  const normalizedCurrency = currency.trim().toLowerCase();
+  return normalizedCurrency || "usd";
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -22,3 +22,32 @@ test("GET /health returns ok payload", async () => {
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });
+test("POST /api/payments normalizes currency values", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      amount: 1250,
+      currency: " USD "
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.currency, "usd");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #7059
Parent bounty: #743

## Summary
- normalize payment currency values by trimming whitespace and lowercasing strings
- default invalid or empty currency values to usd
- add API coverage for mixed-case whitespace-padded currency input

## Test
node --test apps/api/src/tests/health.test.js