### PR TITLE
Reject public admin registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -3,8 +3,17 @@ import { loginUser, refreshToken, registerUser } from "../services/authService.j
 import { ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.errors
+    });
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/authRegister.test.js
+++ b/apps/api/src/tests/authRegister.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRegister(baseUrl, body) {
+  return fetch(`${baseUrl}/api/auth/register`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register defaults public users to client role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const payload = await response.json();
+    const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "client");
+    assert.equal(decoded.role, "client");
+  });
+});
+
+test("POST /api/auth/register allows freelancer role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+    const payload = await response.json();
+    const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.role, "freelancer");
+    assert.equal(decoded.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/register rejects admin role assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRegister(baseUrl, {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("role")));
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- restrict public registration roles to client and freelancer
- return 400 validation details when role: admin is submitted
- preserve default client registration and explicit freelancer registration
- add route-level coverage that also verifies the signed token role

Closes #7729
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/auth.js
- node --check apps/api/src/controllers/authController.js
- node --check apps/api/src/tests/authRegister.test.js
- git diff --check