### PR TITLE
fix(billing): render mock billing overview with invoices and payout method

### DIFF
--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -1,8 +1,22 @@
+const mockInvoices = [
+  { id: "inv-001", amount: "$500", status: "Paid", date: "2026-05-01" },
+  { id: "inv-002", amount: "$1,200", status: "Pending", date: "2026-06-01" }
+];
+
 export default function BillingPage() {
   return (
     <section className="card">
       <h2>Billing</h2>
-      <p>Invoices, payout methods, and transaction history are managed here.</p>
+      <h3>Invoices</h3>
+      <ul>
+        {mockInvoices.map(inv => (
+          <li key={inv.id}>
+            {inv.date} — {inv.amount} — <strong>{inv.status}</strong> (#{inv.id})
+          </li>
+        ))}
+      </ul>
+      <h3>Payout method</h3>
+      <p>Bank account ending in <strong>4242</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7577

## Summary
Replaces the billing page placeholder with a mock overview showing invoice history and payout method details.

## Changes
- apps/web/app/billing/page.tsx: Replace placeholder with mock invoice list and payout method section