### PR TITLE
Resolve mock job detail pages

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,22 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job matches <strong>{params.id}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Responsibilities, milestones, and proposals for <strong>{job.id}</strong> would be shown here.</p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7705

## Summary
- look up job detail pages from `apps/web/lib/mock.ts` by route id
- render the matched job title and budget for known listings
- show a clear not-found fallback for unknown ids

## Validation
- `npm run build -w apps/web`