### PR TITLE
Derive admin metrics from in-memory stores

### DIFF
--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,13 @@
+import { listJobs } from "./jobService.js";
+import { listUsers } from "./userService.js";
+
 export async function getAdminMetrics() {
+  const [jobs, users] = await Promise.all([listJobs(), listUsers()]);
+
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    openJobs: jobs.filter((job) => job.status === "open").length,
+    activeFreelancers: users.filter((user) => user.role === "freelancer").length,
+    flaggedAccounts: 0,
+    monthlyVolume: 0
   };
 }

--- a/apps/api/src/tests/adminService.test.js
+++ b/apps/api/src/tests/adminService.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getAdminMetrics } from "../services/adminService.js";
+import { createJob } from "../services/jobService.js";
+import { createUser } from "../services/userService.js";
+
+test("getAdminMetrics starts from conservative zero values", async () => {
+  assert.deepEqual(await getAdminMetrics(), {
+    openJobs: 0,
+    activeFreelancers: 0,
+    flaggedAccounts: 0,
+    monthlyVolume: 0
+  });
+});
+
+test("getAdminMetrics reflects open jobs and freelancer users", async () => {
+  const before = await getAdminMetrics();
+
+  await createJob({
+    title: "Build onboarding flow",
+    description: "Create a polished onboarding workflow",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_design"
+  });
+  await createJob({
+    title: "Closed maintenance task",
+    description: "Already completed maintenance work",
+    budgetMin: 50,
+    budgetMax: 100,
+    categoryId: "cat_ops",
+    status: "closed"
+  });
+  await createUser({ email: "freelancer@example.com", role: "freelancer" });
+  await createUser({ email: "client@example.com", role: "client" });
+
+  const metrics = await getAdminMetrics();
+
+  assert.equal(metrics.openJobs, before.openJobs + 1);
+  assert.equal(metrics.activeFreelancers, before.activeFreelancers + 1);
+  assert.equal(metrics.flaggedAccounts, 0);
+  assert.equal(metrics.monthlyVolume, 0);
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded admin metrics with values derived from the existing in-memory job and user services
- Count open jobs from job records and active freelancers from user records
- Keep metrics without backing data conservative at `0`
- Add focused service tests for empty stores and created open job / freelancer records

Fixes #7716
/claim #743

## Validation

- `node --test apps/api/src/tests/adminService.test.js apps/api/src/tests/health.test.js` - 3 tests passed
- `git diff --check` - passed

Note: `npm test -w apps/api` is still blocked by the pre-existing package script issue where `node --test src/tests` attempts to load the test directory as a module under Node 22. The direct test-file command above validates this change and the existing health route.