### PR TITLE
fix: enforce 100kb limit on JSON request bodies

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
## Summary

Closes #7064

`express.json()` was called without a size limit, allowing arbitrarily large JSON bodies to be read into memory — a denial-of-service vector.

### Change

`apps/api/src/app.js`:

```js
app.use(express.json({ limit: "100kb" }));
```

Requests exceeding 100 kb now receive `413 Payload Too Large` before any body parsing.

Refers to parent bounty #743.