### PR TITLE
fix: require auth for POST /api/payments

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
Closes #7632

## What was wrong
`POST /api/payments` lacked `authMiddleware`, allowing unauthenticated payment creation.

## Fix
Added `authMiddleware` to `POST /api/payments` route.