### PR TITLE
Reject admin role during public registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/authRegistrationRole.test.js
+++ b/apps/api/src/tests/authRegistrationRole.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register rejects public admin role assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/register", {
+      email: "attacker@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/register still allows normal public roles", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/register", {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "freelancer");
+    assert.ok(payload.data.token);
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

Closes #7216
Refs #743

## Summary
- remove `admin` from the public registration role enum
- return the shared 400 failure envelope for invalid registration payloads before issuing a token
- add route tests proving `admin` is rejected and normal public roles still register successfully
- fix the API test script glob so the standard workspace test command runs the test files on current Node

## Validation
- `npm test -w apps/api`
- `git diff --check`
