### PR TITLE
fix(web): freelancer profile page resolves and renders matching mock profile

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No profile for <strong>{params.username}</strong> exists.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #7533

/claim #743

## Summary
- Imports `freelancers` mock array and finds the matching profile by `params.username`
- Renders rate and skills when found
- Renders a "Freelancer Not Found" fallback when the username does not match any mock profile