### PR TITLE
fix(auth): refreshToken requires a credential — reject calls with no token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,8 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const token = req.body?.token ?? req.headers["x-refresh-token"];
+  if (!token) return fail(res, "Refresh token required", 400);
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
+export async function refreshToken(existingToken) {
+  if (!existingToken) throw new Error("Refresh token required");
   return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
 }

--- a/apps/api/src/tests/auth-refresh-validation.test.js
+++ b/apps/api/src/tests/auth-refresh-validation.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refreshToken } from "../services/authService.js";
+
+test("refreshToken throws when no token is supplied", async () => {
+  await assert.rejects(
+    () => refreshToken(undefined),
+    /Refresh token required/
+  );
+});
+
+test("refreshToken returns a token when a credential is supplied", async () => {
+  const result = await refreshToken("some-refresh-token");
+  assert.ok(typeof result.token === "string" && result.token.length > 0);
+});


### PR DESCRIPTION
Closes #7483

/claim #743

## Summary
- `refreshToken(existingToken)` now throws `Error("Refresh token required")` when called without a credential
- The `refresh` controller reads the token from `req.body.token` or `X-Refresh-Token` header and returns 400 when absent
- Adds regression tests for missing-token rejection and the success path