### PR TITLE
Fix API test script file target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

- Update the API workspace test script to target concrete `src/tests/*.test.js` files
- Avoid Node 22+ trying to load `src/tests` as a module
- Keep the change limited to `apps/api/package.json`

Fixes #7720
/claim #743

## Validation

- `npm test -w apps/api` - 1 test passed
- `git diff --check` - passed