### PR TITLE
fix: error handler returns 400 with field details for ZodError

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((e) => ({
+        field: e.path.join("."),
+        message: e.message
+      }))
+    });
   }
 
   return res.status(500).json({


### PR DESCRIPTION
Closes #7365
Parent bounty: #743

## Summary

The global error handler returned `500 Unexpected server error` for **all** errors, including `ZodError` thrown by Zod schema validation. Clients could not distinguish validation failures (400) from actual server errors (500).

## Changes

### `apps/api/src/middleware/errorHandler.js`
Added a `ZodError` branch that returns `400 Bad Request` with structured field-level error details:
```json
{
  "success": false,
  "message": "Validation error",
  "errors": [
    { "field": "amount", "message": "Number must be greater than 0" }
  ]
}
```
Non-Zod errors continue to return `500`.