### PR TITLE
fix(search): validate query parameter in search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,9 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+  if (!q || q.length === 0) return fail(res, "Query parameter q is required", 400);
+  if (q.length > 200) return fail(res, "Query parameter q must not exceed 200 characters", 400);
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Closes #7567

## Summary
Adds query parameter validation to the search endpoint. Returns 400 if q is missing/empty or exceeds 200 characters.

## Changes
- apps/api/src/controllers/searchController.js: Validate q query param (non-empty, max 200 chars)