### PR TITLE
fix: return 400 for zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,17 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const isZodError = err?.name === "ZodError";
+  const status = isZodError ? 400 : 500;
+
+  if (status >= 500) {
+    console.error("Unhandled API error:", err);
+  }
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: isZodError ? "Invalid request" : "Unexpected server error"
   });
 }

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 for ZodError-like failures", () => {
+  const res = createResponse();
+  const err = { name: "ZodError" };
+
+  errorHandler(err, {}, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Invalid request"
+  });
+});
+
+test("errorHandler returns 500 for unknown errors", () => {
+  const res = createResponse();
+  const err = new Error("boom");
+  const originalError = console.error;
+  console.error = () => {};
+
+  try {
+    errorHandler(err, {}, res, () => {});
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});


### PR DESCRIPTION
Closes #7365.

## Summary
- detect Zod-style validation failures in the API error handler
- return 400 with a client-safe validation message
- keep all other unknown errors as 500s
- add regression tests for both branches

## Validation
- `node --test apps/api/src/tests/errorHandler.test.js`