### PR TITLE
fix(proposals): validate proposal creation input with Zod schema

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "development-secret";
+
+test("POST /api/proposals returns 400 when required fields are missing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => { server.once("listening", resolve); server.once("error", reject); });
+  const { port } = server.address();
+  const token = jwt.sign({ sub: "usr_1", role: "client" }, JWT_SECRET, { expiresIn: "1h" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+    body: "{}"
+  });
+  assert.equal(res.status, 400);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7534

/claim #743

## Summary
- Adds `createProposalSchema` requiring `coverLetter`, `bidAmount` (positive number), `estDuration`, and `jobId`
- `postProposal` controller now parses `req.body` through Zod before calling the service
- Adds regression test verifying an empty body returns 400