### PR TITLE
fix: validate upload payloads

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,13 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,42 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const allowedMimeTypes = new Set(["image/jpeg", "image/png", "application/pdf"]);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter(req, file, cb) {
+    if (!allowedMimeTypes.has(file.mimetype)) {
+      const error = new Error("Unsupported file type");
+      error.status = 415;
+      return cb(error);
+    }
+
+    return cb(null, true);
+  }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+function handleUpload(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "File is too large", 413);
+    }
+
+    if (error.status === 415) {
+      return fail(res, "Unsupported file type", 415);
+    }
+
+    return next(error);
+  });
+}
+
+uploadRoutes.post("/", handleUpload, uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects missing file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File is required");
+  });
+});
+
+test("POST /api/uploads rejects unsupported file types", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"], { type: "text/plain" }), "note.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 415);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unsupported file type");
+  });
+});
+
+test("POST /api/uploads rejects oversized files", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const oversizedContent = "a".repeat(5 * 1024 * 1024 + 1);
+    form.set("file", new Blob([oversizedContent], { type: "application/pdf" }), "large.pdf");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File is too large");
+  });
+});
+
+test("POST /api/uploads accepts valid small files", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["%PDF-1.4"], { type: "application/pdf" }), "resume.pdf");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "resume.pdf",
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
Closes #7513.

## Summary
- Reject upload requests that do not include the expected `file` field with `400`.
- Reject unsupported MIME types with `415` and oversized files with `413`.
- Keep valid small image/PDF uploads returning `201`.

## Validation
- `node --test apps/api/src/tests/upload.test.js`
- `node --test apps/api/src/tests/health.test.js`