### PR TITLE
fix: set Cache-Control: no-store on health endpoint

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 


### PR DESCRIPTION
## Summary
The /health endpoint returned no cache-control directive, allowing intermediaries or clients to cache stale health responses.

## Fix
Added `res.set("Cache-Control", "no-store")` to the health route handler so responses are never cached.

## Verification
- GET /health now includes `Cache-Control: no-store` in the response headers.
- The JSON body `{ ok: true, service: "api" }` is unchanged.

Fixes SecureBananaLabs/bug-bounty#7189