### PR TITLE
Preserve server-owned message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage preserves server-owned id and sentAt fields", async () => {
+  const message = await sendMessage({
+    id: "client_supplied_id",
+    sentAt: "2000-01-01T00:00:00.000Z",
+    body: "Hello from the client",
+    recipientId: "usr_recipient"
+  });
+
+  assert.match(message.id, /^msg_\d+$/);
+  assert.notEqual(message.id, "client_supplied_id");
+  assert.notEqual(message.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.equal(message.body, "Hello from the client");
+  assert.equal(message.recipientId, "usr_recipient");
+});


### PR DESCRIPTION
Closes #7268

## Summary
- ensure `sendMessage` applies server-owned `id` after caller payload fields
- keep `sentAt` server-generated while preserving normal message fields
- add service-level regression coverage for caller-supplied `id`/`sentAt`

## Validation
- node --test apps/api/src/tests/messageService.test.js
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/services/messageService.js
- node --check apps/api/src/tests/messageService.test.js
- git diff --check