### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,17 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: parsed.error.errors
+    });
+  }
+
+  return ok(res, await globalSearch(parsed.data.q));
 }

--- a/apps/api/src/tests/searchValidation.test.js
+++ b/apps/api/src/tests/searchValidation.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects missing and empty search queries", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/search`);
+    const empty = await fetch(`${baseUrl}/api/search?q=%20%20`);
+    const missingPayload = await missing.json();
+    const emptyPayload = await empty.json();
+
+    assert.equal(missing.status, 400);
+    assert.equal(missingPayload.success, false);
+    assert.equal(missingPayload.message, "Validation failed");
+    assert.ok(missingPayload.errors.some((error) => error.path.includes("q")));
+
+    assert.equal(empty.status, 400);
+    assert.equal(emptyPayload.success, false);
+    assert.equal(emptyPayload.message, "Validation failed");
+    assert.ok(emptyPayload.errors.some((error) => error.path.includes("q")));
+  });
+});
+
+test("GET /api/search rejects overly long search queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"x".repeat(101)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.ok(payload.errors.some((error) => error.path.includes("q")));
+  });
+});
+
+test("GET /api/search passes trimmed valid search queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20react%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "react");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().min(1).max(100)
+}).strict();


### PR DESCRIPTION
## Summary
- add strict query validation for the global search endpoint
- reject missing, whitespace-only, and overly long q values with 400 validation details
- trim valid search queries before passing them to the service
- add route-level regression coverage for invalid and valid search requests

Closes #7745
/claim #743

## Validation
- node --test src/tests/*.test.js (from apps/api)
- node --check apps/api/src/validators/search.js
- node --check apps/api/src/controllers/searchController.js
- node --check apps/api/src/tests/searchValidation.test.js
- git diff --check