### PR TITLE
fix: require authentication on message, review, and proposal endpoints

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
-
+import { authMiddleware } from "../middleware/auth.js";
 export const messageRoutes = Router();
-
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", authMiddleware, getMessages);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
-
+import { authMiddleware } from "../middleware/auth.js";
 export const proposalRoutes = Router();
-
-proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.get("/", authMiddleware, getProposals);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
-
+import { authMiddleware } from "../middleware/auth.js";
 export const reviewRoutes = Router();
-
-reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.get("/", authMiddleware, getReviews);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
## Summary

`GET` and `POST` on `/api/messages`, `/api/reviews`, and `/api/proposals` were accessible without authentication.

## Change

All six route handlers now require `authMiddleware`. Unauthenticated requests receive 401.

## Files changed
- `apps/api/src/routes/messageRoutes.js`
- `apps/api/src/routes/reviewRoutes.js`
- `apps/api/src/routes/proposalRoutes.js`

Resolves #7339
Resolves #7340
Resolves #7344
Parent bounty: #743