### PR TITLE
fix: ZodError returns 400, authenticate GET /users, enforce body size limit

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
## Summary

This PR fixes three security/correctness bugs discovered during a code audit, each raised as a dedicated issue referencing parent bounty #743.

---

### Fix 1 — Closes #7062: ZodError validation failures return 400 instead of 500

**File:** `apps/api/src/middleware/errorHandler.js`

Zod validation errors thrown by schema `.parse()` calls (e.g. in `authController`) were not caught by the error handler — they fell through to the generic 500 branch, sending back `"Unexpected server error"` for what are purely client-side bad-input problems.

Added an `instanceof ZodError` check that returns `400 Bad Request` with the structured `err.errors` array.

```js
import { ZodError } from "zod";

// inside errorHandler:
if (err instanceof ZodError) {
  return res.status(400).json({
    success: false,
    message: "Validation error",
    errors: err.errors
  });
}
```

---

### Fix 2 — Closes #7063: GET /api/users requires authentication

**File:** `apps/api/src/routes/userRoutes.js`

`GET /api/users` was mounted without `authMiddleware`, allowing any anonymous caller to enumerate the full user list.

Added `authMiddleware` to the GET route:

```js
userRoutes.get("/", authMiddleware, getUsers);
```

---

### Fix 3 — Closes #7064: Body parser enforces 100kb size limit

**File:** `apps/api/src/app.js`

`express.json()` was called with no size limit, allowing arbitrarily large request bodies and opening a denial-of-service vector.

Added `{ limit: "100kb" }`:

```js
app.use(express.json({ limit: "100kb" }));
```

---

**Refers to parent bounty:** #743