### PR TITLE
fix(messages): validate message creation input with Zod schema

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { sendMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,6 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/tests/message-validation.test.js
+++ b/apps/api/src/tests/message-validation.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = process.env.JWT_SECRET ?? "development-secret";
+
+test("POST /api/messages returns 400 when required fields are missing", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => { server.once("listening", resolve); server.once("error", reject); });
+  const { port } = server.address();
+  const token = jwt.sign({ sub: "usr_1", role: "client" }, JWT_SECRET, { expiresIn: "1h" });
+  const res = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+    body: "{}"
+  });
+  assert.equal(res.status, 400);
+  await new Promise((resolve, reject) => server.close(e => e ? reject(e) : resolve()));
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  content: z.string().min(1),
+  recipientId: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7536

/claim #743

## Summary
- Adds `sendMessageSchema` requiring `content` (non-empty string) and `recipientId` (non-empty string)
- `postMessage` controller now parses `req.body` through Zod before calling the service
- Adds regression test verifying an empty body returns 400