### PR TITLE
fix: user service strips password and passwordHash from stored records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _id, password: _pw, passwordHash: _hash, ...safe } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safe };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
`createUser` spread the full payload which could include password fields.\n\nNow explicitly destructures and discards `password` and `passwordHash` before building the stored record.\n\nResolves #6935 #6955 #6965 #6976 #6988 #7227\nParent bounty: #743