### PR TITLE
fix(web): remove Admin link from public navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -6,8 +6,7 @@ const links = [
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
+  ["/messaging", "Messaging"]
 ];
 
 export function Navigation() {


### PR DESCRIPTION
Closes #7528

/claim #743

## Summary
- Removes the `["/admin", "Admin"]` entry from the public `Navigation` links array
- The admin panel is no longer visible or navigable from the public nav for regular users