### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -7,6 +7,15 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.errors
+    });
+  }
+
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/jobBudget.test.js
+++ b/apps/api/src/tests/jobBudget.test.js
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build analytics dashboard",
+  description: "Create charts and filters for weekly metrics.",
+  budgetMin: 500,
+  budgetMax: 1200,
+  categoryId: "analytics",
+  skills: ["node"]
+};
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJob(baseUrl, body) {
+  return fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("createJobSchema accepts ordered and equal budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1000,
+    budgetMax: 1000
+  }).success, true);
+});
+
+test("updateJobSchema rejects inverted ranges only when both budget fields are present", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 2000 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 1000 }).success, true);
+  assert.equal(updateJobSchema.safeParse({
+    budgetMin: 2000,
+    budgetMax: 1000
+  }).success, false);
+});
+
+test("POST /api/jobs rejects inverted budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJob(baseUrl, {
+      ...validJob,
+      budgetMin: 2000,
+      budgetMax: 1000
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("budgetMax")));
+  });
+});
+
+test("POST /api/jobs still creates jobs with valid budget ranges", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJob(baseUrl, validJob);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, validJob.budgetMin);
+    assert.equal(payload.data.budgetMax, validJob.budgetMax);
+    assert.equal(payload.data.status, "open");
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,26 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobFields = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+};
+
+function hasValidBudgetRange(payload) {
+  return payload.budgetMin === undefined ||
+    payload.budgetMax === undefined ||
+    payload.budgetMin <= payload.budgetMax;
+}
+
+export const createJobSchema = z.object(jobFields).refine(hasValidBudgetRange, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object(jobFields).partial().refine(hasValidBudgetRange, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- add cross-field budget validation for job creation and partial updates
- return 400 validation details when job creation receives an inverted budget range
- preserve valid ordered and equal budget ranges
- add schema and route-level regression coverage

Closes #7735
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/job.js
- node --check apps/api/src/controllers/jobController.js
- node --check apps/api/src/tests/jobBudget.test.js
- git diff --check