### PR TITLE
fix: require authentication on GET /api/users

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
## Summary

Closes #7063

`GET /api/users` was mounted without `authMiddleware`, allowing any anonymous caller to enumerate the full user list.

### Change

`apps/api/src/routes/userRoutes.js` — added `authMiddleware` to the GET route:

```js
userRoutes.get("/", authMiddleware, getUsers);
```

Unauthenticated requests now receive `401 Unauthorized`.

Refers to parent bounty #743.