### PR TITLE
fix: malformed JSON request bodies return 400 instead of 500

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,6 +21,14 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
+
+  // Return 400 for malformed JSON instead of 500
+  app.use((err, req, res, next) => {
+    if (err.type === 'entity.parse.failed') {
+      return res.status(400).json({ success: false, message: 'Malformed JSON in request body' });
+    }
+    return next(err);
+  });
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
Without a dedicated error handler for `entity.parse.failed`, Express returns 500 for malformed JSON.\n\nAdded 4-arg middleware after `express.json()` that catches parse errors and returns structured 400.\n\nResolves #6916 #6960 #6968 #6990 #7176 #7187\nParent bounty: #743