### PR TITLE
fix: validate and length-limit search query; remove admin link from public nav

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,20 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let q = req.query.q;
+
+  if (Array.isArray(q)) {
+    return fail(res, "Query parameter q must be a single string", 400);
+  }
+
+  if (typeof q !== "string") {
+    q = "";
+  }
+
+  q = q.trim().slice(0, MAX_QUERY_LENGTH);
+  return ok(res, await globalSearch(q));
 }

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -6,8 +6,7 @@ const links = [
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
 export function Navigation() {


### PR DESCRIPTION
## Summary

- Search endpoint passed `req.query.q` to the service unvalidated — attacker could send huge strings or repeated params
- Navigation bar exposed `/admin` to all unauthenticated users

## Changes

- Search: rejects array `q` with 400, trims and truncates to 200 chars
- Navigation: removed `/admin` from public nav

## Files changed

- `apps/api/src/controllers/searchController.js`
- `apps/web/components/Navigation.tsx`

Resolves #7322
Resolves #7076
Resolves #2833
Resolves #1777
Resolves #1781
Parent bounty: #743