### PR TITLE
fix: proposal creation requires estimatedDuration field

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
-
-export async function getProposals(req, res) {
-  return ok(res, await listProposals());
-}
-
+export async function getProposals(req, res) { return ok(res, await listProposals()); }
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.string().min(1, "estimatedDuration is required"),
+  coverLetter: z.string().min(1).optional()
+});


### PR DESCRIPTION
`createProposalSchema` marks `estimatedDuration` as required (`z.string().min(1)`). Missing or empty value returns 400 with a field-level error via errorHandler.\n\nResolves #6932 #6941 #6994 #7007 #7324\nParent bounty: #743