### PR TITLE
Reject upload requests without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      })
+  };
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const response = await fetch(`${server.url}/api/uploads`, {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /api/uploads accepts a real uploaded file", async () => {
+  const app = createApp();
+  const server = await listen(app);
+
+  try {
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob(["hello upload"], { type: "text/plain" }),
+      "hello.txt"
+    );
+
+    const response = await fetch(`${server.url}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
Fixes #7305
/claim #743

## Summary
- return the shared failure envelope when `POST /api/uploads` receives no uploaded file
- reserve the existing `201 Created` success response for requests with a real file
- add focused upload route coverage for missing-file rejection and successful multipart upload

## Validation
- `node --test apps/api/src/tests/upload.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/controllers/uploadController.js`
- `node --check apps/api/src/tests/upload.test.js`
- `git diff --check`

Parent bounty: #743

Disclosure: AI-assisted with Codex; validated locally.