### PR TITLE
fix: require estimatedDuration in proposal creation schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7324
Parent bounty: #743

## Summary

`POST /api/proposals` passed `req.body` directly to `createProposal()` with no validation. Proposals could be submitted without the required `estimatedDuration` field (and without any other required fields like `jobId`, `coverLetter`, or `bidAmount`), resulting in incomplete records being stored.

## Changes

### `apps/api/src/validators/proposal.js` (new)
Defines `createProposalSchema` with Zod:
- `jobId` — non-empty string
- `coverLetter` — minimum 10 characters
- `bidAmount` — positive number
- `estimatedDuration` — non-empty string (enforces the required field)

### `apps/api/src/controllers/proposalController.js`
Updated `postProposal` to parse and validate with `createProposalSchema` before calling the service. Invalid or incomplete payloads throw a `ZodError` caught by the global error handler and returned as a 400 response.

## Testing

Existing tests pass. Payloads missing `estimatedDuration` (or any other required field) now return `400 Bad Request`.