### PR TITLE
fix: validate refresh token before renewal

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,19 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const parsed = refreshSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Refresh token is required");
+  }
+
+  let result;
+
+  try {
+    result = await refreshToken(parsed.data.refreshToken);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
+
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,31 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: userId, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const tokenPayload = { sub: "usr_existing", role: "client" };
+
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken(tokenPayload),
+    refreshToken: signRefreshToken(tokenPayload)
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  const payload = verifyRefreshToken(token);
+
+  return { token: signAccessToken({ sub: payload.sub, role: payload.role }) };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects missing refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    });
+
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/auth/refresh rejects invalid refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: "not-a-valid-token" })
+    });
+
+    assert.equal(response.status, 401);
+  });
+});
+
+test("POST /api/auth/refresh accepts issued refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123"
+      })
+    });
+    const loginPayload = await loginResponse.json();
+
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken: loginPayload.data.refreshToken })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,14 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign(payload, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
+  return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- Issue refresh tokens from login/register alongside access tokens.
- Require `refreshToken` in `POST /api/auth/refresh` before minting a replacement access token.
- Verify refresh tokens and return 400/401 for missing or invalid refresh requests.
- Add HTTP tests for missing, invalid, and valid refresh-token flows.
- Make the API test script target test files explicitly so `npm test` runs in this environment.

## Validation
- `npm test`

Closes #7882