### PR TITLE
Require auth for notification creation

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects missing and invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userId: "usr_1", message: "Invoice ready" })
+    });
+    const invalid = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer not-a-valid-token",
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ userId: "usr_1", message: "Invoice ready" })
+    });
+
+    assert.equal(missing.status, 401);
+    assert.deepEqual(await missing.json(), {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    assert.equal(invalid.status, 401);
+    assert.deepEqual(await invalid.json(), {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("POST /api/notifications creates notifications for valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_notification_sender", role: "client" });
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ userId: "usr_1", message: "Invoice ready" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.message, "Invoice ready");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7642 by requiring a valid bearer token before `POST /api/notifications` creates notifications.

## Changes

- Applies `authMiddleware` to the notification creation route.
- Keeps the change scoped to `POST /api/notifications`.
- Adds route coverage for missing token, invalid token, and valid token creation.

## Verification

- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `git diff --check` -> passed

Note: the current `npm --workspace=apps/api test` script on main invokes `node --test src/tests`, which fails by treating the directory as a test file in this local Node runtime. The explicit file-pattern command above validates the existing health test and the new notification-auth tests.