### PR TITLE
fix(notifications): render mock notification feed on notifications page

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -1,8 +1,20 @@
+const mockNotifications = [
+  { id: "ntf-1", message: "Your proposal was accepted for \"Build an AI widget\".", read: false },
+  { id: "ntf-2", message: "New message from maya-dev.", read: true },
+  { id: "ntf-3", message: "Invoice #inv-002 is due.", read: false }
+];
+
 export default function NotificationsPage() {
   return (
     <section className="card">
       <h2>Notifications</h2>
-      <p>Proposal updates, unread messages, and billing alerts appear in this feed.</p>
+      <ul>
+        {mockNotifications.map(n => (
+          <li key={n.id} style={{ fontWeight: n.read ? "normal" : "bold" }}>
+            {n.message} {!n.read && <span style={{ color: "blue" }}>(unread)</span>}
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7579

## Summary
Replaces the notifications page placeholder with a mock notification feed. Unread notifications are rendered in bold with an '(unread)' badge.

## Changes
- apps/web/app/notifications/page.tsx: Replace placeholder with mock notification list