### PR TITLE
fix(job): return defensive copies and prevent id/status injection

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,12 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map(j => ({ ...j }));
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { title, description, budgetMin, budgetMax, categoryId, skills } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", title, description, budgetMin, budgetMax, categoryId, skills };
   jobs.push(job);
-  return job;
+  return { ...job };
 }


### PR DESCRIPTION
Closes #7604

## Summary
Return defensive copies from jobService and prevent callers from injecting id or status via payload spread.

## Changes
- apps/api/src/services/jobService.js: map for list, destructure approved fields only, spread copy for create