### PR TITLE
Validate production JWT secret

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,23 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+function readJwtSecret() {
+  const secret = process.env.JWT_SECRET;
+
+  if (nodeEnv !== "production") {
+    return secret ?? "development-secret";
+  }
+
+  if (!secret || secret.trim().length < 32) {
+    throw new Error("JWT_SECRET must be set to at least 32 characters in production");
+  }
+
+  return secret;
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: readJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const ORIGINAL_ENV = { ...process.env };
+let importCounter = 0;
+
+async function importEnv(overrides = {}) {
+  process.env = { ...ORIGINAL_ENV, ...overrides };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    }
+  }
+
+  importCounter += 1;
+  return import(`../config/env.js?case=${importCounter}`);
+}
+
+test.afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+test("production requires JWT_SECRET to be set", async () => {
+  await assert.rejects(
+    importEnv({ NODE_ENV: "production", JWT_SECRET: undefined }),
+    /JWT_SECRET must be set to at least 32 characters in production/
+  );
+});
+
+test("production rejects blank JWT_SECRET", async () => {
+  await assert.rejects(
+    importEnv({ NODE_ENV: "production", JWT_SECRET: "   " }),
+    /JWT_SECRET must be set to at least 32 characters in production/
+  );
+});
+
+test("production rejects short JWT_SECRET", async () => {
+  await assert.rejects(
+    importEnv({ NODE_ENV: "production", JWT_SECRET: "too-short" }),
+    /JWT_SECRET must be set to at least 32 characters in production/
+  );
+});
+
+test("production accepts a strong JWT_SECRET", async () => {
+  const { env } = await importEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "12345678901234567890123456789012"
+  });
+
+  assert.equal(env.jwtSecret, "12345678901234567890123456789012");
+});
+
+test("non-production keeps the development JWT_SECRET fallback", async () => {
+  const { env } = await importEnv({ NODE_ENV: "test", JWT_SECRET: undefined });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});


### PR DESCRIPTION
﻿Fixes #7165
/claim #743

## Summary
- require `JWT_SECRET` to be present and at least 32 characters when `NODE_ENV=production`
- keep the existing `development-secret` fallback for non-production/test imports
- add focused config tests for missing, blank, short, valid production secrets, and test-mode fallback behavior

## Validation
- `npm.cmd ci`
- `node --test apps/api/src/tests/env.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/env.test.js`
- `git diff --check`

Note: `npm.cmd test -w apps/api` still fails on the current upstream script because Node 22 receives `src/tests` as a directory entrypoint. I kept this PR scoped to JWT secret validation and used the explicit test-file glob above.

Parent bounty: #743

Disclosure: AI-assisted with Codex; validated locally.
