### PR TITLE
fix: return client errors for bad JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid JSON body"
+    });
+  }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "JSON body too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/bodyParser.test.js
+++ b/apps/api/src/tests/bodyParser.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("malformed JSON bodies return the structured 400 response", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{\"title\":"
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "Invalid JSON body"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("oversized JSON bodies return the structured 413 response", async () => {
+  const app = createApp();
+  const server = app.listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const oversized = JSON.stringify({
+    payload: "x".repeat(120_000)
+  });
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: oversized
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 413);
+  assert.deepEqual(payload, {
+    success: false,
+    message: "JSON body too large"
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Fixes #7187

This handles `express.json()` parse and size errors before the generic 500 fallback, so malformed JSON gets a structured 400 and oversized JSON gets a structured 413.

Tests:
- `npm exec -w apps/api -- node --test src/tests/bodyParser.test.js`