### PR TITLE
fix: catch unhandled rejection in server bootstrap

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -10,4 +10,7 @@ async function bootstrap() {
   });
 }
 
-bootstrap();
+bootstrap().catch((err) => {
+  console.error("Failed to start server:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #7083

`bootstrap()` was invoked with no `.catch()` or `try/catch`. If `connectDb()` or any startup step throws, Node.js emits an unhandled promise rejection — in Node.js 15+ this terminates the process with no useful diagnostic output.

### Change

`apps/api/src/server.js` — added `.catch()` to the bootstrap call:

```js
bootstrap().catch((err) => {
  console.error("Failed to start server:", err);
  process.exit(1);
});
```

Startup errors are now logged clearly before process exit.

Refers to parent bounty #743.