### PR TITLE
fix: require auth on GET /api/users

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
Closes #7674

## What
`GET /api/users` was publicly accessible, exposing all user records (emails, roles, IDs) to unauthenticated callers.

## Fix
Added `authMiddleware` to `userRoutes.get("/")` so only authenticated users can list user records.