### PR TITLE
Resolve freelancer profiles by username

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,29 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+import { notFound } from "next/navigation";
+import { freelancers } from "../../../lib/mock";
+
+type FreelancerProfilePageProps = {
+  params: Promise<{ username: string }>;
+};
+
+export function generateStaticParams() {
+  return freelancers.map((freelancer) => ({
+    username: freelancer.username
+  }));
+}
+
+export default async function FreelancerProfilePage({ params }: FreelancerProfilePageProps) {
+  const { username } = await params;
+  const freelancer = freelancers.find((profile) => profile.username === username);
+
+  if (!freelancer) {
+    notFound();
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p>{freelancer.skills.join(" · ")}</p>
+      <p>{freelancer.rate}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- resolve `/freelancers/[username]` against the existing mock freelancer list
- render the matched mock profile details instead of echoing the route param
- return Next.js 404 for unknown freelancer usernames and prebuild known mock profiles

Fixes #7707

## Verification
- npm run build -w apps/web
- git diff --check