### PR TITLE
Return JSON 405 for unsupported API methods

### DIFF
--- a/apps/api/src/middleware/methodNotAllowed.js
+++ b/apps/api/src/middleware/methodNotAllowed.js
@@ -1,0 +1,10 @@
+import { fail } from "../utils/response.js";
+
+export function methodNotAllowed(allowedMethods) {
+  const allowHeader = allowedMethods.join(", ");
+
+  return (req, res) => {
+    res.set("Allow", allowHeader);
+    return fail(res, "Method not allowed", 405);
+  };
+}

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);
+jobRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);
+messageRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);
+notificationRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const paymentRoutes = Router();
 
 paymentRoutes.post("/", createPayment);
+paymentRoutes.all("/", methodNotAllowed(["POST"]));

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);
+proposalRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
 reviewRoutes.post("/", postReview);
+reviewRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const searchRoutes = Router();
 
 searchRoutes.get("/", search);
+searchRoutes.all("/", methodNotAllowed(["GET"]));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
 uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.all("/", methodNotAllowed(["POST"]));

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { methodNotAllowed } from "../middleware/methodNotAllowed.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);
+userRoutes.all("/", methodNotAllowed(["GET", "POST"]));

--- a/apps/api/src/tests/methodNotAllowed.test.js
+++ b/apps/api/src/tests/methodNotAllowed.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { createApp } from "../app.js";
+
+let server;
+let baseUrl;
+
+before(async () => {
+  await new Promise((resolve) => {
+    server = createApp().listen(0, resolve);
+  });
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+});
+
+describe("method not allowed fallback", () => {
+  it("returns a JSON 405 response for unsupported collection methods", async () => {
+    const response = await fetch(`${baseUrl}/api/jobs`, { method: "PUT" });
+    const body = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET, POST");
+    assert.equal(response.headers.get("content-type").includes("application/json"), true);
+    assert.deepEqual(body, { success: false, message: "Method not allowed" });
+  });
+
+  it("keeps supported collection methods working", async () => {
+    const response = await fetch(`${baseUrl}/api/jobs`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(Array.isArray(body.data), true);
+  });
+
+  it("sets route-specific Allow headers for single-method collections", async () => {
+    const response = await fetch(`${baseUrl}/api/search`, { method: "DELETE" });
+    const body = await response.json();
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("allow"), "GET");
+    assert.deepEqual(body, { success: false, message: "Method not allowed" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared method-not-allowed fallback for known API collection routes
- return the existing JSON error envelope with status 405 and route-specific Allow headers
- cover supported and unsupported collection methods with API tests

## Validation
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/middleware/methodNotAllowed.js
- node --check apps/api/src/tests/methodNotAllowed.test.js
- node --check apps/api/src/routes/jobRoutes.js apps/api/src/routes/messageRoutes.js apps/api/src/routes/notificationRoutes.js apps/api/src/routes/paymentRoutes.js apps/api/src/routes/proposalRoutes.js apps/api/src/routes/reviewRoutes.js apps/api/src/routes/searchRoutes.js apps/api/src/routes/uploadRoutes.js apps/api/src/routes/userRoutes.js
- git diff --check

Closes #7769
/claim #743