### PR TITLE
fix: add Zod validation to postProposal

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { proposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = proposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.flatten(), 422);
+  }
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const proposalSchema = z.object({
+  jobId: z.string(),
+  coverLetter: z.string().min(1),
+  estimatedDuration: z.number().positive(),
+  bidAmount: z.number().positive().optional()
+});


### PR DESCRIPTION
Closes #7662

## What
`postProposal` was passing `req.body` directly to `createProposal()` with no input validation.

## Fix
- Created `apps/api/src/validators/proposal.js` with a Zod schema (jobId, coverLetter, estimatedDuration, optional bidAmount)
- Updated `proposalController.js` to validate and parse the request body before calling the service