### PR TITLE
Restrict API CORS origins when configured

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,6 +1,8 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
+import { createCorsOptions } from "./config/cors.js";
+import { env } from "./config/env.js";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
@@ -15,11 +17,12 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp(options = {}) {
   const app = express();
+  const corsOrigins = options.corsOrigins ?? env.corsOrigins;
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(createCorsOptions(corsOrigins)));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/config/cors.js
+++ b/apps/api/src/config/cors.js
@@ -1,0 +1,14 @@
+export function createCorsOptions(allowedOrigins = []) {
+  const allowed = new Set(allowedOrigins);
+
+  return {
+    origin(origin, callback) {
+      if (!origin || allowed.size === 0 || allowed.has(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(null, false);
+    }
+  };
+}

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,15 @@
+function parseCsv(value) {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  corsOrigins: parseCsv(process.env.CORS_ORIGINS)
 };

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createCorsOptions } from "../config/cors.js";
+
+async function withServer(app, assertions) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function resolveOrigin(options, origin) {
+  return new Promise((resolve, reject) => {
+    options.origin(origin, (error, allowed) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(allowed);
+    });
+  });
+}
+
+test("createCorsOptions allows all origins when no allowlist is configured", async () => {
+  const options = createCorsOptions();
+
+  assert.equal(await resolveOrigin(options, "https://example.com"), true);
+  assert.equal(await resolveOrigin(options), true);
+});
+
+test("createCorsOptions allows only configured browser origins", async () => {
+  const options = createCorsOptions(["https://app.example.com"]);
+
+  assert.equal(await resolveOrigin(options, "https://app.example.com"), true);
+  assert.equal(await resolveOrigin(options, "https://evil.example.com"), false);
+  assert.equal(await resolveOrigin(options), true);
+});
+
+test("CORS middleware reflects allowed origins and omits disallowed origins", async () => {
+  await withServer(createApp({ corsOrigins: ["https://app.example.com"] }), async (baseUrl) => {
+    const allowed = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "https://app.example.com" }
+    });
+    const disallowed = await fetch(`${baseUrl}/health`, {
+      headers: { origin: "https://evil.example.com" }
+    });
+
+    assert.equal(allowed.status, 200);
+    assert.equal(
+      allowed.headers.get("access-control-allow-origin"),
+      "https://app.example.com"
+    );
+    assert.equal(disallowed.status, 200);
+    assert.equal(disallowed.headers.get("access-control-allow-origin"), null);
+  });
+});


### PR DESCRIPTION
## Summary
- add a configurable CORS allowlist driven by CORS_ORIGINS
- keep requests without an Origin header allowed for server-to-server clients
- preserve open development behavior when no allowlist is configured
- add helper and route-level regression coverage for allowed and disallowed origins

Closes #7737
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/config/cors.js
- node --check apps/api/src/config/env.js
- node --check apps/api/src/app.js
- node --check apps/api/src/tests/cors.test.js
- git diff --check