### PR TITLE
fix: job service strips caller-supplied id and status fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _id, status: _status, ...safe } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safe };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
## Id and status injection in job creation

A caller could pass `{ id: "any-id", status: "closed" }` and the spread would override the server-generated values.

Now strips `id` and `status` from the payload before merging, so the server always owns those fields.

Closes #7226 #7318