### PR TITLE
Return defensive review snapshots

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,15 @@
 const reviews = [];
 
+function copyReview(review) {
+  return { ...review };
+}
+
 export async function listReviews() {
-  return reviews;
+  return reviews.map(copyReview);
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return copyReview(review);
 }

--- a/apps/api/src/tests/reviewServiceSnapshots.test.js
+++ b/apps/api/src/tests/reviewServiceSnapshots.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("review service returns defensive snapshots", async () => {
+  const review = await createReview({
+    reviewerId: "usr_client",
+    revieweeId: "usr_freelancer",
+    rating: 5,
+    comment: "Great collaboration"
+  });
+
+  review.comment = "mutated through create response";
+  review.rating = 1;
+
+  const firstSnapshot = await listReviews();
+  const storedReview = firstSnapshot.find((item) => item.id === review.id);
+
+  assert.equal(storedReview.comment, "Great collaboration");
+  assert.equal(storedReview.rating, 5);
+
+  firstSnapshot.push({ id: "rev_injected", rating: 1, comment: "injected" });
+  storedReview.comment = "mutated through list response";
+  storedReview.rating = 2;
+
+  const secondSnapshot = await listReviews();
+  const persistedReview = secondSnapshot.find((item) => item.id === review.id);
+
+  assert.equal(secondSnapshot.some((item) => item.id === "rev_injected"), false);
+  assert.equal(persistedReview.comment, "Great collaboration");
+  assert.equal(persistedReview.rating, 5);
+});


### PR DESCRIPTION
Fixes #7477

/claim #743

## Summary
- make `listReviews()` return a defensive array snapshot with copied review records
- make `createReview()` return a copy of the stored review instead of the stored object itself
- add service regression coverage proving caller mutations cannot corrupt the internal review store

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/reviewService.js`
- `node --check apps/api/src/tests/reviewServiceSnapshots.test.js`
- `git diff --check`
