### PR TITLE
fix: require authentication on job creation and review listing endpoints

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", authMiddleware, getReviews);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
Closes #7342
Parent bounty: #743

## Summary

Two endpoints were missing `authMiddleware`:

- **`POST /api/jobs`** — anonymous users could post unlimited jobs, enabling spam
- **`GET /api/reviews`** — review data (ratings, comments) was publicly accessible without authentication

## Changes

### `apps/api/src/routes/jobRoutes.js`
Added `authMiddleware` to `POST /`.

### `apps/api/src/routes/reviewRoutes.js`
Added `authMiddleware` to both `GET /` and `POST /` — reviews are user-specific data and should require login to read or write.