### PR TITLE
fix(proposals): require authentication on proposal creation endpoint

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposal-auth.test.js
+++ b/apps/api/src/tests/proposal-auth.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/proposals requires authentication", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => { server.once("listening", resolve); server.once("error", reject); });
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ coverLetter: "Hi", bidAmount: 100 })
+  });
+  assert.equal(res.status, 401);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7521

/claim #743

## Summary
- `POST /api/proposals` now runs through `authMiddleware`
- Unauthenticated requests receive 401
- Adds regression test verifying missing Authorization header returns 401