### PR TITLE
fix: add Zod validation to createPayment

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { paymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = paymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.flatten(), 422);
+  }
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const paymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).optional()
+});


### PR DESCRIPTION
Closes #7666

## What
`createPayment` was passing `req.body` directly to `createPaymentIntent()` with no validation, allowing invalid amounts and currency values to reach the payment provider.

## Fix
- Created `apps/api/src/validators/payment.js` with `amount: z.number().positive()` and `currency: z.string().length(3).optional()`
- Updated `paymentController.js` to validate before calling the service