### PR TITLE
fix: upload endpoint requires auth, enforces 5 MB size limit and MIME type allowlist

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,31 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain"
+];
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Unsupported file type: ${file.mimetype}`));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
## Summary

The upload endpoint had no authentication, no file size limit, and accepted any file type.

## Changes

- Applied `authMiddleware` — uploads now require a valid bearer token
- multer `fileSize` limit set to 5 MB to prevent DoS via large uploads
- `fileFilter` rejects any MIME type not in the allowlist (jpeg/png/gif/webp/pdf/txt)

## Files changed

- `apps/api/src/routes/uploadRoutes.js`

Resolves #7075
Resolves #7095
Resolves #1771
Parent bounty: #743