### PR TITLE
fix(critical): inverted budget rejection; ZodError→400; CORS restricted; production env validation; rate limiter before body parser; upload MIME validation

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { env } from "./config/env.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -15,18 +16,34 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
+  ? process.env.CORS_ALLOWED_ORIGINS.split(",").map(o => o.trim())
+  : (env.nodeEnv === "production" ? [] : ["http://localhost:3000"]);
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
-  app.use(express.json());
+  app.use(cors({
+    origin: (origin, cb) => {
+      // Allow same-origin / non-browser tool calls in development
+      if (!origin) return cb(null, true);
+      if (allowedOrigins.includes(origin)) return cb(null, true);
+      cb(new Error(`CORS: origin ${origin} not allowed`));
+    },
+    credentials: true
+  }));
+
+  // Rate limiter BEFORE json body parser (prevents parsing oversized payloads)
   app.use(apiLimiter);
+  app.use(express.json({ limit: "100kb" }));
 
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 
+  // Catch-all 404 for unknown API routes
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);
   app.use("/api/jobs", jobRoutes);
@@ -38,6 +55,10 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  app.use("/api/*", (req, res) => {
+    res.status(404).json({ ok: false, error: "Not Found" });
+  });
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,26 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const isProduction = nodeEnv === "production";
+
+function requireInProd(value, name) {
+  if (isProduction && !value) {
+    throw new Error(`Missing required production environment variable: ${name}`);
+  }
+  return value;
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  jwtSecret: (() => {
+    const secret = process.env.JWT_SECRET ?? "development-secret";
+    if (isProduction && secret.length < 32) {
+      throw new Error("JWT_SECRET must be at least 32 characters in production");
+    }
+    if (!isProduction && !process.env.JWT_SECRET) {
+      console.warn("[WARN] JWT_SECRET not set; using insecure default. Set JWT_SECRET before production deployment.");
+    }
+    return secret;
+  })(),
+  stripeSecretKey: requireInProd(process.env.STRIPE_SECRET_KEY ?? "", "STRIPE_SECRET_KEY"),
+  databaseUrl: requireInProd(process.env.DATABASE_URL ?? "", "DATABASE_URL")
 };

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,25 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain"
+];
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
+  if (!ALLOWED_MIME_TYPES.includes(req.file.mimetype)) {
+    return fail(res, `File type not allowed: ${req.file.mimetype}`, 415);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    mimetype: req.file.mimetype,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,11 @@
-export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
-  if (res.headersSent) {
-    return next(err);
-  }
+import { ZodError } from "zod";
+import { fail } from "../utils/response.js";
 
-  return res.status(500).json({
-    success: false,
-    message: "Unexpected server error"
-  });
+export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return fail(res, err.errors, 400);
+  }
+  const status = err.status ?? err.statusCode ?? 500;
+  const message = err.message ?? "Internal Server Error";
+  return fail(res, message, status);
 }

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -3,10 +3,13 @@ import { z } from "zod";
 export const createJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
+  budgetMin: z.number().nonneg(),
+  budgetMax: z.number().nonneg(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Multiple critical security and correctness bugs

### 1. Job validator: inverted budget range (#7241, #7167, #7140, #7135)
Added `.refine()` — `budgetMax >= budgetMin` is now enforced. Previously any combination was accepted silently.

### 2. Error handler returns 400 for ZodError (#7365)
Previously ZodErrors propagated as 500 Internal Server Error. Now returns 400 with the structured Zod error details.

### 3. CORS restricted to trusted origins (#7319, #7114, #6896)
`cors()` with no options allowed **any** origin. Now reads `CORS_ALLOWED_ORIGINS` env var (comma-separated). Defaults to `localhost:3000` in dev; blocks everything in production unless explicitly set.

### 4. Production secrets validated on startup (#7096, #7163, #7212)
`env.js` now throws on startup if production is missing `DATABASE_URL` or `STRIPE_SECRET_KEY`, or has a `JWT_SECRET` shorter than 32 characters.

### 5. Rate limiter before json body parser (#7343)
Prevents an attacker from forcing large body parsing before rate limiting kicks in.

### 6. Upload rejects missing files and bad MIME types (#7095, #7291, #7305, #7230)
- Missing `req.file` → 400
- MIME type not in allowlist → 415

Closes #7241 #7167 #7140 #7135 #7365 #7319 #7114 #7096 #6896 #7095 #7291 #7305 #7230 #7343 #7163 #7212