### PR TITLE
fix: return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { fail } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -38,6 +39,7 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+  app.use("/api", (req, res) => fail(res, "Not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/app.test.js
+++ b/apps/api/src/tests/app.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+test("unknown /api routes return the shared JSON 404 envelope", async () => {
   const app = createApp();
   const server = app.listen(0, "127.0.0.1");
 
@@ -12,11 +12,15 @@ test("GET /health returns ok payload", async () => {
   });
 
   const { port } = server.address();
-  const response = await fetch(`http://127.0.0.1:${port}/health`);
+  const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
   const payload = await response.json();
 
-  assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  assert.equal(response.status, 404);
+  assert.match(response.headers.get("content-type") ?? "", /^application\/json\b/);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Not found"
+  });
 
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
Fixes #7138

Unknown `/api/*` routes were falling through to Express' default HTML 404. This adds a small API-only fallback so those requests get the same JSON failure envelope as the rest of the API.

Tests:
- `npm exec -w apps/api -- node --test src/tests/health.test.js src/tests/app.test.js`