### PR TITLE
fix: reject inverted job budget ranges (Closes #2835)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,28 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMax >= data.budgetMin, {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema
+  .partial()
+  .refine(
+    (data) =>
+      data.budgetMin === undefined ||
+      data.budgetMax === undefined ||
+      data.budgetMax >= data.budgetMin,
+    {
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    }
+  );


### PR DESCRIPTION
## Summary
- Add `.refine()` validation to `createJobSchema` and `updateJobSchema` to ensure `budgetMax >= budgetMin`
- Rejects payloads where the maximum budget is lower than the minimum budget
- Partial updates only validate the range when both budget fields are present

## Changes
- `apps/api/src/validators/job.js`: Added cross-field refinement to both schemas

## Validation
- `budgetMax < budgetMin` → rejected with 400 error
- `budgetMax >= budgetMin` → accepted
- Only one budget field provided → accepted (partial update)

Closes #2835

/claim #2835