### PR TITLE
fix: auth middleware parses Bearer scheme case-insensitively

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,12 +3,11 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !/^bearer\s+/i.test(authHeader)) {
     return fail(res, "Unauthorized", 401);
   }
-
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    req.user = verifyAccessToken(authHeader.replace(/^bearer\s+/i, ""));
     return next();
   } catch {
     return fail(res, "Invalid token", 401);


### PR DESCRIPTION
RFC 7235 allows the auth-scheme to be case-insensitive. `startsWith('Bearer ')` rejected valid tokens sent as `bearer token` or `BEARER token`.\n\nReplaced with `/^bearer\s+/i` regex test and replace.\n\nResolves #6937 #6992\nParent bounty: #743