### PR TITLE
fix: limit search query length to 200 chars to prevent DoS

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,9 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LEN = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = (req.query.q ?? "").slice(0, MAX_QUERY_LEN);
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
Closes #7656

## What was wrong
The search endpoint passed `req.query.q` to `globalSearch()` with no length limit, enabling DoS via arbitrarily large query strings.

## Fix
Truncate the query to 200 characters before passing to `globalSearch()`.