### PR TITLE
fix: add admin role authorization check to admin routes (Closes #1770)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,12 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary
- Add `requireRole()` middleware that checks `req.user.role` against allowed roles
- Admin routes now require both authentication AND admin role
- Non-admin authenticated users receive 403 Forbidden

## Changes
- `apps/api/src/middleware/auth.js`: Added `requireRole(...roles)` middleware factory
- `apps/api/src/routes/adminRoutes.js`: Applied `requireRole("admin")` after authMiddleware

## Validation
- Unauthenticated request → 401 Unauthorized
- Non-admin authenticated user → 403 Forbidden
- Admin authenticated user → 200 OK

Closes #1770

/claim #1770