### PR TITLE
Expose @freelanceflow/ui workspace entrypoint

### DIFF
--- a/packages/ui/index.cjs
+++ b/packages/ui/index.cjs
@@ -1,0 +1,38 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer",
+      },
+    },
+    children,
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    {
+      style: {
+        border: "1px solid #ddd",
+        borderRadius: 8,
+        padding: "1rem",
+      },
+    },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children),
+  );
+}
+
+module.exports = {
+  Button,
+  Card,
+};

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,11 @@
+import type { ReactElement, ReactNode } from "react";
+
+export function Button({ children }: { children: ReactNode }): ReactElement;
+
+export function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement;

--- a/packages/ui/index.mjs
+++ b/packages/ui/index.mjs
@@ -1,0 +1,4 @@
+import ui from "./index.cjs";
+
+export const { Button, Card } = ui;
+export default ui;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.cjs",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.cjs",
+      "default": "./index.mjs"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
 }

--- a/packages/ui/test/import.test.js
+++ b/packages/ui/test/import.test.js
@@ -1,0 +1,16 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+test("@freelanceflow/ui resolves through the workspace package name for ESM consumers", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});
+
+test("@freelanceflow/ui resolves through the workspace package name for CommonJS consumers", () => {
+  const ui = require("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});


### PR DESCRIPTION
## Summary
- add explicit package exports for `@freelanceflow/ui`
- provide real ESM and CommonJS JavaScript entrypoints for the exported components
- add TypeScript declarations and import tests for workspace package-name resolution

Fixes #2781.

## Validation
- `node --test packages/ui/test/*.test.js`
- direct CommonJS and ESM package-name import check with `require('@freelanceflow/ui')` and `import('@freelanceflow/ui')`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`