### PR TITLE
fix: Card and Button components forward native HTML props via rest spread

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ComponentPropsWithoutRef<"button"> & {
+  children: React.ReactNode;
+};
+
+export function Button({ children, style, ...rest }: ButtonProps) {
   return (
     <button
       style={{
@@ -9,8 +13,10 @@ export function Button({ children }: { children: React.ReactNode }) {
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
+      {...rest}
     >
       {children}
     </button>

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.ComponentPropsWithoutRef<"section"> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function Card({ title, children, style, ...rest }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }} {...rest}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Both components had closed prop types — callers could not pass `onClick`, `className`, `data-*`, or `aria-*` attributes.\n\nNow use `ComponentPropsWithoutRef` and spread `...rest` onto the underlying element.\n\nResolves #6898 #6908 #6928 #7153\nParent bounty: #743