### PR TITLE
fix: require authentication on POST /api/jobs

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
/claim #1783

## Problem
POST /api/jobs had no auth — anyone could create job listings.

## Fix
Added authMiddleware to the POST route.

## Changes
- apps/api/src/routes/jobRoutes.js