### PR TITLE
fix(auth): remove admin from registration role enum to prevent privilege escalation

### DIFF
--- a/apps/api/src/tests/auth-register-no-admin.test.js
+++ b/apps/api/src/tests/auth-register-no-admin.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("registration rejects admin role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "admin@example.com", password: "password123", role: "admin" })
+  });
+  assert.equal(res.status, 400);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #7484

/claim #743

## Summary
- `registerSchema` role enum changed from `["client", "freelancer", "admin"]` to `["client", "freelancer"]`
- Callers who pass `role: "admin"` now receive a Zod 400 validation error before reaching the service layer
- Adds regression test verifying that an admin role registration attempt returns 400