### PR TITLE
fix(api): require non-empty runtime env values

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,39 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+export function loadEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret = source.JWT_SECRET ?? (nodeEnv === "development" ? "development-secret" : undefined);
+  const requireRuntimeConfig = nodeEnv !== "development";
+  const databaseUrl = readEnv(source, "DATABASE_URL", { required: requireRuntimeConfig, fallback: "" });
+  const stripeSecretKey = readEnv(source, "STRIPE_SECRET_KEY", { required: requireRuntimeConfig, fallback: "" });
+
+  if (!jwtSecret) {
+    throw new Error("JWT_SECRET is required outside development");
+  }
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret,
+    stripeSecretKey,
+    databaseUrl
+  };
+}
+
+function readEnv(source, key, { required, fallback }) {
+  const value = source[key];
+
+  if (typeof value !== "string") {
+    if (required) {
+      throw new Error(`${key} is required`);
+    }
+
+    return fallback;
+  }
+
+  if (value.trim() === "") {
+    throw new Error(`${key} is required`);
+  }
+
+  return value;
+}
+
+export const env = loadEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadEnv } from "../config/env.js";
+
+const requiredEnv = {
+  DATABASE_URL: "postgresql://localhost/freelanceflow",
+  STRIPE_SECRET_KEY: "sk_test_replace_me"
+};
+
+test("loadEnv keeps the development JWT fallback", () => {
+  const env = loadEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("loadEnv requires JWT_SECRET outside development", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", ...requiredEnv }),
+    /JWT_SECRET is required outside development/
+  );
+});
+
+test("loadEnv accepts JWT_SECRET outside development", () => {
+  const env = loadEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "replace-me-with-a-real-secret",
+    ...requiredEnv
+  });
+
+  assert.equal(env.jwtSecret, "replace-me-with-a-real-secret");
+});
+
+test("loadEnv requires DATABASE_URL", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", JWT_SECRET: "replace-me-with-a-real-secret", STRIPE_SECRET_KEY: "sk_test_replace_me" }),
+    /DATABASE_URL is required/
+  );
+});
+
+test("loadEnv rejects blank DATABASE_URL", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", JWT_SECRET: "replace-me-with-a-real-secret", DATABASE_URL: "  ", STRIPE_SECRET_KEY: "sk_test_replace_me" }),
+    /DATABASE_URL is required/
+  );
+});
+
+test("loadEnv requires STRIPE_SECRET_KEY", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", JWT_SECRET: "replace-me-with-a-real-secret", DATABASE_URL: "postgresql://localhost/freelanceflow" }),
+    /STRIPE_SECRET_KEY is required/
+  );
+});
+
+test("loadEnv rejects blank STRIPE_SECRET_KEY", () => {
+  assert.throws(
+    () => loadEnv({ NODE_ENV: "production", JWT_SECRET: "replace-me-with-a-real-secret", DATABASE_URL: "postgresql://localhost/freelanceflow", STRIPE_SECRET_KEY: "\t" }),
+    /STRIPE_SECRET_KEY is required/
+  );
+});


### PR DESCRIPTION
## Summary
- Require non-empty `DATABASE_URL` and `STRIPE_SECRET_KEY` when loading non-development runtime config.
- Reject explicitly blank/whitespace values so production cannot start with invalid database or Stripe configuration.
- Keep the existing development defaults compatible while adding focused regression coverage.

## Validation
- `node --test apps/api/src/tests/env.test.js`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/env.test.js`

Closes #7096