### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,10 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const result = createJobSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid request body", 400);
+  }
+
+  return ok(res, await createJob(result.data), 201);
 }

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API docs",
+  description: "Write and polish the first pass of the public API docs.",
+  budgetMin: 500,
+  budgetMax: 900,
+  categoryId: "docs",
+  skills: ["writing", "api"]
+};
+
+test("createJobSchema accepts a valid budget range", () => {
+  assert.deepEqual(createJobSchema.parse(validJob), validJob);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(() => {
+    createJobSchema.parse({
+      ...validJob,
+      budgetMin: 900,
+      budgetMax: 500
+    });
+  });
+});
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...validJob,
+      budgetMin: 900,
+      budgetMax: 500
+    })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Invalid request body"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,18 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine((payload) => payload.budgetMax >= payload.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = baseJobSchema.partial().refine((payload) => {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+
+  return payload.budgetMax >= payload.budgetMin;
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
Fixes #7140

This adds a small Zod refinement so `budgetMax` can't be lower than `budgetMin`, and switches the job POST handler to `safeParse` so invalid payloads return the normal 400 envelope instead of bubbling into the error handler.

Tests:
- `npm exec -w apps/api -- node --test src/tests/job.test.js`