### PR TITLE
fix(users): strip caller-supplied id in createUser to prevent id injection

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignored, ...safePayload } = payload;
+  const user = { ...safePayload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-service-id-injection.test.js
+++ b/apps/api/src/tests/user-service-id-injection.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser ignores caller-supplied id and uses server-generated id", async () => {
+  const result = await createUser({ email: "test@example.com", fullName: "Test User", id: "hacked-id" });
+  assert.notEqual(result.id, "hacked-id", "caller-supplied id must be ignored");
+  assert.ok(result.id.startsWith("usr_"), "id should be server-generated");
+});


### PR DESCRIPTION
Closes #7487

/claim #743

## Summary
- Destructures `id` out of payload and discards it before constructing the user object
- Server-generated `id` is placed last so it always wins
- Adds regression test verifying a caller-supplied `id` is ignored