### PR TITLE
Require auth for file uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createUploadForm() {
+  const form = new FormData();
+  form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+  return form;
+}
+
+test("POST /api/uploads rejects missing and invalid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const missing = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: createUploadForm()
+    });
+    const invalid = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: "Bearer not-a-valid-token" },
+      body: createUploadForm()
+    });
+
+    assert.equal(missing.status, 401);
+    assert.deepEqual(await missing.json(), {
+      success: false,
+      message: "Unauthorized"
+    });
+
+    assert.equal(invalid.status, 401);
+    assert.deepEqual(await invalid.json(), {
+      success: false,
+      message: "Invalid token"
+    });
+  });
+});
+
+test("POST /api/uploads accepts files for valid bearer tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_uploader", role: "client" });
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: createUploadForm()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "hello.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7634 by requiring a valid bearer token before `POST /api/uploads` runs multer and accepts uploaded files.

## Changes

- Applies `authMiddleware` before `upload.single("file")` on the upload route.
- Keeps the change scoped to `POST /api/uploads`.
- Adds route coverage for missing token, invalid token, and valid authenticated uploads.

## Verification

- `node --test apps/api/src/tests/*.test.js` -> 3 tests passed
- `git diff --check` -> passed

Note: the current `npm --workspace=apps/api test` script on main invokes `node --test src/tests`, which fails by treating the directory as a test file in this local Node runtime. The explicit file-pattern command above validates the existing health test and the new upload-auth tests.