### PR TITLE
fix: enforce budgetMin <= budgetMax in job creation schema

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must not exceed budgetMax",
+  path: ["budgetMin"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Closes #7654

## What was wrong
`createJobSchema` validated `budgetMin` and `budgetMax` individually as non-negative but allowed `budgetMin > budgetMax", creating inverted budget ranges.

## Fix
Added a `.refine()` check that rejects requests where `budgetMin > budgetMax`.