### PR TITLE
fix(notifications): add Zod input validation to notification creation endpoint

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) return fail(res, result.error.errors[0].message, 400);
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7563

## Summary
Adds Zod validation to the notification creation endpoint. Returns 400 if userId or message are missing or empty.

## Changes
- apps/api/src/validators/notification.js: New Zod schema requiring userId and message
- apps/api/src/controllers/notificationController.js: Validate req.body before calling createNotification