### PR TITLE
fix(web): resolve job details by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,30 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+import Link from "next/link";
+import { jobs } from "../../../lib/mock";
+
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const job = jobs.find((item) => item.id === id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job matches <strong>{id}</strong>.</p>
+        <p>Review the active listings to choose an available project.</p>
+        <Link href="/jobs">Back to jobs</Link>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <p>{job.category}</p>
+      <h2>{job.title}</h2>
+      <p>{job.summary}</p>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p><strong>Timeline:</strong> {job.timeline}</p>
+      <p><strong>Skills:</strong> {job.skills.join(", ")}</p>
+      <Link href="/jobs">Back to jobs</Link>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,31 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    category: "AI Engineering",
+    timeline: "3 weeks",
+    summary: "Create an embeddable support widget with conversation history, escalation rules, and analytics.",
+    skills: ["Next.js", "OpenAI API", "Customer support"]
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    category: "Backend Engineering",
+    timeline: "5 weeks",
+    summary: "Move a legacy REST API onto a Node.js service with typed routes, tests, and deployment notes.",
+    skills: ["Node.js", "PostgreSQL", "API migration"]
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    category: "Product Design",
+    timeline: "2 weeks",
+    summary: "Design activation-focused onboarding screens, empty states, and handoff-ready interaction notes.",
+    skills: ["Figma", "UX writing", "SaaS onboarding"]
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
## Summary
- resolve `/jobs/[id]` against the shared mock jobs list
- render the selected job title, budget, timeline, category, skills, and project summary
- show a clear not-found fallback for unknown job ids instead of placeholder success copy

Closes #2755

Also addresses the duplicate public report #2760.

## Verification
- `C:\Users\deski\Desktop\work\node\npm.cmd run build` from `apps/web` with portable Node on PATH
- Browser check at `http://127.0.0.1:3104/jobs/job-101`: title, budget, and project context rendered
- Browser check at `http://127.0.0.1:3104/jobs/not-a-real-job`: not-found fallback and Back to jobs link rendered
- `git diff --check`
