### PR TITLE
fix(proposals): strip caller-supplied id to prevent id injection

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...safePayload } = payload;
+  const proposal = { ...safePayload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-service-id.test.js
+++ b/apps/api/src/tests/proposal-service-id.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal ignores caller-supplied id", async () => {
+  const result = await createProposal({ coverLetter: "Hello", bidAmount: 500, id: "evil-id" });
+  assert.notEqual(result.id, "evil-id");
+  assert.ok(result.id.startsWith("prp_"));
+});


### PR DESCRIPTION
Closes #7518

/claim #743

## Summary
- Destructures and discards any `id` from payload before building the proposal
- Server-generated `id` is placed last and is always authoritative
- Adds regression test verifying caller-supplied `id` is ignored