### PR TITLE
fix(admin): enforce admin role check to prevent privilege escalation

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  const role = req.user?.role;
+  if (role !== "ADMIN" && role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-role-check.test.js
+++ b/apps/api/src/tests/admin-role-check.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "development-secret";
+
+test("GET /api/admin/metrics returns 403 for non-admin role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const token = jwt.sign({ sub: "usr_1", role: "client" }, JWT_SECRET, { expiresIn: "1h" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { "Authorization": `Bearer ${token}` }
+  });
+  assert.equal(res.status, 403, "non-admin user must receive 403");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7493

/claim #743

## Summary
- Adds `adminMiddleware` that checks `req.user.role` is `"ADMIN"` or `"admin"`
- Admin routes now chain `authMiddleware → adminMiddleware` before the handler
- Non-admin authenticated users receive 403 Forbidden
- Adds regression test verifying a client-role JWT receives 403 on the metrics endpoint