### PR TITLE
fix: unknown API routes return JSON 404 instead of falling through

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -39,6 +39,11 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  // JSON 404 for unknown routes
+  app.use((req, res) => {
+    res.status(404).json({ success: false, message: `Route not found: ${req.method} ${req.path}` });
+  });
+
   app.use(errorHandler);
   return app;
 }


### PR DESCRIPTION
Unmatched routes fell through to Express's default HTML 404. Added a catch-all before `errorHandler` that returns `{ success: false, message: 'Route not found: METHOD /path' }` with status 404.\n\nResolves #6943 #6949 #6962 #6970 #6974 #6989 #7132 #7138 #7142\nParent bounty: #743