### PR TITLE
fix: validate and length-limit search query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,24 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q;
+
+  if (Array.isArray(raw)) {
+    return fail(res, "Query parameter 'q' must be a single string", 400);
+  }
+
+  const q = typeof raw === "string" ? raw.trim() : "";
+
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(
+      res,
+      `Query parameter 'q' must not exceed ${MAX_QUERY_LENGTH} characters`,
+      400
+    );
+  }
+
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Closes #7322
Parent bounty: #743

## Summary

`GET /api/search` passed `req.query.q` directly to `globalSearch()` with no validation:
- A repeated `?q=a&q=b` parameter is parsed by Express as an array, causing `globalSearch` to receive `['a','b']` instead of a string.
- An arbitrarily long string could be sent to exhaust resources.

## Changes

### `apps/api/src/controllers/searchController.js`
1. **Array guard** — reject repeated `q` params with `400 Bad Request`
2. **Type coerce + trim** — convert to string and strip leading/trailing whitespace
3. **Length limit** — reject queries longer than 200 characters with `400 Bad Request`
4. Pass the sanitised string to `globalSearch()`

## Testing

Existing tests pass. Edge cases verified:
- `?q=hello` → 200 OK
- `?q=a&q=b` → 400
- `?q=` (201-char string) → 400
- No `q` param → empty string passed to search service → 200 OK