### PR TITLE
Reject admin role during registration

### DIFF
--- a/apps/api/src/tests/auth-validation.test.js
+++ b/apps/api/src/tests/auth-validation.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("public registration rejects admin role assignment", () => {
+  assert.equal(
+    registerSchema.parse({
+      email: "client@example.com",
+      password: "password123"
+    }).role,
+    "client"
+  );
+
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "attacker@example.com",
+      password: "password123",
+      role: "admin"
+    });
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #7691

## Summary
- remove `admin` from the public registration role schema
- keep omitted roles defaulting to `client`
- add a focused regression test for admin self-assignment rejection

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 2 passing