### PR TITLE
Normalize payment intent currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = String(payload.currency ?? "usd").trim().toLowerCase();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes submitted currency codes", async () => {
+  const paymentIntent = await createPaymentIntent({
+    amount: 2500,
+    currency: " USD "
+  });
+
+  assert.equal(paymentIntent.currency, "usd");
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const paymentIntent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(paymentIntent.currency, "usd");
+});


### PR DESCRIPTION
## Summary

- Normalize submitted payment intent currency values with `trim().toLowerCase()` before returning them
- Preserve the existing default `usd` currency when no currency is submitted
- Add focused service tests for mixed-case/whitespace input and default behavior

Fixes #7710
/claim #743

## Validation

- `node --test apps/api/src/tests/paymentService.test.js apps/api/src/tests/health.test.js` - 3 tests passed
- `git diff --check` - passed

Note: `npm test -w apps/api` is still blocked by the pre-existing package script issue where `node --test src/tests` attempts to load the test directory as a module under Node 22. The direct test-file command above validates the changed service and the existing health test.