### PR TITLE
fix: validate and limit search query length to prevent DoS

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+
+  if (!q || typeof q !== "string" || q.trim().length === 0) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Search query must not exceed ${MAX_QUERY_LENGTH} characters`, 400);
+  }
+
+  return ok(res, await globalSearch(q.trim()));
 }


### PR DESCRIPTION
/claim #2833

## Problem
`GET /api/search` passed `req.query.q` directly to the search service with no validation. An attacker could send arbitrarily large queries causing resource exhaustion.

## Fix
- Returns 400 when query is missing or blank
- Returns 400 when query exceeds 200 characters
- Trims whitespace before searching

## Changes
- `apps/api/src/controllers/searchController.js`