### PR TITLE
fix: add auth and Zod validation to message endpoints

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { sendMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  recipientId: z.string().min(1),
+  body: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7340
Parent bounty: #743

## Summary

Both `GET /api/messages` and `POST /api/messages` were fully public — private message threads could be read by anyone, and messages could be injected with arbitrary payloads.

## Changes

### `apps/api/src/validators/message.js` (new)
`sendMessageSchema`: `recipientId` (non-empty string), `body` (min 1 char).

### `apps/api/src/controllers/messageController.js`
`postMessage` now validates with `sendMessageSchema` before calling the service.

### `apps/api/src/routes/messageRoutes.js`
Added `authMiddleware` via `router.use()` so all message routes require authentication.