### PR TITLE
Require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job-auth.test.js
+++ b/apps/api/src/tests/job-auth.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const server = createApp().listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("job creation requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const listResponse = await fetch(`${baseUrl}/api/jobs`);
+    assert.equal(listResponse.status, 200);
+
+    const createResponse = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build a dashboard",
+        description: "Create a useful dashboard for clients",
+        budgetMin: 100,
+        budgetMax: 500,
+        categoryId: "cat_analytics",
+        skills: ["react"]
+      })
+    });
+    assert.equal(createResponse.status, 401);
+  });
+});

--- a/apps/api/src/tests/job-auth.test.js
+++ b/apps/api/src/tests/job-auth.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
 
 async function withServer(assertions) {
   const server = createApp().listen(0);
@@ -19,6 +20,17 @@ async function withServer(assertions) {
   }
 }
 
+function jobPayload() {
+  return {
+    title: "Build a dashboard",
+    description: "Create a useful dashboard for clients",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_analytics",
+    skills: ["react"]
+  };
+}
+
 test("job creation requires authentication", async () => {
   await withServer(async (baseUrl) => {
     const listResponse = await fetch(`${baseUrl}/api/jobs`);
@@ -27,15 +39,49 @@ test("job creation requires authentication", async () => {
     const createResponse = await fetch(`${baseUrl}/api/jobs`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        title: "Build a dashboard",
-        description: "Create a useful dashboard for clients",
-        budgetMin: 100,
-        budgetMax: 500,
-        categoryId: "cat_analytics",
-        skills: ["react"]
-      })
+      body: JSON.stringify(jobPayload())
     });
     assert.equal(createResponse.status, 401);
+  });
+});
+
+test("job creation rejects invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer not-a-valid-token",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(jobPayload())
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token");
+  });
+});
+
+test("job creation accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(jobPayload())
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.title, "Build a dashboard");
+    assert.equal(payload.data.status, "open");
+    assert.match(payload.data.id, /^job_\d+$/);
   });
 });


### PR DESCRIPTION
Closes #7699

## Summary
- require `authMiddleware` on `POST /api/jobs`
- keep `GET /api/jobs` publicly readable
- add regression coverage for missing and invalid bearer tokens returning 401
- keep authenticated job creation covered so valid callers still receive a 201 created job

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 4 passing
- `git diff --check` -> clean