### PR TITLE
fix: validate message body with Zod schema

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { sendMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  body: z.string().min(1),
+  senderId: z.string().min(1),
+  receiverId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #7068

`POST /api/messages` was passing `req.body` directly to `sendMessage()` with no validation, allowing empty message bodies, missing sender/receiver IDs, and structurally invalid data to be stored silently.

### Changes

**New file:** `apps/api/src/validators/message.js`
```js
export const sendMessageSchema = z.object({
  body: z.string().min(1),
  senderId: z.string().min(1),
  receiverId: z.string().min(1)
});
```

**Updated:** `apps/api/src/controllers/messageController.js`
- `postMessage` now calls `sendMessageSchema.parse(req.body)` before `sendMessage`
- Invalid requests receive `400 Bad Request`

Refers to parent bounty #743.