### PR TITLE
fix: rate limiter returns JSON 429 error responses; skip /health; add authLimiter

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -4,5 +4,19 @@ export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  skip: (req) => req.path === "/health",
+  handler: (req, res) => {
+    res.status(429).json({ success: false, message: "Too many requests, please try again later." });
+  }
+});
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({ success: false, message: "Too many auth attempts, please try again later." });
+  }
 });


### PR DESCRIPTION
Rate limiter returned default HTML on 429. /health was subject to the global limiter. No dedicated brute-force protection on auth routes.\n\n- Custom JSON handler on apiLimiter and authLimiter\n- /health skipped from apiLimiter\n- authLimiter: 10 req/15min\n\nResolves #6884 #6890 #7082 #7090\nParent bounty: #743