### PR TITLE
fix(web): render mock freelancer profile fallback (#2763)

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,25 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((profile) => profile.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No mock profile exists for <strong>{params.username}</strong>.</p>
+        <p>Return to freelancer search to choose an available profile.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.name}</h2>
+      <p><strong>Username:</strong> {freelancer.username}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p>{freelancer.summary}</p>
     </section>
   );
 }

--- a/apps/web/lib/mock.ts
+++ b/apps/web/lib/mock.ts
@@ -5,6 +5,18 @@ export const jobs = [
 ];
 
 export const freelancers = [
-  { username: "maya-dev", skills: ["Next.js", "TypeScript"], rate: "$65/hr" },
-  { username: "jordan-ux", skills: ["Figma", "UX Research"], rate: "$52/hr" }
+  {
+    username: "maya-dev",
+    name: "Maya Chen",
+    skills: ["Next.js", "TypeScript"],
+    rate: "$65/hr",
+    summary: "Frontend engineer focused on marketplace dashboards and AI-assisted workflows."
+  },
+  {
+    username: "jordan-ux",
+    name: "Jordan Lee",
+    skills: ["Figma", "UX Research"],
+    rate: "$52/hr",
+    summary: "Product designer specializing in onboarding, research synthesis, and SaaS flows."
+  }
 ];


### PR DESCRIPTION
## Summary

Updates the freelancer profile route to resolve mock profiles by username and show a clear fallback for unknown usernames.

Fixes #2763.

## Changes

- Added display names and profile summaries to mock freelancer records.
- Updated `/freelancers/[username]` to render matching profile details, skills, rate, and summary.
- Added a clear "Freelancer not found" fallback for unknown usernames.

## Validation

- `npm run build` in `apps/web` passed
