### PR TITLE
fix: require auth for POST /api/notifications

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);


### PR DESCRIPTION
Closes #7642

## What was wrong
`POST /api/notifications` lacked `authMiddleware`, allowing unauthenticated notification creation.

## Fix
Added `authMiddleware` to the POST route.