### PR TITLE
fix(config): throw startup error when JWT_SECRET is missing in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,15 @@
+const jwtSecretRaw = process.env.JWT_SECRET ?? "development-secret";
+
+if (process.env.NODE_ENV === "production") {
+  if (!process.env.JWT_SECRET || process.env.JWT_SECRET.length < 32) {
+    throw new Error("JWT_SECRET must be set to at least 32 characters in production");
+  }
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: jwtSecretRaw,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env-jwt-secret.test.js
+++ b/apps/api/src/tests/env-jwt-secret.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("env module throws in production when JWT_SECRET is not set", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", "import \"../config/env.js\""],
+    {
+      cwd: resolve(__dirname, ".."),
+      env: { ...process.env, NODE_ENV: "production", JWT_SECRET: "" },
+      encoding: "utf8"
+    }
+  );
+  assert.ok(result.status !== 0, "process should exit with non-zero when JWT_SECRET is absent in production");
+  assert.ok(result.stderr.includes("JWT_SECRET"), "error message should mention JWT_SECRET");
+});


### PR DESCRIPTION
Closes #7497

/claim #743

## Summary
- Validates `JWT_SECRET` at module load time when `NODE_ENV=production`
- Throws `Error` if `JWT_SECRET` is absent or shorter than 32 characters
- Development environments retain the `"development-secret"` fallback
- Adds regression test verifying the process exits non-zero with an absent `JWT_SECRET` in production mode