### PR TITLE
fix(search): validate and length-limit query parameter

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+  if (typeof q !== "string") return fail(res, "Invalid query parameter", 400);
+  if (q.length > MAX_QUERY_LENGTH) return fail(res, `Query exceeds maximum length of ${MAX_QUERY_LENGTH} characters`, 400);
+  return ok(res, await globalSearch(q.trim()));
 }

--- a/apps/api/src/tests/search-validation.test.js
+++ b/apps/api/src/tests/search-validation.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/search returns 400 when query exceeds maximum length", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const longQuery = "a".repeat(201);
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=${encodeURIComponent(longQuery)}`);
+  assert.equal(res.status, 400, "oversized query must return 400");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});
+
+test("GET /api/search returns 200 for a valid short query", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/search?q=developer`);
+  assert.equal(res.status, 200);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7492

/claim #743

## Summary
- Validates that `q` is a string type; returns 400 if not
- Enforces a 200-character maximum length; returns 400 if exceeded with a descriptive message
- Trims whitespace before passing to the search service
- Adds regression tests for oversized query rejection and valid query success