### PR TITLE
fix: restrict CORS to configured allowed origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,12 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin: (process.env.ALLOWED_ORIGINS ?? "http://localhost:3000")
+      .split(",")
+      .map(o => o.trim()),
+    credentials: true
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
## Summary\n\nThe API was configured with `cors()` and no options, allowing requests from any origin.\n\n## Changes\n\n- Replaced open `cors()` with an origin allowlist in `apps/api/src/app.js`\n- Defaults to `http://localhost:3000`; configurable via `ALLOWED_ORIGINS` env var (comma-separated)\n- Added `credentials: true` to support authenticated cross-origin requests\n\nCloses #1774