### PR TITLE
fix(ui): forward native HTML props in Button and Card components

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+export function Button({
+  children,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <button
       style={{
@@ -11,6 +14,7 @@ export function Button({ children }: { children: React.ReactNode }) {
         padding: "0.6rem 0.9rem",
         cursor: "pointer"
       }}
+      {...props}
     >
       {children}
     </button>

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export function Card({
+  title,
+  children,
+  ...props
+}: { title: string; children: React.ReactNode } & React.HTMLAttributes<HTMLElement>) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }} {...props}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Closes #7613

## Summary
Update Button and Card components to accept and forward all standard HTML props via rest spread, making them usable as form controls and interactive elements.

## Changes
- packages/ui/src/Button.tsx: accept React.ButtonHTMLAttributes<HTMLButtonElement>, spread remaining props onto button element
- packages/ui/src/Card.tsx: accept React.HTMLAttributes<HTMLElement> in addition to title/children, spread remaining props onto section element