### PR TITLE
fix(web): add baseline security headers

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,35 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self'",
+  "upgrade-insecure-requests"
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;

--- a/apps/web/tests/security-headers.test.mjs
+++ b/apps/web/tests/security-headers.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const nextConfig = require("../next.config.js");
+
+test("applies baseline security headers to every frontend route", async () => {
+  const routes = await nextConfig.headers();
+
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].source, "/(.*)");
+
+  const headers = Object.fromEntries(
+    routes[0].headers.map(({ key, value }) => [key, value])
+  );
+
+  assert.equal(headers["X-Frame-Options"], "DENY");
+  assert.equal(headers["X-Content-Type-Options"], "nosniff");
+  assert.equal(headers["Referrer-Policy"], "strict-origin-when-cross-origin");
+  assert.equal(headers["Permissions-Policy"], "camera=(), microphone=(), geolocation=()");
+  assert.match(headers["Content-Security-Policy"], /default-src 'self'/);
+  assert.match(headers["Content-Security-Policy"], /frame-ancestors 'none'/);
+  assert.match(headers["Content-Security-Policy"], /object-src 'none'/);
+});


### PR DESCRIPTION
/claim #743

Fixes #7123.

## Summary
- Add baseline security response headers for all Next.js frontend routes.
- Include CSP, frame blocking, MIME-sniffing protection, referrer policy, and feature permissions restrictions.
- Add a focused Node test that imports `next.config.js` and verifies the configured route/header set.

## Validation
- `node --test apps/web/tests/security-headers.test.mjs`
- `npm run build -w apps/web`
- `git diff --cached --check` before commit

Demo proof: the focused test exercises the exported Next.js `headers()` configuration and the production build completed successfully.
