### PR TITLE
fix: enforce authentication on job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobRoutes.test.js
+++ b/apps/api/src/tests/jobRoutes.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs returns 401 without auth token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title: "Test Job", description: "Test" }),
+  });
+  
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Unauthorized");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Fixes #7147

## What this does
Adds the `authMiddleware` to the `POST /api/jobs` endpoint to prevent unauthorized job creation.

## How to use it
The endpoint now correctly requires a valid `Bearer` token in the `Authorization` header when making a POST request to `/api/jobs`.

## Testing (How I tested it)
I created an automated test in `apps/api/src/tests/jobRoutes.test.js` that verifies making an unauthenticated `POST /api/jobs` request returns a `401 Unauthorized` status and payload. I ran this test locally using `npm test -w apps/api` which successfully confirmed the endpoint is protected.