### PR TITLE
fix(middleware): ZodError returns 400 client error instead of 500 server error

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: err.errors[0]?.message ?? "Validation error"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/error-handler-zod.test.js
+++ b/apps/api/src/tests/error-handler-zod.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Zod validation failure returns 400 not 500", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => { server.once("listening", resolve); server.once("error", reject); });
+  const { port } = server.address();
+  // POST /api/auth/register with invalid email triggers ZodError
+  const res = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email", password: "short" })
+  });
+  assert.equal(res.status, 400, "Zod validation error must return 400");
+  const body = await res.json();
+  assert.equal(body.success, false);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});


### PR DESCRIPTION
Closes #7527

/claim #743

## Summary
- `errorHandler` now detects `ZodError` instances (`instanceof ZodError`) and returns 400 with the first validation message
- All other unexpected errors still return 500
- Adds integration test verifying a Zod validation failure returns 400