### PR TITLE
fix(app): move rate limiter before body parser to throttle before JSON parsing

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });


### PR DESCRIPTION
Closes #7495

/claim #743

## Summary
- Moves `app.use(apiLimiter)` to run before `app.use(express.json())`
- Rate limiting now occurs before body parsing, preventing large payloads from consuming CPU/memory before throttling kicks in
- Middleware order is now: `helmet → cors → apiLimiter → express.json()`