### PR TITLE
fix(packages): add main and exports fields to @freelanceflow/db for workspace resolution

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
Closes #7530

/claim #743

## Summary
- Adds `"main": "src/index.ts"` and `"exports": { ".": "./src/index.ts" }` to `packages/db/package.json`
- Other workspace packages that import `@freelanceflow/db` can now resolve the entry point