### PR TITLE
fix(notification): return defensive copies and prevent read flag override

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,12 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map(n => ({ ...n }));
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { userId, message } = payload;
+  const notification = { id: `ntf_${Date.now()}`, userId, message, read: false };
   notifications.push(notification);
-  return notification;
+  return { ...notification };
 }


### PR DESCRIPTION
Closes #7602

## Summary
Return defensive copies from notificationService and fix payload spread order bug that allowed callers to override server-owned fields.

## Changes
- apps/api/src/services/notificationService.js: map for list, destructure payload, place id/read after payload fields for create