### PR TITLE
fix: add Zod validation to postMessage

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { messageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = messageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.flatten(), 422);
+  }
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const messageSchema = z.object({
+  recipientId: z.string(),
+  body: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7668

## What
`postMessage` was passing `req.body` directly to `sendMessage()` with no validation, allowing empty message bodies and missing recipient IDs.

## Fix
- Created `apps/api/src/validators/message.js` with `recipientId: z.string()` and `body: z.string().min(1)`
- Updated `messageController.js` to validate before calling the service