### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid request payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/messages.test.js
+++ b/apps/api/src/tests/messages.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: "", arbitrary: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request payload"
+    });
+  });
+});
+
+test("POST /api/messages creates messages from validated payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        body: "Thanks, I can start on this today.",
+        senderId: "usr_sender",
+        receiverId: "usr_receiver"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.body, "Thanks, I can start on this today.");
+    assert.equal(payload.data.senderId, "usr_sender");
+    assert.equal(payload.data.receiverId, "usr_receiver");
+    assert.equal(typeof payload.data.sentAt, "string");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  body: z.string().min(1),
+  senderId: z.string().min(1),
+  receiverId: z.string().min(1)
+});
+
+export const updateMessageSchema = createMessageSchema.partial();


### PR DESCRIPTION
## Summary
- add a Zod schema for message creation payloads
- validate `POST /api/messages` before passing data to `sendMessage`
- add focused API tests for invalid and valid message creation payloads
- update the API test script so Node's test runner executes test files recursively

## Root cause
`postMessage` passed `req.body` directly into the service layer, so malformed message records could be persisted without a message body, sender id, or receiver id.

## Validation
- `npm test`

Closes #7432
