### PR TITLE
fix(packages): add exports field to @freelanceflow/ui for workspace resolution

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
 }


### PR DESCRIPTION
Closes #7529

/claim #743

## Summary
- Adds `"exports": { ".": "./src/index.ts" }` to `packages/ui/package.json`
- Workspace packages that `import from "@freelanceflow/ui"` can now resolve the entry point
- `main` field retained for legacy compatibility