### PR TITLE
fix: Job detail route should resolve mock jobs by id

### DIFF
--- a/apps/web/app/jobs/[id]/route.ts
+++ b/apps/web/app/jobs/[id]/route.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { jobs } from "@/lib/mock";
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+  if (!job) {
+    return Response.json({ error: "Job not found" }, { status: 404 });
+  }
+  return Response.json(job);
+}


### PR DESCRIPTION
Closes #2790

Adds mock job lookup by id in the job detail route. Returns 404 if job not found.