### PR TITLE
fix: validate refresh token input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,16 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const token = req.body?.refreshToken;
+
+  if (typeof token !== "string" || token.length === 0) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,13 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  const payload = verifyAccessToken(refreshTokenValue);
+
+  return {
+    token: signAccessToken({
+      sub: payload.sub,
+      role: payload.role
+    })
+  };
 }

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh requires a refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refresh tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: "not-a-jwt" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh issues a token for the provided refresh token subject", async () => {
+  await withServer(async (baseUrl) => {
+    const refreshToken = signAccessToken({ sub: "usr_123", role: "freelancer" });
+
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken })
+    });
+    const payload = await response.json();
+    const decoded = verifyAccessToken(payload.data.token);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_123");
+    assert.equal(decoded.role, "freelancer");
+  });
+});


### PR DESCRIPTION
Closes #7625
/claim #7625

Related to #743 and mirrors #1775 for my own claim.

Summary:
- Requires POST /api/auth/refresh to receive a refreshToken in the request body.
- Verifies the provided token before issuing a replacement token for the same subject and role.
- Adds API tests for missing, invalid, and valid refresh tokens.
- Updates the API test script to run test files explicitly on current Node versions.

Testing:
- npm test -w apps/api