### PR TITLE
fix: add Zod validation to postReview

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { reviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = reviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.flatten(), 422);
+  }
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const reviewSchema = z.object({
+  targetId: z.string(),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7664

## What
`postReview` was passing `req.body` directly to `createReview()` with no input validation, allowing invalid ratings and missing fields.

## Fix
- Created `apps/api/src/validators/review.js` with a Zod schema (targetId: string, rating: int 1–5, comment: string)
- Updated `reviewController.js` to validate before calling the service