### PR TITLE
Reject missing upload files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/uploadController.test.js
+++ b/apps/api/src/tests/uploadController.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createMockResponse() {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("uploadFile rejects requests without a file", async () => {
+  const res = createMockResponse();
+
+  await uploadFile({}, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "File is required"
+  });
+});
+
+test("uploadFile returns uploaded status when a file is present", async () => {
+  const res = createMockResponse();
+
+  await uploadFile({ file: { originalname: "brief.pdf" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.body, {
+    success: true,
+    data: {
+      filename: "brief.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- return 400 Bad Request when the upload controller receives no file
- keep successful uploads returning 201 with uploaded status
- add focused controller coverage for missing-file and uploaded-file paths

/claim #7701

## Validation
- node --test src/tests/*.test.js (from apps/api)
- git diff --check