### PR TITLE
Require auth for notification listing

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationRoutes.test.js
+++ b/apps/api/src/tests/notificationRoutes.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/notifications returns notifications for authenticated users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { success: true, data: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- require bearer authentication before listing notifications
- keep notification creation behavior unchanged for this scoped fix
- add route tests for unauthenticated rejection and authenticated reads

## Security impact
Before this change, `GET /api/notifications` returned the full notification list to anonymous clients. Notifications can contain user-specific account or workflow metadata, so listing them should require a verified caller.

## Validation
```bash
PATH="/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" node --test apps/api/src/tests/*.test.js
```

Result: 3 tests pass.

Closes #7173
Refs #743
/claim #743