### PR TITLE
Require JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+const DEFAULT_JWT_SECRET = "development-secret";
+
+function resolveJwtSecret() {
+  const jwtSecret = process.env.JWT_SECRET ?? DEFAULT_JWT_SECRET;
+
+  if (process.env.NODE_ENV === "production" && jwtSecret === DEFAULT_JWT_SECRET) {
+    throw new Error("JWT_SECRET must be set in production");
+  }
+
+  return jwtSecret;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalJwtSecret = process.env.JWT_SECRET;
+
+const restoreEnv = () => {
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  if (originalJwtSecret === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = originalJwtSecret;
+  }
+};
+
+const importFreshEnv = async (name) => {
+  return import(`../config/env.js?test=${name}-${Date.now()}-${Math.random()}`);
+};
+
+test("env allows the development JWT fallback outside production", async () => {
+  delete process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+
+  try {
+    const { env } = await importFreshEnv("development-fallback");
+    assert.equal(env.jwtSecret, "development-secret");
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("env rejects the development JWT fallback in production", async () => {
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  try {
+    await assert.rejects(
+      importFreshEnv("production-missing-secret"),
+      /JWT_SECRET must be set in production/
+    );
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("env accepts an explicit JWT secret in production", async () => {
+  process.env.NODE_ENV = "production";
+  process.env.JWT_SECRET = "prod-secret";
+
+  try {
+    const { env } = await importFreshEnv("production-secret");
+    assert.equal(env.jwtSecret, "prod-secret");
+  } finally {
+    restoreEnv();
+  }
+});


### PR DESCRIPTION
## Summary
- keep the local-development JWT fallback outside production
- fail fast when production starts without a real JWT_SECRET
- add config regression tests for development and production behavior

## Security impact
Before this change, production could run with the hard-coded development-secret when JWT_SECRET was missing. That would make access tokens predictable for anyone who knows the public fallback value.

## Validation
```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 4 tests pass.

Closes #7171
Refs #743
/claim #743