### PR TITLE
fix: prevent client-controlled id override in user and message services

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { content, senderId, receiverId, jobId } = payload;
+  const message = { id: `msg_${Date.now()}`, content, senderId, receiverId, jobId, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { email, password, role } = payload;
+  const user = { id: `usr_${Date.now()}`, email, password, role };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

Prevents client-controlled `id` override in `userService.js` and `messageService.js` by destructuring only known safe fields from the payload instead of spreading the full object.

## Changes

- **userService.js**: Extract `email, password, role` from payload
- **messageService.js**: Extract `content, senderId, receiverId, jobId` from payload

Server-generated `id` is now immutable — clients cannot overwrite it via request body injection.

## Issue

Fixes #1656 (reissue of #7372)

## Testing

- Syntax check passed for all modified files
- Existing health test passes (`node --test src/tests/health.test.js` ✔)
- Note: `npm test` script has a pre-existing path resolution issue unrelated to this change

## Verification

```js
// Before: client could inject id
createUser({ id: "spoofed_123", email: "test@x.com" }) // → { id: "spoofed_123", ... }

// After: server-generated id preserved
createUser({ id: "spoofed_123", email: "test@x.com" }) // → { id: "usr_1234567890", ... }
```