### PR TITLE
fix: payment creation rejects non-positive amounts via Zod validation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,7 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
-
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
-
-export async function getProposals(req, res) {
-  return ok(res, await listProposals());
-}
-
+export async function getProposals(req, res) { return ok(res, await listProposals()); }
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+export const createPaymentSchema = z.object({
+  amount: z.number().positive("amount must be a positive number"),
+  currency: z.string().length(3).default("usd"),
+  jobId: z.string().min(1).optional()
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.string().min(1, "estimatedDuration is required"),
+  coverLetter: z.string().min(1).optional()
+});


### PR DESCRIPTION
`createPaymentSchema` enforces `amount > 0`. Zero and negative values return 400 with a field-level error.\n\nResolves #6917 #6987 #7218 #7351\nParent bounty: #743