### PR TITLE
fix: restrict CORS to explicit origin allowlist

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,7 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(",") ?? [] }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Closes #7628

## What was wrong
`app.use(cors())` with no options allowed any origin (`Access-Control-Allow-Origin: *`), enabling cross-origin credential theft.

## Fix
Pass an explicit `origin` allowlist via `ALLOWED_ORIGINS` env var. Empty array by default (deny-all), so production must set the env var.