### PR TITLE
Validate proposal creation payloads

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.errors
+    });
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposalValidation.test.js
+++ b/apps/api/src/tests/proposalValidation.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+const validProposal = {
+  jobId: "job_123",
+  freelancerId: "usr_456",
+  coverLetter: "I can deliver this project with a tested implementation.",
+  bidAmount: 750
+};
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postProposal(baseUrl, body) {
+  return fetch(`${baseUrl}/api/proposals`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/proposals rejects invalid proposal payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, {
+      ...validProposal,
+      jobId: " ",
+      bidAmount: -1
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.ok(payload.errors.some((error) => error.path.includes("jobId")));
+    assert.ok(payload.errors.some((error) => error.path.includes("bidAmount")));
+  });
+});
+
+test("POST /api/proposals creates valid proposals", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postProposal(baseUrl, validProposal);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.jobId, validProposal.jobId);
+    assert.equal(payload.data.freelancerId, validProposal.freelancerId);
+    assert.equal(payload.data.coverLetter, validProposal.coverLetter);
+    assert.equal(payload.data.bidAmount, validProposal.bidAmount);
+    assert.match(payload.data.id, /^prp_/);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1),
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().positive()
+}).strict();


### PR DESCRIPTION
## Summary
- add a strict proposal creation validator for required identifiers, cover letter, and positive bid amount
- return 400 validation details for invalid proposal payloads
- preserve valid proposal creation behavior
- add route-level regression coverage for invalid and valid proposal creation

Closes #7743
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/proposal.js
- node --check apps/api/src/controllers/proposalController.js
- node --check apps/api/src/tests/proposalValidation.test.js
- git diff --check