### PR TITLE
Require auth for payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects missing and invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const invalid = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer not-a-valid-token",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+
+    assert.equal(missing.status, 401);
+    assert.deepEqual(await missing.json(), {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    assert.equal(invalid.status, 401);
+    assert.deepEqual(await invalid.json(), {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("POST /api/payments creates payment intents for valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_payment_auth", role: "client" });
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ amount: 2500, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 2500);
+    assert.equal(payload.data.currency, "usd");
+    assert.equal(payload.data.provider, "stripe");
+    assert.match(payload.data.paymentId, /^pay_/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7697 by requiring a valid bearer token before `POST /api/payments` can create a payment intent placeholder.

## Changes

- Applies `authMiddleware` to the payment creation route only.
- Adds route coverage for missing token, invalid token, and valid token behavior.
- Preserves successful 201 payment intent creation for authenticated callers.

## Verification

- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `git diff --check` -> passed

Note: the current `npm --workspace=apps/api test` script on main invokes `node --test src/tests`, which fails by treating the directory as a test file in this local Node runtime. The explicit file-pattern command above validates the existing health test and the new payment-auth tests.