### PR TITLE
Return client errors for bad JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
+  if (err?.type === "entity.parse.failed") {
+    return fail(res, "Malformed JSON request body", 400);
+  }
+
+  if (err?.type === "entity.too.large") {
+    return fail(res, "Request body too large", 413);
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/tests/bodyParserErrors.test.js
+++ b/apps/api/src/tests/bodyParserErrors.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const withTestServer = async (run) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+};
+
+test("malformed JSON request bodies return a structured 400 response", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"email\":"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});
+
+test("oversized JSON request bodies return a structured 413 response", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "correct-horse-battery-staple",
+        bio: "x".repeat(110 * 1024)
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Request body too large"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- return structured `400` JSON for malformed request bodies raised by `express.json()`
- return structured `413` JSON for oversized JSON request bodies instead of a generic 500
- keep the existing 500 fallback for unexpected server errors

Fixes #7176
/claim #743

## Validation
```bash
node --check apps/api/src/middleware/errorHandler.js
node --check apps/api/src/tests/bodyParserErrors.test.js
node --test apps/api/src/tests/bodyParserErrors.test.js
node --test apps/api/src/tests/*.test.js
git diff --check
```