### PR TITLE
fix: require JWT_SECRET env var in production to prevent hardcoded fallback

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,17 @@
+function requireEnv(key) {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.NODE_ENV === "production"
+    ? requireEnv("JWT_SECRET")
+    : (process.env.JWT_SECRET ?? "development-secret"),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
/claim #1779

## Problem
env.js silently fell back to 'development-secret' in all environments, exposing production to token forgery.

## Fix
In production, throw at startup if JWT_SECRET is unset.

## Changes
- apps/api/src/config/env.js