### PR TITLE
Require auth for proposal review and upload writes

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -6,5 +6,5 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  return ok(res, await createProposal(req.body, req.user), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -6,5 +6,5 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  return ok(res, await createReview(req.body, req.user), 201);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -3,6 +3,7 @@ import { ok } from "../utils/response.js";
 export async function uploadFile(req, res) {
   return ok(res, {
     filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    status: req.file ? "uploaded" : "no-file",
+    uploaderId: req.user.sub
   }, 201);
 }

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -4,8 +4,13 @@ export async function listProposals() {
   return proposals;
 }
 
-export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+export async function createProposal(payload, user) {
+  const { id, freelancerId, ...proposalFields } = payload;
+  const proposal = {
+    ...proposalFields,
+    id: `prp_${Date.now()}`,
+    freelancerId: user.sub
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -4,8 +4,13 @@ export async function listReviews() {
   return reviews;
 }
 
-export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+export async function createReview(payload, user) {
+  const { id, reviewerId, ...reviewFields } = payload;
+  const review = {
+    ...reviewFields,
+    id: `rev_${Date.now()}`,
+    reviewerId: user.sub
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/write-auth.test.js
+++ b/apps/api/src/tests/write-auth.test.js
@@ -1,0 +1,143 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jobId: "job_1", freelancerId: "usr_spoof" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/proposals uses authenticated user as freelancer", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_auth" });
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        id: "prp_spoof",
+        jobId: "job_1",
+        freelancerId: "usr_spoof",
+        coverLetter: "Scoped delivery plan"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.coverLetter, "Scoped delivery plan");
+    assert.equal(payload.data.freelancerId, "usr_auth");
+    assert.match(payload.data.id, /^prp_/);
+    assert.notEqual(payload.data.id, "prp_spoof");
+  });
+});
+
+test("POST /api/reviews requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contractId: "ctr_1", reviewerId: "usr_spoof" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/reviews uses authenticated user as reviewer", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_auth" });
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        id: "rev_spoof",
+        contractId: "ctr_1",
+        reviewerId: "usr_spoof",
+        rating: 5
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.contractId, "ctr_1");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.reviewerId, "usr_auth");
+    assert.match(payload.data.id, /^rev_/);
+    assert.notEqual(payload.data.id, "rev_spoof");
+  });
+});
+
+test("POST /api/uploads requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/uploads records the authenticated uploader", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_auth" });
+    const body = new FormData();
+    body.set("file", new Blob(["hello"], { type: "text/plain" }), "note.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "note.txt",
+        status: "uploaded",
+        uploaderId: "usr_auth"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- require bearer authentication before creating proposals, reviews, and uploads
- derive `freelancerId`, `reviewerId`, and `uploaderId` from the verified access token instead of trusting client-controlled values
- keep proposal and review IDs server-owned even when clients send `id` values
- add API tests for unauthenticated rejection and ID/user spoofing protection

## Security impact

Before this change, anonymous clients could write proposals, reviews, and uploads. Proposal and review creation also trusted client-provided user identity fields, allowing freelancer/reviewer impersonation and client-controlled IDs.

## Validation

```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 7 tests pass.

Refs #743
/claim #743