### PR TITLE
fix(users): validate user creation input with Zod schema

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,6 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/tests/user-creation-validation.test.js
+++ b/apps/api/src/tests/user-creation-validation.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/users returns 400 when required fields are missing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}"
+  });
+  assert.equal(res.status, 400);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
Closes #7486

/claim #743

## Summary
- Adds `createUserSchema` (email, fullName, role allowlist) in `validators/user.js`
- `postUser` controller now parses through Zod before calling the service
- Adds regression test verifying an empty body returns 400