### PR TITLE
fix: add main, types and exports entrypoint to @freelanceflow/db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
/claim #2775

## Problem
`@freelanceflow/db` had no `main`, `types`, or `exports` fields, making it unresolvable as a workspace package.

## Fix
Add `main`, `types`, and `exports` fields to `package.json`.

## Changes
- `packages/db/package.json`