### PR TITLE
fix: expose importable JS entrypoint for @freelanceflow/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@freelanceflow/ui",
+  "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "types": "./src/index.d.ts"
+    }
+  }
 }

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,2 @@
+export * from "./Button.js";
+export * from "./Card.js";


### PR DESCRIPTION
## Summary

`@freelanceflow/ui` declared `main` as `src/index.ts` with no JS entrypoints, making `import('@freelanceflow/ui')` fail at runtime.

## Changes

- Added `src/index.js` as a real JavaScript entrypoint
- Updated `package.json` with `main`, `types`, and `exports` fields

## Files changed

- `packages/ui/package.json`
- `packages/ui/src/index.js` (new)

Resolves #2781
Resolves #2787
Parent bounty: #743