### PR TITLE
fix: set 100kb body size limit on express.json()

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {


### PR DESCRIPTION
Closes #7680

## What
`express.json()` was called without an explicit `limit` option, leaving the body size limit unenforcedly large, which allows large-payload DoS attacks.

## Fix
Changed to `app.use(express.json({ limit: "100kb" }))` to explicitly cap incoming JSON bodies at 100 KB.