### PR TITLE
fix(jobs): reject inverted budget ranges where budgetMin exceeds budgetMax

### DIFF
--- a/apps/api/src/tests/job-budget-range.test.js
+++ b/apps/api/src/tests/job-budget-range.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "development-secret";
+
+test("POST /api/jobs returns 400 for inverted budget range", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const token = jwt.sign({ sub: "usr_1", role: "client" }, JWT_SECRET, { expiresIn: "1h" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      title: "Test Job",
+      description: "A test job description",
+      budgetMin: 1000,
+      budgetMax: 1,
+      categoryId: "cat_1"
+    })
+  });
+  assert.equal(res.status, 400, "inverted budget range must return 400");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must not exceed budgetMax",
+  path: ["budgetMin"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Closes #7494

/claim #743

## Summary
- Adds `.refine(data => data.budgetMin <= data.budgetMax, ...)` to `createJobSchema`
- Inverted ranges (e.g. `budgetMin: 1000, budgetMax: 1`) return a descriptive 400 validation error
- Adds regression test verifying that an inverted range returns 400