### PR TITLE
fix: admin routes require admin role — any authenticated user was previously allowed in

### DIFF
--- a/apps/api/src/middleware/requireRole.js
+++ b/apps/api/src/middleware/requireRole.js
@@ -1,0 +1,10 @@
+import { fail } from "../utils/response.js";
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/requireRole.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary

Admin routes applied `authMiddleware` (valid JWT) but had no role check. Any authenticated user with a `client` or `freelancer` token could access `/api/admin/metrics`.

## Changes

- Added `requireRole(...roles)` middleware that checks `req.user.role` against an allowlist and returns 403 if not matched
- Admin routes now chain `authMiddleware → requireRole('admin')`

## Files changed

- `apps/api/src/middleware/requireRole.js` (new)
- `apps/api/src/routes/adminRoutes.js`

Resolves #1770
Resolves #1764
Resolves #7320
Parent bounty: #743