### PR TITLE
fix: add auth + Zod validation to messages and reviews, return defensive copies

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { sendMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = sendMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
-messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.get("/", authMiddleware, getMessages);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,11 +1,15 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((m) => ({ ...m }));
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    id: `msg_${Date.now()}`,
+    ...payload,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
-  return message;
+  return { ...message };
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,11 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((r) => ({ ...r }));
 }
 
 export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
-  return review;
+  return { ...review };
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+  recipientId: z.string().min(1, "recipientId is required"),
+  content: z.string().min(1, "content is required").max(5000, "content too long")
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  jobId: z.string().min(1, "jobId is required"),
+  revieweeId: z.string().min(1, "revieweeId is required"),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(1, "comment is required").max(2000)
+});


### PR DESCRIPTION
/claim #7830
/claim #7831
/claim #7832
/claim #7833
/claim #7834
/claim #7835

## Summary
Fixes 6 bugs across the messages and reviews API layer.

## Changes

### Messages
- `POST /api/messages` — added `authMiddleware` (fixes #7830)
- `GET /api/messages` — added `authMiddleware`
- `postMessage` — added `sendMessageSchema` Zod validation (fixes #7834)
- `messageService` — returns shallow copies to prevent mutable-state corruption (fixes #7833)

### Reviews
- `POST /api/reviews` — added `authMiddleware` (fixes #7831)
- `postReview` — added `createReviewSchema` Zod validation requiring jobId, revieweeId, rating (1-5), comment (fixes #7835)
- `reviewService` — returns shallow copies (fixes #7832)

## Files changed
- `apps/api/src/validators/message.js` (new)
- `apps/api/src/validators/review.js` (new)
- `apps/api/src/controllers/messageController.js`
- `apps/api/src/controllers/reviewController.js`
- `apps/api/src/routes/messageRoutes.js`
- `apps/api/src/routes/reviewRoutes.js`
- `apps/api/src/services/messageService.js`
- `apps/api/src/services/reviewService.js`