### PR TITLE
fix: reject whitespace-only auth passwords

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginSchema, registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects whitespace-only passwords", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "        ",
+    role: "client"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("loginSchema rejects whitespace-only passwords", () => {
+  const result = loginSchema.safeParse({
+    email: "client@example.com",
+    password: "        "
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("auth schemas still accept non-blank passwords that meet the length requirement", () => {
+  assert.equal(registerSchema.safeParse({
+    email: "client@example.com",
+    password: "valid pass",
+    role: "client"
+  }).success, true);
+
+  assert.equal(loginSchema.safeParse({
+    email: "client@example.com",
+    password: "valid pass"
+  }).success, true);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,16 @@
 import { z } from "zod";
 
+const passwordSchema = z.string()
+  .min(8)
+  .refine((value) => value.trim().length > 0, "Password must not be blank");
+
 export const registerSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8),
+  password: passwordSchema,
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(8)
+  password: passwordSchema
 });


### PR DESCRIPTION
Closes #6336

## Summary

- add a shared auth password schema that preserves the existing minimum length requirement
- reject whitespace-only passwords for both registration and login validation
- add focused validator regression coverage for blank registration and login passwords
- fix the API test script so workspace test commands run `*.test.js` files directly

## Security impact

Prevents registration and login payloads such as `"        "` from passing authentication schema validation solely because they meet the minimum string length.

## Tests

- `npm run test -w apps/api`
- `npm run test`

## Notes

`npm audit --json` still reports 3 moderate existing dependency advisories in Next/PostCSS/qs. Those are unrelated to this validator-only fix and were not changed in this PR.
