### PR TITLE
fix: loginUser response includes id and role fields

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -12,9 +12,13 @@ export async function registerUser(payload) {
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const id = "usr_existing";
+  const role = "client";
   return {
+    id,
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    role,
+    token: signAccessToken({ sub: id, role })
   };
 }
 


### PR DESCRIPTION
Closes #7370
Related: #7369
Parent bounty: #743

## Summary

`loginUser` returned only `{ email, token }`. Clients had no access to the user's `id` or `role` without decoding the JWT, and the response shape was inconsistent with `registerUser`.

## Changes

### `apps/api/src/services/authService.js`
- Extracted `id` and `role` as named constants before building the response
- Returns `{ id, email, role, token }` — matching the `registerUser` response shape
- Both `id` and `role` are reused for the JWT claims, ensuring they are consistent