### PR TITLE
fix(review): return defensive copies from listReviews and createReview

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,12 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map(r => ({ ...r }));
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { reviewerId, targetId, rating, comment } = payload;
+  const review = { id: `rev_${Date.now()}`, reviewerId, targetId, rating, comment };
   reviews.push(review);
-  return review;
+  return { ...review };
 }


### PR DESCRIPTION
Closes #7608

## Summary
Return defensive copies from reviewService list and create functions to prevent mutable internal state exposure.

## Changes
- apps/api/src/services/reviewService.js: map for list, destructure approved fields only, spread copy for create