### PR TITLE
Expose @freelanceflow/db workspace entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
-    "migrate": "prisma migrate dev"
+    "migrate": "prisma migrate dev",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@prisma/client": "^5.17.0"

--- a/packages/db/test/import.test.js
+++ b/packages/db/test/import.test.js
@@ -1,0 +1,9 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/db resolves through the workspace package name", () => {
+  const dbPackage = require("@freelanceflow/db");
+
+  assert.equal(typeof dbPackage.PrismaClient, "function");
+  assert.ok(dbPackage.Prisma);
+});


### PR DESCRIPTION
## Summary

- Adds explicit `main`, `types`, and `exports` metadata for `@freelanceflow/db`.
- Adds a root JavaScript entrypoint that re-exports `@prisma/client` for Node workspace consumers.
- Adds a focused Node test proving the package resolves through the workspace package name.

Fixes #2775.

## Validation

- `/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test packages/db/test/*.test.js`
- `/Users/bytedance/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test apps/api/src/tests/*.test.js`
- `require('@freelanceflow/db')` from the repo root now resolves and exposes `PrismaClient`.
- Dynamic `import('@freelanceflow/db')` from the repo root now resolves and exposes `PrismaClient`.