### PR TITLE
Preserve user server-owned fields

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id, isVerified, ...profile } = payload;
+  const user = { ...profile, id: `usr_${Date.now()}`, isVerified: false };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps id and verification status server-owned", async () => {
+  const user = await createUser({
+    id: "usr_attacker",
+    email: "freelancer@example.com",
+    fullName: "Freelancer Example",
+    role: "freelancer",
+    isVerified: true
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "usr_attacker");
+  assert.equal(user.isVerified, false);
+  assert.equal(user.email, "freelancer@example.com");
+  assert.equal(user.fullName, "Freelancer Example");
+  assert.equal(user.role, "freelancer");
+});


### PR DESCRIPTION
## Summary

- Ignore client-supplied `id` during user creation so users keep a server-generated `usr_...` id
- Ignore client-supplied `isVerified` and default new users to `false`
- Preserve ordinary profile fields such as email, fullName, and role
- Add focused service regression coverage for server-owned fields

Fixes #7718
/claim #743

## Validation

- `node --test apps/api/src/tests/userService.test.js apps/api/src/tests/health.test.js` - 2 tests passed
- `git diff --check` - passed

Note: `npm test -w apps/api` is still blocked by the pre-existing package script issue where `node --test src/tests` attempts to load the test directory as a module under Node 22. The direct test-file command above validates this change and the existing health route.