### PR TITLE
fix: remove admin panel link from public navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -6,8 +6,7 @@ const links = [
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
 export function Navigation() {


### PR DESCRIPTION
## Summary

Closes #7076

`Navigation.tsx` included a public `/admin` link visible to every visitor regardless of role or auth status, advertising the admin route to unauthenticated users.

### Change

`apps/web/components/Navigation.tsx` — removed `["/admin", "Admin"]` from the `links` array.

The admin panel is no longer linked from the public navigation bar.

Refers to parent bounty #743.