### PR TITLE
fix(api): return defensive list service snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return snapshotList(jobs);
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return snapshotList(messages);
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return snapshotList(notifications);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return snapshotList(proposals);
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return snapshotList(reviews);
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,9 @@
+import { snapshotList } from "../utils/snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return snapshotList(users);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertListSnapshot({ create, list, record, mutateField, assertOriginal }) {
+  await create(record);
+
+  const listed = await list();
+  const target = listed.at(-1);
+  assert.ok(target);
+
+  listed.push({ id: "injected-record" });
+  mutateField(target);
+
+  const later = await list();
+  assert.equal(later.some((item) => item.id === "injected-record"), false);
+  assertOriginal(later.at(-1));
+}
+
+test("list services return defensive snapshots of stored records", async () => {
+  await assertListSnapshot({
+    create: createJob,
+    list: listJobs,
+    record: {
+      title: "Snapshot test job",
+      description: "Verify job list snapshots",
+      budgetMin: 100,
+      budgetMax: 200,
+      categoryId: "engineering",
+      skills: ["node", "api"]
+    },
+    mutateField: (job) => {
+      job.title = "mutated";
+      job.skills.push("mutated-skill");
+    },
+    assertOriginal: (job) => {
+      assert.equal(job.title, "Snapshot test job");
+      assert.deepEqual(job.skills, ["node", "api"]);
+    }
+  });
+
+  await assertListSnapshot({
+    create: sendMessage,
+    list: listMessages,
+    record: { senderId: "usr_a", receiverId: "usr_b", body: "Hello" },
+    mutateField: (message) => {
+      message.body = "mutated";
+    },
+    assertOriginal: (message) => {
+      assert.equal(message.body, "Hello");
+    }
+  });
+
+  await assertListSnapshot({
+    create: createNotification,
+    list: listNotifications,
+    record: { userId: "usr_a", type: "proposal", text: "Proposal updated" },
+    mutateField: (notification) => {
+      notification.text = "mutated";
+      notification.read = true;
+    },
+    assertOriginal: (notification) => {
+      assert.equal(notification.text, "Proposal updated");
+      assert.equal(notification.read, false);
+    }
+  });
+
+  await assertListSnapshot({
+    create: createProposal,
+    list: listProposals,
+    record: { jobId: "job_a", freelancerId: "usr_b", bidAmount: 150, coverLetter: "I can help" },
+    mutateField: (proposal) => {
+      proposal.bidAmount = 1;
+    },
+    assertOriginal: (proposal) => {
+      assert.equal(proposal.bidAmount, 150);
+    }
+  });
+
+  await assertListSnapshot({
+    create: createReview,
+    list: listReviews,
+    record: { reviewerId: "usr_a", revieweeId: "usr_b", rating: 5, comment: "Great work" },
+    mutateField: (review) => {
+      review.rating = 1;
+    },
+    assertOriginal: (review) => {
+      assert.equal(review.rating, 5);
+    }
+  });
+
+  await assertListSnapshot({
+    create: createUser,
+    list: listUsers,
+    record: { email: "snapshot@example.com", role: "client", skills: ["hiring"] },
+    mutateField: (user) => {
+      user.email = "mutated@example.com";
+      user.skills.push("mutated-skill");
+    },
+    assertOriginal: (user) => {
+      assert.equal(user.email, "snapshot@example.com");
+      assert.deepEqual(user.skills, ["hiring"]);
+    }
+  });
+});

--- a/apps/api/src/utils/snapshot.js
+++ b/apps/api/src/utils/snapshot.js
@@ -1,0 +1,21 @@
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+
+  if (value && typeof value === "object") {
+    return snapshotRecord(value);
+  }
+
+  return value;
+}
+
+export function snapshotRecord(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, cloneValue(value)])
+  );
+}
+
+export function snapshotList(records) {
+  return records.map(snapshotRecord);
+}


### PR DESCRIPTION
/claim #743

Closes #7876.

## Summary

- Added a shared `snapshotList`/`snapshotRecord` helper for defensive list-service responses.
- Updated `listJobs`, `listMessages`, `listNotifications`, `listProposals`, `listReviews`, and `listUsers` to return snapshots instead of backing arrays/objects.
- Added service-level regression coverage proving callers cannot mutate backing stores by pushing into a listed result, editing listed record fields, or mutating array-valued fields on listed records.

## Scope Control

This PR only changes list-service output snapshots. It does not change route auth, validation, generated IDs, create-service returned-record behavior, persistence, upload handling, CORS, rate limiting, or error handling.

## Validation

```bash
node --test apps/api/src/tests/*.test.js
```

Result:

```text
# Subtest: GET /health returns ok payload
ok 1 - GET /health returns ok payload
# Subtest: list services return defensive snapshots of stored records
ok 2 - list services return defensive snapshots of stored records
1..2
# tests 2
# pass 2
# fail 0
```

```bash
npm run build -w apps/web
```

Result:

```text
✓ Compiled successfully
✓ Generating static pages using 7 workers (13/13)
```

```bash
git diff --check
```

Result: passed with no output.
