### PR TITLE
fix: throw on missing or short JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,13 @@
+const rawJwtSecret = process.env.JWT_SECRET ?? "development-secret";
+const nodeEnv = process.env.NODE_ENV ?? "development";
+if (nodeEnv === "production" && (!process.env.JWT_SECRET || process.env.JWT_SECRET.length < 32)) {
+  throw new Error("JWT_SECRET must be set to a string of at least 32 characters in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: rawJwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Closes #7092

The JWT_SECRET fell back to the hardcoded string 'development-secret' when the environment variable was absent or empty, enabling an attacker to forge valid JWTs in production. This PR throws at startup when NODE_ENV=production and JWT_SECRET is absent or shorter than 32 characters.