### PR TITLE
fix(jobs): reject inverted budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build an AI assistant",
+  description: "Create a production-ready assistant workflow.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "engineering",
+  skills: ["Node.js"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.budgetMin, 500);
+  assert.equal(result.data.budgetMax, 1500);
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 900,
+    budgetMax: 300
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("updateJobSchema permits single budget field partial updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 900 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 900 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+export const createJobSchema = jobFieldsSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobFieldsSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
﻿## Summary
- add shared budget range validation for job payloads
- reject `budgetMax < budgetMin` on job creation
- reject inverted partial update ranges only when both budget fields are supplied
- add focused schema coverage for valid create ranges, invalid create ranges, invalid update ranges, and single-field partial updates

Closes #2853

## Verification
- `C:\Users\deski\Desktop\work\node\node.exe --test src/tests/*.test.js` from `apps/api` (5/5 passing)
- `C:\Users\deski\Desktop\work\node\node.exe --check src/validators/job.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check src/tests/jobValidation.test.js`
- `git diff --check`
