### PR TITLE
fix: prevent client-controlled id override in job, review, and message services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { title, description, budgetMin, budgetMax, categoryId, skills } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", title, description, budgetMin, budgetMax, categoryId, skills };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { content, senderId, receiverId, jobId } = payload;
+  const message = { id: `msg_${Date.now()}`, content, senderId, receiverId, jobId, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { rating, comment, jobId, freelancerId, clientId } = payload;
+  const review = { id: `rev_${Date.now()}`, rating, comment, jobId, freelancerId, clientId };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
## Summary

Prevents client-controlled `id` override in `jobService.js`, `reviewService.js`, and `messageService.js` by destructuring only known safe fields from the payload instead of spreading the full object.

## Changes

- **jobService.js**: Extract `title, description, budgetMin, budgetMax, categoryId, skills` from payload
- **reviewService.js**: Extract `rating, comment, jobId, freelancerId, clientId` from payload  
- **messageService.js**: Extract `content, senderId, receiverId, jobId` from payload

Server-generated `id` and `status` fields are now immutable — clients cannot overwrite them via request body injection.

## Issue

Fixes #1662 (reissue of #7373)

## Testing

- Syntax check passed for all 3 modified files
- Existing health test passes (`node --test src/tests/health.test.js` ✔)
- Note: `npm test` script has a pre-existing path resolution issue unrelated to this change

## Verification

```js
// Before: client could inject id
createJob({ id: "spoofed_123", title: "test" }) // → { id: "spoofed_123", ... }

// After: server-generated id preserved
createJob({ id: "spoofed_123", title: "test" }) // → { id: "job_1234567890", ... }
```