### PR TITLE
Return client errors for invalid JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/jsonErrors.test.js
+++ b/apps/api/src/tests/jsonErrors.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, body) {
+  return fetch(`${baseUrl}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body
+  });
+}
+
+test("malformed JSON requests return a 400 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "{bad json");
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});
+
+test("oversized JSON requests return a 413 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, JSON.stringify({
+      title: "Large body",
+      description: "x".repeat(110 * 1024)
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Request body too large"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- map malformed JSON parser failures to a clear 400 JSON response
- map oversized JSON parser failures to a clear 413 JSON response
- preserve the existing 500 fallback for unexpected server errors
- add route-level regression coverage for both client-error paths

Closes #7741
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/middleware/errorHandler.js
- node --check apps/api/src/tests/jsonErrors.test.js
- git diff --check