### PR TITLE
fix(api): require auth for notification listing

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notification-auth.test.js
+++ b/apps/api/src/tests/notification-auth.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications requires bearer authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/notifications returns notifications for a valid bearer token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_123" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { success: true, data: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- require bearer authentication for `GET /api/notifications`
- leave notification creation behavior unchanged
- add regression tests for anonymous and authenticated notification listing

/claim #7173

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/routes/notificationRoutes.js`
- `node --check apps/api/src/tests/notification-auth.test.js`
- `git diff --check`

Note: `npm test --workspace @freelanceflow/api` currently fails because the package script runs `node --test src/tests`, which Node resolves as a missing module path in this checkout; I used the explicit `src/tests/*.test.js` pattern above for validation.
