### PR TITLE
fix: validate upload file payloads

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,50 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/webp"
+]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_UPLOAD_SIZE_BYTES
+  },
+  fileFilter: (req, file, callback) => {
+    if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      return callback(null, true);
+    }
+
+    const error = new Error("Unsupported file type");
+    error.statusCode = 415;
+    return callback(error);
+  }
+});
+
+function singleFileUpload(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File exceeds maximum size of 5MB", 413);
+    }
+
+    if (error.statusCode === 415) {
+      return fail(res, "Unsupported file type", 415);
+    }
+
+    return next(error);
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", singleFileUpload, uploadFile);

--- a/apps/api/src/tests/upload-validation.test.js
+++ b/apps/api/src/tests/upload-validation.test.js
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postUpload(baseUrl, body) {
+  return fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    ...(body ? { body } : {})
+  });
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postUpload(baseUrl);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["not an allowed upload"], { type: "text/plain" }), "notes.txt");
+
+    const response = await postUpload(baseUrl, form);
+    const payload = await response.json();
+
+    assert.equal(response.status, 415);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unsupported file type"
+    });
+  });
+});
+
+test("POST /api/uploads rejects oversized files", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedBytes = new Uint8Array(5 * 1024 * 1024 + 1);
+    const form = new FormData();
+    form.set("file", new Blob([oversizedBytes], { type: "image/png" }), "oversized.png");
+
+    const response = await postUpload(baseUrl, form);
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File exceeds maximum size of 5MB"
+    });
+  });
+});
+
+test("POST /api/uploads accepts valid small image uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }), "avatar.png");
+
+    const response = await postUpload(baseUrl, form);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "avatar.png",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #7468
Refs #743

## Summary
- reject `POST /api/uploads` requests that do not include a `file` field
- add Multer memory-upload guardrails: 5MB maximum file size and an allowlist for PDF/JPEG/PNG/WebP uploads
- return clear shared failure envelopes for missing, unsupported, and oversized upload payloads
- add regression coverage for invalid uploads and the valid small image path

## Validation
- `git diff --check`
- `node --test apps/api/src/tests/upload-validation.test.js`
- `node --test apps/api/src/tests/*.test.js`
