### PR TITLE
Require auth for message creation

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -6,5 +6,5 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  return ok(res, await sendMessage(req.body, req.user), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -4,8 +4,13 @@ export async function listMessages() {
   return messages;
 }
 
-export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+export async function sendMessage(payload, user) {
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    senderId: user.sub,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-auth.test.js
+++ b/apps/api/src/tests/message-auth.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects unauthenticated message creation", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: "hello", receiverId: "usr_receiver" })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/messages uses authenticated user as sender", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_authenticated", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        id: "msg_client_supplied",
+        body: "hello",
+        senderId: "usr_spoofed",
+        receiverId: "usr_receiver"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.body, "hello");
+    assert.equal(payload.data.receiverId, "usr_receiver");
+    assert.equal(payload.data.senderId, "usr_authenticated");
+    assert.notEqual(payload.data.id, "msg_client_supplied");
+    assert.match(payload.data.id, /^msg_/);
+    assert.equal(typeof payload.data.sentAt, "string");
+  });
+});


### PR DESCRIPTION
## Summary

- require bearer authentication before creating messages
- derive `senderId` from the verified access token instead of trusting the request body
- keep server-owned message fields such as `id` and `sentAt` generated by the service
- add API tests for unauthenticated rejection and sender spoofing protection

## Security impact

Before this change, `POST /api/messages` accepted unauthenticated requests and allowed clients to provide arbitrary `senderId` values. That made message injection and sender impersonation possible.

## Validation

```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 3 tests pass.

Refs #743
/claim #743