### PR TITLE
Require JWT secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,18 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+export function createEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret = source.JWT_SECRET ?? "";
+
+  if (nodeEnv === "production" && !jwtSecret) {
+    throw new Error("JWT_SECRET is required in production");
+  }
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret: jwtSecret || "development-secret",
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: source.DATABASE_URL ?? ""
+  };
+}
+
+export const env = createEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createEnv } from "../config/env.js";
+
+test("createEnv keeps development JWT fallback", () => {
+  const env = createEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("createEnv rejects missing production JWT_SECRET", () => {
+  assert.throws(
+    () => createEnv({ NODE_ENV: "production" }),
+    /JWT_SECRET is required in production/
+  );
+});
+
+test("createEnv accepts explicit production JWT_SECRET", () => {
+  const env = createEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "prod-secret",
+    PORT: "5000"
+  });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.jwtSecret, "prod-secret");
+  assert.equal(env.port, 5000);
+});


### PR DESCRIPTION
## Summary
- extract API env creation into a testable createEnv helper
- keep the development JWT fallback for local environments
- throw during production config creation when JWT_SECRET is missing
- add focused config coverage for development fallback, production rejection, and explicit production secrets

Closes #7733
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/config/env.js
- node --check apps/api/src/tests/env.test.js
- git diff --check