### PR TITLE
fix(jobs): strip caller-supplied id and status to prevent injection

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _ignoredId, status: _ignoredStatus, ...safePayload } = payload;
+  const job = { ...safePayload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service-injection.test.js
+++ b/apps/api/src/tests/job-service-injection.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob ignores caller-supplied id and status", async () => {
+  const result = await createJob({
+    title: "Test Job",
+    description: "Test desc",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    id: "hacked-id",
+    status: "completed"
+  });
+  assert.notEqual(result.id, "hacked-id", "caller-supplied id must be ignored");
+  assert.equal(result.status, "open", "status must always be server-assigned open");
+  assert.ok(result.id.startsWith("job_"), "id should be server-generated");
+});


### PR DESCRIPTION
Closes #7488

/claim #743

## Summary
- Destructures and discards `id` and `status` from `payload` before constructing the job object
- Server-assigned `id` (timestamped) and `status: "open"` are always placed last and cannot be overridden
- Adds regression test verifying caller-supplied `id` and `status: "completed"` are both ignored