### PR TITLE
fix: remove admin from registration role enum to prevent privilege escalation

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #7650

## What was wrong
`registerSchema` allowed `role: "admin"` in the registration body, letting any user self-assign admin privileges.

## Fix
Removed `"admin"` from the allowed values in the registration schema. Only `"client"` and `"freelancer"` can be self-assigned.