### PR TITLE
fix: return HTTP 400 with validation details for ZodError

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"


### PR DESCRIPTION
Closes #7652

## What was wrong
The `errorHandler` did not check for `ZodError`, so schema parse failures returned generic HTTP 500 responses with no useful information.

## Fix
Added an `instanceof ZodError` check before the generic 500 handler. Zod validation errors now return HTTP 400 with the full `errors` array from the ZodError.