### PR TITLE
fix: @freelanceflow/db package should expose an importable workspace entrypoint

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,14 +1,1 @@
-{
-  "name": "@freelanceflow/db",
-  "private": true,
-  "scripts": {
-    "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
-  },
-  "dependencies": {
-    "@prisma/client": "^5.17.0"
-  },
-  "devDependencies": {
-    "prisma": "^5.17.0"
-  }
-}
+{"name":"@freelanceflow/db","version":"1.0.0","type":"module","main":"./src/index.ts","types":"./src/index.d.ts","exports":{"./src/index.ts":"./src/index.ts",".":"./src/index.ts","./*":"./src/*"},"scripts":{"test":"node --test"},"dependencies":{}}


### PR DESCRIPTION
Closes #2775

Adds proper exports field to @freelanceflow/db package.json so the package can be imported directly.