### PR TITLE
fix: registration token subject should match returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  // Generate ID once and use it consistently
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "assert";
+import { registerUser } from "../services/authService.js";
+
+describe("authService", () => {
+  it("registerUser should return a token with the correct subject", async () => {
+    const payload = { email: "test@example.com", role: "client" };
+    const result = await registerUser(payload);
+
+    assert.ok(result.token, "Token should be generated");
+    const tokenPayload = JSON.parse(
+      Buffer.from(result.token.split(".")[1], "base64").toString()
+    );
+    assert.equal(
+      tokenPayload.sub,
+      result.id,
+      "Token subject should match the returned user ID"
+    );
+  });
+});


### PR DESCRIPTION
## Fix

The `registerUser` function called `Date.now()` twice, producing different IDs for the return value and JWT subject.

Fix: generate the ID once and reuse it.

Test passes:
```
# pass 1 - registerUser should return a token with the correct subject
```

Closes #2768