### PR TITLE
fix: messaging page renders mock conversation list

### DIFF
--- a/apps/web/app/messaging/page.tsx
+++ b/apps/web/app/messaging/page.tsx
@@ -1,8 +1,43 @@
+const threads = [
+  {
+    id: "thread-1",
+    participant: "maya-dev",
+    lastMessage: "Sounds good, I can start Monday.",
+    timestamp: "2024-06-10 14:32",
+    unread: true
+  },
+  {
+    id: "thread-2",
+    participant: "jordan-ux",
+    lastMessage: "I've uploaded the revised wireframes.",
+    timestamp: "2024-06-09 09:15",
+    unread: false
+  },
+  {
+    id: "thread-3",
+    participant: "alex-backend",
+    lastMessage: "The API is ready for review.",
+    timestamp: "2024-06-08 17:44",
+    unread: false
+  }
+];
+
 export default function MessagingPage() {
   return (
-    <section className="card">
+    <section>
       <h2>Messaging</h2>
-      <p>Threaded conversations and real-time chat features are represented here.</p>
+      <div className="grid">
+        {threads.map((thread) => (
+          <article className="card" key={thread.id}>
+            <h3>
+              {thread.participant}
+              {thread.unread && <span> 🔵</span>}
+            </h3>
+            <p>{thread.lastMessage}</p>
+            <p>{thread.timestamp}</p>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7357
Parent bounty: #743

Replaced placeholder paragraph with a list of mock conversation threads showing participant name, last message, timestamp, and unread indicator.