### PR TITLE
fix: user service should not allow client-controlled id override

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,12 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = {
+    id: `usr_${Date.now()}`,
+    email: payload.email,
+    fullName: payload.fullName,
+    role: payload.role ?? "client"
+  };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Closes #7372
Parent bounty: #743

`createUser` spread the entire payload after the server-generated id: `{ id: 'usr_...', ...payload }`. A caller passing `{ id: 'custom-id' }` would silently overwrite the server id.

Replaced the spread with explicit field assignment (`email`, `fullName`, `role`) ensuring the server-generated id is always used.