### PR TITLE
fix(critical): auth — fullName required; no admin self-assign; token sub matches id; login returns id+role; OAuth validates provider; refresh requires token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema, SUPPORTED_OAUTH_PROVIDERS } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -15,13 +15,15 @@ export async function login(req, res) {
 }
 
 export async function oauthCallback(req, res) {
-  return ok(res, {
-    provider: req.params.provider,
-    status: "callback-received"
-  });
+  const provider = req.params.provider;
+  if (!SUPPORTED_OAUTH_PROVIDERS.includes(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
+  return ok(res, { provider, status: "callback-received" });
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { refreshToken: token } = refreshSchema.parse(req.body);
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,35 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+  // TODO: persist new user via Prisma; check for duplicate email
+  const id = `usr_${Date.now()}`;
+  const { password: _pw, ...safePayload } = payload;
   return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    id,
+    email: safePayload.email,
+    fullName: safePayload.fullName,
+    role: safePayload.role,
+    token: signAccessToken({ sub: id, role: safePayload.role }),
+    refreshToken: signRefreshToken({ sub: id, role: safePayload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  // TODO: look up user, verify bcrypt password hash, require isVerified === true
+  const id = "usr_existing";
   return {
+    id,
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    role: "client",
+    token: signAccessToken({ sub: id, role: "client" }),
+    refreshToken: signRefreshToken({ sub: id, role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const decoded = verifyRefreshToken(token);
+  return {
+    token: signAccessToken({ sub: decoded.sub, role: decoded.role }),
+    refreshToken: signRefreshToken({ sub: decoded.sub, role: decoded.role })
+  };
 }

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,14 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
+  return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,10 +3,17 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});
+
+export const SUPPORTED_OAUTH_PROVIDERS = ["google", "github"];


### PR DESCRIPTION
## Critical auth service bugs — 6 issues in one

### Problems fixed

**1. Admin self-assignment on register** (#7235, #7191, #7216)
`role` enum now only accepts `client | freelancer`. Passing `admin` triggers a Zod validation error.

**2. JWT sub ≠ returned id** (#7323, #7217, #7247)
Previously two separate `Date.now()` calls meant the token `sub` and the returned `id` were different values. Now one `id` is generated and reused for both.

**3. Login response missing id and role** (#7370)
`loginUser` now returns `{ id, email, role, token, refreshToken }`.

**4. Refresh token minted without any credential** (#7168, #7194)
`POST /auth/refresh` required no body at all — any unauthenticated caller could get a fresh access token. The endpoint now validates a `refreshToken` field via Zod and verifies it cryptographically before issuing new tokens.

**5. OAuth callback reflects arbitrary provider strings** (#7162, #7195)
Provider is now checked against an allowlist (`google`, `github`); unsupported values return 400.

**6. Registration requires fullName** (#7245)
`fullName` is now a required field in `registerSchema`, matching the User model.

**Bonus:** password stripped from register response (#7369); refresh token also issued on register/login.