### PR TITLE
fix: env.js validates required vars in production; JWT_SECRET no longer defaults in prod

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,21 @@
+function requireEnv(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return val;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  jwtSecret: process.env.NODE_ENV === "production"
+    ? requireEnv("JWT_SECRET")
+    : (process.env.JWT_SECRET ?? "development-secret"),
+  stripeSecretKey: process.env.NODE_ENV === "production"
+    ? requireEnv("STRIPE_SECRET_KEY")
+    : (process.env.STRIPE_SECRET_KEY ?? ""),
+  databaseUrl: process.env.NODE_ENV === "production"
+    ? requireEnv("DATABASE_URL")
+    : (process.env.DATABASE_URL ?? "")
 };


### PR DESCRIPTION
## Summary

`env.js` silently accepted empty `DATABASE_URL` / `STRIPE_SECRET_KEY` and defaulted `JWT_SECRET` to `'development-secret'` in all environments.

## Changes

- In production: `DATABASE_URL`, `STRIPE_SECRET_KEY`, and `JWT_SECRET` are required — server throws on startup if missing
- Non-production environments retain fallbacks for local dev convenience

## Files changed

- `apps/api/src/config/env.js`

Resolves #7096
Resolves #7092
Parent bounty: #743