### PR TITLE
fix: add strict rate limit on auth routes to prevent brute-force

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,10 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);


### PR DESCRIPTION
## Summary

Closes #7082

The global `apiLimiter` (200 req / 15 min) was the only throttle on `/api/auth/login`, allowing 200 password attempts per IP per 15 minutes — ample for credential-stuffing attacks.

### Changes

**`apps/api/src/middleware/rateLimit.js`** — added a dedicated `authLimiter`:
```js
export const authLimiter = rateLimit({
  windowMs: 15 * 60 * 1000,
  limit: 10,
  standardHeaders: "draft-7",
  legacyHeaders: false
});
```

**`apps/api/src/routes/authRoutes.js`** — applied `authLimiter` to login, register, and refresh:
```js
authRoutes.post("/login", authLimiter, login);
authRoutes.post("/register", authLimiter, register);
authRoutes.post("/refresh", authLimiter, refresh);
```

Refers to parent bounty #743.