### PR TITLE
fix: enforce authentication on job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Summary

The `POST /api/jobs` endpoint did not require authentication, allowing anyone to create job listings without being logged in. This could lead to spam or malicious job postings.

## Changes

- Added `authMiddleware` import from `../middleware/auth.js`
- Added `authMiddleware` to the POST route, ensuring only authenticated users can create jobs

## Code Change

```js
// Before
jobRoutes.post("/", postJob);

// After
jobRoutes.post("/", authMiddleware, postJob);
```

## Testing

- Verified the auth middleware is properly imported
- GET route remains public (correct behavior)
- POST route now requires Bearer token

Fixes #1783