### PR TITLE
Return login user identity fields

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -12,9 +12,14 @@ export async function registerUser(payload) {
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const id = "usr_existing";
+  const role = "client";
+
   return {
+    id,
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    role,
+    token: signAccessToken({ sub: id, role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loginUser } from "../services/authService.js";
+
+test("loginUser returns id and role with the login response", async () => {
+  const result = await loginUser({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(result.id, "usr_existing");
+  assert.equal(result.email, "client@example.com");
+  assert.equal(result.role, "client");
+  assert.equal(typeof result.token, "string");
+  assert.ok(result.token.length > 0);
+});


### PR DESCRIPTION
## Summary
- include id and role in the loginUser response alongside email and token
- reuse the same id and role values when signing the login access token
- add a focused service-level test for the login response fields

Closes #7761
/claim #743

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/authService.js`
- `node --check apps/api/src/tests/authService.test.js`
- `git diff --check`

Note: `npm --workspace=apps/api test` still fails on main because the script runs `node --test src/tests`, which this Node version resolves as a missing file rather than discovering test files in the directory.