### PR TITLE
fix: validate proposal body with Zod schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});


### PR DESCRIPTION
## Summary

Closes #7070

`POST /api/proposals` was passing `req.body` directly to `createProposal()` with no validation, allowing negative bid amounts, empty cover letters, and missing job/freelancer references to be stored silently.

### Changes

**New file:** `apps/api/src/validators/proposal.js`
```js
export const createProposalSchema = z.object({
  coverLetter: z.string().min(10),
  bidAmount: z.number().positive(),
  estDuration: z.string().min(1),
  jobId: z.string().min(1),
  freelancerId: z.string().min(1)
});
```

**Updated:** `apps/api/src/controllers/proposalController.js`
- `postProposal` now calls `createProposalSchema.parse(req.body)` before `createProposal`
- Invalid requests receive `400 Bad Request`

Refers to parent bounty #743.