### PR TITLE
Omit password fields from created users

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, passwordHash, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser omits password fields from returned users", async () => {
+  const user = await createUser({
+    email: "client@example.com",
+    role: "client",
+    fullName: "Client Example",
+    password: "plaintext-secret",
+    passwordHash: "hashed-secret"
+  });
+
+  assert.match(user.id, /^usr_/);
+  assert.equal(user.email, "client@example.com");
+  assert.equal(user.role, "client");
+  assert.equal(user.fullName, "Client Example");
+  assert.equal("password" in user, false);
+  assert.equal("passwordHash" in user, false);
+});


### PR DESCRIPTION
## Summary
- strip password and passwordHash from user creation payloads before storing/returning users
- preserve ordinary non-sensitive profile fields such as email, role, and fullName
- add a focused service-level regression test for credential-field redaction

Closes #7763
/claim #743

## Tests
- `node --test apps/api/src/tests/*.test.js`
- `node --check apps/api/src/services/userService.js`
- `node --check apps/api/src/tests/userService.test.js`
- `git diff --check`

Note: `npm --workspace=apps/api test` still fails on main because the script runs `node --test src/tests`, which this Node version resolves as a missing file rather than discovering test files in the directory.