### PR TITLE
fix(freelancer-dashboard): replace static placeholder with mock proposals and earnings

### DIFF
--- a/apps/web/app/dashboard/freelancer/page.tsx
+++ b/apps/web/app/dashboard/freelancer/page.tsx
@@ -1,8 +1,24 @@
+import { jobs } from "../../../lib/mock";
+
+const mockProposals = [
+  { id: "prp-1", jobTitle: "Build an AI customer support widget", bidAmount: "$1,400", status: "Pending" },
+  { id: "prp-2", jobTitle: "Migrate legacy API to Node.js", bidAmount: "$2,600", status: "Accepted" }
+];
+
+const mockEarnings = { thisMonth: "$2,600", total: "$14,200" };
+
 export default function FreelancerDashboardPage() {
   return (
     <section className="card">
       <h2>Dashboard (Freelancer)</h2>
-      <p>Manage proposals, accepted jobs, earnings, and response metrics.</p>
+      <h3>Earnings</h3>
+      <p>This month: <strong>{mockEarnings.thisMonth}</strong> · All time: <strong>{mockEarnings.total}</strong></p>
+      <h3>My Proposals</h3>
+      <ul>
+        {mockProposals.map(p => (
+          <li key={p.id}>{p.jobTitle} — {p.bidAmount} — <em>{p.status}</em></li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7619

## Summary
Replace the static freelancer dashboard placeholder with a rendered page showing mock earnings summary and proposal list.

## Changes
- apps/web/app/dashboard/freelancer/page.tsx: render mockEarnings and mockProposals