### PR TITLE
fix: resolve mock freelancer profile by username with not-found fallback

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find((f) => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer with username <strong>{params.username}</strong> exists.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{profile.username}</h2>
+      <p><strong>Skills:</strong> {profile.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {profile.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
/claim #2849

## Problem
The `/freelancers/[username]` route rendered a static placeholder instead of looking up the matching mock profile.

## Fix
Lookup the freelancer by username from `apps/web/lib/mock.ts`. Renders a not-found message if no match.

## Changes
- `apps/web/app/freelancers/[username]/page.tsx`