### PR TITLE
fix(ui): expose runtime package entrypoint

### DIFF
--- a/packages/ui/dist/Button.js
+++ b/packages/ui/dist/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/dist/Card.js
+++ b/packages/ui/dist/Card.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/dist/index.cjs
+++ b/packages/ui/dist/index.cjs
@@ -1,0 +1,29 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Button, Card };

--- a/packages/ui/dist/index.js
+++ b/packages/ui/dist/index.js
@@ -1,0 +1,2 @@
+export * from "./Button.js";
+export * from "./Card.js";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,16 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  }
 }


### PR DESCRIPTION
﻿## Summary
- point `@freelanceflow/ui` at checked-in runtime JavaScript entrypoints instead of raw TypeScript source
- expose ESM and CommonJS entrypoints while preserving TypeScript types from `src/index.ts`
- add runtime JS exports for `Button` and `Card` so workspace consumers can import the package directly

Closes #2781

## Verification
- Before fix: `node -e "import('@freelanceflow/ui')..."` failed with `ERR_MODULE_NOT_FOUND` from `packages/ui/src/index.ts`
- `C:\Users\deski\Desktop\work\node\node.exe -e "import('@freelanceflow/ui').then(...)"` returns `Button` and `Card` functions
- `C:\Users\deski\Desktop\work\node\node.exe -e "const m=require('@freelanceflow/ui'); ..."` returns `Button` and `Card` functions
- `C:\Users\deski\Desktop\work\node\node.exe --check packages/ui/dist/index.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check packages/ui/dist/Button.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check packages/ui/dist/Card.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check packages/ui/dist/index.cjs`
- `git diff --check`
