### PR TITLE
fix(web): add security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,39 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const securityHeaders = [
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff"
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY"
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin"
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=()"
+  }
+];
+
+if (process.env.NODE_ENV === "production") {
+  securityHeaders.push({
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains"
+  });
+}
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Add global Next.js security headers for every web route.
- Set `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, and a restrictive `Permissions-Policy`.
- Add production-only `Strict-Transport-Security` so local development over HTTP is not affected.

## Validation
- `node --check apps/web/next.config.js`
- Loaded `apps/web/next.config.js` and verified `headers()` returns the expected global rule and header values.

Closes #7093