### PR TITLE
fix(auth): require fullName in registration validator to match User model

### DIFF
--- a/apps/api/src/tests/auth-register-fullname.test.js
+++ b/apps/api/src/tests/auth-register-fullname.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("registration without fullName returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "user@example.com", password: "password123" })
+  });
+  assert.equal(res.status, 400, "missing fullName should produce a 400 response");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
Closes #7485

/claim #743

## Summary
- Adds `fullName: z.string().min(1)` to `registerSchema`
- Registrations without `fullName` now receive a clean 400 validation error before reaching the service or database
- Adds regression test verifying that a request without `fullName` returns 400