### PR TITLE
fix(critical): admin privilege escalation — any authenticated user could access admin endpoints

### DIFF
--- a/apps/api/src/middleware/requireRole.js
+++ b/apps/api/src/middleware/requireRole.js
@@ -1,0 +1,10 @@
+import { fail } from "../utils/response.js";
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/requireRole.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Severity: Critical — Privilege Escalation

`/api/admin/metrics` was protected by `authMiddleware` only. Any valid JWT — including client/freelancer tokens — passed the check and received admin data.

### Fix
Added `requireRole.js` middleware and wired it on the admin router:
```
adminRoutes.use(authMiddleware);
adminRoutes.use(requireRole('admin'));
```
Non-admin requests now receive **403 Forbidden** immediately.

Resolves #1770
Resolves #1764
Resolves #7320
Parent bounty: #743