### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,12 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  const parsed = createJobSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400);
+  }
+
+  const payload = parsed.data;
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build a job board",
+  description: "Create a small job board for freelance projects.",
+  budgetMin: 500,
+  budgetMax: 1500,
+  categoryId: "development",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts an ordered budget range", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts an equal budget range", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1500,
+    budgetMax: 1500
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects an inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 1500,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("updateJobSchema accepts partial budget updates", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects an inverted budget range when both values are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 1500,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("POST /api/jobs rejects an inverted budget range with a client error", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...validJob,
+        budgetMin: 1500,
+        budgetMax: 500
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Validation failed"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("POST /api/jobs still creates a job with a valid budget range", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.budgetMin, validJob.budgetMin);
+    assert.equal(payload.data.budgetMax, validJob.budgetMax);
+    assert.equal(payload.data.status, "open");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchemaFields = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,22 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+const hasValidBudgetRange = (payload) =>
+  payload.budgetMin === undefined ||
+  payload.budgetMax === undefined ||
+  payload.budgetMax >= payload.budgetMin;
+
+const budgetRangeValidation = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = jobSchemaFields.refine(
+  hasValidBudgetRange,
+  budgetRangeValidation
+);
+
+export const updateJobSchema = jobSchemaFields.partial().refine(
+  hasValidBudgetRange,
+  budgetRangeValidation
+);


### PR DESCRIPTION
Closes #7896

/claim #743

## Summary
- Add shared budget range validation for job create and update schemas.
- Reject payloads where both budget values are present and `budgetMax` is lower than `budgetMin`.
- Return a 400 JSON failure response from `POST /api/jobs` when job validation fails instead of falling through to the generic 500 handler.
- Keep partial job updates valid when only one budget field is supplied.
- Preserve valid ordered and equal budget ranges.
- Add focused validator and route coverage for valid, equal, and inverted ranges.

## Validation
- `node --test src/tests/*.test.js` from `apps/api` (8 passing tests)
- `git diff --check`