### PR TITLE
fix: job detail route resolves mock job by id

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,22 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job exists for id <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p><strong>Job ID:</strong> {job.id}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

`/jobs/[id]` rendered placeholder text with the raw id instead of looking up the job from `mock.ts`.

## Changes

- Known ids (job-101, job-102, job-103) render matching title and budget
- Unknown ids render a clear not-found fallback

## Files changed

- `apps/web/app/jobs/[id]/page.tsx`

Resolves #2760
Resolves #2755
Resolves #2790
Parent bounty: #743