### PR TITLE
fix: require auth for POST /api/messages

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);


### PR DESCRIPTION
Closes #7636

## What was wrong
`POST /api/messages` lacked `authMiddleware`, allowing anonymous message posting.

## Fix
Added `authMiddleware` to the POST route.