### PR TITLE
fix: prevent job field overrides

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,17 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { title, description, budgetMin, budgetMax, categoryId, skills = [] } = payload;
+  const job = {
+    id: `job_${Date.now()}`,
+    status: "open",
+    title,
+    description,
+    budgetMin,
+    budgetMax,
+    categoryId,
+    skills
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob ignores client-controlled id and status values", async () => {
+  const created = await createJob({
+    id: "attacker",
+    status: "closed",
+    title: "Build a dashboard",
+    description: "Build a small analytics dashboard with filters.",
+    budgetMin: 100,
+    budgetMax: 250,
+    categoryId: "cat_1",
+    skills: ["React"]
+  });
+
+  assert.notEqual(created.id, "attacker");
+  assert.match(created.id, /^job_/);
+  assert.equal(created.status, "open");
+  assert.deepEqual(created.skills, ["React"]);
+});
+
+test("listJobs reflects stored jobs", async () => {
+  const jobs = await listJobs();
+
+  assert.ok(Array.isArray(jobs));
+  assert.ok(jobs.length >= 1);
+  assert.equal(jobs[jobs.length - 1].status, "open");
+});


### PR DESCRIPTION
Closes #7569.

## Summary
- Prevent client-controlled overrides of job `id` and `status`.
- Keep jobs server-owned with a generated `job_...` id and `open` status.
- Add a focused service test proving payload-supplied `id` and `status` are ignored.

## Validation
- `node --test apps/api/src/tests/jobService.test.js`
- `node --test apps/api/src/tests/health.test.js`