### PR TITLE
fix: render matching job details

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -10,7 +10,7 @@ export default function JobDetailPage({ params }: { params: { id: string } }) {
         <div style={{ display: "grid", gap: "0.5rem" }}>
           <p>{job.title}</p>
           <p>{job.budget}</p>
-          <p>Responsibilities, milestones, and proposals would be shown here.</p>
+          <p>{job.description}</p>
         </div>
       ) : (
         <p>Job not found</p>

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,20 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((entry) => entry.id === params.id);
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      {job ? (
+        <div style={{ display: "grid", gap: "0.5rem" }}>
+          <p>{job.title}</p>
+          <p>{job.budget}</p>
+          <p>Responsibilities, milestones, and proposals would be shown here.</p>
+        </div>
+      ) : (
+        <p>Job not found</p>
+      )}
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,22 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    description: "Create a chat assistant that can answer common support questions."
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    description: "Rebuild the existing REST API with a cleaner service architecture."
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    description: "Improve activation with a clearer signup and first-run experience."
+  }
 ];
 
 export const freelancers = [

--- a/apps/web/tests/job-detail-page.test.js
+++ b/apps/web/tests/job-detail-page.test.js
@@ -10,7 +10,7 @@ test("job detail page renders mock data and fallback", async () => {
 
   assert.match(source, /jobs\.find/);
   assert.match(source, /Job not found/);
-  assert.match(source, /Responsibilities, milestones, and proposals would be shown here\./);
+  assert.match(source, /job\.description/);
   assert.match(source, /job\.title/);
   assert.match(source, /job\.budget/);
 });

--- a/apps/web/tests/job-detail-page.test.js
+++ b/apps/web/tests/job-detail-page.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const pagePath = resolve("apps/web/app/jobs/[id]/page.tsx");
+
+test("job detail page renders mock data and fallback", async () => {
+  const source = await readFile(pagePath, "utf8");
+
+  assert.match(source, /jobs\.find/);
+  assert.match(source, /Job not found/);
+  assert.match(source, /Responsibilities, milestones, and proposals would be shown here\./);
+  assert.match(source, /job\.title/);
+  assert.match(source, /job\.budget/);
+});


### PR DESCRIPTION
Closes #7573.

## Summary
- Render job detail pages from the existing mock jobs list.
- Show the matching job title and budget, with a "Job not found" fallback.
- Add a focused test that checks the page source includes the expected lookup and fallback behavior.

## Validation
- `npm run build -w apps/web`
- `node --test apps/web/tests/job-detail-page.test.js`