### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coverLetter: "too short", arbitrary: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});
+
+test("POST /api/proposals creates proposals from validated payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        coverLetter: "I can deliver this project with clean milestones.",
+        bidAmount: 1200,
+        estDuration: "2 weeks",
+        jobId: "job_123",
+        freelancerId: "usr_456"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.coverLetter, "I can deliver this project with clean milestones.");
+    assert.equal(payload.data.bidAmount, 1200);
+    assert.equal(payload.data.estDuration, "2 weeks");
+    assert.equal(payload.data.jobId, "job_123");
+    assert.equal(payload.data.freelancerId, "usr_456");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1),
+  freelancerId: z.string().min(1)
+});
+
+export const updateProposalSchema = createProposalSchema.partial();


### PR DESCRIPTION
## Summary
- add a Zod schema for proposal creation payloads
- validate `POST /api/proposals` before passing data to `createProposal`
- add focused API tests for invalid and valid proposal creation payloads
- update the API test script so Node's test runner executes test files recursively

## Root cause
`postProposal` passed `req.body` directly into the service layer, so malformed proposal records could be persisted without required proposal fields.

## Validation
- `npm test`

Closes #7430
