### PR TITLE
fix: validate notification body with Zod schema

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,6 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  title: z.string().min(1),
+  body: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #7069

`POST /api/notifications` was passing `req.body` directly to `createNotification()` with no validation, allowing missing titles, empty bodies, and absent userIds to be stored silently.

### Changes

**New file:** `apps/api/src/validators/notification.js`
```js
export const createNotificationSchema = z.object({
  userId: z.string().min(1),
  title: z.string().min(1),
  body: z.string().min(1)
});
```

**Updated:** `apps/api/src/controllers/notificationController.js`
- `postNotification` now calls `createNotificationSchema.parse(req.body)` before `createNotification`
- Invalid requests receive `400 Bad Request`

Refers to parent bounty #743.