### PR TITLE
fix(auth): validate OAuth provider against allowlist in oauthCallback

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -14,9 +14,15 @@ export async function login(req, res) {
   return ok(res, result);
 }
 
+const ALLOWED_PROVIDERS = new Set(["github", "google", "linkedin"]);
+
 export async function oauthCallback(req, res) {
+  const { provider } = req.params;
+  if (!ALLOWED_PROVIDERS.has(provider)) {
+    return fail(res, `Unsupported OAuth provider: ${provider}`, 400);
+  }
   return ok(res, {
-    provider: req.params.provider,
+    provider,
     status: "callback-received"
   });
 }


### PR DESCRIPTION
Closes #7611

## Summary
Validate the OAuth provider route parameter against an allowlist of known providers to reject arbitrary strings.

## Changes
- apps/api/src/controllers/authController.js: add ALLOWED_PROVIDERS set, return 400 for unsupported providers, import fail from response utils