### PR TITLE
Return JSON for unknown API routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { fail } from "./utils/response.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -38,6 +39,8 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use("/api", (req, res) => fail(res, "Route not found", 404));
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/tests/apiNotFound.test.js
+++ b/apps/api/src/tests/apiNotFound.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unknown API routes return JSON 404 payload", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/not-a-real-route`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get("content-type") ?? "", /application\/json/);
+    assert.deepEqual(payload, { success: false, message: "Route not found" });
+  });
+});


### PR DESCRIPTION
## Summary

- add a JSON fallback for unknown `/api/*` routes
- reuse the existing `fail()` response shape
- add a route test that verifies 404 status, JSON content type, and payload

## Validation

```bash
node --test apps/api/src/tests/*.test.js
```

Result: 2 tests pass.

Closes #7142
Refs #743
/claim #743