### PR TITLE
fix: validate payment payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,14 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid payment payload", 400);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects an empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments rejects negative amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: -25, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid payment payload"
+    });
+  });
+});
+
+test("POST /api/payments accepts valid payment payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 250, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 250);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).optional()
+});


### PR DESCRIPTION
Closes #7561.

## Summary
- Validate payment creation payloads with Zod before creating an intent response.
- Return `400` for empty or invalid payment submissions.
- Keep valid payment payloads returning `201` with the existing provider behavior.

## Validation
- `node --test apps/api/src/tests/payment.test.js`
- `node --test apps/api/src/tests/health.test.js`