### PR TITLE
fix: wire Zod validation into all unvalidated POST controllers

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,6 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,6 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,6 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((e) => ({ path: e.path.join("."), message: e.message }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().min(1),
+  body: z.string().min(1)
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().min(1),
+  userId: z.string().min(1).optional()
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).default("usd"),
+  jobId: z.string().min(1).optional()
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.string().min(1),
+  coverLetter: z.string().min(1).optional()
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1).optional()
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
## Summary

Six controllers passed `req.body` directly to service functions with no validation.

## Changes

All POST handlers now parse `req.body` through their Zod schema before calling the service. Invalid payloads rejected with 400 via errorHandler.

## Files changed

- `apps/api/src/controllers/reviewController.js`
- `apps/api/src/controllers/messageController.js`
- `apps/api/src/controllers/proposalController.js`
- `apps/api/src/controllers/notificationController.js`
- `apps/api/src/controllers/paymentController.js`
- `apps/api/src/controllers/userController.js`

Resolves #7067
Resolves #7068
Resolves #7069
Resolves #7070
Resolves #7094
Resolves #1773
Parent bounty: #743