### PR TITLE
fix: ignore client user id overrides

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...safePayload } = payload;
+  const user = { ...safePayload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser ignores client-controlled id override", async () => {
+  const user = await createUser({
+    id: "client-controlled",
+    email: "person@example.com",
+    role: "client"
+  });
+
+  assert.notEqual(user.id, "client-controlled");
+  assert.match(user.id, /^usr_/);
+  assert.equal(user.email, "person@example.com");
+  assert.equal(user.role, "client");
+});


### PR DESCRIPTION
Closes #7372.

## Summary
- strip any client-supplied `id` before building the stored user object
- keep the service-generated id authoritative
- add a regression test proving `createUser` ignores client-controlled ids

## Validation
- `node --test apps/api/src/tests/userService.test.js`