### PR TITLE
fix: preserve server-owned id and read state in notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,12 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((n) => ({ ...n }));
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
-  return notification;
+  return { ...notification };
 }


### PR DESCRIPTION
/claim #2762

## Problem
`createNotification` spread the full payload after setting server fields, so a caller could override the generated id or pre-set `read: true`.

## Fix
Strip client-supplied `id` and `read` fields before spreading the payload.

## Changes
- `apps/api/src/services/notificationService.js`