### PR TITLE
fix: render matching freelancer profile

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,20 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((entry) => entry.username === params.username);
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      {freelancer ? (
+        <div style={{ display: "grid", gap: "0.5rem" }}>
+          <p>{freelancer.username}</p>
+          <p>{freelancer.skills.join(", ")}</p>
+          <p>{freelancer.rate}</p>
+        </div>
+      ) : (
+        <p>Freelancer not found</p>
+      )}
     </section>
   );
 }

--- a/apps/web/tests/freelancer-profile-page.test.js
+++ b/apps/web/tests/freelancer-profile-page.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const pagePath = resolve("apps/web/app/freelancers/[username]/page.tsx");
+
+test("freelancer profile page renders mock data and fallback", async () => {
+  const source = await readFile(pagePath, "utf8");
+
+  assert.match(source, /freelancers\.find/);
+  assert.match(source, /Freelancer not found/);
+  assert.match(source, /freelancer\.skills\.join/);
+  assert.match(source, /freelancer\.rate/);
+  assert.match(source, /freelancer\.username/);
+});


### PR DESCRIPTION
Closes #7575.

## Summary
- Render freelancer profiles from the existing mock freelancer list.
- Show matching skills and rate, with a "Freelancer not found" fallback.
- Add a focused test that checks the page source for the expected lookup and fallback behavior.

## Validation
- `npm run build -w apps/web`
- `node --test apps/web/tests/freelancer-profile-page.test.js`