### PR TITLE
fix: return JSON 404 for unknown /api routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,10 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use("/api", (req, res) => {
+    res.status(404).json({ success: false, message: "Not found" });
+  });
+
   app.use(errorHandler);
   return app;
 }


### PR DESCRIPTION
## Summary
Unknown routes under `/api` fell through to Express' default HTML 404 handler. API consumers expect JSON responses consistent with the rest of the API.

## Fix
Added a catch-all middleware mounted at `/api` (after all route handlers, before the error handler) that returns `404 { success: false, message: "Not found" }`.

## Verification
- GET /api/nonexistent returns `404` with `Content-Type: application/json` and body `{ "success": false, "message": "Not found" }`.
- All existing known routes are unaffected.

Fixes SecureBananaLabs/bug-bounty#7138