### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,21 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: payload.error.issues
+    });
+  }
+
+  return ok(res, await createReview(payload.data), 201);
 }

--- a/apps/api/src/tests/reviewValidation.test.js
+++ b/apps/api/src/tests/reviewValidation.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, body) {
+  return fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/reviews rejects missing reviewerId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      targetId: "user_2",
+      rating: 5,
+      comment: "Great work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+    assert.equal(payload.errors[0].path[0], "reviewerId");
+  });
+});
+
+test("POST /api/reviews rejects invalid rating", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      reviewerId: "user_1",
+      targetId: "user_2",
+      rating: 6,
+      comment: "Great work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.errors[0].path[0], "rating");
+  });
+});
+
+test("POST /api/reviews creates review for valid payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      reviewerId: "user_1",
+      targetId: "user_2",
+      rating: 5,
+      comment: "Great work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.reviewerId, "user_1");
+    assert.equal(payload.data.targetId, "user_2");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Great work");
+    assert.match(payload.data.id, /^rev_/);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  targetId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- add a Zod schema for review creation payloads
- reject missing reviewerId/targetId/comment values and invalid ratings before storing reviews
- cover invalid and valid review creation requests

Closes #7759
/claim #743

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/validators/review.js`
- `node --check apps/api/src/controllers/reviewController.js`
- `node --check apps/api/src/tests/reviewValidation.test.js`
- `git diff --check`

Note: `npm --workspace=apps/api test` still fails on main because the script runs `node --test src/tests`, which this Node version resolves as a missing file rather than discovering test files in the directory.