### PR TITLE
feat(admin): implement operations control panel

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,90 @@
-import { ok } from "../utils/response.js";
-import { getAdminMetrics } from "../services/adminService.js";
+import { fail, ok } from "../utils/response.js";
+import {
+  getAdminMetrics,
+  getAdminUser,
+  getDispute,
+  getPlatformControls,
+  listAdminUsers,
+  listAuditLog,
+  listDisputes,
+  listModerationJobs,
+  moderateJob,
+  ruleOnDispute,
+  updateAdminUserStatus,
+  updatePlatformControls
+} from "../services/adminService.js";
+
+function sendServiceResult(res, result, successKey) {
+  if (result?.error) {
+    return fail(res, result.error, result.status ?? 400);
+  }
+
+  return ok(res, successKey ? result[successKey] : result);
+}
 
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
+}
+
+export async function users(req, res) {
+  return ok(res, await listAdminUsers(req.query));
+}
+
+export async function userProfile(req, res) {
+  const user = await getAdminUser(req.params.userId);
+  if (!user) {
+    return fail(res, "User not found", 404);
+  }
+
+  return ok(res, user);
+}
+
+export async function userStatus(req, res) {
+  return sendServiceResult(
+    res,
+    await updateAdminUserStatus(req.params.userId, req.body, req.user)
+  );
+}
+
+export async function moderationJobs(req, res) {
+  return ok(res, await listModerationJobs(req.query));
+}
+
+export async function moderationAction(req, res) {
+  return sendServiceResult(
+    res,
+    await moderateJob(req.params.jobId, req.body, req.user)
+  );
+}
+
+export async function disputes(req, res) {
+  return ok(res, await listDisputes(req.query));
+}
+
+export async function disputeDetails(req, res) {
+  const dispute = await getDispute(req.params.disputeId);
+  if (!dispute) {
+    return fail(res, "Dispute not found", 404);
+  }
+
+  return ok(res, dispute);
+}
+
+export async function disputeRuling(req, res) {
+  return sendServiceResult(
+    res,
+    await ruleOnDispute(req.params.disputeId, req.body, req.user)
+  );
+}
+
+export async function controls(req, res) {
+  return ok(res, await getPlatformControls());
+}
+
+export async function updateControls(req, res) {
+  return sendServiceResult(res, await updatePlatformControls(req.body, req.user));
+}
+
+export async function auditLog(req, res) {
+  return ok(res, await listAuditLog(req.query));
 }

--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin access required", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,34 @@
 import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import {
+  auditLog,
+  controls,
+  disputeDetails,
+  disputeRuling,
+  disputes,
+  metrics,
+  moderationAction,
+  moderationJobs,
+  updateControls,
+  userProfile,
+  userStatus,
+  users
+} from "../controllers/adminController.js";
+import { requireAdmin } from "../middleware/admin.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireAdmin);
+
 adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/users", users);
+adminRoutes.get("/users/:userId", userProfile);
+adminRoutes.patch("/users/:userId/status", userStatus);
+adminRoutes.get("/jobs/moderation", moderationJobs);
+adminRoutes.patch("/jobs/moderation/:jobId", moderationAction);
+adminRoutes.get("/disputes", disputes);
+adminRoutes.get("/disputes/:disputeId", disputeDetails);
+adminRoutes.patch("/disputes/:disputeId/ruling", disputeRuling);
+adminRoutes.get("/controls", controls);
+adminRoutes.patch("/controls", updateControls);
+adminRoutes.get("/audit-log", auditLog);

--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,429 @@
-export async function getAdminMetrics() {
-  return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+const seedUsers = [
+  {
+    id: "usr_client_101",
+    name: "Avery Stone",
+    email: "avery@example.com",
+    role: "client",
+    status: "active",
+    joinedAt: "2026-01-12T10:20:00.000Z",
+    trustScore: 86,
+    activeJobs: ["job_marketplace_redesign"],
+    disputes: ["dsp_escrow_copy"]
+  },
+  {
+    id: "usr_freelancer_204",
+    name: "Maya Patel",
+    email: "maya@example.com",
+    role: "freelancer",
+    status: "active",
+    joinedAt: "2026-02-03T14:45:00.000Z",
+    trustScore: 94,
+    activeJobs: ["job_api_audit"],
+    disputes: []
+  },
+  {
+    id: "usr_client_188",
+    name: "Noah Kim",
+    email: "noah@example.com",
+    role: "client",
+    status: "suspended",
+    joinedAt: "2026-03-21T08:10:00.000Z",
+    trustScore: 41,
+    activeJobs: [],
+    disputes: ["dsp_mobile_refund"]
+  },
+  {
+    id: "usr_freelancer_319",
+    name: "Lena Ortiz",
+    email: "lena@example.com",
+    role: "freelancer",
+    status: "under_review",
+    joinedAt: "2026-04-09T18:30:00.000Z",
+    trustScore: 58,
+    activeJobs: ["job_checkout_fix"],
+    disputes: ["dsp_mobile_refund"]
+  }
+];
+
+const seedModerationJobs = [
+  {
+    id: "mod_job_901",
+    title: "Crypto payout integration",
+    postedBy: "usr_client_101",
+    postedByName: "Avery Stone",
+    status: "pending",
+    reason: "Payment terms mention off-platform settlement",
+    reports: 3,
+    flaggedAt: "2026-06-12T12:00:00.000Z",
+    notification: null
+  },
+  {
+    id: "mod_job_902",
+    title: "Scrape competitor profiles",
+    postedBy: "usr_client_188",
+    postedByName: "Noah Kim",
+    status: "pending",
+    reason: "Automated policy scanner detected prohibited scraping language",
+    reports: 5,
+    flaggedAt: "2026-06-13T09:15:00.000Z",
+    notification: null
+  }
+];
+
+const seedDisputes = [
+  {
+    id: "dsp_escrow_copy",
+    clientId: "usr_client_101",
+    freelancerId: "usr_freelancer_204",
+    clientName: "Avery Stone",
+    freelancerName: "Maya Patel",
+    jobTitle: "Landing page copy refresh",
+    status: "open",
+    amountCents: 85000,
+    openedAt: "2026-06-10T11:30:00.000Z",
+    thread: [
+      "Client says final copy missed compliance notes.",
+      "Freelancer attached the approved brief and revision log."
+    ],
+    evidence: ["approved-brief.pdf", "revision-log.md"],
+    transaction: { escrowId: "esc_2039", capturedCents: 85000, refundableCents: 85000 },
+    notifications: []
+  },
+  {
+    id: "dsp_mobile_refund",
+    clientId: "usr_client_188",
+    freelancerId: "usr_freelancer_319",
+    clientName: "Noah Kim",
+    freelancerName: "Lena Ortiz",
+    jobTitle: "Mobile checkout QA",
+    status: "under_review",
+    amountCents: 42000,
+    openedAt: "2026-06-11T16:05:00.000Z",
+    thread: [
+      "Client requested a refund after crash reports continued.",
+      "Freelancer attached device logs showing a third-party SDK fault."
+    ],
+    evidence: ["device-crash.log", "sdk-vendor-ticket.txt"],
+    transaction: { escrowId: "esc_2044", capturedCents: 42000, refundableCents: 30000 },
+    notifications: []
+  }
+];
+
+const seedControls = {
+  registrationsEnabled: true,
+  jobPostingsEnabled: true,
+  lastChangedAt: null,
+  lastChangedBy: null
+};
+
+const seedAuditLog = [
+  {
+    id: "aud_seed_001",
+    adminId: "system",
+    actionType: "system_snapshot",
+    targetType: "platform",
+    targetId: "admin-panel",
+    message: "Admin panel seed state initialized",
+    createdAt: "2026-06-12T00:00:00.000Z"
+  }
+];
+
+let users;
+let moderationJobs;
+let disputes;
+let controls;
+let auditLog;
+
+resetAdminState();
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function adminIdOf(admin) {
+  return admin?.sub ?? admin?.id ?? "admin_unknown";
+}
+
+function appendAudit({ adminId, actionType, targetType, targetId, message }) {
+  const entry = {
+    id: `aud_${Date.now()}_${auditLog.length + 1}`,
+    adminId,
+    actionType,
+    targetType,
+    targetId,
+    message,
+    createdAt: now()
   };
+  auditLog.push(entry);
+  return entry;
+}
+
+function paginate(items, query = {}) {
+  const page = Math.max(Number.parseInt(query.page ?? "1", 10) || 1, 1);
+  const pageSize = Math.min(Math.max(Number.parseInt(query.pageSize ?? "10", 10) || 10, 1), 50);
+  const start = (page - 1) * pageSize;
+
+  return {
+    items: clone(items.slice(start, start + pageSize)),
+    page,
+    pageSize,
+    total: items.length,
+    totalPages: Math.max(Math.ceil(items.length / pageSize), 1)
+  };
+}
+
+function matchesDateRange(isoDate, from, to) {
+  const time = Date.parse(isoDate);
+  if (from && time < Date.parse(from)) return false;
+  if (to && time > Date.parse(to)) return false;
+  return true;
+}
+
+function bucketTrustScores() {
+  return [
+    { range: "0-49", count: users.filter((user) => user.trustScore <= 49).length },
+    { range: "50-74", count: users.filter((user) => user.trustScore >= 50 && user.trustScore <= 74).length },
+    { range: "75-89", count: users.filter((user) => user.trustScore >= 75 && user.trustScore <= 89).length },
+    { range: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+  ];
+}
+
+export function resetAdminState() {
+  users = clone(seedUsers);
+  moderationJobs = clone(seedModerationJobs);
+  disputes = clone(seedDisputes);
+  controls = clone(seedControls);
+  auditLog = clone(seedAuditLog);
+}
+
+export async function getAdminMetrics() {
+  const activeJobs = users.reduce((sum, user) => sum + user.activeJobs.length, 0);
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = moderationJobs.filter((job) => job.status === "pending").length;
+
+  return {
+    totalUsers: users.length,
+    activeJobs,
+    openDisputes,
+    flaggedListings,
+    revenueCurrentPeriodCents: 12890000,
+    controls: clone(controls),
+    trustScoreDistribution: bucketTrustScores(),
+    platformHealth: {
+      api: "operational",
+      payments: "operational",
+      moderationQueueDepth: flaggedListings,
+      disputeSlaBreaches: disputes.filter((dispute) => dispute.status === "open").length
+    },
+    refreshedAt: now()
+  };
+}
+
+export async function listAdminUsers(query = {}) {
+  const search = query.search?.toLowerCase?.().trim();
+  const filtered = users.filter((user) => {
+    if (query.role && user.role !== query.role) return false;
+    if (query.status && user.status !== query.status) return false;
+    if (!matchesDateRange(user.joinedAt, query.joinedFrom, query.joinedTo)) return false;
+    if (search) {
+      const haystack = `${user.name} ${user.email} ${user.id}`.toLowerCase();
+      if (!haystack.includes(search)) return false;
+    }
+    return true;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getAdminUser(userId) {
+  const user = users.find((candidate) => candidate.id === userId);
+  if (!user) return null;
+
+  return clone({
+    ...user,
+    profile: {
+      headline: user.role === "freelancer" ? "Verified freelance operator" : "Marketplace client",
+      activeJobs: user.activeJobs,
+      disputeHistory: user.disputes
+    }
+  });
+}
+
+export async function updateAdminUserStatus(userId, { action, reason }, admin) {
+  const statusByAction = {
+    suspend: "suspended",
+    reinstate: "active",
+    ban: "banned"
+  };
+  const nextStatus = statusByAction[action];
+  if (!nextStatus) {
+    return { error: "Unsupported user action", status: 400 };
+  }
+
+  const user = users.find((candidate) => candidate.id === userId);
+  if (!user) {
+    return { error: "User not found", status: 404 };
+  }
+
+  user.status = nextStatus;
+  user.statusReason = reason ?? null;
+  user.updatedAt = now();
+
+  const audit = appendAudit({
+    adminId: adminIdOf(admin),
+    actionType: `user_${action}`,
+    targetType: "user",
+    targetId: user.id,
+    message: `${action} applied to ${user.email}${reason ? `: ${reason}` : ""}`
+  });
+
+  return { user: clone(user), audit: clone(audit) };
+}
+
+export async function listModerationJobs(query = {}) {
+  const filtered = moderationJobs.filter((job) => {
+    if (query.status && job.status !== query.status) return false;
+    if (!matchesDateRange(job.flaggedAt, query.flaggedFrom, query.flaggedTo)) return false;
+    return true;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function moderateJob(jobId, { action, reason }, admin) {
+  const statusByAction = {
+    approve: "approved",
+    reject: "rejected",
+    escalate: "escalated"
+  };
+  const nextStatus = statusByAction[action];
+  if (!nextStatus) {
+    return { error: "Unsupported moderation action", status: 400 };
+  }
+
+  const job = moderationJobs.find((candidate) => candidate.id === jobId);
+  if (!job) {
+    return { error: "Moderation job not found", status: 404 };
+  }
+
+  job.status = nextStatus;
+  job.resolutionReason = reason ?? null;
+  job.reviewedAt = now();
+  job.reviewedBy = adminIdOf(admin);
+  if (action === "reject") {
+    job.notification = {
+      toUserId: job.postedBy,
+      message: `Your listing "${job.title}" was rejected${reason ? `: ${reason}` : "."}`,
+      createdAt: now()
+    };
+  }
+
+  const audit = appendAudit({
+    adminId: adminIdOf(admin),
+    actionType: `job_${action}`,
+    targetType: "job",
+    targetId: job.id,
+    message: `${action} applied to ${job.title}${reason ? `: ${reason}` : ""}`
+  });
+
+  return { job: clone(job), audit: clone(audit), notification: clone(job.notification) };
+}
+
+export async function listDisputes(query = {}) {
+  const filtered = disputes.filter((dispute) => {
+    if (query.status && dispute.status !== query.status) return false;
+    if (!matchesDateRange(dispute.openedAt, query.openedFrom, query.openedTo)) return false;
+    return true;
+  });
+
+  return paginate(filtered, query);
+}
+
+export async function getDispute(disputeId) {
+  const dispute = disputes.find((candidate) => candidate.id === disputeId);
+  return dispute ? clone(dispute) : null;
+}
+
+export async function ruleOnDispute(disputeId, { action, note }, admin) {
+  const dispute = disputes.find((candidate) => candidate.id === disputeId);
+  if (!dispute) {
+    return { error: "Dispute not found", status: 404 };
+  }
+
+  const resolutionByAction = {
+    favor_client: "resolved",
+    favor_freelancer: "resolved",
+    refund: "resolved",
+    escalate: "under_review"
+  };
+  const nextStatus = resolutionByAction[action];
+  if (!nextStatus) {
+    return { error: "Unsupported dispute action", status: 400 };
+  }
+
+  dispute.status = nextStatus;
+  dispute.ruling = action;
+  dispute.rulingNote = note ?? null;
+  dispute.ruledAt = now();
+  dispute.ruledBy = adminIdOf(admin);
+  dispute.notifications.push(
+    { toUserId: dispute.clientId, message: `Dispute ${dispute.id} updated: ${action}`, createdAt: now() },
+    { toUserId: dispute.freelancerId, message: `Dispute ${dispute.id} updated: ${action}`, createdAt: now() }
+  );
+
+  const audit = appendAudit({
+    adminId: adminIdOf(admin),
+    actionType: `dispute_${action}`,
+    targetType: "dispute",
+    targetId: dispute.id,
+    message: `Ruling ${action} recorded for ${dispute.jobTitle}${note ? `: ${note}` : ""}`
+  });
+
+  return { dispute: clone(dispute), audit: clone(audit) };
+}
+
+export async function getPlatformControls() {
+  return clone(controls);
+}
+
+export async function updatePlatformControls(payload, admin) {
+  if (payload.confirmed !== true) {
+    return { error: "Control changes require confirmation", status: 409 };
+  }
+
+  const changes = {};
+  for (const key of ["registrationsEnabled", "jobPostingsEnabled"]) {
+    if (typeof payload[key] === "boolean" && controls[key] !== payload[key]) {
+      changes[key] = { from: controls[key], to: payload[key] };
+      controls[key] = payload[key];
+    }
+  }
+
+  controls.lastChangedAt = now();
+  controls.lastChangedBy = adminIdOf(admin);
+
+  const audit = appendAudit({
+    adminId: adminIdOf(admin),
+    actionType: "platform_controls_update",
+    targetType: "platform",
+    targetId: "controls",
+    message: `Platform controls updated: ${Object.keys(changes).join(", ") || "no-op"}`
+  });
+
+  return { controls: clone(controls), changes, audit: clone(audit) };
+}
+
+export async function listAuditLog(query = {}) {
+  const filtered = auditLog.filter((entry) => {
+    if (query.adminId && entry.adminId !== query.adminId) return false;
+    if (query.actionType && entry.actionType !== query.actionType) return false;
+    if (!matchesDateRange(entry.createdAt, query.from, query.to)) return false;
+    return true;
+  });
+
+  return paginate([...filtered].reverse(), query);
 }

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,165 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { resetAdminState } from "../services/adminService.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+beforeEach(() => {
+  resetAdminState();
+});
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function token(role = "admin", sub = "admin_test") {
+  return signAccessToken({ sub, role });
+}
+
+function authHeaders(role = "admin") {
+  return {
+    Authorization: `Bearer ${token(role)}`,
+    "Content-Type": "application/json"
+  };
+}
+
+test("admin routes reject non-admin users server-side", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: authHeaders("client")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, { success: false, message: "Admin access required" });
+  });
+});
+
+test("admin metrics include platform health and trust score distribution", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: authHeaders()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.totalUsers, 4);
+    assert.equal(payload.data.flaggedListings, 2);
+    assert.equal(payload.data.platformHealth.api, "operational");
+    assert.equal(payload.data.trustScoreDistribution.length, 4);
+  });
+});
+
+test("admin user list supports role/status search and server-side pagination", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/admin/users?role=client&status=active&page=1&pageSize=1&search=avery`,
+      { headers: authHeaders() }
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.page, 1);
+    assert.equal(payload.data.pageSize, 1);
+    assert.equal(payload.data.total, 1);
+    assert.equal(payload.data.items[0].email, "avery@example.com");
+  });
+});
+
+test("admin can suspend a user and append an audit entry", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/users/usr_freelancer_204/status`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ action: "suspend", reason: "Risk review" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.user.status, "suspended");
+    assert.equal(payload.data.audit.actionType, "user_suspend");
+
+    const auditResponse = await fetch(`${baseUrl}/api/admin/audit-log?actionType=user_suspend`, {
+      headers: authHeaders()
+    });
+    const auditPayload = await auditResponse.json();
+
+    assert.equal(auditPayload.data.total, 1);
+    assert.equal(auditPayload.data.items[0].targetId, "usr_freelancer_204");
+  });
+});
+
+test("rejecting a flagged job records a notification and audit event", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/jobs/moderation/mod_job_902`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ action: "reject", reason: "Prohibited scraping request" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.job.status, "rejected");
+    assert.equal(payload.data.notification.toUserId, "usr_client_188");
+    assert.match(payload.data.notification.message, /rejected/);
+    assert.equal(payload.data.audit.actionType, "job_reject");
+  });
+});
+
+test("platform control changes require confirmation and are audited", async () => {
+  await withServer(async (baseUrl) => {
+    const blocked = await fetch(`${baseUrl}/api/admin/controls`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ registrationsEnabled: false })
+    });
+    const blockedPayload = await blocked.json();
+
+    assert.equal(blocked.status, 409);
+    assert.equal(blockedPayload.message, "Control changes require confirmation");
+
+    const response = await fetch(`${baseUrl}/api/admin/controls`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ registrationsEnabled: false, confirmed: true })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.controls.registrationsEnabled, false);
+    assert.equal(payload.data.audit.actionType, "platform_controls_update");
+  });
+});
+
+test("admin can rule on a dispute and notify both parties", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/disputes/dsp_escrow_copy/ruling`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ action: "refund", note: "Brief mismatch validated" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.dispute.status, "resolved");
+    assert.equal(payload.data.dispute.ruling, "refund");
+    assert.equal(payload.data.dispute.notifications.length, 2);
+    assert.equal(payload.data.audit.actionType, "dispute_refund");
+  });
+});

--- a/apps/web/app/admin/forbidden/page.tsx
+++ b/apps/web/app/admin/forbidden/page.tsx
@@ -1,0 +1,9 @@
+export default function AdminForbiddenPage() {
+  return (
+    <section className="admin-section" role="alert" aria-labelledby="admin-forbidden-title">
+      <p className="eyebrow">403</p>
+      <h2 id="admin-forbidden-title">Admin access required</h2>
+      <p>This route only renders for authenticated admin sessions.</p>
+    </section>
+  );
+}

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,34 @@
-export default function AdminPanelPage() {
-  return (
-    <section className="card">
-      <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
-    </section>
-  );
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { AdminPanel } from "../../components/AdminPanel";
+import { adminSnapshot } from "../../lib/adminMock";
+
+export const dynamic = "force-dynamic";
+
+async function requireAdminSession() {
+  const headerStore = await headers();
+  const cookieStore = await cookies();
+  const role =
+    headerStore.get("x-admin-role") ??
+    cookieStore.get("ff_role")?.value ??
+    process.env.ADMIN_PANEL_ROLE ??
+    "admin";
+
+  if (role !== "admin") {
+    redirect("/admin/forbidden");
+  }
+
+  return {
+    adminId:
+      headerStore.get("x-admin-id") ??
+      cookieStore.get("ff_admin_id")?.value ??
+      process.env.ADMIN_PANEL_ADMIN_ID ??
+      adminSnapshot.session.adminId
+  };
+}
+
+export default async function AdminPanelPage() {
+  const session = await requireAdminSession();
+
+  return <AdminPanel initialState={{ ...adminSnapshot, session }} />;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,50 @@
 * { box-sizing: border-box; }
-body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0b1020; color: #f2f5ff; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0f1420; color: #f2f5ff; }
 a { color: inherit; text-decoration: none; }
-main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem; }
-.card { background: #151c35; border: 1px solid #2a3765; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 1rem; }
+button, input, select { font: inherit; }
+.card { background: #171d2b; border: 1px solid #303a4f; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
 .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.eyebrow { color: #f8bf4a; font-size: 0.78rem; font-weight: 700; letter-spacing: 0; margin: 0 0 0.25rem; text-transform: uppercase; }
+.admin-panel { display: grid; gap: 1rem; }
+.admin-toolbar, .section-head, .control-row { align-items: center; display: flex; gap: 1rem; justify-content: space-between; }
+.admin-toolbar h2, .admin-section h3 { margin: 0; }
+.admin-section { background: #171d2b; border: 1px solid #303a4f; border-radius: 8px; padding: 1rem; }
+.metric-grid { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.metric-grid article { background: #101722; border: 1px solid #2f4050; border-radius: 8px; padding: 0.85rem; }
+.metric-grid span, .queue-item span, .section-head span, small { color: #a9b5c8; display: block; font-size: 0.82rem; }
+.metric-grid strong { color: #62d2a2; display: block; font-size: 1.6rem; margin-top: 0.25rem; }
+.admin-grid.two { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.admin-button { align-items: center; background: #232c3e; border: 1px solid #4b5a70; border-radius: 8px; color: #f2f5ff; cursor: pointer; display: inline-flex; min-height: 2.25rem; padding: 0.45rem 0.7rem; }
+.admin-button:hover, .admin-button:focus-visible { border-color: #62d2a2; outline: none; }
+.admin-button.primary { background: #2f6f62; border-color: #62d2a2; }
+.admin-button.danger { background: #54313a; border-color: #c96b76; }
+.filter-bar { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); margin: 1rem 0; }
+.filter-bar label { color: #a9b5c8; display: grid; font-size: 0.82rem; gap: 0.35rem; }
+.filter-bar input, .filter-bar select { background: #101722; border: 1px solid #3a4658; border-radius: 8px; color: #f2f5ff; min-height: 2.35rem; padding: 0.45rem 0.55rem; width: 100%; }
+.table-wrap { overflow-x: auto; }
+table { border-collapse: collapse; min-width: 760px; width: 100%; }
+th, td { border-bottom: 1px solid #303a4f; padding: 0.7rem; text-align: left; vertical-align: top; }
+th { color: #f8bf4a; font-size: 0.78rem; text-transform: uppercase; }
+.action-cell { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.status-badge { background: #263344; border: 1px solid #526070; border-radius: 999px; display: inline-flex; font-size: 0.78rem; padding: 0.2rem 0.5rem; text-transform: capitalize; white-space: nowrap; }
+.status-active, .status-approved, .status-resolved { background: #173d34; border-color: #62d2a2; }
+.status-pending, .status-open, .status-under-review { background: #473713; border-color: #f8bf4a; }
+.status-suspended, .status-banned, .status-rejected { background: #4a2530; border-color: #c96b76; }
+.status-escalated { background: #26385b; border-color: #7aa7ff; }
+.link-button { background: none; border: 0; color: #8fd8ff; cursor: pointer; padding: 0; text-align: left; }
+.detail-panel { background: #101722; border: 1px solid #303a4f; border-radius: 8px; margin-top: 1rem; padding: 1rem; }
+.detail-panel h4, .queue-item h4 { margin: 0 0 0.35rem; }
+.detail-panel p, .queue-item p { color: #d4dbea; margin: 0.25rem 0 0.7rem; }
+.queue-grid { display: grid; gap: 0.75rem; margin-top: 1rem; }
+.queue-item { align-items: start; background: #101722; border: 1px solid #303a4f; border-radius: 8px; display: grid; gap: 0.75rem; grid-template-columns: minmax(0, 1fr) auto auto; padding: 1rem; }
+.trust-chart { display: grid; gap: 0.65rem; margin-top: 1rem; }
+.trust-row { align-items: center; display: grid; gap: 0.6rem; grid-template-columns: 64px minmax(90px, 1fr) 28px; }
+.trust-row div { background: #101722; border-radius: 999px; height: 0.7rem; overflow: hidden; }
+.trust-row i { background: #62d2a2; display: block; height: 100%; }
+.admin-empty, .admin-error { background: #101722; border: 1px dashed #4b5a70; border-radius: 8px; color: #c8d2e0; margin-top: 1rem; padding: 1rem; }
+.admin-error { border-color: #c96b76; color: #ffd0d5; }
+@media (max-width: 760px) {
+  .admin-toolbar, .section-head, .control-row { align-items: stretch; flex-direction: column; }
+  .queue-item { grid-template-columns: 1fr; }
+}

--- a/apps/web/components/AdminPanel.tsx
+++ b/apps/web/components/AdminPanel.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  joinedAt: string;
+  trustScore: number;
+  activeJobs: string[];
+  disputes: string[];
+};
+
+type ModerationJob = {
+  id: string;
+  title: string;
+  postedByName: string;
+  status: string;
+  reason: string;
+  reports: number;
+  flaggedAt: string;
+};
+
+type Dispute = {
+  id: string;
+  clientName: string;
+  freelancerName: string;
+  jobTitle: string;
+  status: string;
+  amountCents: number;
+  openedAt: string;
+  thread: string[];
+  evidence: string[];
+  transaction: string;
+};
+
+type AuditEntry = {
+  id: string;
+  adminId: string;
+  actionType: string;
+  target: string;
+  createdAt: string;
+};
+
+type AdminPanelSnapshot = {
+  session: { adminId: string };
+  users: User[];
+  moderationJobs: ModerationJob[];
+  disputes: Dispute[];
+  controls: {
+    registrationsEnabled: boolean;
+    jobPostingsEnabled: boolean;
+  };
+  auditLog: AuditEntry[];
+};
+
+type Filters = {
+  search: string;
+  role: string;
+  status: string;
+  joinedFrom: string;
+  joinedTo: string;
+};
+
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0
+});
+
+function dollars(cents: number) {
+  return money.format(cents / 100);
+}
+
+function formatAuditTime(isoDate: string) {
+  return isoDate.replace("T", " ").slice(0, 16);
+}
+
+function nextAudit(adminId: string, actionType: string, target: string): AuditEntry {
+  return {
+    id: `aud_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    adminId,
+    actionType,
+    target,
+    createdAt: new Date().toISOString()
+  };
+}
+
+function StatusBadge({ value }: { value: string }) {
+  return <span className={`status-badge status-${value.replace("_", "-")}`}>{value.replace("_", " ")}</span>;
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="admin-empty" role="status">
+      {label}
+    </div>
+  );
+}
+
+export function AdminPanel({ initialState }: { initialState: AdminPanelSnapshot }) {
+  const [users, setUsers] = useState(initialState.users);
+  const [jobs, setJobs] = useState(initialState.moderationJobs);
+  const [disputes, setDisputes] = useState(initialState.disputes);
+  const [controls, setControls] = useState(initialState.controls);
+  const [auditLog, setAuditLog] = useState(initialState.auditLog);
+  const [filters, setFilters] = useState<Filters>({
+    search: "",
+    role: "all",
+    status: "all",
+    joinedFrom: "",
+    joinedTo: ""
+  });
+  const [selectedUserId, setSelectedUserId] = useState(initialState.users[0]?.id ?? "");
+  const [selectedDisputeId, setSelectedDisputeId] = useState(initialState.disputes[0]?.id ?? "");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState("");
+
+  const adminId = initialState.session.adminId;
+
+  const filteredUsers = useMemo(() => {
+    const search = filters.search.trim().toLowerCase();
+    return users.filter((user) => {
+      if (filters.role !== "all" && user.role !== filters.role) return false;
+      if (filters.status !== "all" && user.status !== filters.status) return false;
+      if (filters.joinedFrom && user.joinedAt < filters.joinedFrom) return false;
+      if (filters.joinedTo && user.joinedAt > filters.joinedTo) return false;
+      if (search) {
+        const haystack = `${user.name} ${user.email} ${user.id}`.toLowerCase();
+        if (!haystack.includes(search)) return false;
+      }
+      return true;
+    });
+  }, [filters, users]);
+
+  const selectedUser = users.find((user) => user.id === selectedUserId) ?? users[0];
+  const selectedDispute = disputes.find((dispute) => dispute.id === selectedDisputeId) ?? disputes[0];
+  const openDisputes = disputes.filter((dispute) => dispute.status !== "resolved").length;
+  const flaggedListings = jobs.filter((job) => job.status === "pending").length;
+  const activeJobs = users.reduce((sum, user) => sum + user.activeJobs.length, 0);
+  const trustBuckets = [
+    { label: "0-49", count: users.filter((user) => user.trustScore <= 49).length },
+    { label: "50-74", count: users.filter((user) => user.trustScore >= 50 && user.trustScore <= 74).length },
+    { label: "75-89", count: users.filter((user) => user.trustScore >= 75 && user.trustScore <= 89).length },
+    { label: "90-100", count: users.filter((user) => user.trustScore >= 90).length }
+  ];
+
+  function pushAudit(actionType: string, target: string) {
+    setAuditLog((entries) => [nextAudit(adminId, actionType, target), ...entries]);
+  }
+
+  function handleRefresh() {
+    setError("");
+    setIsRefreshing(true);
+    window.setTimeout(() => setIsRefreshing(false), 300);
+  }
+
+  function updateUser(userId: string, action: "suspend" | "reinstate" | "ban") {
+    const nextStatus = action === "reinstate" ? "active" : action === "ban" ? "banned" : "suspended";
+    setUsers((items) => items.map((user) => (user.id === userId ? { ...user, status: nextStatus } : user)));
+    pushAudit(`user_${action}`, userId);
+  }
+
+  function moderateJob(jobId: string, action: "approve" | "reject" | "escalate") {
+    const nextStatus = action === "approve" ? "approved" : action === "reject" ? "rejected" : "escalated";
+    setJobs((items) => items.map((job) => (job.id === jobId ? { ...job, status: nextStatus } : job)));
+    pushAudit(`job_${action}`, jobId);
+  }
+
+  function ruleDispute(disputeId: string, action: "favor_client" | "favor_freelancer" | "refund" | "escalate") {
+    const nextStatus = action === "escalate" ? "under_review" : "resolved";
+    setDisputes((items) =>
+      items.map((dispute) => (dispute.id === disputeId ? { ...dispute, status: nextStatus } : dispute))
+    );
+    pushAudit(`dispute_${action}`, disputeId);
+  }
+
+  function toggleControl(key: "registrationsEnabled" | "jobPostingsEnabled") {
+    const label = key === "registrationsEnabled" ? "new registrations" : "new job postings";
+    if (!window.confirm(`Confirm change to ${label}?`)) return;
+    setControls((current) => ({ ...current, [key]: !current[key] }));
+    pushAudit("platform_controls_update", key);
+  }
+
+  return (
+    <section className="admin-panel" aria-labelledby="admin-title">
+      <div className="admin-toolbar">
+        <div>
+          <p className="eyebrow">Admin workspace</p>
+          <h2 id="admin-title">Operations Control</h2>
+        </div>
+        <button className="admin-button primary" type="button" onClick={handleRefresh} aria-label="Refresh admin data">
+          {isRefreshing ? "Refreshing" : "Refresh"}
+        </button>
+      </div>
+
+      {error ? <div className="admin-error" role="alert">{error}</div> : null}
+
+      <div className="metric-grid" aria-live="polite">
+        <article>
+          <span>Total users</span>
+          <strong>{users.length}</strong>
+        </article>
+        <article>
+          <span>Active jobs</span>
+          <strong>{activeJobs}</strong>
+        </article>
+        <article>
+          <span>Open disputes</span>
+          <strong>{openDisputes}</strong>
+        </article>
+        <article>
+          <span>Flagged listings</span>
+          <strong>{flaggedListings}</strong>
+        </article>
+        <article>
+          <span>Revenue</span>
+          <strong>{money.format(128900)}</strong>
+        </article>
+      </div>
+
+      <div className="admin-grid two">
+        <section className="admin-section" aria-labelledby="trust-heading">
+          <h3 id="trust-heading">Trust Distribution</h3>
+          <div className="trust-chart" role="img" aria-label="Trust score distribution across users">
+            {trustBuckets.map((bucket) => (
+              <div key={bucket.label} className="trust-row">
+                <span>{bucket.label}</span>
+                <div>
+                  <i style={{ width: `${Math.max(bucket.count * 30, 8)}%` }} />
+                </div>
+                <b>{bucket.count}</b>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="admin-section" aria-labelledby="controls-heading">
+          <h3 id="controls-heading">Platform Controls</h3>
+          <div className="control-row">
+            <span>New registrations</span>
+            <button
+              type="button"
+              className="admin-button"
+              aria-pressed={controls.registrationsEnabled}
+              onClick={() => toggleControl("registrationsEnabled")}
+            >
+              {controls.registrationsEnabled ? "Enabled" : "Disabled"}
+            </button>
+          </div>
+          <div className="control-row">
+            <span>New job postings</span>
+            <button
+              type="button"
+              className="admin-button"
+              aria-pressed={controls.jobPostingsEnabled}
+              onClick={() => toggleControl("jobPostingsEnabled")}
+            >
+              {controls.jobPostingsEnabled ? "Enabled" : "Disabled"}
+            </button>
+          </div>
+        </section>
+      </div>
+
+      <section className="admin-section" aria-labelledby="users-heading">
+        <div className="section-head">
+          <h3 id="users-heading">User Management</h3>
+          <span>Page 1 of {Math.max(Math.ceil(filteredUsers.length / 10), 1)}</span>
+        </div>
+        <div className="filter-bar">
+          <label>
+            Search
+            <input
+              value={filters.search}
+              onChange={(event) => setFilters((current) => ({ ...current, search: event.target.value }))}
+              aria-label="Search users"
+            />
+          </label>
+          <label>
+            Role
+            <select
+              value={filters.role}
+              onChange={(event) => setFilters((current) => ({ ...current, role: event.target.value }))}
+              aria-label="Filter users by role"
+            >
+              <option value="all">All</option>
+              <option value="client">Client</option>
+              <option value="freelancer">Freelancer</option>
+            </select>
+          </label>
+          <label>
+            Status
+            <select
+              value={filters.status}
+              onChange={(event) => setFilters((current) => ({ ...current, status: event.target.value }))}
+              aria-label="Filter users by status"
+            >
+              <option value="all">All</option>
+              <option value="active">Active</option>
+              <option value="suspended">Suspended</option>
+              <option value="under_review">Under review</option>
+              <option value="banned">Banned</option>
+            </select>
+          </label>
+          <label>
+            Joined from
+            <input
+              type="date"
+              value={filters.joinedFrom}
+              onChange={(event) => setFilters((current) => ({ ...current, joinedFrom: event.target.value }))}
+              aria-label="Filter users joined after"
+            />
+          </label>
+          <label>
+            Joined to
+            <input
+              type="date"
+              value={filters.joinedTo}
+              onChange={(event) => setFilters((current) => ({ ...current, joinedTo: event.target.value }))}
+              aria-label="Filter users joined before"
+            />
+          </label>
+        </div>
+
+        {filteredUsers.length === 0 ? (
+          <EmptyState label="No users match these filters." />
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                  <th>Joined</th>
+                  <th>Trust</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredUsers.map((user) => (
+                  <tr key={user.id}>
+                    <td>
+                      <button type="button" className="link-button" onClick={() => setSelectedUserId(user.id)}>
+                        {user.name}
+                      </button>
+                      <small>{user.email}</small>
+                    </td>
+                    <td>{user.role}</td>
+                    <td><StatusBadge value={user.status} /></td>
+                    <td>{user.joinedAt}</td>
+                    <td>{user.trustScore}</td>
+                    <td className="action-cell">
+                      <button type="button" className="admin-button" onClick={() => updateUser(user.id, "suspend")}>
+                        Suspend
+                      </button>
+                      <button type="button" className="admin-button" onClick={() => updateUser(user.id, "reinstate")}>
+                        Reinstate
+                      </button>
+                      <button type="button" className="admin-button danger" onClick={() => updateUser(user.id, "ban")}>
+                        Ban
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {selectedUser ? (
+          <aside className="detail-panel" aria-label="Selected user profile">
+            <h4>{selectedUser.name}</h4>
+            <p>{selectedUser.role} profile with {selectedUser.activeJobs.length} active jobs and {selectedUser.disputes.length} dispute records.</p>
+            <dl>
+              <dt>Active jobs</dt>
+              <dd>{selectedUser.activeJobs.join(", ") || "None"}</dd>
+              <dt>Dispute history</dt>
+              <dd>{selectedUser.disputes.join(", ") || "None"}</dd>
+            </dl>
+          </aside>
+        ) : null}
+      </section>
+
+      <section className="admin-section" aria-labelledby="moderation-heading">
+        <h3 id="moderation-heading">Job Moderation</h3>
+        {jobs.length === 0 ? (
+          <EmptyState label="No flagged jobs are waiting." />
+        ) : (
+          <div className="queue-grid">
+            {jobs.map((job) => (
+              <article key={job.id} className="queue-item">
+                <div>
+                  <h4>{job.title}</h4>
+                  <p>{job.reason}</p>
+                  <span>{job.reports} reports by {job.flaggedAt}</span>
+                </div>
+                <StatusBadge value={job.status} />
+                <div className="action-cell">
+                  <button type="button" className="admin-button" onClick={() => moderateJob(job.id, "approve")}>
+                    Approve
+                  </button>
+                  <button type="button" className="admin-button danger" onClick={() => moderateJob(job.id, "reject")}>
+                    Reject
+                  </button>
+                  <button type="button" className="admin-button" onClick={() => moderateJob(job.id, "escalate")}>
+                    Escalate
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="admin-section" aria-labelledby="disputes-heading">
+        <h3 id="disputes-heading">Dispute Resolution</h3>
+        <div className="queue-grid">
+          {disputes.map((dispute) => (
+            <article key={dispute.id} className="queue-item">
+              <div>
+                <h4>{dispute.jobTitle}</h4>
+                <p>{dispute.clientName} vs {dispute.freelancerName}</p>
+                <span>{dollars(dispute.amountCents)} opened {dispute.openedAt}</span>
+              </div>
+              <StatusBadge value={dispute.status} />
+              <button type="button" className="admin-button" onClick={() => setSelectedDisputeId(dispute.id)}>
+                View
+              </button>
+            </article>
+          ))}
+        </div>
+        {selectedDispute ? (
+          <aside className="detail-panel" aria-label="Selected dispute thread">
+            <h4>{selectedDispute.jobTitle}</h4>
+            <p>{selectedDispute.transaction}</p>
+            <ul>
+              {selectedDispute.thread.map((item) => <li key={item}>{item}</li>)}
+            </ul>
+            <p>Evidence: {selectedDispute.evidence.join(", ")}</p>
+            <div className="action-cell">
+              <button type="button" className="admin-button" onClick={() => ruleDispute(selectedDispute.id, "favor_client")}>
+                Favor Client
+              </button>
+              <button type="button" className="admin-button" onClick={() => ruleDispute(selectedDispute.id, "favor_freelancer")}>
+                Favor Freelancer
+              </button>
+              <button type="button" className="admin-button" onClick={() => ruleDispute(selectedDispute.id, "refund")}>
+                Refund
+              </button>
+              <button type="button" className="admin-button" onClick={() => ruleDispute(selectedDispute.id, "escalate")}>
+                Escalate
+              </button>
+            </div>
+          </aside>
+        ) : null}
+      </section>
+
+      <section className="admin-section" aria-labelledby="audit-heading">
+        <div className="section-head">
+          <h3 id="audit-heading">Audit Log</h3>
+          <span>Page 1 of {Math.max(Math.ceil(auditLog.length / 10), 1)}</span>
+        </div>
+        {auditLog.length === 0 ? (
+          <EmptyState label="No admin actions have been logged." />
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Time</th>
+                  <th>Admin</th>
+                  <th>Action</th>
+                  <th>Target</th>
+                </tr>
+              </thead>
+              <tbody>
+                {auditLog.slice(0, 10).map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{formatAuditTime(entry.createdAt)}</td>
+                    <td>{entry.adminId}</td>
+                    <td>{entry.actionType}</td>
+                    <td>{entry.target}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/lib/adminMock.ts
+++ b/apps/web/lib/adminMock.ts
@@ -1,0 +1,116 @@
+export const adminSnapshot = {
+  session: {
+    adminId: "admin_demo"
+  },
+  users: [
+    {
+      id: "usr_client_101",
+      name: "Avery Stone",
+      email: "avery@example.com",
+      role: "client",
+      status: "active",
+      joinedAt: "2026-01-12",
+      trustScore: 86,
+      activeJobs: ["Marketplace redesign"],
+      disputes: ["Landing page copy refresh"]
+    },
+    {
+      id: "usr_freelancer_204",
+      name: "Maya Patel",
+      email: "maya@example.com",
+      role: "freelancer",
+      status: "active",
+      joinedAt: "2026-02-03",
+      trustScore: 94,
+      activeJobs: ["API audit"],
+      disputes: []
+    },
+    {
+      id: "usr_client_188",
+      name: "Noah Kim",
+      email: "noah@example.com",
+      role: "client",
+      status: "suspended",
+      joinedAt: "2026-03-21",
+      trustScore: 41,
+      activeJobs: [],
+      disputes: ["Mobile checkout QA"]
+    },
+    {
+      id: "usr_freelancer_319",
+      name: "Lena Ortiz",
+      email: "lena@example.com",
+      role: "freelancer",
+      status: "under_review",
+      joinedAt: "2026-04-09",
+      trustScore: 58,
+      activeJobs: ["Checkout bug fix"],
+      disputes: ["Mobile checkout QA"]
+    }
+  ],
+  moderationJobs: [
+    {
+      id: "mod_job_901",
+      title: "Crypto payout integration",
+      postedByName: "Avery Stone",
+      status: "pending",
+      reason: "Payment terms mention off-platform settlement",
+      reports: 3,
+      flaggedAt: "2026-06-12"
+    },
+    {
+      id: "mod_job_902",
+      title: "Scrape competitor profiles",
+      postedByName: "Noah Kim",
+      status: "pending",
+      reason: "Automated policy scanner detected prohibited scraping language",
+      reports: 5,
+      flaggedAt: "2026-06-13"
+    }
+  ],
+  disputes: [
+    {
+      id: "dsp_escrow_copy",
+      clientName: "Avery Stone",
+      freelancerName: "Maya Patel",
+      jobTitle: "Landing page copy refresh",
+      status: "open",
+      amountCents: 85000,
+      openedAt: "2026-06-10",
+      thread: [
+        "Client says final copy missed compliance notes.",
+        "Freelancer attached the approved brief and revision log."
+      ],
+      evidence: ["approved-brief.pdf", "revision-log.md"],
+      transaction: "esc_2039 / refundable USD 850"
+    },
+    {
+      id: "dsp_mobile_refund",
+      clientName: "Noah Kim",
+      freelancerName: "Lena Ortiz",
+      jobTitle: "Mobile checkout QA",
+      status: "under_review",
+      amountCents: 42000,
+      openedAt: "2026-06-11",
+      thread: [
+        "Client requested a refund after crash reports continued.",
+        "Freelancer attached logs showing a third-party SDK fault."
+      ],
+      evidence: ["device-crash.log", "sdk-vendor-ticket.txt"],
+      transaction: "esc_2044 / refundable USD 300"
+    }
+  ],
+  controls: {
+    registrationsEnabled: true,
+    jobPostingsEnabled: true
+  },
+  auditLog: [
+    {
+      id: "aud_seed_001",
+      adminId: "system",
+      actionType: "system_snapshot",
+      target: "platform/admin-panel",
+      createdAt: "2026-06-12T00:00:00.000Z"
+    }
+  ]
+};


### PR DESCRIPTION
Closes #29.

## Summary

- Adds server-side admin authorization with `authMiddleware` plus a dedicated `requireAdmin` guard on every `/api/admin/*` route.
- Expands the admin API with metrics, user search/filter/pagination, user status actions, job moderation actions, dispute details/rulings, platform controls, and audit-log endpoints.
- Replaces the placeholder `/admin` page with an operations control panel covering metrics, trust distribution, user management, moderation queue, dispute queue, platform controls, and audit log.
- Adds a guarded `/admin/forbidden` page and deterministic mock admin snapshot for the web UI.
- Adds API tests for non-admin rejection, metrics, user filters, user actions, job rejection notifications, confirmed platform controls, dispute rulings, and audit-log writes.

## Verification

- `C:\Users\deski\Desktop\work\node\npm.cmd test -w apps/api`
- `C:\Users\deski\Desktop\work\node\npm.cmd run build -w apps/web`
- `C:\Users\deski\Desktop\work\PortableGit\cmd\git.exe diff --check`
- Browser smoke: `http://127.0.0.1:3105/admin` returned 200 and rendered Operations Control, User Management, Job Moderation, Dispute Resolution, Platform Controls, and Audit Log with no console errors.