### PR TITLE
fix: restrict CORS to trusted origins via ALLOWED_ORIGINS env var

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,8 +18,24 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 export function createApp() {
   const app = express();
 
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim()).filter(Boolean)
+    : [];
+
   app.use(helmet());
-  app.use(cors());
+  app.use(
+    cors({
+      origin: allowedOrigins.length > 0
+        ? (origin, callback) => {
+            if (!origin || allowedOrigins.includes(origin)) {
+              callback(null, true);
+            } else {
+              callback(new Error(`CORS: origin '${origin}' not allowed`));
+            }
+          }
+        : false
+    })
+  );
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Closes #7319
Parent bounty: #743

## Summary

Previously `cors()` was invoked with no configuration, allowing requests from **any origin**. This creates a medium-risk cross-origin attack surface in production.

## Changes

- `apps/api/src/app.js`: Read `ALLOWED_ORIGINS` (comma-separated) from the environment and pass it as a CORS origin allowlist.
- When `ALLOWED_ORIGINS` is not set or empty, CORS is disabled entirely (`origin: false`), so no cross-origin requests are honoured until the operator explicitly configures the env var.
- When the incoming `origin` is absent (same-origin or non-browser requests) it is always passed through unchanged.

## Testing

Existing health-check test continues to pass. CORS behaviour is environment-driven and can be verified by comparing the `Access-Control-Allow-Origin` header against the allowlist at runtime.