### PR TITLE
fix: validate and limit search query length to 200 characters

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  if (q.length > 200) {
+    return fail(res, "Search query must not exceed 200 characters", 400);
+  }
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Summary\n\nThe search endpoint accepted unbounded query strings with no validation, enabling potential DoS through excessively long queries.\n\n## Changes\n\n- Added query length validation in `apps/api/src/controllers/searchController.js`\n- Queries exceeding 200 characters return a 400 response\n- Query is trimmed before processing and length check\n\nCloses #1777