### PR TITLE
fix: preserve server-generated id in message, review, and proposal services

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignored, ...safePayload } = payload;
+  const message = { id: `msg_${Date.now()}`, ...safePayload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...safePayload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const review = { id: `rev_${Date.now()}`, ...safePayload };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
Closes #7314

## Summary

In `messageService.js`, `reviewService.js`, and `proposalService.js`, the server-generated `id` was placed first in the object literal and then overwritten by `...payload`. This allowed callers to supply their own `id` value and override the server-assigned one.

## Fix

Destructure `id` out of the incoming payload before spreading the rest, ensuring the server-generated ID is always used:

```js
const { id: _ignored, ...safePayload } = payload;
const message = { id: `msg_${Date.now()}`, ...safePayload, sentAt: new Date().toISOString() };
```

The same pattern is applied to `reviewService.js` and `proposalService.js`.