### PR TITLE
fix(payments): require authentication

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/payment-auth.test.js
+++ b/apps/api/src/tests/payment-auth.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run("http://127.0.0.1:" + server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects missing bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(baseUrl + "/api/payments", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/payments accepts a valid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_payment_owner", role: "client" });
+    const response = await fetch(baseUrl + "/api/payments", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer " + token,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});


### PR DESCRIPTION
Closes #2757

## Summary

- Applies the existing `authMiddleware` to `POST /api/payments`.
- Adds route coverage for missing bearer token rejection.
- Adds route coverage showing valid signed bearer tokens can still create payment intents.
- Updates the API test script to run all `.test.js` files explicitly under Node 24.

## Validation

- `npm test -w apps/api` (3/3 passing against fork branch `patch-3`)

## Scope

This change is limited to payment route authentication and focused API coverage.
