### PR TITLE
fix: search endpoint validates and length-limits query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let q = req.query.q;
+  if (Array.isArray(q)) return fail(res, "Query parameter q must be a single string", 400);
+  if (typeof q !== "string") q = "";
+  q = q.trim().slice(0, MAX_QUERY_LENGTH);
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
- Rejects array q params with 400\n- Trims and truncates to 200 chars\n- Handles missing q gracefully\n\nResolves #6875 #6886 #7013 #7022 #7024 #7238 #7304 #7322 #1777 #1781\nParent bounty: #743