### PR TITLE
Use canonical auth token role casing

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,5 +1,7 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const STUBBED_CLIENT_ROLE = "CLIENT";
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
   return {
@@ -14,10 +16,10 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: STUBBED_CLIENT_ROLE })
   };
 }
 
 export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+  return { token: signAccessToken({ sub: "usr_existing", role: STUBBED_CLIENT_ROLE }) };
 }

--- a/apps/api/src/tests/authTokenRoleCasing.test.js
+++ b/apps/api/src/tests/authTokenRoleCasing.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser, refreshToken } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("login token uses canonical client role casing", async () => {
+  const result = await loginUser({ email: "client@example.com", password: "password123" });
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, "usr_existing");
+  assert.equal(decoded.role, "CLIENT");
+});
+
+test("refreshed token uses canonical client role casing", async () => {
+  const result = await refreshToken();
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(decoded.sub, "usr_existing");
+  assert.equal(decoded.role, "CLIENT");
+});


### PR DESCRIPTION
Fixes #7474

/claim #743

## Summary
- use the Prisma-canonical `CLIENT` role claim for stubbed login access tokens
- use the same canonical role claim for stubbed refreshed access tokens
- add service regression tests that decode both JWTs and assert the canonical role casing

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authTokenRoleCasing.test.js`
- `git diff --check`
