### PR TITLE
fix(notifications): strip caller-supplied id and read state to preserve server ownership

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload;
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service-injection.test.js
+++ b/apps/api/src/tests/notification-service-injection.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-supplied id and read state", async () => {
+  const result = await createNotification({
+    message: "Hello",
+    id: "hacked-ntf",
+    read: true
+  });
+  assert.notEqual(result.id, "hacked-ntf", "caller-supplied id must be ignored");
+  assert.equal(result.read, false, "read state must always be server-assigned false");
+  assert.ok(result.id.startsWith("ntf_"), "id should be server-generated");
+});


### PR DESCRIPTION
Closes #7489

/claim #743

## Summary
- Destructures and discards `id` and `read` from `payload` before constructing the notification
- Server-assigned `id` and `read: false` are always placed last and cannot be overridden by callers
- Adds regression test verifying that caller-supplied `id` and `read: true` are both ignored