### PR TITLE
fix: require authentication on POST /api/uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
## Summary\n\nThe file upload endpoint allowed unauthenticated users to upload files.\n\n## Changes\n\n- Added `authMiddleware` before multer on `POST /api/uploads` in `apps/api/src/routes/uploadRoutes.js`\n- Unauthenticated requests now receive 401 before any file processing\n\nCloses #1771