### PR TITLE
fix(api): return 400 for zod validation errors

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,5 +1,7 @@
 export function asyncHandler(handler) {
   return function wrappedHandler(req, res, next) {
-    return Promise.resolve(handler(req, res, next)).catch(next);
+    return Promise.resolve()
+      .then(() => handler(req, res, next))
+      .catch(next);
   };
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/validation-error.test.js
+++ b/apps/api/src/tests/validation-error.test.js
@@ -1,9 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import express from "express";
 import { createApp } from "../app.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
+import { errorHandler } from "../middleware/errorHandler.js";
 
 async function withServer(callback) {
   const app = createApp();
+  await withAppServer(app, callback);
+}
+
+async function withAppServer(app, callback) {
   const server = app.listen(0);
 
   await new Promise((resolve, reject) => {
@@ -37,5 +44,49 @@ test("Zod validation failures return a 400 response", async () => {
       payload.errors.map((error) => error.path).sort(),
       ["email", "password"]
     );
+  });
+});
+
+test("asyncHandler forwards synchronous route errors to the error handler", async () => {
+  const app = express();
+  app.get(
+    "/throws",
+    asyncHandler(() => {
+      throw new Error("boom");
+    })
+  );
+  app.use(errorHandler);
+
+  await withAppServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/throws`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unexpected server error"
+    });
+  });
+});
+
+test("asyncHandler forwards rejected route promises to the error handler", async () => {
+  const app = express();
+  app.get(
+    "/rejects",
+    asyncHandler(async () => {
+      throw new Error("boom");
+    })
+  );
+  app.use(errorHandler);
+
+  await withAppServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/rejects`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unexpected server error"
+    });
   });
 });

--- a/apps/api/src/tests/validation-error.test.js
+++ b/apps/api/src/tests/validation-error.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("Zod validation failures return a 400 response", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", password: "short" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.deepEqual(
+      payload.errors.map((error) => error.path).sort(),
+      ["email", "password"]
+    );
+  });
+});


### PR DESCRIPTION
Fixes #7062

## Summary
- handle ZodError instances in the API error middleware with a structured 400 response
- add an async route wrapper so validation failures from async controllers reach Express error handling
- update the API test script glob and add regression coverage for invalid registration payloads

## Test
- npm test --workspace @freelanceflow/api