### PR TITLE
fix: add Zod validation to payment creation endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).toLowerCase().default("usd"),
+  jobId: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7351
Parent bounty: #743

## Summary

`POST /api/payments` passed `req.body` directly to `createPaymentIntent()` with no Zod validation. A missing `amount` or a negative value would silently reach the Stripe integration layer, risking invalid or zero-amount charges.

## Changes

### `apps/api/src/validators/payment.js` (new)
`createPaymentSchema`: `amount` (positive number), `currency` (3-char ISO string, lowercase, default `'usd'`), `jobId` (non-empty string).

### `apps/api/src/controllers/paymentController.js`
`createPayment` now parses the request body with `createPaymentSchema` before calling the service. Invalid payloads return `400 Bad Request`.