### PR TITLE
docs: add .env.example documenting all required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# ============================================================
+# FreelanceFlow API — Environment Variables
+# Copy to .env and fill in values before running the server.
+# ============================================================
+
+# Server
+NODE_ENV=development
+PORT=4000
+
+# Auth — REQUIRED in production (min 32 chars, randomly generated)
+JWT_SECRET=change-me-to-a-long-random-secret-in-production
+
+# Database — REQUIRED in production
+DATABASE_URL=postgresql://user:password@localhost:5432/freelanceflow
+
+# Stripe — REQUIRED in production
+STRIPE_SECRET_KEY=sk_test_...
+
+# CORS — comma-separated allowed frontend origins
+ALLOWED_ORIGINS=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.*
 coverage
 *.log
+!.env.example


### PR DESCRIPTION
No `.env.example` existed. New developers had no reference for required configuration.\n\nAdded `.env.example` with descriptions and safe placeholder values for NODE_ENV, PORT, JWT_SECRET, DATABASE_URL, STRIPE_SECRET_KEY, and ALLOWED_ORIGINS. Added `!.env.example` to `.gitignore` so it can be checked in.\n\nResolves #6910\nParent bounty: #743