### PR TITLE
fix(db): expose workspace package entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.test.mjs
+++ b/packages/db/index.test.mjs
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("@freelanceflow/db resolves through the workspace package entrypoint", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.equal(typeof db.PrismaClient, "function");
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test index.test.mjs"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"


### PR DESCRIPTION
Closes #2775

## Summary

- Adds an explicit runtime entrypoint for `@freelanceflow/db`.
- Declares `main`, `types`, and package `exports` metadata.
- Adds a focused workspace import regression test.

## Validation

- `npm test -w packages/db` (1/1 passing against fork branch `patch-2`)
- `node -e "import('@freelanceflow/db').then(m=>console.log(typeof m.PrismaClient, Object.keys(m).includes('Prisma')))"` -> `function true`

## Scope

This change is limited to the DB package entrypoint and an import test.
