### PR TITLE
Fix: validate message content and recipient

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { validateMessage } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const validation = validateMessage(req.body);
+  
+  if (!validation.success) {
+    return res.status(400).json({
+      error: "Validation Failed",
+      details: validation.error.format()
+    });
+  }
+
+  return ok(res, await sendMessage(validation.data), 201);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const messageSchema = z.object({
+  content: z.string()
+    .min(1, { message: "Message content cannot be empty" })
+    .max(10000, { message: "Message content is too long (max 10,000 characters)" })
+    .trim(),
+  recipientId: z.string()
+    .min(1, { message: "Recipient ID is required" })
+    .trim(),
+});
+
+export function validateMessage(data) {
+  return messageSchema.safeParse(data);
+}


### PR DESCRIPTION
This PR fixes issue #5582 by implementing Zod schema validation for the message creation endpoint.

Changes:
- Added  with a Zod schema.
- Integrated validation into  controller.
- Now returns 400 Bad Request if content is empty or recipientId is missing.

This prevents the creation of empty messages and ensures data integrity.