### PR TITLE
fix: validate message payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,18 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects an empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages rejects missing recipient ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid message payload"
+    });
+  });
+});
+
+test("POST /api/messages accepts valid message payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Hello there", recipientId: "usr_1" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.content, "Hello there");
+    assert.equal(payload.data.recipientId, "usr_1");
+    assert.match(payload.data.id, /^msg_/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().min(1),
+  recipientId: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7559.

## Summary
- Validate message creation payloads with Zod before persisting.
- Return `400` for empty or invalid message submissions.
- Keep valid messages working as before.

## Validation
- `node --test apps/api/src/tests/message.test.js`
- `node --test apps/api/src/tests/health.test.js`