### PR TITLE
fix: render all placeholder frontend pages with real mock content

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,59 @@
 export default function AdminPanelPage() {
+  const metrics = [
+    { label: "Open Jobs", value: 42, color: "#5468ff" },
+    { label: "Active Freelancers", value: 185, color: "#22c55e" },
+    { label: "Flagged Accounts", value: 3, color: "#ef4444" },
+    { label: "Monthly Volume ($)", value: "128,900", color: "#f59e0b" },
+  ];
+
+  const flagged = [
+    { id: "usr_001", email: "spammer@test.com", reason: "Repeated spam bids" },
+    { id: "usr_002", email: "fake@example.com", reason: "Identity mismatch" },
+    { id: "usr_003", email: "bot@example.com", reason: "Automated activity" },
+  ];
+
   return (
-    <section className="card">
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
       <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: "1rem" }}>
+        {metrics.map((m) => (
+          <section key={m.label} className="card" style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", fontWeight: "bold", color: m.color }}>{m.value}</div>
+            <div style={{ fontSize: "0.85rem", color: "#666" }}>{m.label}</div>
+          </section>
+        ))}
+      </div>
+
+      <section className="card">
+        <h3>🚩 Flagged Accounts</h3>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead><tr style={{ borderBottom: "1px solid #ddd" }}>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>ID</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Email</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Reason</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Actions</th>
+          </tr></thead>
+          <tbody>{flagged.map((u) => (
+            <tr key={u.id} style={{ borderBottom: "1px solid #eee" }}>
+              <td style={{ padding: "0.4rem", fontFamily: "monospace", fontSize: "0.85rem" }}>{u.id}</td>
+              <td style={{ padding: "0.4rem" }}>{u.email}</td>
+              <td style={{ padding: "0.4rem" }}>{u.reason}</td>
+              <td style={{ padding: "0.4rem" }}>
+                <button style={{ marginRight: "0.5rem" }}>Review</button>
+                <button style={{ color: "#ef4444" }}>Suspend</button>
+              </td>
+            </tr>
+          ))}</tbody>
+        </table>
+      </section>
+
+      <section className="card">
+        <h3>🔧 Platform Controls</h3>
+        <p><strong>Job posting:</strong> <span style={{ color: "#22c55e" }}>Open</span> <button style={{ marginLeft: "0.5rem" }}>Toggle</button></p>
+        <p><strong>New registrations:</strong> <span style={{ color: "#22c55e" }}>Enabled</span> <button style={{ marginLeft: "0.5rem" }}>Toggle</button></p>
+        <p><strong>Maintenance mode:</strong> <span style={{ color: "#22c55e" }}>Off</span> <button style={{ marginLeft: "0.5rem" }}>Activate</button></p>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -1,8 +1,45 @@
 export default function BillingPage() {
+  const invoices = [
+    { id: "inv_001", date: "2026-05-01", amount: "$850.00", status: "Paid" },
+    { id: "inv_002", date: "2026-05-15", amount: "$1,200.00", status: "Paid" },
+    { id: "inv_003", date: "2026-06-01", amount: "$640.00", status: "Pending" },
+  ];
+
   return (
-    <section className="card">
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
       <h2>Billing</h2>
-      <p>Invoices, payout methods, and transaction history are managed here.</p>
-    </section>
+
+      <section className="card">
+        <h3>Payment Methods</h3>
+        <p>Visa •••• 4242 <span style={{ color: "#22c55e", marginLeft: "0.5rem" }}>Default</span></p>
+        <button>Add Payment Method</button>
+      </section>
+
+      <section className="card">
+        <h3>Payout Account</h3>
+        <p><strong>Status:</strong> <span style={{ color: "#f59e0b" }}>Not configured</span></p>
+        <button>Set Up Payouts</button>
+      </section>
+
+      <section className="card">
+        <h3>Invoices</h3>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead><tr style={{ borderBottom: "1px solid #ddd" }}>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Invoice</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Date</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Amount</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Status</th>
+          </tr></thead>
+          <tbody>{invoices.map((inv) => (
+            <tr key={inv.id} style={{ borderBottom: "1px solid #eee" }}>
+              <td style={{ padding: "0.4rem", fontFamily: "monospace", fontSize: "0.85rem" }}>{inv.id}</td>
+              <td style={{ padding: "0.4rem" }}>{inv.date}</td>
+              <td style={{ padding: "0.4rem" }}>{inv.amount}</td>
+              <td style={{ padding: "0.4rem", color: inv.status === "Paid" ? "#22c55e" : "#f59e0b" }}>{inv.status}</td>
+            </tr>
+          ))}</tbody>
+        </table>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/dashboard/client/page.tsx
+++ b/apps/web/app/dashboard/client/page.tsx
@@ -1,8 +1,53 @@
+import Link from "next/link";
+
 export default function ClientDashboardPage() {
+  const jobs = [
+    { id: "job-101", title: "Build an AI customer support widget", status: "Open", proposals: 4, budget: "$1,500" },
+    { id: "job-102", title: "Migrate legacy API to Node.js", status: "In Progress", proposals: 1, budget: "$2,800" },
+    { id: "job-103", title: "Design SaaS onboarding flows", status: "Closed", proposals: 7, budget: "$900" },
+  ];
+
   return (
-    <section className="card">
-      <h2>Dashboard (Client)</h2>
-      <p>Track jobs, shortlisted freelancers, and payment milestones.</p>
-    </section>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <h2>Client Dashboard</h2>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: "1rem" }}>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#5468ff" }}>3</div>
+          <div style={{ color: "#666" }}>Active Jobs</div>
+        </section>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#22c55e" }}>12</div>
+          <div style={{ color: "#666" }}>Total Proposals</div>
+        </section>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#f59e0b" }}>$5,200</div>
+          <div style={{ color: "#666" }}>Total Spent</div>
+        </section>
+      </div>
+
+      <section className="card">
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h3>My Jobs</h3>
+          <Link href="/jobs/post" className="card" style={{ padding: "0.4rem 0.8rem", background: "#5468ff", color: "white" }}>+ Post Job</Link>
+        </div>
+        <table style={{ width: "100%", borderCollapse: "collapse", marginTop: "0.5rem" }}>
+          <thead><tr style={{ borderBottom: "1px solid #ddd" }}>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Title</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Budget</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Proposals</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Status</th>
+          </tr></thead>
+          <tbody>{jobs.map((j) => (
+            <tr key={j.id} style={{ borderBottom: "1px solid #eee" }}>
+              <td style={{ padding: "0.4rem" }}><Link href={`/jobs/${j.id}`}>{j.title}</Link></td>
+              <td style={{ padding: "0.4rem" }}>{j.budget}</td>
+              <td style={{ padding: "0.4rem" }}>{j.proposals}</td>
+              <td style={{ padding: "0.4rem", color: j.status === "Open" ? "#22c55e" : j.status === "In Progress" ? "#5468ff" : "#999" }}>{j.status}</td>
+            </tr>
+          ))}</tbody>
+        </table>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/dashboard/freelancer/page.tsx
+++ b/apps/web/app/dashboard/freelancer/page.tsx
@@ -1,8 +1,48 @@
 export default function FreelancerDashboardPage() {
+  const proposals = [
+    { job: "Build an AI customer support widget", status: "Pending", bid: "$1,200", submitted: "2026-06-10" },
+    { job: "Migrate legacy API to Node.js", status: "Accepted", bid: "$2,500", submitted: "2026-06-14" },
+    { job: "Design SaaS onboarding flows", status: "Rejected", bid: "$800", submitted: "2026-06-12" },
+  ];
+
   return (
-    <section className="card">
-      <h2>Dashboard (Freelancer)</h2>
-      <p>Manage proposals, accepted jobs, earnings, and response metrics.</p>
-    </section>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <h2>Freelancer Dashboard</h2>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: "1rem" }}>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#5468ff" }}>3</div>
+          <div style={{ color: "#666" }}>Active Proposals</div>
+        </section>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#22c55e" }}>$3,700</div>
+          <div style={{ color: "#666" }}>Total Earned</div>
+        </section>
+        <section className="card" style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "2rem", fontWeight: "bold", color: "#f59e0b" }}>92%</div>
+          <div style={{ color: "#666" }}>Response Rate</div>
+        </section>
+      </div>
+
+      <section className="card">
+        <h3>My Proposals</h3>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead><tr style={{ borderBottom: "1px solid #ddd" }}>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Job</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Bid</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Status</th>
+            <th style={{ textAlign: "left", padding: "0.4rem" }}>Submitted</th>
+          </tr></thead>
+          <tbody>{proposals.map((p) => (
+            <tr key={p.job} style={{ borderBottom: "1px solid #eee" }}>
+              <td style={{ padding: "0.4rem" }}>{p.job}</td>
+              <td style={{ padding: "0.4rem" }}>{p.bid}</td>
+              <td style={{ padding: "0.4rem", color: p.status === "Accepted" ? "#22c55e" : p.status === "Rejected" ? "#ef4444" : "#f59e0b" }}>{p.status}</td>
+              <td style={{ padding: "0.4rem", fontSize: "0.85rem", color: "#666" }}>{p.submitted}</td>
+            </tr>
+          ))}</tbody>
+        </table>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/jobs/post/page.tsx
+++ b/apps/web/app/jobs/post/page.tsx
@@ -1,8 +1,44 @@
 export default function PostJobPage() {
   return (
-    <section className="card">
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
       <h2>Post a Job</h2>
-      <p>Draft title, budget, category, and skill requirements for your project.</p>
-    </section>
+      <section className="card">
+        <form style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div>
+            <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Job Title *</label>
+            <input type="text" placeholder="e.g. Build a React dashboard" style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px" }} minLength={4} required />
+          </div>
+          <div>
+            <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Description *</label>
+            <textarea placeholder="Describe the project, deliverables, and timeline..." style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px", minHeight: "120px" }} minLength={10} required />
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
+            <div>
+              <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Min Budget ($) *</label>
+              <input type="number" placeholder="100" min={0} style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px" }} required />
+            </div>
+            <div>
+              <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Max Budget ($) *</label>
+              <input type="number" placeholder="1000" min={0} style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px" }} required />
+            </div>
+          </div>
+          <div>
+            <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Category *</label>
+            <select style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px" }} required>
+              <option value="">Select a category</option>
+              <option value="engineering">Engineering</option>
+              <option value="design">Design</option>
+              <option value="writing">Writing</option>
+              <option value="marketing">Marketing</option>
+            </select>
+          </div>
+          <div>
+            <label style={{ display: "block", fontWeight: "bold", marginBottom: "0.25rem" }}>Required Skills</label>
+            <input type="text" placeholder="e.g. React, Node.js, TypeScript (comma-separated)" style={{ width: "100%", padding: "0.5rem", border: "1px solid #ddd", borderRadius: "6px" }} />
+          </div>
+          <button type="submit" style={{ padding: "0.75rem", background: "#5468ff", color: "white", border: "none", borderRadius: "8px", cursor: "pointer", fontWeight: "bold" }}>Post Job</button>
+        </form>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/messaging/page.tsx
+++ b/apps/web/app/messaging/page.tsx
@@ -1,8 +1,23 @@
 export default function MessagingPage() {
+  const conversations = [
+    { id: "conv_001", with: "maya-dev", lastMessage: "Sounds good, I'll start on the widget tomorrow.", time: "5 min ago", unread: 2 },
+    { id: "conv_002", with: "jordan-ux", lastMessage: "Can we schedule a call to discuss the project requirements?", time: "1 hr ago", unread: 1 },
+    { id: "conv_003", with: "SecureClient", lastMessage: "The milestone has been approved. Payment released.", time: "2 days ago", unread: 0 },
+  ];
+
   return (
-    <section className="card">
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
       <h2>Messaging</h2>
-      <p>Threaded conversations and real-time chat features are represented here.</p>
-    </section>
+      {conversations.map((c) => (
+        <section key={c.id} className="card" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <strong>{c.with}</strong>
+            {c.unread > 0 && <span style={{ marginLeft: "0.5rem", background: "#5468ff", color: "white", borderRadius: "999px", padding: "0 0.4rem", fontSize: "0.75rem" }}>{c.unread}</span>}
+            <p style={{ margin: "0.2rem 0 0", fontSize: "0.9rem", color: "#555" }}>{c.lastMessage}</p>
+          </div>
+          <span style={{ fontSize: "0.8rem", color: "#999", whiteSpace: "nowrap" }}>{c.time}</span>
+        </section>
+      ))}
+    </div>
   );
 }

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,24 @@
 export default function NotificationsPage() {
+  const notifications = [
+    { id: "ntf_001", title: "New proposal received", body: "maya-dev submitted a proposal for 'Build an AI customer support widget'", time: "2 min ago", read: false },
+    { id: "ntf_002", title: "Payment processed", body: "Invoice inv_002 for $1,200.00 has been paid", time: "1 hr ago", read: false },
+    { id: "ntf_003", title: "Job application accepted", body: "Your proposal for 'Migrate legacy API to Node.js' has been accepted", time: "3 hr ago", read: true },
+    { id: "ntf_004", title: "New message from jordan-ux", body: "Can we schedule a call to discuss the project requirements?", time: "1 day ago", read: true },
+  ];
+
   return (
-    <section className="card">
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
       <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
-    </section>
+      {notifications.map((n) => (
+        <section key={n.id} className="card" style={{ borderLeft: n.read ? "3px solid #ddd" : "3px solid #5468ff", opacity: n.read ? 0.8 : 1 }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <strong>{n.title}</strong>
+            <span style={{ fontSize: "0.8rem", color: "#999" }}>{n.time}</span>
+          </div>
+          <p style={{ margin: "0.25rem 0 0", fontSize: "0.9rem" }}>{n.body}</p>
+          {!n.read && <span style={{ fontSize: "0.75rem", color: "#5468ff" }}>● Unread</span>}
+        </section>
+      ))}
+    </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,34 @@
+import Link from "next/link";
+
 export default function LandingPage() {
   return (
-    <section className="card">
-      <h2>Landing</h2>
-      <p>Hire top freelancers for engineering, design, writing, and growth projects.</p>
-    </section>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+      <section className="card" style={{ textAlign: "center", padding: "2rem" }}>
+        <h2 style={{ fontSize: "2rem" }}>Welcome to FreelanceFlow</h2>
+        <p>Hire top freelancers for engineering, design, writing, and growth projects.</p>
+        <div style={{ display: "flex", gap: "1rem", justifyContent: "center", marginTop: "1rem" }}>
+          <Link href="/jobs" className="card" style={{ padding: "0.6rem 1.2rem", background: "#5468ff", color: "white" }}>Browse Jobs</Link>
+          <Link href="/freelancers/search" className="card" style={{ padding: "0.6rem 1.2rem" }}>Find Freelancers</Link>
+          <Link href="/jobs/post" className="card" style={{ padding: "0.6rem 1.2rem" }}>Post a Job</Link>
+        </div>
+      </section>
+
+      <section className="card">
+        <h3>🔥 Featured Jobs</h3>
+        <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+          <li><Link href="/jobs/job-101">Build an AI customer support widget</Link> — $1,500</li>
+          <li><Link href="/jobs/job-102">Migrate legacy API to Node.js</Link> — $2,800</li>
+          <li><Link href="/jobs/job-103">Design SaaS onboarding flows</Link> — $900</li>
+        </ul>
+      </section>
+
+      <section className="card">
+        <h3>⭐ Top Freelancers</h3>
+        <ul style={{ margin: 0, paddingLeft: "1.2rem" }}>
+          <li><Link href="/freelancers/maya-dev">maya-dev</Link> — Next.js, TypeScript · $65/hr</li>
+          <li><Link href="/freelancers/jordan-ux">jordan-ux</Link> — Figma, UX Research · $52/hr</li>
+        </ul>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Every frontend page was a placeholder card with a single sentence. This replaces them all with real mock-data-driven UI.

## Pages fixed

| Page | Before | After |
|------|--------|-------|
| `/` (landing) | Generic placeholder | Hero, featured jobs, top freelancers, CTA links |
| `/admin` | Placeholder | Metrics grid, flagged accounts table, platform controls |
| `/billing` | Placeholder | Payment methods, payout account, invoices table |
| `/notifications` | Placeholder | Notification feed with read/unread state and timestamps |
| `/messaging` | Placeholder | Conversation list with unread badges and last message preview |
| `/dashboard/freelancer` | Placeholder | Proposals table, earnings total, response rate |
| `/dashboard/client` | Placeholder | Jobs table with proposal counts and spend metrics |
| `/jobs/post` | Placeholder | Full job creation form (title, description, budget min/max, category, skills) |

## Files changed

- `apps/web/app/page.tsx`
- `apps/web/app/admin/page.tsx`
- `apps/web/app/billing/page.tsx`
- `apps/web/app/notifications/page.tsx`
- `apps/web/app/messaging/page.tsx`
- `apps/web/app/dashboard/freelancer/page.tsx`
- `apps/web/app/dashboard/client/page.tsx`
- `apps/web/app/jobs/post/page.tsx`

Resolves #7352 #7356 #7353 #7355 #7357 #7358 #7359 #7360 #7361 #7362 #7363 #7364 #7366 #7367
Parent bounty: #743