### PR TITLE
fix: health endpoint sets Cache-Control: no-store

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 


### PR DESCRIPTION
The `/health` endpoint had no cache headers. Proxies and CDNs could serve stale health state.\n\nAdded `res.set('Cache-Control', 'no-store')` before the response.\n\nResolves #6905 #6921 #6957 #6964 #6969 #6978 #6984 #7179 #7189 #7214\nParent bounty: #743