### PR TITLE
fix: add auth and Zod validation to review creation endpoint

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,6 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(10)
+});


### PR DESCRIPTION
Closes #7339
Parent bounty: #743

## Summary

`POST /api/reviews` had no authentication and no input validation — unauthenticated users could post fake reviews with arbitrary payloads.

## Changes

### `apps/api/src/validators/review.js` (new)
`createReviewSchema`: `jobId` (non-empty string), `rating` (integer 1–5), `comment` (min 10 chars).

### `apps/api/src/controllers/reviewController.js`
`postReview` now validates with `createReviewSchema` before calling the service.

### `apps/api/src/routes/reviewRoutes.js`
Added `authMiddleware` to `POST /api/reviews`. GET remains public (read-only listing).