### PR TITLE
fix: render mock job details by id with not-found fallback

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,21 @@
+import { jobs } from "../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job with id <strong>{params.id}</strong> could be found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

The `/jobs/[id]` route was rendering placeholder text for all job ids instead of looking up the job from mock data.

## Changes

- Updated `apps/web/app/jobs/[id]/page.tsx` to import `jobs` from mock data
- Known ids (`job-101`, `job-102`, `job-103`) now render the matching title and budget
- Unknown ids render a clear "Job not found" fallback

Closes #2755