### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = typeof req.query.q === "string" ? req.query.q.trim() : "";
+
+  if (!query) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Search query must be ${MAX_QUERY_LENGTH} characters or fewer`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects missing query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is required"
+    });
+  });
+});
+
+test("GET /api/search rejects empty query after trimming", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is required"
+    });
+  });
+});
+
+test("GET /api/search rejects overly long query", async () => {
+  await withServer(async (baseUrl) => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query must be 200 characters or fewer"
+    });
+  });
+});
+
+test("GET /api/search trims and passes valid query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20engineer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "engineer");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});


### PR DESCRIPTION
## Summary
- validate `/api/search` query input before calling the search service
- reject missing, whitespace-only, and overly long `q` values with 400 responses
- pass the trimmed query through for valid searches
- make the API test script target `*.test.js` files explicitly

## Validation
- `npm test -w apps/api` passes: 5/5 tests

Fixes #7765
Related to #743

/claim #7765