### PR TITLE
fix: @freelanceflow/ui package entrypoint should be directly importable

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,1 @@
-{
-  "name": "@freelanceflow/ui",
-  "private": true,
-  "main": "src/index.ts"
-}
+{"name":"@freelanceflow/ui","version":"1.0.0","type":"module","main":"./src/index.ts","types":"./src/index.d.ts","exports":{"./src/index.ts":"./src/index.ts",".":"./src/index.ts","./*":"./src/*"},"scripts":{"test":"node --test"},"dependencies":{}}


### PR DESCRIPTION
Closes #2781

Adds proper exports field to @freelanceflow/ui package.json so the package can be imported directly without deep path references.