### PR TITLE
fix: require fullName during registration (#2770)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/registerFullName.test.js
+++ b/apps/api/src/tests/registerFullName.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+
+test("registerSchema requires a non-empty fullName", () => {
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+  });
+
+  assert.throws(() => {
+    registerSchema.parse({
+      email: "client@example.com",
+      password: "password123",
+      fullName: "   ",
+      role: "client"
+    });
+  });
+});
+
+test("registerUser preserves a valid fullName", async () => {
+  const result = await registerUser({
+    email: "client@example.com",
+    password: "password123",
+    fullName: "Avery Client",
+    role: "client"
+  });
+
+  assert.equal(result.fullName, "Avery Client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().trim().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
## Summary

Requires registration payloads to include a non-empty `fullName` and preserves that value in the returned user payload.

Fixes #2770.

## Changes

- Added `fullName` validation to `registerSchema`.
- Returned `fullName` from `registerUser` so the service shape matches the required user model field.
- Added focused tests for missing/blank names and preservation of a valid name.
- Updates the API test script to run test files directly.

## Validation

- `npm test` in `apps/api` -> 3 tests passed
