### PR TITLE
fix(critical): upload endpoint rejects missing file with 400 and validates MIME type

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,30 @@
 import { ok } from "../utils/response.js";
 
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain"
+];
+
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({ success: false, message: "No file uploaded" });
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(req.file.mimetype)) {
+    return res.status(415).json({
+      success: false,
+      message: `Unsupported file type: ${req.file.mimetype}`
+    });
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    mimetype: req.file.mimetype,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Critical Upload Fix

Closes #7305 #7291

### Problem

The upload endpoint returned 201 success even when no file was included in the request. It also accepted any MIME type with no validation.

### Fix

- `!req.file` => 400 Bad Request with message 'No file uploaded'
- MIME type checked against an allow-list; unsupported types => 415 Unsupported Media Type
- Allowed types: image/jpeg, image/png, image/gif, image/webp, application/pdf, text/plain