### PR TITLE
fix(api): validate payment request body

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payment = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payment), 201);
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = payload.currency?.trim().toLowerCase() ?? "usd";
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
+
+test("createPaymentIntent normalizes provided currency codes", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500,
+    currency: " USD "
+  });
+
+  assert.equal(paymentIntent.currency, "usd");
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500
+  });
+
+  assert.equal(paymentIntent.currency, "usd");
+});
+
+test("createPaymentSchema accepts positive integer amount and optional currency", () => {
+  assert.deepEqual(createPaymentSchema.parse({ amount: 2500, currency: "USD" }), {
+    amount: 2500,
+    currency: "USD"
+  });
+
+  assert.deepEqual(createPaymentSchema.parse({ amount: 2500 }), {
+    amount: 2500
+  });
+});
+
+test("createPaymentSchema rejects missing, zero, negative, and decimal amounts", () => {
+  assert.throws(() => createPaymentSchema.parse({ currency: "USD" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: 0, currency: "USD" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: -1, currency: "USD" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: 10.5, currency: "USD" }));
+});
+
+test("createPaymentSchema rejects invalid currency codes", () => {
+  assert.throws(() => createPaymentSchema.parse({ amount: 2500, currency: "" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: 2500, currency: "US" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: 2500, currency: "USDT" }));
+  assert.throws(() => createPaymentSchema.parse({ amount: 2500, currency: "12$" }));
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().int().positive(),
+  currency: z
+    .string()
+    .trim()
+    .regex(/^[a-zA-Z]{3}$/, "Currency must be a three-letter ISO code")
+    .optional()
+});


### PR DESCRIPTION
## Summary
- Validate `POST /api/payments` request bodies before creating a payment intent.
- Require a positive integer `amount` and restrict `currency` to optional three-letter alphabetic codes.
- Trim currency before normalization so whitespace-padded values cannot bypass validation/normalization expectations.
- Add focused regression coverage for accepted payloads, invalid amounts, and invalid currency codes.

## Validation
- `node --check apps/api/src/controllers/paymentController.js`
- `node --check apps/api/src/services/paymentService.js`
- `node --check apps/api/src/validators/payment.js`
- `node --check apps/api/src/tests/paymentService.test.js`
- Focused service validation passed for currency trimming/normalization and default USD behavior.
- `node --test apps/api/src/tests/paymentService.test.js` could not run in this local checkout because dependencies are not installed; Node fails before executing tests on missing package `zod`, which is already declared in `apps/api/package.json` and used by existing validators.

Closes #7094