### PR TITLE
Validate production database and Stripe env config

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,24 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+function requireProductionEnv(name) {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function readRequiredProductionEnv(name) {
+  if (nodeEnv === "production") {
+    return requireProductionEnv(name);
+  }
+  return process.env[name] ?? "";
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  stripeSecretKey: readRequiredProductionEnv("STRIPE_SECRET_KEY"),
+  databaseUrl: readRequiredProductionEnv("DATABASE_URL")
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const originalEnv = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY
+};
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+function restoreEnv() {
+  for (const [name, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+function applyEnv(overrides) {
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+async function loadEnv(overrides) {
+  restoreEnv();
+  applyEnv(overrides);
+
+  const url = new URL("../config/env.js", import.meta.url);
+  url.searchParams.set("case", `${Date.now()}-${Math.random()}`);
+  return import(url.href);
+}
+
+test("production config rejects a missing database URL", async () => {
+  await assert.rejects(
+    () =>
+      loadEnv({
+        DATABASE_URL: "",
+        NODE_ENV: "production",
+        STRIPE_SECRET_KEY: "sk_test_configured"
+      }),
+    /Missing required environment variable: DATABASE_URL/
+  );
+});
+
+test("production config rejects a blank Stripe secret", async () => {
+  await assert.rejects(
+    () =>
+      loadEnv({
+        DATABASE_URL: "postgres://user:pass@localhost:5432/app",
+        NODE_ENV: "production",
+        STRIPE_SECRET_KEY: "   "
+      }),
+    /Missing required environment variable: STRIPE_SECRET_KEY/
+  );
+});
+
+test("production config accepts nonblank required variables", async () => {
+  const { env } = await loadEnv({
+    DATABASE_URL: "postgres://user:pass@localhost:5432/app",
+    NODE_ENV: "production",
+    STRIPE_SECRET_KEY: "sk_test_configured"
+  });
+
+  assert.equal(env.databaseUrl, "postgres://user:pass@localhost:5432/app");
+  assert.equal(env.stripeSecretKey, "sk_test_configured");
+});
+
+test("test config keeps existing empty defaults for lightweight imports", async () => {
+  const { env } = await loadEnv({
+    DATABASE_URL: undefined,
+    NODE_ENV: "test",
+    STRIPE_SECRET_KEY: undefined
+  });
+
+  assert.equal(env.databaseUrl, "");
+  assert.equal(env.stripeSecretKey, "");
+});


### PR DESCRIPTION
Fixes #7163
/claim #743

## Summary
- reject missing or blank `DATABASE_URL` and `STRIPE_SECRET_KEY` when `NODE_ENV=production`
- keep non-production/test imports compatible with the existing lightweight local setup
- add focused env config tests for missing, blank, valid production config, and test-mode defaults

## Validation
- `npm.cmd ci`
- `node --test apps/api/src/tests/env.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/env.test.js`
- `git diff --check`

Parent bounty: #743

Disclosure: AI-assisted with Codex; validated locally.
