### PR TITLE
fix: require auth for POST /api/jobs

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
Closes #7630

## What was wrong
`POST /api/jobs` lacked `authMiddleware`, allowing anonymous job creation.

## Fix
Added `authMiddleware` to `POST /api/jobs` route.