### PR TITLE
Reject self-directed messages

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +6,9 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
+  if (req.body?.senderId && req.body.senderId === req.body.receiverId) {
+    return fail(res, "Sender and receiver must be different users", 400);
+  }
+
   return ok(res, await sendMessage(req.body), 201);
 }

--- a/apps/api/src/tests/messageController.test.js
+++ b/apps/api/src/tests/messageController.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects self-directed messages", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_same",
+        receiverId: "usr_same",
+        body: "hello myself"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Sender and receiver must be different users"
+    });
+  });
+});
+
+test("POST /api/messages accepts messages between different users", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        senderId: "usr_sender",
+        receiverId: "usr_receiver",
+        body: "hello"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.senderId, "usr_sender");
+    assert.equal(payload.data.receiverId, "usr_receiver");
+  });
+});


### PR DESCRIPTION
## Summary

- Reject message creation requests where `senderId` and `receiverId` are the same user
- Return the shared JSON error shape with HTTP 400 before storing the message
- Add API regression coverage for rejected self-directed messages and accepted two-user messages

Fixes #7714
/claim #743

## Validation

- `node --test apps/api/src/tests/messageController.test.js apps/api/src/tests/health.test.js` - 3 tests passed
- `git diff --check` - passed

Note: `npm test -w apps/api` is still blocked by the pre-existing package script issue where `node --test src/tests` attempts to load the test directory as a module under Node 22. The direct test-file command above validates this change and the existing health route.