### PR TITLE
Preserve notification generated fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves generated id and unread status", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1710000000000;
+
+  try {
+    const notification = await createNotification({
+      id: "ntf_client_controlled",
+      userId: "usr_recipient",
+      type: "message",
+      message: "You have a new message",
+      read: true
+    });
+
+    assert.equal(notification.id, "ntf_1710000000000");
+    assert.equal(notification.read, false);
+    assert.equal(notification.userId, "usr_recipient");
+    assert.equal(notification.type, "message");
+    assert.equal(notification.message, "You have a new message");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #7220
Refs #743

## Summary
- preserve notification service-owned `id` and `read` fields by applying payload fields first
- keep new notifications unread even when callers submit `read: true`
- add a focused service regression test for caller-supplied `id` / `read`
- fix the API test script glob so the standard workspace test command runs the test files on current Node

## Validation
- `npm test -w apps/api`
- `git diff --check`
