### PR TITLE
Limit in-memory upload size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,29 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_UPLOAD_BYTES }
+});
+
+function singleFileUpload(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File too large", 413);
+    }
+
+    if (error) {
+      return next(error);
+    }
+
+    return next();
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", singleFileUpload, uploadFile);

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_UPLOAD_BYTES } from "../routes/uploadRoutes.js";
+
+const withTestServer = async (run) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+};
+
+test("POST /api/uploads accepts files within the memory limit", async () => {
+  await withTestServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "note.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "note.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});
+
+test("POST /api/uploads rejects files over the memory limit", async () => {
+  await withTestServer(async (baseUrl) => {
+    const form = new FormData();
+    const tooLargeFile = new Uint8Array(MAX_UPLOAD_BYTES + 1);
+    form.append("file", new Blob([tooLargeFile]), "large.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, { success: false, message: "File too large" });
+  });
+});


### PR DESCRIPTION
## Summary
- cap multer memory uploads at 5 MiB
- return a structured 413 JSON response when a file exceeds that limit
- add multipart route tests for accepted and rejected upload sizes

## Security impact
Before this change, `/api/uploads` used `multer.memoryStorage()` without a size limit. A large multipart upload could force the API process to buffer unbounded request data in memory before the controller handled it. The route now rejects oversized files early with a deterministic 413 response.

## Validation
```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 3 tests pass.

Refs #743
/claim #743