### PR TITLE
fix: require JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET?.trim() || "development-secret";
+
+if (nodeEnv === "production" && jwtSecret === "development-secret") {
+  throw new Error("JWT_SECRET must be set to a non-default value in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url);
+
+async function loadEnvWith(overrides) {
+  const previous = {
+    NODE_ENV: process.env.NODE_ENV,
+    JWT_SECRET: process.env.JWT_SECRET
+  };
+
+  if (overrides.NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = overrides.NODE_ENV;
+  }
+
+  if (overrides.JWT_SECRET === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = overrides.JWT_SECRET;
+  }
+
+  try {
+    return await import(`${envModuleUrl.href}?t=${Date.now()}-${Math.random()}`);
+  } finally {
+    if (previous.NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previous.NODE_ENV;
+    }
+
+    if (previous.JWT_SECRET === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = previous.JWT_SECRET;
+    }
+  }
+}
+
+test("development keeps the fallback JWT secret", async () => {
+  const { env } = await loadEnvWith({
+    NODE_ENV: "development",
+    JWT_SECRET: undefined
+  });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("production rejects a missing JWT secret", async () => {
+  await assert.rejects(
+    loadEnvWith({
+      NODE_ENV: "production",
+      JWT_SECRET: undefined
+    }),
+    /JWT_SECRET must be set to a non-default value in production/
+  );
+});
+
+test("production rejects the default JWT secret value", async () => {
+  await assert.rejects(
+    loadEnvWith({
+      NODE_ENV: "production",
+      JWT_SECRET: "development-secret"
+    }),
+    /JWT_SECRET must be set to a non-default value in production/
+  );
+});
+
+test("production accepts a non-default JWT secret", async () => {
+  const { env } = await loadEnvWith({
+    NODE_ENV: "production",
+    JWT_SECRET: "super-secret-prod-key"
+  });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.jwtSecret, "super-secret-prod-key");
+});


### PR DESCRIPTION
Fixes #7209

This keeps the local development fallback, but stops production from booting with the default JWT secret. That way the app fails fast instead of signing production tokens with a predictable public secret.

Tests:
- `npm exec -w apps/api -- node --test src/tests/env.test.js`