### PR TITLE
fix(web): render mock job detail fallback (#2755)

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,24 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No mock job exists for <strong>{params.id}</strong>.</p>
+        <p>Return to the job listings to choose an available project.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>{job.brief}</p>
+      <p><strong>Estimated timeline:</strong> {job.timeline}</p>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -1,7 +1,25 @@
 export const jobs = [
-  { id: "job-101", title: "Build an AI customer support widget", budget: "$1,500" },
-  { id: "job-102", title: "Migrate legacy API to Node.js", budget: "$2,800" },
-  { id: "job-103", title: "Design SaaS onboarding flows", budget: "$900" }
+  {
+    id: "job-101",
+    title: "Build an AI customer support widget",
+    budget: "$1,500",
+    brief: "Create an embeddable chat widget with retrieval-backed answers and escalation handoff.",
+    timeline: "2 weeks"
+  },
+  {
+    id: "job-102",
+    title: "Migrate legacy API to Node.js",
+    budget: "$2,800",
+    brief: "Move a monolithic REST API to a typed Node.js service with compatibility coverage.",
+    timeline: "4 weeks"
+  },
+  {
+    id: "job-103",
+    title: "Design SaaS onboarding flows",
+    budget: "$900",
+    brief: "Produce low-friction onboarding screens for teams inviting their first collaborators.",
+    timeline: "1 week"
+  }
 ];
 
 export const freelancers = [


### PR DESCRIPTION
## Summary

Updates the job detail route to resolve mock jobs by `id` and render a clear fallback for unknown ids instead of showing placeholder copy.

Fixes #2755.

## Changes

- Added brief and timeline fields to the existing mock jobs so detail pages have useful project context.
- Updated `/jobs/[id]` to render matching title, budget, brief, and timeline.
- Added a clear "Job not found" fallback for unknown route ids.

## Validation

- `npm install` in `apps/web` to install local dependencies
- `npm run build` in `apps/web` passed
