### PR TITLE
Validate refresh token requests

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,22 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const parsed = refreshSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.errors
+    });
+  }
+
+  let result;
+  try {
+    result = await refreshToken(parsed.data.refreshToken);
+  } catch {
+    return fail(res, "Invalid token", 401);
+  }
+
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { env } from "../config/env.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRefresh(baseUrl, body) {
+  return fetch(`${baseUrl}/api/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/refresh rejects missing refreshToken", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("refreshToken")));
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refreshToken", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postRefresh(baseUrl, { refreshToken: "not-a-token" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh issues a token for verified refreshToken payload", async () => {
+  await withServer(async (baseUrl) => {
+    const refreshToken = signAccessToken({ sub: "usr_123", role: "freelancer" });
+    const response = await postRefresh(baseUrl, { refreshToken });
+    const payload = await response.json();
+    const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(decoded.sub, "usr_123");
+    assert.equal(decoded.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- require refreshToken in the auth refresh request body
- return 400 validation details for malformed refresh payloads
- reject invalid tokens with 401 instead of minting a hardcoded token
- issue refreshed tokens from the verified subject and role
- add route-level coverage for missing, invalid, and valid refresh token behavior

Closes #7731
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/auth.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/controllers/authController.js
- node --check apps/api/src/tests/authRefresh.test.js
- git diff --check