### PR TITLE
Reject review self-submissions

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +6,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
+  if (req.body?.reviewerId && req.body.reviewerId === req.body.revieweeId) {
+    return fail(res, "Reviewer and reviewee must be different users", 400);
+  }
+
   return ok(res, await createReview(req.body), 201);
 }

--- a/apps/api/src/tests/reviewController.test.js
+++ b/apps/api/src/tests/reviewController.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects self-reviews", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_same",
+        revieweeId: "usr_same",
+        rating: 5,
+        comment: "self boost"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Reviewer and reviewee must be different users"
+    });
+  });
+});
+
+test("POST /api/reviews accepts reviews between different users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_reviewer",
+        revieweeId: "usr_reviewee",
+        rating: 5,
+        comment: "great work"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.reviewerId, "usr_reviewer");
+    assert.equal(payload.data.revieweeId, "usr_reviewee");
+  });
+});


### PR DESCRIPTION
## Summary

- Reject review creation requests where `reviewerId` and `revieweeId` are the same user
- Return the shared JSON error shape with HTTP 400 before storing the review
- Add API regression coverage for rejected self-reviews and accepted different-user reviews

Fixes #7712
/claim #743

## Validation

- `node --test apps/api/src/tests/reviewController.test.js apps/api/src/tests/health.test.js` - 3 tests passed
- `git diff --check` - passed

Note: `npm test -w apps/api` is still blocked by the pre-existing package script issue where `node --test src/tests` attempts to load the test directory as a module under Node 22. The direct test-file command above validates this change and the existing health route.