### PR TITLE
fix: require auth on GET /api/proposals

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
-proposalRoutes.get("/", getProposals);
+proposalRoutes.get("/", authMiddleware, getProposals);
 proposalRoutes.post("/", postProposal);


### PR DESCRIPTION
Closes #7684

## What
`GET /api/proposals` was publicly accessible, exposing all proposals (bid amounts, cover letters, freelancer details) to unauthenticated callers.

## Fix
Added `authMiddleware` to `proposalRoutes.get("/")` so only authenticated users can list proposals.