### PR TITLE
Limit search query length

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = String(req.query.q ?? "").trim();
+  if (query.length > 120) {
+    return fail(res, "Search query must be 120 characters or fewer", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search-validation.test.js
+++ b/apps/api/src/tests/search-validation.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const server = createApp().listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("search rejects overlong queries before service execution", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"x".repeat(121)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 120 characters or fewer"
+    });
+  });
+});


### PR DESCRIPTION
Closes #7703

## Summary
- trim incoming search queries before passing them to the service
- reject queries longer than 120 characters with 400 Bad Request
- add regression coverage for overlong query rejection

## Validation
- `node --test "src/tests/**/*.test.js"` from `apps/api` -> 2 passing