### PR TITLE
fix: resolve mock job detail by id with not-found fallback

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,21 @@
+import { jobs } from "../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job with id <strong>{params.id}</strong> exists.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
     </section>
   );
 }


### PR DESCRIPTION
/claim #2790

## Problem
The `/jobs/[id]` route rendered a static placeholder instead of resolving the matching mock job.

## Fix
Lookup job by id from `apps/web/lib/mock.ts`. Renders a not-found message if no match.

## Changes
- `apps/web/app/jobs/[id]/page.tsx`