### PR TITLE
fix(notifications): preserve server-owned fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: "ntf_" + Date.now(), read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and read state", async () => {
+  const notification = await createNotification({
+    id: "client_supplied",
+    read: true,
+    message: "Proposal was accepted"
+  });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.notEqual(notification.id, "client_supplied");
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Proposal was accepted");
+});


### PR DESCRIPTION
Closes #2762

## Summary

- Ensures caller payload cannot override the server-generated notification `id`.
- Ensures newly-created notifications always start with `read: false`.
- Adds focused service coverage for both server-owned fields.
- Updates the API test script to run all `.test.js` files explicitly under Node 24.

## Validation

- `npm test -w apps/api` (2/2 passing against fork branch `patch-4`)

## Scope

This change is limited to notification creation behavior and focused service coverage.
