### PR TITLE
fix(messages): add Zod input validation to message creation endpoint

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) return fail(res, result.error.errors[0].message, 400);
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().min(1),
+  content: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7559

## Summary
Adds Zod validation to the message creation endpoint. Returns 400 if recipientId or content are missing or empty.

## Changes
- apps/api/src/validators/message.js: New Zod schema requiring recipientId and content
- apps/api/src/controllers/messageController.js: Validate req.body before calling sendMessage