### PR TITLE
fix: bootstrap() catches unhandled rejection and exits with code 1

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -10,4 +10,7 @@ async function bootstrap() {
   });
 }
 
-bootstrap();
+bootstrap().catch((err) => {
+  console.error("Fatal: server failed to start:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`bootstrap()` was called without `.catch()`, so startup failures produced an unhandled promise rejection and a running-but-broken server.

## Changes

Added `.catch()` that logs the error and calls `process.exit(1)`.

## Files changed

- `apps/api/src/server.js`

Resolves #7083
Parent bounty: #743