### PR TITLE
Return JSON envelope for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,8 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use("/api", (req, res) => fail(res, "Not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/api-404.test.js
+++ b/apps/api/src/tests/api-404.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown API routes return the shared JSON 404 envelope", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/unknown/nested`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ping: true })
+    });
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+    assert.deepEqual(await response.json(), { success: false, message: "Not found" });
+  });
+});
+
+test("registered non-API routes still reach their handlers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/health`);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
Fixes #7132
/claim #743

## Summary
- add a final `/api` fallback after registered API routers
- return the shared JSON failure envelope via `fail(res, "Not found", 404)`
- cover unknown nested API routes and the existing health handler with focused `node:test` tests

## Validation
- `npm.cmd ci`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Demo: the added test posts to `/api/unknown/nested` and asserts the 404 JSON envelope `{ "success": false, "message": "Not found" }`.

Disclosure: AI-assisted with Codex; validated locally.
