### PR TITLE
fix: require auth on GET /api/messages

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);


### PR DESCRIPTION
Closes #7686

## What
`GET /api/messages` was publicly accessible, exposing all private user messages to unauthenticated callers — a severe privacy violation.

## Fix
Added `authMiddleware` to `messageRoutes.get("/")` so only authenticated users can list messages.