### PR TITLE
fix: add 5MB file size limit to multer

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,7 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } });
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
Closes #7682

## What
`multer` in `uploadRoutes.js` had no `limits` option, allowing clients to upload files of unlimited size into server memory (memoryStorage), risking OOM crashes.

## Fix
Added `limits: { fileSize: 5 * 1024 * 1024 }` (5 MB cap) to the multer configuration.