### PR TITLE
fix: prevent user id override

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { email, fullName, role } = payload;
+  const user = { id: `usr_${Date.now()}`, email, fullName, role };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser ignores client-controlled id values", async () => {
+  const created = await createUser({
+    id: "attacker",
+    email: "person@example.com",
+    fullName: "Test Person",
+    role: "client"
+  });
+
+  assert.notEqual(created.id, "attacker");
+  assert.match(created.id, /^usr_/);
+  assert.deepEqual(created, {
+    id: created.id,
+    email: "person@example.com",
+    fullName: "Test Person",
+    role: "client"
+  });
+  const users = await listUsers();
+
+  assert.ok(Array.isArray(users));
+  assert.ok(users.length >= 1);
+  assert.notEqual(users[users.length - 1].id, "attacker");
+  assert.equal(users[users.length - 1].id, created.id);
+});


### PR DESCRIPTION
Closes #7565.

## Summary
- Prevent client-controlled `id` overrides in user creation.
- Keep the generated `usr_...` id server-owned.
- Add a focused service test proving a payload-supplied id is ignored.

## Validation
- `node --test apps/api/src/tests/userService.test.js`
- `node --test apps/api/src/tests/health.test.js`