### PR TITLE
fix: require authentication on proposal list and post endpoints

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);


### PR DESCRIPTION
Closes #7344
Parent bounty: #743

## Summary

Both `GET /api/proposals` and `POST /api/proposals` were fully public:
- Bid amounts and cover letters (sensitive freelancer data) were readable by anyone
- Anonymous users could submit proposals without an identity

## Changes

### `apps/api/src/routes/proposalRoutes.js`
Added `router.use(authMiddleware)` so all proposal routes require a valid JWT. Unauthenticated requests receive `401 Unauthorized`.