### PR TITLE
fix: enforce admin role authorization on admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Closes #7320
Parent bounty: #743

## Summary

Admin routes only applied `authMiddleware`, which verified the JWT signature but never checked the user's role. Any authenticated user (client or freelancer) could call `GET /api/admin/metrics` — a **high-severity privilege escalation**.

## Changes

### `apps/api/src/middleware/auth.js`
Added `adminMiddleware`: reads `req.user.role` set by `authMiddleware` and returns `403 Forbidden` for any role that is not `'admin'`.

### `apps/api/src/routes/adminRoutes.js`
Applied `adminMiddleware` immediately after `authMiddleware` so all admin route handlers are protected.

## Testing

- Non-admin JWT → `403 Forbidden`
- Admin JWT → request proceeds normally
- Unauthenticated request → `401 Unauthorized` (unchanged)