### PR TITLE
fix: enforce 5 MB file size limit on multer upload

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 } // 5 MB
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Summary

Closes #7075

`multer` was configured with `memoryStorage` and no `limits` option, allowing any caller to upload arbitrarily large files and exhaust server memory.

### Change

`apps/api/src/routes/uploadRoutes.js` — added `limits: { fileSize: 5 * 1024 * 1024 }`:

```js
const upload = multer({
  storage: multer.memoryStorage(),
  limits: { fileSize: 5 * 1024 * 1024 }
});
```

Files exceeding 5 MB are rejected by multer before being fully read into memory.

Refers to parent bounty #743.