### PR TITLE
fix: add notifications feed

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,21 @@
 export default function NotificationsPage() {
+  const alerts = [
+    { label: "Proposal updates", detail: "A new proposal landed on job-102." },
+    { label: "Unread messages", detail: "Jordan left you 2 unread messages." },
+    { label: "Billing alerts", detail: "Your payout method was verified." }
+  ];
+
   return (
     <section className="card">
       <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
+      <div style={{ display: "grid", gap: "0.5rem" }}>
+        {alerts.map((alert) => (
+          <article key={alert.label}>
+            <strong>{alert.label}</strong>
+            <p>{alert.detail}</p>
+          </article>
+        ))}
+      </div>
     </section>
   );
 }

--- a/apps/web/tests/notifications-page.test.js
+++ b/apps/web/tests/notifications-page.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const pagePath = resolve("apps/web/app/notifications/page.tsx");
+
+test("notifications page renders mock alerts", async () => {
+  const source = await readFile(pagePath, "utf8");
+
+  assert.match(source, /Proposal updates/);
+  assert.match(source, /Unread messages/);
+  assert.match(source, /Billing alerts/);
+  assert.match(source, /alerts\.map/);
+});


### PR DESCRIPTION
Closes #7579.

## Summary
- Replace the static notifications placeholder with a small mock alerts feed.
- Show proposal updates, unread messages, and billing alerts as separate items.
- Add a focused test that checks the page includes the expected alert labels.

## Validation
- `npm run build -w apps/web`
- `node --test apps/web/tests/notifications-page.test.js`