### PR TITLE
Reject unsupported OAuth callback providers

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,8 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const SUPPORTED_OAUTH_PROVIDERS = new Set(["github", "google"]);
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,6 +17,10 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
+  if (!SUPPORTED_OAUTH_PROVIDERS.has(req.params.provider)) {
+    return fail(res, "Unsupported OAuth provider", 400);
+  }
+
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"

--- a/apps/api/src/tests/authRoutes.test.js
+++ b/apps/api/src/tests/authRoutes.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const withTestServer = async (run) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+};
+
+test("GET /api/auth/oauth/:provider/callback accepts supported providers", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/github/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        provider: "github",
+        status: "callback-received"
+      }
+    });
+  });
+});
+
+test("GET /api/auth/oauth/:provider/callback rejects unsupported providers", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/oauth/not-a-provider/callback`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported OAuth provider"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit allowlist for OAuth callback providers
- return `400` for unsupported provider path segments instead of reporting callback success
- add route-level regression tests for supported and unsupported providers

Fixes #7162
/claim #743

## Validation
```bash
node --check apps/api/src/controllers/authController.js
node --check apps/api/src/tests/authRoutes.test.js
node --test apps/api/src/tests/authRoutes.test.js
node --test apps/api/src/tests/*.test.js
git diff --check
```