### PR TITLE
fix(users): prevent client-controlled id override in user service

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { email, password, role, fullName } = payload;
+  const user = { id: `usr_${Date.now()}`, email, password, role, fullName };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Closes #7565

## Summary
Replaces the spread of the entire payload with explicit destructuring of approved fields only. This prevents a client from supplying an arbitrary id to override the server-generated one.

## Changes
- apps/api/src/services/userService.js: Destructure only email, password, role, fullName; always generate id server-side