### PR TITLE
test: comprehensive API tests for auth, jobs, payments, and admin role checks

### DIFF
--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((res, rej) => { server.once("listening", () => res(server)); server.once("error", rej); });
+}
+function close(server) {
+  return new Promise((res, rej) => server.close((e) => e ? rej(e) : res()));
+}
+
+test("GET /api/admin/metrics - rejects unauthenticated", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+  assert.equal(res.status, 401);
+  await close(server);
+});
+
+test("GET /api/admin/metrics - rejects non-admin role", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const regRes = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "client@test.com", password: "password1", fullName: "Client User", role: "client" })
+  });
+  const { data } = await regRes.json();
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { Authorization: `Bearer ${data.token}` }
+  });
+  assert.equal(res.status, 403);
+  await close(server);
+});

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((res, rej) => { server.once("listening", () => res(server)); server.once("error", rej); });
+}
+function close(server) {
+  return new Promise((res, rej) => server.close((e) => e ? rej(e) : res()));
+}
+
+test("POST /api/auth/register - rejects admin role", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "a@b.com", password: "password1", fullName: "Test", role: "admin" })
+  });
+  assert.ok(res.status === 400 || res.status === 422, `expected 4xx got ${res.status}`);
+  await close(server);
+});
+
+test("POST /api/auth/register - rejects missing fullName", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "a@b.com", password: "password1" })
+  });
+  assert.ok(res.status === 400 || res.status === 422, `expected 4xx got ${res.status}`);
+  await close(server);
+});
+
+test("POST /api/auth/register - token sub matches returned id", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "test@example.com", password: "password1", fullName: "Test User", role: "client" })
+  });
+  const body = await res.json();
+  assert.equal(res.status, 201);
+  const decoded = JSON.parse(Buffer.from(body.data.token.split(".")[1], "base64url").toString());
+  assert.equal(decoded.sub, body.data.id, "JWT sub must match returned id");
+  await close(server);
+});
+
+test("POST /api/auth/refresh - rejects missing token with error", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({})
+  });
+  assert.ok(res.status >= 400, `expected error status got ${res.status}`);
+  await close(server);
+});

--- a/apps/api/src/tests/jobs.test.js
+++ b/apps/api/src/tests/jobs.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((res, rej) => { server.once("listening", () => res(server)); server.once("error", rej); });
+}
+function close(server) {
+  return new Promise((res, rej) => server.close((e) => e ? rej(e) : res()));
+}
+async function getToken(port) {
+  const r = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: `job${Date.now()}@test.com`, password: "password1", fullName: "Tester", role: "client" })
+  });
+  return (await r.json()).data?.token;
+}
+
+test("POST /api/jobs - rejects unauthenticated requests", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title: "Test", description: "A test job description here", budgetMin: 100, budgetMax: 500, categoryId: "c1" })
+  });
+  assert.equal(res.status, 401);
+  await close(server);
+});
+
+test("POST /api/jobs - rejects inverted budget", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const token = await getToken(port);
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ title: "Test", description: "A test job description here", budgetMin: 500, budgetMax: 100, categoryId: "c1" })
+  });
+  assert.ok(res.status === 400 || res.status === 422, `expected 4xx got ${res.status}`);
+  await close(server);
+});
+
+test("POST /api/jobs - server id cannot be injected", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const token = await getToken(port);
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ id: "injected", title: "Test job here ok", description: "A test job description here long enough", budgetMin: 100, budgetMax: 500, categoryId: "c1", status: "closed" })
+  });
+  const body = await res.json();
+  assert.equal(res.status, 201);
+  assert.notEqual(body.data.id, "injected");
+  assert.equal(body.data.status, "open");
+  await close(server);
+});

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function listen(app) {
+  const server = app.listen(0);
+  return new Promise((res, rej) => { server.once("listening", () => res(server)); server.once("error", rej); });
+}
+function close(server) {
+  return new Promise((res, rej) => server.close((e) => e ? rej(e) : res()));
+}
+
+test("POST /api/payments - rejects unauthenticated", async () => {
+  const server = await listen(createApp());
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 100, currency: "usd" })
+  });
+  assert.equal(res.status, 401);
+  await close(server);
+});


### PR DESCRIPTION
## Summary

Adds test coverage for the security behaviors expected by open bounty issues. Tests run with `npm test` (Node built-in test runner).

**auth.test.js**
- Registration rejects `role: admin` → 400/422
- Registration rejects missing `fullName` → 400/422
- Token `sub` matches returned `id` on successful registration
- Refresh without token returns error status

**jobs.test.js**
- Unauthenticated `POST /api/jobs` → 401
- Inverted budget (`budgetMax < budgetMin`) → 400/422
- Caller-supplied `id` and `status: closed` are ignored — server generates id and sets `status: open`

**payments.test.js**
- Unauthenticated `POST /api/payments` → 401

**admin.test.js**
- Unauthenticated `GET /api/admin/metrics` → 401
- Authenticated non-admin (`role: client`) → 403

Parent bounty: #743