### PR TITLE
Resolve mock freelancer profiles

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((item) => item.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer matches <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(" · ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p>Portfolio, reviews, and active proposals for <strong>{freelancer.username}</strong> appear here.</p>
     </section>
   );
 }


### PR DESCRIPTION
Closes #7707

## Summary
- look up freelancer profile pages from `apps/web/lib/mock.ts` by username
- render matched skills and hourly rate for known profiles
- show a clear not-found fallback for unknown usernames

## Validation
- `npm run build -w apps/web`