### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
The `registerSchema` in `apps/api/src/validators/auth.js` accepted `"admin"` as a valid role value, allowing any unauthenticated caller to self-elevate to the admin role on registration.

## Fix
Removed `"admin"` from the `role` enum, restricting registration to `"client"` and `"freelancer"` only.

## Verification
- `POST /api/auth/register` with `{"role": "admin"}` now returns a Zod validation error.
- `POST /api/auth/register` with `{"role": "client"}` continues to work normally.
- `POST /api/auth/register` without a `role` field defaults to `"client"`.

Fixes SecureBananaLabs/bug-bounty#7191