### PR TITLE
Fix production next-env route types import

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Closes #7906
- Aligns the tracked web `next-env.d.ts` route-types import with the production build output path.
- Prevents `npm run build -w apps/web` from rewriting the tracked file from `.next/dev/types/routes.d.ts` to `.next/types/routes.d.ts`.

## Bounty

/claim #743

## Validation

- `npm run build -w apps/web`
- `git diff --check`
- `git diff --exit-code HEAD -- apps/web/next-env.d.ts`

## Demo Video

- Demo clip: https://github.com/jaxassistant55/bug-bounty/releases/download/securebanana-20260618-demos/securebanana-pr-7907-demo.mp4
