### PR TITLE
fix(payments): add Zod input validation to payment creation endpoint

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,9 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) return fail(res, result.error.errors[0].message, 400);
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("usd")
+});


### PR DESCRIPTION
Closes #7561

## Summary
Adds Zod validation to the payment creation endpoint. Returns 400 if amount is missing or not a positive number. Currency defaults to 'usd' if not supplied.

## Changes
- apps/api/src/validators/payment.js: New Zod schema requiring amount (positive number), optional currency (default 'usd')
- apps/api/src/controllers/paymentController.js: Validate req.body before calling createPaymentIntent