### PR TITLE
Align register token subject with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registerToken.test.js
+++ b/apps/api/src/tests/registerToken.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("register token subject matches the returned user id", async () => {
+  const originalNow = Date.now;
+  const timestamps = [1700000000000, 1700000001000];
+  Date.now = () => timestamps.shift() ?? 1700000001000;
+
+  try {
+    const result = await registerUser({
+      email: "new-client@example.com",
+      password: "correct horse battery staple",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, result.role);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- generate one server-owned user id during registration
- use that same id as the access-token subject
- add a regression test proving the returned user id matches the token subject

## Security impact
Before this change, registration generated the response user id and JWT subject from separate `Date.now()` calls. If those calls diverged, the API could return credentials whose token subject did not match the user id returned to the client, breaking identity binding immediately after signup.

## Validation
```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 2 tests pass.

Refs #743
/claim #743