### PR TITLE
Add no-store cache control to health endpoint

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,7 +24,8 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+  res.set("Cache-Control", "no-store");
+  res.status(200).json({ ok: true, service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,6 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Closes #7179
Parent bounty: #743

## Summary
- add Cache-Control: no-store to GET /health
- cover the response header in the existing health endpoint test

## Test
node --test apps/api/src/tests/health.test.js