### PR TITLE
Validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidators.test.js
+++ b/apps/api/src/tests/jobValidators.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Build webhook integration",
+  description: "Implement a small webhook integration for testing.",
+  budgetMin: 100,
+  budgetMax: 200,
+  categoryId: "cat_development",
+  skills: ["node"]
+};
+
+test("createJobSchema rejects budget ranges where min exceeds max", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMin must be less than or equal to budgetMax"
+  );
+});
+
+test("createJobSchema accepts equal budget bounds", () => {
+  const result = createJobSchema.safeParse({
+    ...validJobPayload,
+    budgetMin: 100,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema validates provided budget ranges", () => {
+  const invalidRange = updateJobSchema.safeParse({
+    budgetMin: 300,
+    budgetMax: 200
+  });
+  const partialRange = updateJobSchema.safeParse({
+    budgetMin: 300
+  });
+
+  assert.equal(invalidRange.success, false);
+  assert.equal(partialRange.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const validateBudgetRange = (payload, ctx) => {
+  if (
+    payload.budgetMin !== undefined &&
+    payload.budgetMax !== undefined &&
+    payload.budgetMin > payload.budgetMax
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMin must be less than or equal to budgetMax",
+      path: ["budgetMax"]
+    });
+  }
+};
+
+export const createJobSchema = jobFields.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobFields.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## Summary
- reject job payloads where budgetMin exceeds budgetMax
- preserve valid equal or ascending budget ranges
- add validator regression coverage for create and partial update payloads

## Impact
Before this change, the job schema accepted impossible budget ranges such as budgetMin: 500 and budgetMax: 100. Invalid budget data can make job listings misleading and force downstream code to handle contradictory bounds.

## Validation
```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 4 tests pass.

Closes #7167
Refs #743
/claim #743