### PR TITLE
fix(auth): require registration full name

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -4,6 +4,7 @@ export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
+    fullName: payload.fullName,
     email: payload.email,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })

--- a/apps/api/src/tests/registrationFullName.test.js
+++ b/apps/api/src/tests/registrationFullName.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema requires a non-empty fullName", () => {
+  const withoutName = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "supersecret",
+    role: "client"
+  });
+  const blankName = registerSchema.safeParse({
+    fullName: "   ",
+    email: "client@example.com",
+    password: "supersecret",
+    role: "client"
+  });
+
+  assert.equal(withoutName.success, false);
+  assert.equal(blankName.success, false);
+});
+
+test("registerUser preserves the validated fullName", async () => {
+  const payload = registerSchema.parse({
+    fullName: "  Maya Patel  ",
+    email: "maya@example.com",
+    password: "supersecret",
+    role: "freelancer"
+  });
+  const result = await registerUser(payload);
+
+  assert.equal(payload.fullName, "Maya Patel");
+  assert.equal(result.fullName, "Maya Patel");
+  assert.equal(result.email, "maya@example.com");
+  assert.equal(result.role, "freelancer");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().trim().min(1),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
﻿## Summary
- require a trimmed, non-empty `fullName` in registration payload validation
- carry the validated `fullName` into the `registerUser()` response payload
- add focused tests for missing/blank names and preservation of a valid trimmed name

Closes #2770

## Verification
- `C:\Users\deski\Desktop\work\node\node.exe --test src/tests/*.test.js` from `apps/api` (3/3 passing)
- `C:\Users\deski\Desktop\work\node\node.exe --check src/validators/auth.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check src/services/authService.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check src/tests/registrationFullName.test.js`
- `git diff --check`
