### PR TITLE
Require valid refresh token for auth refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.safeParse(req.body);
+  if (!payload.success) {
+    return fail(res, "Refresh token is required", 401);
+  }
+
+  const result = await refreshToken(payload.data.refreshToken);
+  if (!result) {
+    return fail(res, "Invalid refresh token", 401);
+  }
+
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,21 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
+
+function createTokenPair(payload) {
+  return {
+    token: signAccessToken(payload),
+    refreshToken: signRefreshToken(payload)
+  };
+}
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    ...createTokenPair({ sub: userId, role: payload.role })
   };
 }
 
@@ -14,10 +23,17 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    ...createTokenPair({ sub: "usr_existing", role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  try {
+    const payload = verifyRefreshToken(refreshTokenValue);
+    const role = typeof payload.role === "string" ? payload.role : "client";
+
+    return { token: signAccessToken({ sub: payload.sub, role }) };
+  } catch {
+    return null;
+  }
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/refresh", {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const loginPayload = await loginResponse.json();
+
+    const response = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: loginPayload.data.token
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh issues a token for a valid refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const loginPayload = await loginResponse.json();
+
+    assert.equal(loginResponse.status, 200);
+    assert.equal(typeof loginPayload.data.refreshToken, "string");
+
+    const response = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: loginPayload.data.refreshToken
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, "client");
+  });
+});
+
+test("register returns refresh token tied to the created user", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/register", {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 201);
+    assert.equal(typeof payload.data.refreshToken, "string");
+    assert.equal(decoded.sub, payload.data.id);
+    assert.equal(decoded.role, "admin");
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -1,10 +1,33 @@
 import jwt from "jsonwebtoken";
 import { env } from "../config/env.js";
 
+function signToken(payload, expiresIn) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn });
+}
+
 export function signAccessToken(payload) {
-  return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
+  return signToken(payload, "15m");
+}
+
+export function signRefreshToken(payload) {
+  return signToken({ ...payload, tokenUse: "refresh" }, "7d");
 }
 
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
+  const payload = jwt.verify(token, env.jwtSecret);
+
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    payload.tokenUse !== "refresh" ||
+    typeof payload.sub !== "string"
+  ) {
+    throw new Error("Invalid refresh token");
+  }
+
+  return payload;
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
﻿Fixes #7168
/claim #743

## Summary
- require `POST /api/auth/refresh` to receive a valid refresh token before minting a new access token
- return refresh tokens from register/login responses and keep refreshed access tokens tied to the refresh token subject/role
- reject missing refresh tokens and access-token-only refresh attempts with 401 responses
- add focused API tests for missing refresh token, access token misuse, valid refresh, and register token subject consistency

## Validation
- `npm.cmd ci`
- `node --test apps/api/src/tests/auth.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/utils/jwt.js`
- `node --check apps/api/src/validators/auth.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/controllers/authController.js`
- `node --check apps/api/src/tests/auth.test.js`
- `git diff --check`

Note: the current upstream `npm.cmd test -w apps/api` script still fails on Node 22 because it points to `src/tests` as a directory entrypoint. I kept this PR scoped to refresh authentication and validated with the explicit test-file glob above.

Parent bounty: #743

Disclosure: AI-assisted with Codex; validated locally.
