### PR TITLE
fix: apply rate limiter before JSON body parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });


### PR DESCRIPTION
Closes #7343
Parent bounty: #743

## Summary

In `app.js` the middleware order was:
```
helmet → cors → express.json() → apiLimiter
```

`express.json()` runs before `apiLimiter`, so malformed or oversized JSON request bodies are parsed (and can throw errors or consume CPU) **before** the rate limiter counts the request. An attacker can flood the server with malformed bodies that bypass rate limiting entirely.

## Fix

Swap the order so `apiLimiter` runs **before** `express.json()`:
```
helmet → cors → apiLimiter → express.json()
```

Now every request — including malformed-body requests — is counted against the rate limit window before any body parsing occurs.