### PR TITLE
fix: validate user creation input

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { z } from "zod";
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/tests/user-validation.test.js
+++ b/apps/api/src/tests/user-validation.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users validates input", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const validResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "demo@example.com", role: "client" })
+  });
+  const validPayload = await validResponse.json();
+
+  assert.equal(validResponse.status, 201);
+  assert.equal(validPayload.success, true);
+  assert.equal(validPayload.data.email, "demo@example.com");
+  assert.equal(validPayload.data.role, "client");
+
+  const invalidResponse = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ role: "client" })
+  });
+  const invalidPayload = await invalidResponse.json();
+
+  assert.equal(invalidResponse.status, 500);
+  assert.equal(invalidPayload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #7428.

## Summary
- validate `POST /api/users` with a Zod schema before creating records
- accept only email and supported role values
- add an API regression test for valid and invalid user creation payloads

## Validation
- Added `apps/api/src/tests/user-validation.test.js`
- Note: local test run timed out in this worktree after dependencies were installed; the test is scoped to the new endpoint behavior and should run under the repository's normal Node test runner.