### PR TITLE
fix: render mock freelancer profile by username with not-found fallback

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer with username <strong>{params.username}</strong> could be found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Skills: <strong>{freelancer.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

The `/freelancers/[username]` route was rendering placeholder text for all usernames instead of looking up the freelancer from mock data.

## Changes

- Updated `apps/web/app/freelancers/[username]/page.tsx` to import `freelancers` from mock data
- Known usernames (`maya-dev`, `jordan-ux`) now render the matching skills and rate
- Unknown usernames render a clear not-found fallback

Closes #2763