### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: payload.error.issues
+    });
+  }
+
+  return ok(res, await createNotification(payload.data), 201);
 }

--- a/apps/api/src/tests/notificationValidation.test.js
+++ b/apps/api/src/tests/notificationValidation.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postNotification(baseUrl, body) {
+  return fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/notifications rejects missing required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      userId: "user_1",
+      title: "Welcome"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.errors[0].path[0], "message");
+  });
+});
+
+test("POST /api/notifications rejects malformed userId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      userId: 123,
+      title: "Welcome",
+      message: "Your account is ready"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.errors[0].path[0], "userId");
+  });
+});
+
+test("POST /api/notifications creates notification for valid payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      userId: "user_1",
+      title: "Welcome",
+      message: "Your account is ready"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "user_1");
+    assert.equal(payload.data.title, "Welcome");
+    assert.equal(payload.data.message, "Your account is ready");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string(),
+  title: z.string(),
+  message: z.string()
+});


### PR DESCRIPTION
## Summary
- add a Zod schema for notification creation payloads
- reject missing or malformed userId/title/message values before storing notifications
- cover invalid and valid notification creation requests

Fixes #7670

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm --workspace=apps/api test` still fails on main because the script runs `node --test src/tests`, which this Node version resolves as a missing file rather than discovering test files in the directory.