### PR TITLE
fix: restrict CORS to trusted origins; move rate limiter before body parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,13 +15,28 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
+  : ["http://localhost:3000"];
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error(`CORS: origin ${origin} not allowed`));
+    }
+  },
+  credentials: true
+};
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
-  app.use(express.json());
+  app.use(cors(corsOptions));
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });


### PR DESCRIPTION
## Summary

CORS was configured with no origin restrictions (`cors()`) and the rate limiter was applied after `express.json()`, meaning large bodies could be parsed before rate limiting kicked in.

## Changes

- CORS origin allowlist sourced from `ALLOWED_ORIGINS` env var (CSV), defaults to `localhost:3000`
- `credentials: true` for cookie/auth flows
- `apiLimiter` moved before `express.json()`

## Files changed

- `apps/api/src/app.js`

Resolves #7089
Resolves #1774
Parent bounty: #743