### PR TITLE
fix: restrict CORS to configured origin (Closes #1774)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { env } from "./config/env.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -19,7 +20,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: env.corsOrigin }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,6 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigin: process.env.CORS_ORIGIN ?? "http://localhost:3000"
 };


### PR DESCRIPTION
## Summary
- Add `CORS_ORIGIN` environment variable to configure allowed origin
- Default to `http://localhost:3000` for development
- `cors()` now uses the configured origin instead of allowing all origins

## Changes
- `apps/api/src/config/env.js`: Added `corsOrigin` from `CORS_ORIGIN` env var
- `apps/api/src/app.js`: Pass `{ origin: env.corsOrigin }` to `cors()`

## Validation
- Cross-origin requests from allowed origin → succeed
- Cross-origin requests from other origins → blocked by CORS policy

Closes #1774

/claim #1774