### PR TITLE
Validate payment creation payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: result.error.errors
+    });
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postPayment(baseUrl, body) {
+  return fetch(`${baseUrl}/api/payments`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/payments accepts valid payment payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 1500,
+      currency: "usd",
+      jobId: "job_123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 1500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});
+
+test("POST /api/payments rejects missing required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      currency: "usd",
+      jobId: "job_123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("amount")));
+  });
+});
+
+test("POST /api/payments rejects non-positive amounts", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 0,
+      currency: "usd",
+      jobId: "job_123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("amount")));
+  });
+});
+
+test("POST /api/payments rejects caller-supplied system fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postPayment(baseUrl, {
+      amount: 1500,
+      currency: "usd",
+      jobId: "job_123",
+      paymentId: "pay_attacker",
+      provider: "other"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.code === "unrecognized_keys"));
+  });
+});

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().trim().min(1),
+  jobId: z.string().trim().min(1)
+}).strict();


### PR DESCRIPTION
## Summary
- add a strict Zod schema for payment creation payloads
- reject missing amount/currency/jobId, non-positive amounts, and unknown system fields before service execution
- keep valid payment intent responses unchanged
- add route-level regression coverage for valid, invalid, and system-field injection payloads

Closes #7727
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/payment.js
- node --check apps/api/src/controllers/paymentController.js
- node --check apps/api/src/tests/paymentRoutes.test.js
- git diff --check