### PR TITLE
fix(proposal): return defensive copies from listProposals and createProposal

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,12 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map(p => ({ ...p }));
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { jobId, coverLetter, bidAmount, estDuration } = payload;
+  const proposal = { id: `prp_${Date.now()}`, jobId, coverLetter, bidAmount, estDuration };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }


### PR DESCRIPTION
Closes #7598

## Summary
Return defensive copies from proposalService list and create functions to prevent mutable internal state exposure.

## Changes
- apps/api/src/services/proposalService.js: map over proposals array for list, destructure payload and spread for create