### PR TITLE
fix: require auth for POST /api/proposals

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);


### PR DESCRIPTION
Closes #7638

## What was wrong
`POST /api/proposals` lacked `authMiddleware`, allowing anonymous proposal submission.

## Fix
Added `authMiddleware` to the POST route.