### PR TITLE
fix: align registration token subject (#2768)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const result = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.match(result.id, /^usr_\d+$/);
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, "client");
+});


### PR DESCRIPTION
## Summary

Ensures registration generates the user id once and signs the access token with the same id in the `sub` claim.

Fixes #2768.

## Changes

- Reuses a single `userId` for the registration response and JWT subject.
- Adds a focused service test that decodes the token and compares `sub` with `result.id`.
- Updates the API test script to run test files directly.

## Validation

- `npm test` in `apps/api` -> 2 tests passed
