### PR TITLE
fix: require authentication on POST /api/jobs

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Summary

The job creation endpoint accepted unauthenticated requests, allowing anyone to post jobs.

## Changes

- Added `authMiddleware` to `POST /api/jobs` in `apps/api/src/routes/jobRoutes.js`
- Unauthenticated requests now receive a 401 response

Closes #1776