### PR TITLE
fix(api): add input validation and length limit to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,19 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchSchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchSchema.safeParse(req.query);
+
+  if (!parsed.success) {
+    return fail(res, parsed.error.errors[0].message);
+  }
+
+  const { q } = parsed.data;
+
+  if (q.length === 0) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const searchSchema = z.object({
+  q: z.string()
+    .trim()
+    .max(200, "Search query must be at most 200 characters")
+    .optional()
+    .default("")
+});


### PR DESCRIPTION
## Summary

Fixes #7859

Adds input validation and length limit to the search endpoint to prevent potential DoS attacks via overly long query strings.

## Changes

- New file: `apps/api/src/validators/search.js` - Zod schema for search query validation
- Modified: `apps/api/src/controllers/searchController.js` - Added validation before processing search

## Validation

- Query param `q` is trimmed of whitespace
- Maximum length: 200 characters
- Returns 400 error for empty or invalid queries

## Testing

Manually tested:
- Empty query → 400 error
- Query > 200 chars → 400 error
- Valid query → 200 success

/claim #7859