### PR TITLE
Avoid storing token in leaderboard origin

### DIFF
--- a/.github/workflows/update-pr-leaderboard.test.mjs
+++ b/.github/workflows/update-pr-leaderboard.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflowPath = new URL("./update-pr-leaderboard.yml", import.meta.url);
+
+test("leaderboard workflow keeps credentials out of the origin remote", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.equal(workflow.includes("git remote set-url origin"), false);
+  assert.equal(workflow.includes("x-access-token"), false);
+  assert.match(workflow, /http\.https:\/\/github\.com\/\.extraheader=AUTHORIZATION: bearer \$\{GH_TOKEN\}/);
+  assert.match(workflow, /git -c "[^"]+" push origin "HEAD:\$\{DEFAULT_BRANCH\}"/);
+});

--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -36,7 +36,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git checkout "${DEFAULT_BRANCH}"
           git pull --ff-only origin "${DEFAULT_BRANCH}"
@@ -63,4 +62,4 @@ jobs:
 
           git commit -m "chore: update leaderboard for PR #${PR_NUMBER}"
           git pull --rebase origin "${DEFAULT_BRANCH}"
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GH_TOKEN}" push origin "HEAD:${DEFAULT_BRANCH}"


### PR DESCRIPTION
## Summary
- stop writing the workflow token into the local origin remote URL
- keep origin on the normal repository URL and pass the token only to the push command via an ephemeral auth header
- add a focused regression test that guards against token-bearing origin URLs

## Validation
- node --test .github/workflows/update-pr-leaderboard.test.mjs
- node --check .github/workflows/update-pr-leaderboard.test.mjs
- git diff --check

Closes #7773
/claim #743