### PR TITLE
fix: require auth for POST /api/reviews

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
Closes #7640

## What was wrong
`POST /api/reviews` lacked `authMiddleware`, allowing anonymous or fake review submission.

## Fix
Added `authMiddleware` to the POST route.