### PR TITLE
fix: generate user id once so registration token sub matches returned id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser: token sub matches returned user id", async () => {
+  const result = await registerUser({ email: "test@example.com", password: "secret123", role: "client" });
+
+  assert.ok(result.id, "result.id should be present");
+  assert.ok(result.token, "result.token should be present");
+
+  const decoded = jwt.decode(result.token);
+  assert.equal(
+    decoded.sub,
+    result.id,
+    `JWT sub '${decoded.sub}' should equal result.id '${result.id}'`
+  );
+});


### PR DESCRIPTION
Closes #7323
Parent bounty: #743

## Summary

`registerUser` in `authService.js` called `Date.now()` twice — once to set the returned `id` field and once inside `signAccessToken({ sub: `usr_${Date.now()}` })`. If the two calls land on different milliseconds (likely on a loaded machine), the signed JWT's `sub` claim references a **different id** than the one returned to the client. Downstream identity checks that compare `req.user.sub` to a stored user id will silently fail.

## Changes

### `apps/api/src/services/authService.js`
Generate the user id once (`const id = `usr_${Date.now()}``) and use it for both the `id` response field and the JWT `sub` claim.

### `apps/api/src/tests/auth.test.js` (new)
Focused service test decoding the returned token with `jwt.decode` and asserting `decoded.sub === result.id`.

## Testing

```
✔ registerUser: token sub matches returned user id (7ms)
```