### PR TITLE
fix: require a strong JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET?.trim() || "development-secret";
+
+if (nodeEnv === "production" && jwtSecret.length < 32) {
+  throw new Error("JWT_SECRET must be at least 32 characters in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url);
+
+async function loadEnvWith(overrides) {
+  const keys = ["NODE_ENV", "JWT_SECRET"];
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+  for (const key of keys) {
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await import(`${envModuleUrl.href}?t=${Date.now()}-${Math.random()}`);
+  } finally {
+    for (const key of keys) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
+test("development keeps the fallback JWT secret", async () => {
+  const { env } = await loadEnvWith({
+    NODE_ENV: "development",
+    JWT_SECRET: undefined
+  });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("production rejects a missing JWT secret", async () => {
+  await assert.rejects(
+    loadEnvWith({
+      NODE_ENV: "production",
+      JWT_SECRET: undefined
+    }),
+    /JWT_SECRET must be at least 32 characters in production/
+  );
+});
+
+test("production rejects a blank JWT secret", async () => {
+  await assert.rejects(
+    loadEnvWith({
+      NODE_ENV: "production",
+      JWT_SECRET: "   "
+    }),
+    /JWT_SECRET must be at least 32 characters in production/
+  );
+});
+
+test("production rejects a short JWT secret", async () => {
+  await assert.rejects(
+    loadEnvWith({
+      NODE_ENV: "production",
+      JWT_SECRET: "short-secret"
+    }),
+    /JWT_SECRET must be at least 32 characters in production/
+  );
+});
+
+test("production accepts a long enough JWT secret", async () => {
+  const { env } = await loadEnvWith({
+    NODE_ENV: "production",
+    JWT_SECRET: "12345678901234567890123456789012"
+  });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.jwtSecret, "12345678901234567890123456789012");
+});


### PR DESCRIPTION
Fixes #7312

This keeps the lightweight development fallback, but stops production from booting with a missing, blank, or too-short JWT secret. That way the API fails fast instead of signing tokens with a weak or public secret.

Tests:
- `npm exec -w apps/api -- node --test src/tests/env.test.js`