### PR TITLE
fix(jobs): resolve mock job by id on job detail page

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,22 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find(j => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job matches id <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p><strong>Job ID:</strong> {job.id}</p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7573

## Summary
Job detail page now looks up the matching mock job by id and renders its title, budget, and id. Shows a not-found fallback when no job matches.

## Changes
- apps/web/app/jobs/[id]/page.tsx: Resolve job from mock data, render detail or not-found fallback