### PR TITLE
fix: validate review payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,18 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects an empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews rejects out-of-range ratings", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 6, comment: "Too high" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid review payload"
+    });
+  });
+});
+
+test("POST /api/reviews accepts valid review payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "Excellent work" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent work");
+    assert.match(payload.data.id, /^rev_/);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7554.

## Summary
- Validate review creation payloads with Zod before persisting.
- Return `400` for empty or out-of-range review submissions.
- Keep valid review payloads working as before.

## Validation
- `node --test apps/api/src/tests/review.test.js`
- `node --test apps/api/src/tests/health.test.js`