### PR TITLE
fix(critical): payment requires auth + Zod validation; upload requires auth

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const SUPPORTED_CURRENCIES = ["usd", "eur", "gbp", "cad", "aud"];
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive({ message: "amount must be a positive number" }),
+  currency: z.string()
+    .transform(c => c.toLowerCase())
+    .refine(c => SUPPORTED_CURRENCIES.includes(c), {
+      message: `currency must be one of: ${SUPPORTED_CURRENCIES.join(", ")}`
+    })
+    .default("usd"),
+  jobId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Payment and upload endpoints missing authentication

### Problems

1. **POST /api/payments** — no authentication (#7251, #7192, #7145): any anonymous caller could create payment intents
2. **POST /api/uploads** — no authentication (#7341): any anonymous caller could upload files  
3. **Payment validation missing** (#7351): non-positive amounts and unsupported currencies accepted

### Fixes

- `paymentRoutes`: added `authMiddleware` to POST
- `uploadRoutes`: added `authMiddleware` before multer on POST
- Added `createPaymentSchema` (Zod): `amount` must be positive; `currency` normalized to lowercase and checked against allowlist (usd/eur/gbp/cad/aud)

Closes #7251 #7192 #7145 #7341 #7351