### PR TITLE
docs: add original technical poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,21 @@
+# Ledger of Small Fixes
+
+In the marketplace at midnight,
+cards glow like quiet ports;
+each bid is a little lantern,
+each patch a ship with reports.
+
+The client asks for certainty,
+the builder answers with tests;
+between them runs a narrow bridge
+where trust is measured best.
+
+A token guards the doorway,
+a benchmark keeps the beat;
+the bug that hid in daylight
+steps out into the street.
+
+So pay the honest artifact,
+merge what proves its claim;
+small fixes become infrastructure
+when signatures hold their name.


### PR DESCRIPTION
## Summary
- add `POEM.md` with an original four-stanza technical poem for the project

Closes #76

Creative note: I used a ledger/bridge metaphor because this project is about turning small verified work into trusted marketplace value.

## Verification
- `POEM.md` exists in the project root
- poem has 4 stanzas and 16 non-heading lines
