### PR TITLE
fix: require authentication on GET /api/notifications

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
+notificationRoutes.get("/", authMiddleware, getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
Closes #7173

GET /api/notifications was accessible without any authentication, exposing all stored notifications to unauthenticated callers. This PR adds `authMiddleware` to the GET route.