### PR TITLE
feat(api): create Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.2.1",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,10 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
-export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+export async function createPayment(req, res, next) {
+  try {
+    return ok(res, await createPaymentIntent(req.body), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,13 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.statusCode) {
+    return res.status(err.statusCode).json({
+      success: false,
+      message: err.message
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,71 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+import Stripe from "stripe";
+import { z } from "zod";
+import { env } from "../config/env.js";
+
+const paymentPayloadSchema = z.object({
+  amount: z
+    .number({ required_error: "amount is required" })
+    .int("amount must be an integer in the smallest currency unit")
+    .positive("amount must be a positive integer"),
+  currency: z
+    .string()
+    .trim()
+    .regex(/^[a-z]{3}$/i, "currency must be a 3-letter ISO code")
+    .default("usd")
+    .transform((currency) => currency.toLowerCase()),
+  metadata: z.record(z.string()).optional()
+});
+
+let stripeClient;
+
+export class PaymentServiceError extends Error {
+  constructor(message, statusCode = 400, cause) {
+    super(message);
+    this.name = "PaymentServiceError";
+    this.statusCode = statusCode;
+    this.cause = cause;
+  }
+}
+
+function getStripeClient() {
+  if (!env.stripeSecretKey) {
+    throw new PaymentServiceError("STRIPE_SECRET_KEY is required to create payment intents", 500);
+  }
+
+  stripeClient ??= new Stripe(env.stripeSecretKey);
+  return stripeClient;
+}
+
+function parsePaymentPayload(payload) {
+  const result = paymentPayloadSchema.safeParse(payload);
+  if (!result.success) {
+    throw new PaymentServiceError(result.error.issues[0].message, 400, result.error);
+  }
+
+  return result.data;
+}
+
+export async function createPaymentIntent(payload, options = {}) {
+  const parsed = parsePaymentPayload(payload);
+  const stripe = options.stripeClient ?? getStripeClient();
+  const createParams = {
+    amount: parsed.amount,
+    currency: parsed.currency,
+    ...(parsed.metadata ? { metadata: parsed.metadata } : {})
   };
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(createParams);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount ?? parsed.amount,
+      currency: paymentIntent.currency ?? parsed.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    const message = error?.message ?? "Unable to create Stripe PaymentIntent";
+    throw new PaymentServiceError(`Stripe error: ${message}`, 502, error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+function createStripeMock(responseOrError, calls = []) {
+  return {
+    paymentIntents: {
+      async create(params) {
+        calls.push(params);
+        if (responseOrError instanceof Error) {
+          throw responseOrError;
+        }
+        return responseOrError;
+      }
+    }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent with validated arguments", async () => {
+  const calls = [];
+  const stripeClient = createStripeMock(
+    {
+      id: "pi_mocked",
+      client_secret: "pi_mocked_secret",
+      amount: 2500,
+      currency: "usd"
+    },
+    calls
+  );
+
+  const result = await createPaymentIntent(
+    {
+      amount: 2500,
+      currency: "USD",
+      metadata: { jobId: "job_123", clientId: "usr_123" }
+    },
+    { stripeClient }
+  );
+
+  assert.deepEqual(calls, [
+    {
+      amount: 2500,
+      currency: "usd",
+      metadata: { jobId: "job_123", clientId: "usr_123" }
+    }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_mocked",
+    clientSecret: "pi_mocked_secret",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+  const stripeClient = createStripeMock(
+    {
+      id: "pi_default_currency",
+      client_secret: "pi_default_currency_secret"
+    },
+    calls
+  );
+
+  const result = await createPaymentIntent({ amount: 1200 }, { stripeClient });
+
+  assert.equal(calls[0].currency, "usd");
+  assert.equal(result.currency, "usd");
+});
+
+test("createPaymentIntent rejects invalid amounts before calling Stripe", async () => {
+  const calls = [];
+  const stripeClient = createStripeMock({ id: "pi_should_not_exist" }, calls);
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, { stripeClient }),
+    /amount must be a positive integer/
+  );
+
+  assert.equal(calls.length, 0);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeError = new Error("Your card was declined");
+  stripeError.type = "StripeCardError";
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 1500, currency: "usd" }, { stripeClient: createStripeMock(stripeError) }),
+    /Your card was declined/
+  );
+});
+
+test(
+  "createPaymentIntent can create a real Stripe test-mode PaymentIntent",
+  {
+    skip:
+      process.env.RUN_STRIPE_SMOKE_TEST === "1" && process.env.STRIPE_SECRET_KEY
+        ? false
+        : "Set RUN_STRIPE_SMOKE_TEST=1 and STRIPE_SECRET_KEY to run"
+  },
+  async () => {
+    const result = await createPaymentIntent({
+      amount: 100,
+      currency: "usd",
+      metadata: { source: "api-smoke-test" }
+    });
+
+    assert.match(result.paymentId, /^pi_/);
+    assert.match(result.clientSecret, /^pi_/);
+    assert.equal(result.amount, 100);
+    assert.equal(result.currency, "usd");
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.2.1",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.2.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.1.tgz",
+      "integrity": "sha512-ULAtq25USBEx3yeN5zimEkfYVFETVMP5om25Ryr8ol11P62imaCZLBIEW78T7zm7Wg3wnZi+80S72yf3LCpNhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- replace the payment stub with Stripe SDK `PaymentIntent` creation
- validate amount, currency, and metadata before calling Stripe
- return `paymentId` and `clientSecret` from the Stripe response
- preserve Stripe error messages through a payment service error
- add unit coverage with a mocked Stripe client and a guarded real Stripe smoke test
- make the API test script run the committed test files

Closes #1

## Verification
- `C:\Users\deski\Desktop\work\node\npm.cmd test -w apps/api` (5 passing, 1 Stripe smoke test skipped unless `RUN_STRIPE_SMOKE_TEST=1` and `STRIPE_SECRET_KEY` are set)
- `C:\Users\deski\Desktop\work\node\node.exe --check apps/api/src/controllers/paymentController.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check apps/api/src/services/paymentService.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check apps/api/src/tests/paymentService.test.js`
- `C:\Users\deski\Desktop\work\node\node.exe --check apps/api/src/middleware/errorHandler.js`
- HTTP smoke check without `STRIPE_SECRET_KEY` returns JSON error: `STRIPE_SECRET_KEY is required to create payment intents`
- `git diff --check`
