### PR TITLE
fix: all services strip caller-supplied id to prevent id injection

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,8 @@
 const jobs = [];
-
-export async function listJobs() {
-  return jobs;
-}
-
+export async function listJobs() { return jobs; }
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _id, status: _s, ...safe } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safe };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,8 @@
 const messages = [];
-
-export async function listMessages() {
-  return messages;
-}
-
+export async function listMessages() { return messages; }
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _id, sentAt: _s, ...safe } = payload;
+  const message = { id: `msg_${Date.now()}`, ...safe, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,8 @@
 const notifications = [];
-
-export async function listNotifications() {
-  return notifications;
-}
-
+export async function listNotifications() { return notifications; }
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _r, ...safe } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safe };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,8 @@
 const proposals = [];
-
-export async function listProposals() {
-  return proposals;
-}
-
+export async function listProposals() { return proposals; }
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _id, ...safe } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...safe };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,8 @@
 const reviews = [];
-
-export async function listReviews() {
-  return reviews;
-}
-
+export async function listReviews() { return reviews; }
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _id, ...safe } = payload;
+  const review = { id: `rev_${Date.now()}`, ...safe };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,8 @@
 const users = [];
-
-export async function listUsers() {
-  return users;
-}
-
+export async function listUsers() { return users; }
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _id, password: _pw, passwordHash: _hash, ...safe } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safe };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
job, review, message, proposal, notification, and user services all prevent id injection by destructuring and discarding caller-supplied fields before building records.\n\n- jobService: strips id + status (always open)\n- notificationService: strips id + read (always false)\n- messageService: strips id + sentAt (always server timestamp)\n- userService: strips id + password + passwordHash\n\nResolves #7219 #7220 #7226 #7227 #7228 #7229 #7314 #7318 #7372 #7373 #7196\nParent bounty: #743