### PR TITLE
fix: prevent client-controlled id override in job, review, and message services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,16 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = {
+    id: `job_${Date.now()}`,
+    status: "open",
+    title: payload.title,
+    description: payload.description,
+    budgetMin: payload.budgetMin,
+    budgetMax: payload.budgetMax,
+    categoryId: payload.categoryId,
+    skills: payload.skills ?? []
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,12 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    id: `msg_${Date.now()}`,
+    recipientId: payload.recipientId,
+    body: payload.body,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,12 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    id: `rev_${Date.now()}`,
+    jobId: payload.jobId,
+    rating: payload.rating,
+    comment: payload.comment
+  };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
Closes #7373
Parent bounty: #743

`jobService`, `reviewService`, and `messageService` all spread the full payload after the server-generated id. A caller passing an `id` field in the request body would overwrite the server id, enabling id injection attacks.

Replaced all three spreads with explicit field assignments so server-generated ids are always used.