### PR TITLE
fix: require authentication on POST /api/payments

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
## Summary

The payment creation endpoint allowed unauthenticated callers to create payment intents.

## Changes

- Added `authMiddleware` to `POST /api/payments` in `apps/api/src/routes/paymentRoutes.js`
- Unauthenticated requests now receive 401

Closes #1772