### PR TITLE
fix: strict rate limit on auth endpoints; skip /health from api limiter

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -4,5 +4,14 @@ export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  skip: (req) => req.path === "/health"
+});
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { success: false, message: "Too many auth attempts, please try again later." }
 });

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);


### PR DESCRIPTION
## Summary

The login/register/refresh endpoints had no dedicated rate limit, making them vulnerable to brute-force. The `/health` endpoint was also subject to the global API limiter, which could exhaust quota for monitoring tools.

## Changes

- Added `authLimiter`: 10 requests per 15-minute window on register/login/refresh
- `apiLimiter` now skips `/health`

## Files changed

- `apps/api/src/middleware/rateLimit.js`
- `apps/api/src/routes/authRoutes.js`

Resolves #7082
Resolves #7090
Resolves #1782
Parent bounty: #743