### PR TITLE
fix(jobs): require authentication on job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job-auth.test.js
+++ b/apps/api/src/tests/job-auth.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs requires authentication", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: "Test Job",
+      description: "A test job description",
+      budgetMin: 100,
+      budgetMax: 500,
+      categoryId: "cat_1"
+    })
+  });
+  assert.equal(res.status, 401, "unauthenticated job creation must return 401");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7491

/claim #743

## Summary
- `POST /api/jobs` now runs through `authMiddleware` before `postJob`
- `GET /api/jobs` remains public (read-only listing)
- Unauthenticated POST requests receive 401
- Adds regression test verifying that a request without an Authorization header returns 401