### PR TITLE
fix: apply rate limiter before body parser in app.js

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });


### PR DESCRIPTION
Closes #7678

## What
`app.use(express.json())` was registered before `app.use(apiLimiter)`, meaning body parsing happened before rate limiting. A flood of large or malformed JSON bodies could exhaust parsing resources before the limiter rejected any requests.

## Fix
Swapped the order so `app.use(apiLimiter)` runs before `app.use(express.json())`, ensuring requests are rate-checked before the body is read.