### PR TITLE
fix: harden notifications/upload/services and add refresh token support

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,8 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
-  return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
-  }, 201);
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+  return ok(res, { filename: req.file.originalname, status: "uploaded" }, 201);
 }

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
-notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.get("/", authMiddleware, getNotifications);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,12 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((j) => ({ ...j }));
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _id, status: _status, ...safePayload } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safePayload };
   jobs.push(job);
-  return job;
+  return { ...job };
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,11 +1,12 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((n) => ({ ...n }));
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...safePayload } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safePayload };
   notifications.push(notification);
-  return notification;
+  return { ...notification };
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,12 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((p) => ({ ...p }));
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _id, ...safePayload } = payload;
+  const proposal = { id: `prp_${Date.now()}`, ...safePayload };
   proposals.push(proposal);
-  return proposal;
+  return { ...proposal };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,12 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((u) => ({ ...u }));
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _id, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
-  return user;
+  return { ...user };
 }

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,14 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
+  return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1, "userId is required"),
+  type: z.string().min(1, "type is required"),
+  message: z.string().min(1, "message is required")
+});


### PR DESCRIPTION
/claim #7838
/claim #7839
/claim #7840
/claim #7841
/claim #7842
/claim #7843
/claim #7844
/claim #7845

## Summary — 8 backend fixes

**Notifications**
- GET + POST `/api/notifications` now require `authMiddleware` (#7838 #7839)
- `postNotification` validates body with Zod `createNotificationSchema` (#7840)
- Service returns defensive copies, strips client-supplied `id`/`read` fields

**Upload**
- Returns HTTP 400 when no file attached instead of 201 with `no-file` status (#7841)

**Services — defensive copies + injection prevention**
- `userService`: strips client-supplied `id`, returns copies (#7842)
- `jobService`: strips `id` and `status` overrides, returns copies (#7843)
- `proposalService`: strips `id`, returns copies (#7844)

**JWT**
- Added `signRefreshToken` (7d expiry) and `verifyRefreshToken` (#7845)

## Files changed
- `apps/api/src/validators/notification.js` (new)
- `apps/api/src/controllers/notificationController.js`
- `apps/api/src/routes/notificationRoutes.js`
- `apps/api/src/services/notificationService.js`
- `apps/api/src/controllers/uploadController.js`
- `apps/api/src/services/userService.js`
- `apps/api/src/services/jobService.js`
- `apps/api/src/services/proposalService.js`
- `apps/api/src/utils/jwt.js`