### PR TITLE
Require auth for user listing

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/userAuth.test.js
+++ b/apps/api/src/tests/userAuth.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/users rejects missing and invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/users`);
+    const invalid = await fetch(`${baseUrl}/api/users`, {
+      headers: { authorization: "Bearer not-a-valid-token" }
+    });
+
+    assert.equal(missing.status, 401);
+    assert.deepEqual(await missing.json(), {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    assert.equal(invalid.status, 401);
+    assert.deepEqual(await invalid.json(), {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("GET /api/users lists users for valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_user_reader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/users`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7674 by requiring a valid bearer token before `GET /api/users` returns user records.

## Changes

- Applies `authMiddleware` to the user list route.
- Keeps the change scoped to `GET /api/users`.
- Adds route coverage for missing token, invalid token, and valid token access.

## Verification

- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `git diff --check` -> passed

Note: the current `npm --workspace=apps/api test` script on main invokes `node --test src/tests`, which fails by treating the directory as a test file in this local Node runtime. The explicit file-pattern command above validates the existing health test and the new user-auth tests.