### PR TITLE
fix: return defensive list service snapshots

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return snapshotRecords(jobs);
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return snapshotRecords(messages);
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return snapshotRecords(notifications);
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return snapshotRecords(proposals);
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return snapshotRecords(reviews);
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/snapshot.js
+++ b/apps/api/src/services/snapshot.js
@@ -1,0 +1,13 @@
+export function snapshotRecords(records) {
+  return records.map((record) => {
+    const snapshot = { ...record };
+
+    for (const [key, value] of Object.entries(snapshot)) {
+      if (Array.isArray(value)) {
+        snapshot[key] = [...value];
+      }
+    }
+
+    return snapshot;
+  });
+}

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,9 @@
+import { snapshotRecords } from "./snapshot.js";
+
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return snapshotRecords(users);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { listMessages, sendMessage } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+const services = [
+  {
+    name: "jobs",
+    create: createJob,
+    list: listJobs,
+    payload: { title: "Original job", skills: ["node"] },
+    mutateField: "title"
+  },
+  {
+    name: "proposals",
+    create: createProposal,
+    list: listProposals,
+    payload: { coverLetter: "Original proposal", tags: ["api"] },
+    mutateField: "coverLetter"
+  },
+  {
+    name: "reviews",
+    create: createReview,
+    list: listReviews,
+    payload: { body: "Original review", tags: ["quality"] },
+    mutateField: "body"
+  },
+  {
+    name: "messages",
+    create: sendMessage,
+    list: listMessages,
+    payload: { body: "Original message", tags: ["inbox"] },
+    mutateField: "body"
+  },
+  {
+    name: "notifications",
+    create: createNotification,
+    list: listNotifications,
+    payload: { title: "Original notification", tags: ["system"] },
+    mutateField: "title"
+  },
+  {
+    name: "users",
+    create: createUser,
+    list: listUsers,
+    payload: { name: "Original user", tags: ["client"] },
+    mutateField: "name"
+  }
+];
+
+for (const service of services) {
+  test(`${service.name} list returns defensive snapshots`, async () => {
+    const created = await service.create(service.payload);
+    const firstList = await service.list();
+    const listed = firstList.find((record) => record.id === created.id);
+    const arrayField = Object.keys(service.payload).find((key) => Array.isArray(service.payload[key]));
+
+    assert.ok(listed);
+
+    firstList.push({ id: "injected-record" });
+    listed[service.mutateField] = "mutated";
+    listed[arrayField].push("mutated");
+
+    const secondList = await service.list();
+    const later = secondList.find((record) => record.id === created.id);
+
+    assert.equal(secondList.some((record) => record.id === "injected-record"), false);
+    assert.equal(later[service.mutateField], service.payload[service.mutateField]);
+    assert.deepEqual(later[arrayField], service.payload[arrayField]);
+  });
+}


### PR DESCRIPTION
## Summary
- Return defensive snapshots from all in-memory list services.
- Copy array-valued record fields so callers cannot mutate stored arrays through listed records.
- Add service tests for array mutation, record mutation, and list push mutation across jobs, proposals, reviews, messages, notifications, and users.
- Make the API test script target test files explicitly so `npm test` runs the suite in this environment.

## Validation
- `npm test`

Closes #7878