### PR TITLE
fix(upload): return 400 when no file is uploaded instead of 201 no-file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file uploaded", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload-missing-file.test.js
+++ b/apps/api/src/tests/upload-missing-file.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads returns 400 when no file is provided", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST"
+  });
+  assert.equal(res.status, 400, "missing file must return 400");
+  const body = await res.json();
+  assert.equal(body.success, false);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});
+
+test("missing file response has no-file status replaced by 400 error", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST"
+  });
+  assert.notEqual(res.status, 201, "missing file must not return 201");
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7498

/claim #743

## Summary
- `uploadFile` now checks for `req.file` and returns 400 with `{ success: false, message: "No file uploaded" }` when absent
- Removes the misleading `201 { status: "no-file" }` response that signalled success with no actual upload
- Adds regression tests verifying 400 status and `success: false` response body on empty upload