### PR TITLE
Restrict API CORS origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,22 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+export function createCorsOptions() {
+  const allowedOrigins = (process.env.CORS_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return {
+    origin: allowedOrigins.length > 0 ? allowedOrigins : false
+  };
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(createCorsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createCorsOptions } from "../app.js";
+
+test("CORS disables wildcard origins unless CORS_ORIGINS is configured", () => {
+  const previous = process.env.CORS_ORIGINS;
+  delete process.env.CORS_ORIGINS;
+
+  assert.deepEqual(createCorsOptions(), { origin: false });
+
+  process.env.CORS_ORIGINS = "https://app.example.com, https://admin.example.com ";
+  assert.deepEqual(createCorsOptions(), {
+    origin: ["https://app.example.com", "https://admin.example.com"]
+  });
+
+  if (previous === undefined) {
+    delete process.env.CORS_ORIGINS;
+  } else {
+    process.env.CORS_ORIGINS = previous;
+  }
+});


### PR DESCRIPTION
Closes #7689

## Summary
- replace unrestricted `cors()` with an explicit `CORS_ORIGINS` allowlist
- disable CORS response headers when no allowlist is configured
- add a focused unit test for default and configured CORS options

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 2 passing

Note: the existing workspace `npm run test -w apps/api` script currently invokes `node --test src/tests` and fails before running test files on this Node version, so I used the explicit test-file glob above.