### PR TITLE
fix(ui): update Card component styles to match dark theme

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section style={{ border: "1px solid #2a3765", borderRadius: 8, padding: "1rem", background: "#151c35", color: "#f2f5ff" }}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
## Summary

The Card component in packages/ui/src/Card.tsx uses hardcoded light-theme styles that clash with the application's dark theme:

- **Border**: #ddd (light gray) instead of #2a3765 (dark blue matching .card CSS class)
- **Background**: missing -- defaults to transparent/white instead of #151c35 (dark background)
- **Text color**: missing -- defaults to black instead of #f2f5ff (light text)

## Changes

Updated packages/ui/src/Card.tsx inline styles to match the dark theme palette used in pps/web/app/globals.css:

- Border: #ddd -> #2a3765
- Added ackground: #151c35
- Added color: #f2f5ff

## Files Changed

- packages/ui/src/Card.tsx -- updated inline styles to match dark theme

## Verification

- git diff --check passes with no whitespace errors
- Style values match the existing .card CSS class in pps/web/app/globals.css

/claim #743