### PR TITLE
Forward native section props in Card

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "node --test src/*.test.mjs"
+  }
 }

--- a/packages/ui/src/Card.test.mjs
+++ b/packages/ui/src/Card.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { Script } from "node:vm";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ts from "typescript";
+
+const require = createRequire(import.meta.url);
+
+function loadCard() {
+  const source = readFileSync(new URL("./Card.tsx", import.meta.url), "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.React,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022
+    }
+  });
+  const module = { exports: {} };
+  const script = new Script(outputText, { filename: "Card.cjs" });
+
+  script.runInNewContext({
+    exports: module.exports,
+    module,
+    require
+  });
+
+  return module.exports.Card;
+}
+
+test("Card forwards native section props and merges caller styles", () => {
+  const Card = loadCard();
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      Card,
+      {
+        title: "Profile",
+        id: "profile-card",
+        className: "featured",
+        "aria-label": "Profile card",
+        "data-testid": "profile-card",
+        style: { marginTop: "4px" }
+      },
+      "Ready"
+    )
+  );
+
+  assert.match(markup, /^<section /);
+  assert.match(markup, /id="profile-card"/);
+  assert.match(markup, /class="featured"/);
+  assert.match(markup, /aria-label="Profile card"/);
+  assert.match(markup, /data-testid="profile-card"/);
+  assert.match(markup, /border:1px solid #ddd/);
+  assert.match(markup, /border-radius:8px/);
+  assert.match(markup, /padding:1rem/);
+  assert.match(markup, /margin-top:4px/);
+});

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,19 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.ComponentPropsWithoutRef<"section"> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+const defaultStyle: React.CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: "1rem"
+};
+
+export function Card({ title, children, style, ...sectionProps }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section {...sectionProps} style={{ ...defaultStyle, ...style }}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Fixes #7153
/claim #743

## Summary
- extend the shared `Card` component with native `<section>` props
- forward remaining props to the rendered section so consumers can use `id`, `className`, `aria-*`, `data-*`, and handlers
- merge caller-provided styles with the default Card border/radius/padding styles
- add focused UI package coverage that renders the component and checks forwarded attributes plus merged styles

## Validation
- `npm.cmd ci`
- `npm.cmd test -w packages/ui`
- `npx.cmd tsc --noEmit --jsx react-jsx --esModuleInterop --skipLibCheck packages/ui/src/Card.tsx`
- `git diff --check`

Parent bounty: #743

Disclosure: AI-assisted with Codex; validated locally.
