### PR TITLE
Limit upload file size

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -11,11 +11,11 @@ import { paymentRoutes } from "./routes/paymentRoutes.js";
 import { reviewRoutes } from "./routes/reviewRoutes.js";
 import { messageRoutes } from "./routes/messageRoutes.js";
 import { notificationRoutes } from "./routes/notificationRoutes.js";
-import { uploadRoutes } from "./routes/uploadRoutes.js";
+import { createUploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
-export function createApp() {
+export function createApp(options = {}) {
   const app = express();
 
   app.use(helmet());
@@ -35,7 +35,9 @@ export function createApp() {
   app.use("/api/reviews", reviewRoutes);
   app.use("/api/messages", messageRoutes);
   app.use("/api/notifications", notificationRoutes);
-  app.use("/api/uploads", uploadRoutes);
+  app.use("/api/uploads", createUploadRoutes({
+    maxFileSizeBytes: options.uploadMaxFileSizeBytes
+  }));
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,16 @@
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  databaseUrl: process.env.DATABASE_URL ?? "",
+  uploadMaxFileSizeBytes: parsePositiveInt(
+    process.env.UPLOAD_MAX_FILE_SIZE_BYTES,
+    5 * 1024 * 1024
+  )
 };

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,30 @@
 import { Router } from "express";
 import multer from "multer";
+import { env } from "../config/env.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export function createUploadRoutes(options = {}) {
+  const maxFileSizeBytes = options.maxFileSizeBytes ?? env.uploadMaxFileSizeBytes;
+  const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: maxFileSizeBytes }
+  });
+  const router = Router();
 
-export const uploadRoutes = Router();
+  router.post("/", upload.single("file"), uploadFile);
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+  router.use((error, req, res, next) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return res.status(413).json({
+        success: false,
+        message: `File too large. Max size is ${maxFileSizeBytes} bytes`
+      });
+    }
+
+    return next(error);
+  });
+
+  return router;
+}
+
+export const uploadRoutes = createUploadRoutes();

--- a/apps/api/src/tests/uploadLimit.test.js
+++ b/apps/api/src/tests/uploadLimit.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(app, assertions) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createFormData(filename, content) {
+  const form = new FormData();
+  form.set("file", new Blob([content]), filename);
+  return form;
+}
+
+test("POST /api/uploads rejects files over the configured size limit", async () => {
+  await withServer(createApp({ uploadMaxFileSizeBytes: 4 }), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: createFormData("large.txt", "12345")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "File too large. Max size is 4 bytes");
+  });
+});
+
+test("POST /api/uploads still accepts files within the configured limit", async () => {
+  await withServer(createApp({ uploadMaxFileSizeBytes: 8 }), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: createFormData("small.txt", "1234")
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "small.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});


### PR DESCRIPTION
## Summary
- add a configurable maximum file size for the upload endpoint
- return a clear 413 JSON response for Multer file-size violations
- keep valid small multipart uploads working
- add route-level regression coverage for both paths

Closes #7739
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/config/env.js
- node --check apps/api/src/app.js
- node --check apps/api/src/routes/uploadRoutes.js
- node --check apps/api/src/tests/uploadLimit.test.js
- git diff --check