### PR TITLE
fix: validate refresh token before issuing new access token (Closes #1750)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = refreshSchema.parse(req.body);
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  token: z.string().min(1, "Refresh token is required")
+});


### PR DESCRIPTION
## Summary
- `POST /api/auth/refresh` now requires a valid token in the request body
- The refresh token is verified before issuing a new access token
- Missing or invalid tokens are rejected with a 400/401 error
- New token preserves the `sub` and `role` from the original token

## Changes
- `apps/api/src/validators/auth.js`: Added `refreshSchema` requiring a non-empty token string
- `apps/api/src/controllers/authController.js`: Parse and pass token from request body
- `apps/api/src/services/authService.js`: `refreshToken(token)` now verifies the token before signing a replacement

## Validation
- `POST /api/auth/refresh` with no body → 400 error
- `POST /api/auth/refresh` with invalid token → 401 error
- `POST /api/auth/refresh` with valid token → new access token issued

Closes #1750

/claim #1750