### PR TITLE
fix: return HTTP 400 with validation details for ZodError instead of 500

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map((e) => ({ path: e.path.join("."), message: e.message }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"


### PR DESCRIPTION
/claim #1776

## Problem
Unhandled ZodError exceptions bubbled up to the generic error handler and returned 500 with no useful detail.

## Fix
ErrorHandler catches ZodError and returns 400 with per-field error messages.

## Changes
- apps/api/src/middleware/errorHandler.js