### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests/*.test.js"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const result = createUserSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  return ok(res, await createUser(result.data), 201);
 }

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", arbitrary: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});
+
+test("POST /api/users creates users from validated payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "maya@example.com",
+        passwordHash: "hashed-password",
+        fullName: "Maya Dev",
+        role: "FREELANCER"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.email, "maya@example.com");
+    assert.equal(payload.data.fullName, "Maya Dev");
+    assert.equal(payload.data.role, "FREELANCER");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -8,4 +8,10 @@ export const createUserSchema = z.object({
   role: z.enum(["CLIENT", "FREELANCER", "ADMIN"]).default("CLIENT")
 });
 
-export const updateUserSchema = createUserSchema.partial();
+export const updateUserSchema = z.object({
+  email: z.string().email().optional(),
+  passwordHash: z.string().min(1).optional(),
+  fullName: z.string().min(1).optional(),
+  bio: z.string().optional(),
+  role: z.enum(["CLIENT", "FREELANCER", "ADMIN"]).optional()
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  passwordHash: z.string().min(1),
+  fullName: z.string().min(1),
+  bio: z.string().optional(),
+  role: z.enum(["CLIENT", "FREELANCER", "ADMIN"]).default("CLIENT")
+});
+
+export const updateUserSchema = createUserSchema.partial();


### PR DESCRIPTION
## Summary
- add a Zod schema for user creation payloads
- validate `POST /api/users` before passing data to `createUser`
- add focused API tests for invalid and valid user creation payloads
- update the API test script so Node's test runner executes the test files explicitly

## Root cause
`postUser` passed `req.body` directly into the service layer, so malformed or arbitrary records could be persisted through `POST /api/users`.

## Validation
- `npm test`

Closes #7428
