### PR TITLE
fix: freelancer profile route resolves mock profile by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find((f) => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No profile exists for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{profile.username}</h2>
+      <p><strong>Skills:</strong> {profile.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {profile.rate}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

`/freelancers/[username]` showed generic placeholder text instead of looking up the freelancer from `mock.ts`.

## Changes

- Known usernames (maya-dev, jordan-ux) render matching skills and hourly rate
- Unknown usernames render a clear not-found fallback

## Files changed

- `apps/web/app/freelancers/[username]/page.tsx`

Resolves #2763
Resolves #2849
Parent bounty: #743