### PR TITLE
fix(messages): strip caller-supplied id and sentAt to preserve server ownership

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _ignoredId, sentAt: _ignoredSentAt, ...safePayload } = payload;
+  const message = { ...safePayload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-service-injection.test.js
+++ b/apps/api/src/tests/message-service-injection.test.js
@@ -1,0 +1,10 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-supplied id and sentAt", async () => {
+  const result = await sendMessage({ content: "Hello", recipientId: "usr_2", id: "evil-id", sentAt: "2000-01-01T00:00:00.000Z" });
+  assert.notEqual(result.id, "evil-id");
+  assert.notEqual(result.sentAt, "2000-01-01T00:00:00.000Z");
+  assert.ok(result.id.startsWith("msg_"));
+});


### PR DESCRIPTION
Closes #7520

/claim #743

## Summary
- Destructures and discards `id` and `sentAt` from the payload before constructing the message
- Server-assigned `id` and `sentAt` are placed last and cannot be overridden
- Adds regression test verifying both fields are ignored