### PR TITLE
fix(message): return defensive copies from listMessages and sendMessage

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,12 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map(m => ({ ...m }));
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { recipientId, content } = payload;
+  const message = { id: `msg_${Date.now()}`, recipientId, content, sentAt: new Date().toISOString() };
   messages.push(message);
-  return message;
+  return { ...message };
 }


### PR DESCRIPTION
Closes #7600

## Summary
Return defensive copies from messageService list and send functions to prevent mutable internal state exposure.

## Changes
- apps/api/src/services/messageService.js: map over messages array for list, destructure payload and spread for sendMessage