### PR TITLE
Reject duplicate registration emails

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,11 +1,18 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
-import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { DuplicateEmailError, loginUser, refreshToken, registerUser } from "../services/authService.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error instanceof DuplicateEmailError) {
+      return fail(res, error.message, 409);
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,13 +1,36 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = new Map();
+
+export class DuplicateEmailError extends Error {
+  constructor() {
+    super("Email already registered");
+    this.name = "DuplicateEmailError";
+  }
+}
+
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
+  const email = normalizeEmail(payload.email);
+
+  if (registeredUsers.has(email)) {
+    throw new DuplicateEmailError();
+  }
+
+  const id = `usr_${Date.now()}`;
+  const user = {
+    id,
+    email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
+
+  registeredUsers.set(email, user);
+  return user;
 }
 
 export async function loginUser(payload) {

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects duplicate emails case-insensitively", async () => {
+  await withServer(async (baseUrl) => {
+    const payload = {
+      email: `duplicate-${Date.now()}@example.com`,
+      password: "password123",
+      role: "client"
+    };
+
+    const firstResponse = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    const firstBody = await firstResponse.json();
+
+    assert.equal(firstResponse.status, 201);
+    assert.equal(firstBody.success, true);
+    assert.equal(firstBody.data.email, payload.email);
+
+    const secondResponse = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...payload, email: payload.email.toUpperCase() })
+    });
+    const secondBody = await secondResponse.json();
+
+    assert.equal(secondResponse.status, 409);
+    assert.deepEqual(secondBody, { success: false, message: "Email already registered" });
+  });
+});


### PR DESCRIPTION
## Summary
- track registered emails in the auth service and normalize email addresses before uniqueness checks
- return the existing JSON error envelope with 409 Conflict for duplicate registrations
- add a regression test for case-insensitive duplicate registration

## Validation
- node --test apps/api/src/tests/*.test.js
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/controllers/authController.js
- node --check apps/api/src/tests/authRegistration.test.js
- git diff --check

Closes #7771
/claim #743