### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #2832

## Problem
`registerSchema` allowed `role: "admin"` in the request body, letting any public caller self-assign administrator privileges at registration time.

## Fix
Removed `"admin"` from the role enum. Only `"client"` and `"freelancer"` are now accepted.

## Changes
- `apps/api/src/validators/auth.js`: removed `admin` from `registerSchema` role enum