### PR TITLE
fix(reviews): strip caller-supplied id to prevent id injection

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...safePayload } = payload;
+  const review = { ...safePayload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-service-id.test.js
+++ b/apps/api/src/tests/review-service-id.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller-supplied id", async () => {
+  const result = await createReview({ rating: 5, comment: "Great!", id: "evil-id" });
+  assert.notEqual(result.id, "evil-id");
+  assert.ok(result.id.startsWith("rev_"));
+});


### PR DESCRIPTION
Closes #7519

/claim #743

## Summary
- Destructures and discards any `id` from payload before building the review
- Server-generated `id` is placed last and is always authoritative
- Adds regression test verifying caller-supplied `id` is ignored