### PR TITLE
Fix health endpoint cache headers

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,6 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- set `Cache-Control: no-store` on `GET /health`
- extend the health endpoint test to assert the non-cacheable response header

## Validation
- `node --test .\apps\api\src\tests\*.test.js`

Fixes #7179
Refs #743
Supersedes #7181 after rebasing the branch onto the latest `main`.

/claim #743