### PR TITLE
fix(admin): render moderation overview with mock platform metrics

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,8 +1,21 @@
+const mockMetrics = {
+  totalUsers: 1204,
+  activeJobs: 87,
+  openReports: 14,
+  pendingPayouts: 6
+};
+
 export default function AdminPanelPage() {
   return (
     <section className="card">
       <h2>Admin Panel</h2>
-      <p>Moderation queues, trust metrics, and platform controls are available here.</p>
+      <h3>Platform Overview</h3>
+      <ul>
+        <li>Total users: <strong>{mockMetrics.totalUsers}</strong></li>
+        <li>Active jobs: <strong>{mockMetrics.activeJobs}</strong></li>
+        <li>Open reports: <strong>{mockMetrics.openReports}</strong></li>
+        <li>Pending payouts: <strong>{mockMetrics.pendingPayouts}</strong></li>
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7581

## Summary
Replaces the admin panel placeholder with a mock moderation overview showing key platform metrics: total users, active jobs, open reports, and pending payouts.

## Changes
- apps/web/app/admin/page.tsx: Replace placeholder with mock admin metrics overview