### PR TITLE
fix: add Zod validation to user creation endpoint

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
 import { createUser, listUsers } from "../services/userService.js";
-
-export async function getUsers(req, res) {
-  return ok(res, await listUsers());
-}
-
+export async function getUsers(req, res) { return ok(res, await listUsers()); }
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
## Summary

`POST /api/users` passed `req.body` directly to the service with no validation — empty payloads, invalid emails, and caller-controlled ids were all accepted.

## Changes

- Added `createUserSchema` (email, fullName, role)
- `postUser` controller parses `req.body` through the schema — invalid payloads return 400

## Files changed

- `apps/api/src/validators/user.js` (new)
- `apps/api/src/controllers/userController.js`

Resolves #7321
Resolves #1773
Resolves #1766
Parent bounty: #743