### PR TITLE
fix: billing page renders mock invoices and payout methods

### DIFF
--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -1,8 +1,43 @@
+const invoices = [
+  { id: "inv-001", date: "2024-05-01", description: "Web Design Project", amount: 1500, status: "Paid" },
+  { id: "inv-002", date: "2024-05-15", description: "API Integration Work", amount: 800, status: "Pending" },
+  { id: "inv-003", date: "2024-06-01", description: "Code Review & Audit", amount: 450, status: "Paid" }
+];
+
+const payoutMethods = [
+  { id: "pm-001", type: "Bank Account", label: "Chase ••••4821", primary: true },
+  { id: "pm-002", type: "PayPal", label: "user@example.com", primary: false }
+];
+
 export default function BillingPage() {
   return (
-    <section className="card">
+    <section>
       <h2>Billing</h2>
-      <p>Invoices, payout methods, and transaction history are managed here.</p>
+
+      <h3>Invoices</h3>
+      <div className="grid">
+        {invoices.map((invoice) => (
+          <article className="card" key={invoice.id}>
+            <h4>{invoice.description}</h4>
+            <p>{invoice.date}</p>
+            <p>${invoice.amount.toLocaleString()}</p>
+            <p>
+              <strong>Status:</strong> {invoice.status}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      <h3>Payout Methods</h3>
+      <div className="grid">
+        {payoutMethods.map((method) => (
+          <article className="card" key={method.id}>
+            <h4>{method.type}</h4>
+            <p>{method.label}</p>
+            {method.primary && <p><strong>Primary</strong></p>}
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7353
Parent bounty: #743

## Summary

The billing page was a single placeholder paragraph. It now renders:
- A list of **mock invoices** (date, description, amount, status)
- A **payout methods** section with static placeholder entries (bank account + PayPal)

## Changes

### `apps/web/app/billing/page.tsx`
Replaced the placeholder with functional sections for invoices and payout methods using static mock data.