### PR TITLE
fix: add Zod validation to proposal creation — require estimatedDuration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  coverLetter: z.string().min(10, "coverLetter must be at least 10 characters"),
+  bidAmount: z.number().positive("bidAmount must be a positive number"),
+  estimatedDuration: z.string().min(1, "estimatedDuration is required")
+});


### PR DESCRIPTION
/claim #1739

## Problem
`POST /api/proposals` accepted any body with no validation, allowing proposals with missing estimatedDuration, jobId, or bidAmount.

## Fix
Added `createProposalSchema` requiring jobId, coverLetter, bidAmount, and estimatedDuration.

## Changes
- `apps/api/src/validators/proposal.js` (new)
- `apps/api/src/controllers/proposalController.js`