### PR TITLE
fix: admin panel page renders mock metrics instead of placeholder text

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,32 @@
+const metrics = {
+  openJobs: 42,
+  activeFreelancers: 185,
+  flaggedAccounts: 3,
+  monthlyVolume: 128900
+};
+
 export default function AdminPanelPage() {
   return (
-    <section className="card">
+    <section>
       <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+      <div className="grid">
+        <article className="card">
+          <h3>Open Jobs</h3>
+          <p>{metrics.openJobs}</p>
+        </article>
+        <article className="card">
+          <h3>Active Freelancers</h3>
+          <p>{metrics.activeFreelancers}</p>
+        </article>
+        <article className="card">
+          <h3>Flagged Accounts</h3>
+          <p>{metrics.flaggedAccounts}</p>
+        </article>
+        <article className="card">
+          <h3>Monthly Volume</h3>
+          <p>${metrics.monthlyVolume.toLocaleString()}</p>
+        </article>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7352
Parent bounty: #743

## Summary

The admin panel page was a single placeholder paragraph. It now renders a grid of metric cards with the same shape as `GET /api/admin/metrics`: **Open Jobs**, **Active Freelancers**, **Flagged Accounts**, and **Monthly Volume**.

## Changes

### `apps/web/app/admin/page.tsx`
Replaced the placeholder `<p>` with a metrics grid that mirrors the backend response structure. Static mock values match `adminService.getAdminMetrics()`.