### PR TITLE
fix: enforce admin role RBAC on admin routes

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,14 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { fail } from "../utils/response.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") return fail(res, "Forbidden", 403);
+  return next();
+}
+
+adminRoutes.use(authMiddleware, requireAdmin);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Closes #7648

## What was wrong
`adminRoutes` used `authMiddleware` but did not check the user's role, allowing any authenticated user to access admin endpoints.

## Fix
Added `requireAdmin` middleware that returns 403 if `req.user.role !== "admin"`. Applied immediately after `authMiddleware` on all admin routes.