### PR TITLE
fix: return 400 for unexpected upload fields

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,17 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
+  const isUnexpectedFile = err?.code === "LIMIT_UNEXPECTED_FILE";
+  const status = isUnexpectedFile ? 400 : 500;
+
+  if (status >= 500) {
+    console.error("Unhandled API error:", err);
+  }
+
+  return res.status(status).json({
     success: false,
-    message: "Unexpected server error"
+    message: isUnexpectedFile ? "Unexpected file field" : "Unexpected server error"
   });
 }

--- a/apps/api/src/tests/upload-error.test.js
+++ b/apps/api/src/tests/upload-error.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 for unexpected upload file fields", () => {
+  const res = createResponse();
+
+  errorHandler({ code: "LIMIT_UNEXPECTED_FILE" }, {}, res, () => {});
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected file field"
+  });
+});
+
+test("errorHandler keeps unknown errors as 500", () => {
+  const res = createResponse();
+  const originalError = console.error;
+  console.error = () => {};
+
+  try {
+    errorHandler(new Error("boom"), {}, res, () => {});
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});


### PR DESCRIPTION
Closes #7470.

## Summary
- detect Multer unexpected file field errors in the API error handler
- return 400 with a clearer client-facing message
- keep generic server errors as 500s
- add a regression test for both error branches

## Validation
- `node --test apps/api/src/tests/upload-error.test.js`