### PR TITLE
fix: deduplicate Date.now() so token sub matches user id on registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
Closes #7644

## What was wrong
`registerUser` called `Date.now()` twice producing different timestamps for the user `id` and the JWT `sub` claim.

## Fix
Capture the id once into a variable and reuse it for both the returned object and the `signAccessToken` call.