### PR TITLE
Require auth for user writes and token refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -6,5 +6,5 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  return ok(res, await createUser(req.body, req.user), 201);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,11 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return {
+    token: signAccessToken({
+      sub: user.sub,
+      role: user.role ?? "client"
+    })
+  };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -4,8 +4,13 @@ export async function listUsers() {
   return users;
 }
 
-export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+export async function createUser(payload, actor) {
+  const { id, createdBy, ...userFields } = payload;
+  const user = {
+    ...userFields,
+    id: `usr_${Date.now()}`,
+    createdBy: actor.sub
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-refresh-auth.test.js
+++ b/apps/api/src/tests/user-refresh-auth.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "usr_spoof", email: "spoof@example.com" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/users keeps id and creator server-owned", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        id: "usr_spoof",
+        email: "new@example.com",
+        role: "freelancer",
+        createdBy: "usr_spoof"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "new@example.com");
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(payload.data.createdBy, "usr_admin");
+    assert.match(payload.data.id, /^usr_/);
+    assert.notEqual(payload.data.id, "usr_spoof");
+  });
+});
+
+test("POST /api/auth/refresh requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh mints a token for the authenticated user", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_freelancer", role: "freelancer" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+    const refreshed = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(refreshed.sub, "usr_freelancer");
+    assert.equal(refreshed.role, "freelancer");
+  });
+});


### PR DESCRIPTION
## Summary

- require bearer authentication before creating users through `/api/users`
- keep user `id` and `createdBy` server-owned instead of trusting request body fields
- require bearer authentication before minting a refreshed access token
- mint refreshed tokens for the verified caller instead of returning a hard-coded user token
- add API tests for unauthenticated rejection and spoofing protection

## Security impact

Before this change, anonymous clients could create arbitrary users through `/api/users` and override server-owned identity fields. The refresh endpoint also minted a token for a hard-coded user without verifying the caller, which allowed unauthenticated token issuance.

## Validation

```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 5 tests pass.

Refs #743
/claim #743