### PR TITLE
Preserve generated proposal ids

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal preserves generated ids", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1710000000000;
+
+  try {
+    const proposal = await createProposal({
+      id: "prp_client_controlled",
+      jobId: "job_123",
+      freelancerId: "usr_456",
+      rate: 120,
+      message: "I can complete this job."
+    });
+
+    assert.equal(proposal.id, "prp_1710000000000");
+    assert.equal(proposal.jobId, "job_123");
+    assert.equal(proposal.freelancerId, "usr_456");
+    assert.equal(proposal.rate, 120);
+    assert.equal(proposal.message, "I can complete this job.");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #7228
Refs #743

## Summary
- preserve service-owned proposal ids by applying payload fields before the generated id
- keep normal proposal payload fields unchanged
- add focused service regression coverage for caller-supplied `id`
- fix the API test script glob so the standard workspace test command runs the test files on current Node

## Validation
- `npm test -w apps/api`
- `git diff --check`
