### PR TITLE
fix(auth): reuse registration id for token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the access token for the returned user id", async () => {
+  const originalNow = Date.now;
+  const ticks = [1710000000000, 1710000000001];
+  let tick = 0;
+  Date.now = () => ticks[Math.min(tick++, ticks.length - 1)];
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "supersecret",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1710000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once and reuse it for both the response and access-token subject
- add focused service coverage that simulates the clock advancing between id generation and token signing
- verify the decoded JWT `sub` always matches `result.id`

Closes #2768

## Verification
- `C:\Users\deski\Desktop\work\node\node.exe --test src/tests/*.test.js` from `apps/api` (2/2 passing)
- `C:\Users\deski\Desktop\work\node\node.exe --check src/services/authService.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check src/tests/authService.test.js`
- `git diff --check`
