### PR TITLE
fix(critical): ZodError→400; CORS allowlist; rate limit order; 100kb body; JSON 404; JWT_SECRET prod validation; search validation

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,16 +14,45 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { env } from "./config/env.js";
+
+const allowedOrigins = env.allowedOrigins
+  ? env.allowedOrigins.split(",").map(s => s.trim()).filter(Boolean)
+  : [];
+
+const corsOptions = {
+  origin: allowedOrigins.length > 0
+    ? (origin, cb) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+          cb(null, true);
+        } else {
+          cb(new Error("CORS: origin not allowed"));
+        }
+      }
+    : false, // block all cross-origin requests when no allowlist is set
+  credentials: true
+};
 
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
-  app.use(express.json());
+  app.use(cors(corsOptions));
+
+  // Rate limiter BEFORE body parser so limits apply before parsing large bodies
   app.use(apiLimiter);
 
+  // Body parser with size limit; return 400 on malformed JSON
+  app.use(express.json({ limit: "100kb" }));
+  app.use((err, req, res, next) => {
+    if (err.type === "entity.parse.failed") {
+      return res.status(400).json({ success: false, message: "Malformed JSON" });
+    }
+    return next(err);
+  });
+
   app.get("/health", (req, res) => {
+    res.set("Cache-Control", "no-store");
     res.status(200).json({ ok: true, service: "api" });
   });
 
@@ -38,6 +67,11 @@ export function createApp() {
   app.use("/api/uploads", uploadRoutes);
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
+
+  // Unknown routes → JSON 404 (not HTML fall-through)
+  app.use((req, res) => {
+    res.status(404).json({ success: false, message: "Route not found" });
+  });
 
   app.use(errorHandler);
   return app;

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -3,5 +3,15 @@ export const env = {
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  allowedOrigins: process.env.ALLOWED_ORIGINS ?? ""
 };
+
+// Validate critical secrets in production
+if (env.nodeEnv === "production") {
+  if (!process.env.JWT_SECRET || process.env.JWT_SECRET.length < 32) {
+    throw new Error("JWT_SECRET must be set to at least 32 characters in production");
+  }
+} else if (!process.env.JWT_SECRET) {
+  console.warn("[warn] JWT_SECRET not set — using insecure development default");
+}

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
+import { z } from "zod";
 import { ok } from "../utils/response.js";
-import { globalSearch } from "../services/searchService.js";
+import { searchAll } from "../services/searchService.js";
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1, "Search query required").max(200, "Query too long")
+});
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchQuerySchema.parse(req.query);
+  return ok(res, await searchAll(q));
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors
+    });
   }
 
   return res.status(500).json({


### PR DESCRIPTION
## Critical App Hardening

Closes #7365 #7319 #7343 #7312 #7322 #7304 #7321 #7351

### Changes

**errorHandler.js**
- ZodError now returns 400 with per-field errors instead of 500

**app.js**
- CORS origin restricted to comma-separated ALLOWED_ORIGINS env var; when unset, all cross-origin requests are blocked
- Rate limiter moved before body parser — prevents DoS via large body exhausting the JSON parser before limits fire
- Body parser limited to 100kb — rejects oversized payloads
- Malformed JSON body returns 400 not 500
- Unknown routes return JSON 404 instead of HTML fall-through
- Health endpoint sets Cache-Control: no-store

**config/env.js**
- Throws at startup in production when JWT_SECRET is absent or shorter than 32 characters
- Logs warning in development when JWT_SECRET is unset

**searchController.js**
- Query param validated: required, min 1 char, max 200 chars