### PR TITLE
fix(proposals): add Zod input validation to proposal creation endpoint

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) return fail(res, result.error.errors[0].message, 400);
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7557

## Summary
Adds Zod validation to the proposal creation endpoint. Returns 400 with a descriptive error message if required fields are missing or invalid.

## Changes
- apps/api/src/validators/proposal.js: New Zod schema requiring jobId, coverLetter, bidAmount, estDuration
- apps/api/src/controllers/proposalController.js: Validate req.body before calling createProposal