### PR TITLE
fix(auth): generate id once so registerUser token sub matches returned id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,12 +2,9 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
-  };
+  const id = `usr_${Date.now()}`;
+  const token = signAccessToken({ sub: id, role: payload.role });
+  return { id, email: payload.email, role: payload.role, token };
 }
 
 export async function loginUser(payload) {

--- a/apps/api/src/tests/auth-register-sub.test.js
+++ b/apps/api/src/tests/auth-register-sub.test.js
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser token sub matches returned user id", async () => {
+  const result = await registerUser({ email: "test@example.com", password: "secret123", role: "client" });
+  const decoded = jwt.decode(result.token);
+  assert.equal(decoded.sub, result.id, "JWT sub must equal returned id");
+});


### PR DESCRIPTION
Closes #7482

/claim #743

## Summary
- Generate a single `id` reused for both the returned user object and the JWT `sub` claim
- Eliminates the two-call race where `Date.now()` advances between calls
- Adds focused regression test decoding the token and asserting `sub === id`