### PR TITLE
fix(freelancers): resolve mock freelancer by username on profile page

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,22 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find(f => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No profile found for <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7575

## Summary
Freelancer profile page now looks up the matching mock freelancer by username and renders their username, rate, and skills. Shows a not-found fallback when no match exists.

## Changes
- apps/web/app/freelancers/[username]/page.tsx: Resolve freelancer from mock data, render profile or not-found fallback