### PR TITLE
fix: require fullName in registerSchema

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(2),
   email: z.string().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")


### PR DESCRIPTION
Closes #7660

## What
`registerSchema` in `validators/auth.js` was missing the `fullName` field, allowing registration without a required User model field.

## Fix
Added `fullName: z.string().min(2)` to `registerSchema` so incomplete payloads are rejected at the validation layer.