### PR TITLE
fix(web): render mock freelancer profiles

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,25 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { freelancers } from "../../../lib/mock";
+
+export default async function FreelancerProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+  const freelancer = freelancers.find((profile) => profile.username === username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock freelancer profile matches <strong>{username}</strong>.</p>
+        <p>Return to search and choose an available freelancer profile.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Hourly rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p>This profile is ready for project matching, portfolio review, and proposal shortlisting.</p>
     </section>
   );
 }


### PR DESCRIPTION
﻿## Summary
- resolve `/freelancers/[username]` against the shared mock freelancer data
- render matching profile details, including hourly rate and skills
- show a clear fallback when the username does not match a mock profile

Closes #2763

## Verification
- `C:\Users\deski\Desktop\work\node\npm.cmd run build -w apps/web`
- `Invoke-WebRequest http://127.0.0.1:3100/freelancers/maya-dev` contains `maya-dev`, `$65/hr`, `Next.js`, and `TypeScript`
- `Invoke-WebRequest http://127.0.0.1:3100/freelancers/jordan-ux` contains `jordan-ux`, `$52/hr`, and `Figma`
- `Invoke-WebRequest http://127.0.0.1:3100/freelancers/unknown-user` contains `Freelancer not found`
- Browser DOM check against `http://127.0.0.1:3100/freelancers/maya-dev` and `/unknown-user`
- `git diff --check`
