### PR TITLE
fix: validate search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+
+  if (typeof q !== "string" || q.trim().length === 0) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  if (q.length > 120) {
+    return fail(res, "Invalid search query", 400);
+  }
+
+  return ok(res, await globalSearch(q.trim()));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects empty queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid search query"
+    });
+  });
+});
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"x".repeat(121)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid search query"
+    });
+  });
+});
+
+test("GET /api/search accepts normal queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=freelance`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "freelance");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});


### PR DESCRIPTION
Closes #7567.

## Summary
- Validate search queries before calling the service.
- Reject empty or overly long queries with `400`.
- Keep normal search requests working as before.

## Validation
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/health.test.js`