### PR TITLE
fix(web): job detail page resolves and renders matching mock job

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,21 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job with id <strong>{params.id}</strong> exists.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #7532

/claim #743

## Summary
- Imports the `jobs` mock array and finds the matching job by `params.id`
- Renders the job title and budget when found
- Renders a "Job Not Found" fallback when the id does not match any mock job