### PR TITLE
fix(user): return defensive copies and prevent id injection

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,12 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(u => ({ ...u }));
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { email, password, role, fullName } = payload;
+  const user = { id: `usr_${Date.now()}`, email, password, role, fullName };
   users.push(user);
-  return user;
+  return { ...user };
 }


### PR DESCRIPTION
Closes #7606

## Summary
Return defensive copies from userService and prevent callers from injecting id via payload spread.

## Changes
- apps/api/src/services/userService.js: map for list, destructure approved fields only, spread copy for create