### PR TITLE
Return 400 for upload parser errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof multer.MulterError || err?.name === "MulterError") {
+    return res.status(400).json({
+      success: false,
+      message: err.message
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/uploadParserErrors.test.js
+++ b/apps/api/src/tests/uploadParserErrors.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads returns 400 for unexpected file fields", async () => {
+  await withTestServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("avatar", new Blob(["not the expected field"], { type: "text/plain" }), "avatar.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unexpected field"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Handle Multer parser errors in the API error middleware as client-side 400 responses.
- Add a focused multipart upload regression test for unexpected file fields.

## Root cause
`POST /api/uploads` uses `upload.single("file")`; when a request sends another file field such as `avatar`, Multer raises `LIMIT_UNEXPECTED_FILE`. The global error handler treated that parser error as an unexpected server failure and returned 500.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/middleware/errorHandler.js`
- `node --check apps/api/src/tests/uploadParserErrors.test.js`
- `git diff --check`

Fixes #7470
/claim #743