### PR TITLE
fix: add settings controls

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,32 @@
+import { freelancers } from "../../lib/mock";
+
 export default function SettingsPage() {
+  const currentUser = {
+    displayName: "Maya Thompson",
+    email: "maya@example.com",
+    notifications: true
+  };
+
   return (
     <section className="card">
       <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
+      <div style={{ display: "grid", gap: "0.75rem" }}>
+        <label>
+          <div>Display name</div>
+          <input defaultValue={currentUser.displayName} />
+        </label>
+        <label>
+          <div>Email</div>
+          <input defaultValue={currentUser.email} readOnly />
+        </label>
+        <label>
+          <div>Notification preferences</div>
+          <input type="checkbox" defaultChecked={currentUser.notifications} />
+          <span>Enable email updates</span>
+        </label>
+        <button type="button">Change password</button>
+        <p>Available freelancer presets: {freelancers.length}</p>
+      </div>
     </section>
   );
 }

--- a/apps/web/tests/settings-page.test.js
+++ b/apps/web/tests/settings-page.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const settingsPagePath = resolve(__dirname, "../app/settings/page.tsx");
+
+test("settings page renders expected account controls", async () => {
+  const source = await readFile(settingsPagePath, "utf8");
+
+  assert.match(source, /Display name/);
+  assert.match(source, /Email/);
+  assert.match(source, /Notification preferences/);
+  assert.match(source, /Change password/);
+  assert.match(source, /readOnly/);
+});


### PR DESCRIPTION
Closes #7571.

## Summary
- Replace the static settings placeholder with editable account controls.
- Keep the page aligned with the existing card-based UI.
- Use the existing mock data as a lightweight reference point.

## Validation
- `npm run build -w apps/web`