### PR TITLE
fix: require JWT_SECRET env var at startup, remove hardcoded default

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,11 @@
+if (!process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is required and must not be empty");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.JWT_SECRET,
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Closes #7658

## What was wrong
`env.js` fell back to `"development-secret"` when `JWT_SECRET` was unset. In production this allows token forgery with the known default.

## Fix
Throw at module-load time if `JWT_SECRET` is missing. The app will refuse to start rather than silently run with an insecure secret.