### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMin <= data.budgetMax,
+  { message: "budgetMin must be less than or equal to budgetMax", path: ["budgetMin"] }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4),
+  description: z.string().min(10),
+  budgetMin: z.number().nonnegative(),
+  budgetMax: z.number().nonnegative(),
+  categoryId: z.string().min(1),
+  skills: z.array(z.string().min(1)).default([])
+}).partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMin <= data.budgetMax;
+    }
+    return true;
+  },
+  { message: "budgetMin must be less than or equal to budgetMax", path: ["budgetMin"] }
+);


### PR DESCRIPTION
## Fix

Adds \ to \ and \ to reject payloads where \.

All 4 job validation tests pass:
- ✅ Accept valid job data
- ✅ Reject inverted budget range
- ✅ Accept equal budgetMin and budgetMax
- ✅ Reject negative budgets

Closes #2853