### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { sendMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: payload.error.issues
+    });
+  }
+
+  return ok(res, await sendMessage(payload.data), 201);
 }

--- a/apps/api/src/tests/messageValidation.test.js
+++ b/apps/api/src/tests/messageValidation.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(baseUrl, body) {
+  return fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/messages rejects missing recipientId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, { body: "Hello" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.errors[0].path[0], "recipientId");
+  });
+});
+
+test("POST /api/messages rejects empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      recipientId: "user_2",
+      body: ""
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.errors[0].path[0], "body");
+  });
+});
+
+test("POST /api/messages creates message for valid payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      recipientId: "user_2",
+      body: "Hello"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.recipientId, "user_2");
+    assert.equal(payload.data.body, "Hello");
+    assert.match(payload.data.id, /^msg_/);
+    assert.match(payload.data.sentAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  recipientId: z.string(),
+  body: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a Zod schema for message creation payloads
- reject missing recipient IDs and empty message bodies before storing messages
- cover invalid and valid message creation requests

Fixes #7668

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm --workspace=apps/api test` still fails on main because the script runs `node --test src/tests`, which this Node version resolves as a missing file rather than discovering test files in the directory.