### PR TITLE
fix: enforce admin role RBAC on admin routes

### DIFF
--- a/apps/api/src/middleware/requireRole.js
+++ b/apps/api/src/middleware/requireRole.js
@@ -1,0 +1,10 @@
+import { fail } from "../utils/response.js";
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/requireRole.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
/claim #1770

## Problem
authMiddleware only verified JWT validity — any authenticated user could hit admin endpoints.

## Fix
Added requireRole('admin') middleware so only admin-role tokens can access /api/admin/*.

## Changes
- apps/api/src/middleware/requireRole.js (new)
- apps/api/src/routes/adminRoutes.js