### PR TITLE
fix: deduplicate Date.now() so token sub matches returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
@@ -18,6 +20,10 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
+export async function refreshToken(token) {
+  if (!token) {
+    throw new Error("Refresh token is required");
+  }
+  // TODO: validate refresh token against stored record
   return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
 }


### PR DESCRIPTION
/claim #2768

## Problem
`registerUser` called `Date.now()` twice — once for the id and once for the JWT `sub` claim — which could produce a mismatch. Also `refreshToken()` ignored its argument entirely.

## Fix
- Store `Date.now()` once and reuse it for both id and JWT sub
- Include `fullName` in returned user object
- Validate presence of `token` arg in `refreshToken()`

## Changes
- `apps/api/src/services/authService.js`