### PR TITLE
fix: require authentication on POST /api/payments

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
/claim #2757

## Problem
`POST /api/payments` had no authentication middleware, allowing unauthenticated callers to create payment intent records.

## Fix
Added `authMiddleware` to the route so only users with a valid Bearer token can create payments.

## Changes
- `apps/api/src/routes/paymentRoutes.js`: added `authMiddleware` to `POST /`