### PR TITLE
Reuse registration id for token subject

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authRegisterToken.test.js
+++ b/apps/api/src/tests/authRegisterToken.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs the access token with the returned user id", async () => {
+  const originalNow = Date.now;
+  let timestamp = 1710000000000;
+  Date.now = () => timestamp++;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      role: "client"
+    });
+    const tokenPayload = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1710000000000");
+    assert.equal(tokenPayload.sub, result.id);
+    assert.equal(tokenPayload.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #7217
Refs #743

## Summary
- generate the registration user id once in `registerUser`
- reuse that id for both the response `id` and JWT `sub` claim
- add a deterministic service regression test with a controlled clock
- fix the API test script glob so the standard workspace test command runs the test files on current Node

## Validation
- `npm test -w apps/api`
- `git diff --check`
