### PR TITLE
Require auth for message listing

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
+messageRoutes.get("/", authMiddleware, getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/messageAuth.test.js
+++ b/apps/api/src/tests/messageAuth.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages rejects missing and invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/messages`);
+    const invalid = await fetch(`${baseUrl}/api/messages`, {
+      headers: { authorization: "Bearer not-a-valid-token" }
+    });
+
+    assert.equal(missing.status, 401);
+    assert.deepEqual(await missing.json(), {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    assert.equal(invalid.status, 401);
+    assert.deepEqual(await invalid.json(), {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("GET /api/messages lists messages for valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_message_reader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7686 by requiring a valid bearer token before `GET /api/messages` returns the message list.

## Changes

- Applies `authMiddleware` to the message list route.
- Keeps the change scoped to `GET /api/messages`.
- Adds route coverage for missing token, invalid token, and valid token access.

## Verification

- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `git diff --check` -> passed

Note: the current `npm --workspace=apps/api test` script on main invokes `node --test src/tests`, which fails by treating the directory as a test file in this local Node runtime. The explicit file-pattern command above validates the existing health test and the new message-auth tests.