### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4).optional(),
+  description: z.string().min(10).optional(),
+  budgetMin: z.number().nonnegative().optional(),
+  budgetMax: z.number().nonnegative().optional(),
+  categoryId: z.string().min(1).optional(),
+  skills: z.array(z.string().min(1)).optional()
+}).refine((data) => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary

`createJobSchema` accepted payloads where `budgetMax < budgetMin`, creating invalid job records like $500–$100 budgets.

## Changes

- Added `.refine()` to `createJobSchema` — rejects when `budgetMax < budgetMin`
- Added same refinement to `updateJobSchema` — only triggers when both fields are present
- Valid ordered ranges continue to parse successfully

## Files changed

- `apps/api/src/validators/job.js`

Resolves #2853
Resolves #2835
Resolves #2827
Parent bounty: #743