### PR TITLE
fix: add npm override for postcss>=8.5.10 to patch GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
+  },
+  "overrides": {
+    "postcss": ">=8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

`npm audit --omit=dev` reported a moderate XSS advisory (GHSA-qx2v-qp2m-jg93) for PostCSS <8.5.10 pulled in transitively by Next.js.

## Change

Added root-level `overrides` so the workspace resolves `postcss@8.5.10+`.

```json
"overrides": {
  "postcss": ">=8.5.10"
}
```

## Files changed

- `package.json`

Resolves #1779
Parent bounty: #743