### PR TITLE
Require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...allowedRoles) {
+  return function roleMiddleware(req, res, next) {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-auth.test.js
+++ b/apps/api/src/tests/admin-auth.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const server = createApp().listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("admin metrics require an admin role", async () => {
+  await withServer(async (baseUrl) => {
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+
+    const clientResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${clientToken}` }
+    });
+    assert.equal(clientResponse.status, 403);
+
+    const adminResponse = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${adminToken}` }
+    });
+    assert.equal(adminResponse.status, 200);
+  });
+});


### PR DESCRIPTION
Closes #7695

## Summary
- add a reusable `requireRole` middleware
- restrict `/api/admin` routes to authenticated admin users
- add regression coverage for client-token rejection and admin-token access

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 2 passing