### PR TITLE
Fix: CORS configured with no origin restrictions — allows any domain

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,17 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const corsOptions = {
+  origin: process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',')
+    : ['http://localhost:3000'],
+};
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(corsOptions));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
## Summary

Replaces `app.use(cors())` (no restrictions, accepts any domain) with an explicit allowlist configured via environment variable.

## Changes

**File:** `apps/api/src/app.js`

- Added `corsOptions` object:
  - Reads `ALLOWED_ORIGINS` from environment (comma-separated URLs)
  - Falls back to `http://localhost:3000` for development
- Passes `corsOptions` to `app.use(cors())`

## Usage

```bash
# Development (fallback)
ALLOWED_ORIGINS=http://localhost:3000

# Production (multiple domains)
ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
```

Closes #7114
Ref: #1774
