### PR TITLE
fix: preserve server-owned notification fields (#2762)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "caller-controlled",
+    read: true,
+    userId: "user_123",
+    title: "Escrow update",
+    body: "Payment released"
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "caller-controlled");
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "user_123");
+  assert.equal(notification.title, "Escrow update");
+});


### PR DESCRIPTION
## Summary

Ensures notification creation keeps server-owned fields authoritative: callers can no longer override the generated notification id or force a new notification to start as read.

Fixes #2762.

## Changes

- Create notifications by applying caller payload first, then overriding `id` and `read` with server-controlled values.
- Added a focused service test covering caller-supplied `id` and `read` being ignored.
- Adjusted the API test script to run `*.test.js` files directly with Node's test runner.

## Validation

- `npm install` in `apps/api` to install local dependencies
- `npm test` in `apps/api` -> 2 tests passed
