### PR TITLE
fix: return 400 for Zod validation errors instead of 500

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({


### PR DESCRIPTION
## Summary

Closes #7062

`ZodError` thrown by `.parse()` calls was not caught by `errorHandler` and fell through to the generic 500 branch, returning `"Unexpected server error"` for purely client-side bad input.

### Change

`apps/api/src/middleware/errorHandler.js` — added `instanceof ZodError` check:

```js
if (err instanceof ZodError) {
  return res.status(400).json({
    success: false,
    message: "Validation error",
    errors: err.errors
  });
}
```

Invalid requests now receive `400 Bad Request` with structured field-level errors.

Refers to parent bounty #743.