### PR TITLE
fix(app): restrict CORS to explicit ALLOWED_ORIGINS allowlist

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,18 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+function buildCorsOptions() {
+  const raw = process.env.ALLOWED_ORIGINS ?? "";
+  const allowlist = raw.split(",").map(s => s.trim()).filter(Boolean);
+  if (allowlist.length === 0) return { origin: false };
+  return { origin: allowlist };
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(buildCorsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors-allowlist.test.js
+++ b/apps/api/src/tests/cors-allowlist.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("CORS blocks unlisted origins when ALLOWED_ORIGINS is not set", async () => {
+  delete process.env.ALLOWED_ORIGINS;
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/health`, {
+    headers: { "Origin": "https://evil.example.com" }
+  });
+  // When cors origin: false, no Access-Control-Allow-Origin header is set
+  assert.ok(!res.headers.get("access-control-allow-origin"), "CORS header must not be set for unlisted origin");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7496

/claim #743

## Summary
- Reads `ALLOWED_ORIGINS` env var (comma-separated list of allowed origins)
- When unset/empty, CORS is configured with `origin: false` — no cross-origin requests allowed
- In production, set `ALLOWED_ORIGINS=https://app.example.com` to allow your frontend
- Adds regression test verifying unlisted origins receive no `Access-Control-Allow-Origin` header