### PR TITLE
fix: add types and exports entrypoint to @freelanceflow/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,12 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  }
 }


### PR DESCRIPTION
/claim #2781

## Problem
`@freelanceflow/ui` had no `types` or `exports` fields, making it unresolvable as a workspace package.

## Fix
Add `types` and `exports` fields to `package.json`.

## Changes
- `packages/ui/package.json`