### PR TITLE
Validate refresh tokens

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,4 +1,4 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
 
@@ -22,6 +22,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const payload = refreshSchema.parse(req.body);
+  const result = await refreshToken(payload.refreshToken);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/refresh-token.test.js
+++ b/apps/api/src/tests/refresh-token.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { refreshSchema } from "../validators/auth.js";
+import { refreshToken } from "../services/authService.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+test("refresh requires and validates the provided refresh token", async () => {
+  assert.throws(() => refreshSchema.parse({}));
+
+  const original = signAccessToken({ sub: "usr_123", role: "freelancer" });
+  const refreshed = await refreshToken(original);
+  const decoded = verifyAccessToken(refreshed.token);
+
+  assert.equal(decoded.sub, "usr_123");
+  assert.equal(decoded.role, "freelancer");
+  await assert.rejects(() => refreshToken("not-a-valid-token"));
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
Closes #7693

## Summary
- require `refreshToken` in the refresh request payload
- validate the supplied token before minting a replacement token
- preserve the validated subject and role instead of hard-coded claims
- add a regression test for required, valid, and invalid refresh tokens

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 2 passing