### PR TITLE
fix: userService strips caller-supplied id to prevent id injection

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _id, ...safe } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safe };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

`createUser` spread the full payload after the server-generated id, allowing a caller to pass `{ id: 'custom' }` and override the generated id.

## Change

Destructures and discards the `id` field from the payload before constructing the user record.

## Files changed

- `apps/api/src/services/userService.js`

Resolves #1766
Parent bounty: #743