### PR TITLE
fix: preserve server-generated id and read state in notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,7 @@
 const notifications = [];
-
-export async function listNotifications() {
-  return notifications;
-}
-
+export async function listNotifications() { return notifications; }
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Summary\n\nSpread order in `createNotification` let callers override server-generated `id` and `read` fields.\n\n## Changes\n\n- Fixed spread order: payload spread first, then `id` and `read: false` applied last so they cannot be overridden by callers\n\nCloses #2762