### PR TITLE
Fix API workspace test script glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
/claim #743

Closes #7915

## Summary
- fix the API workspace test script so Node receives the actual `src/tests/*.test.js` files
- keep the change scoped to `apps/api/package.json`

## Root Cause
`node --test src/tests` treats the `src/tests` directory as the test entrypoint in this environment, which fails with `MODULE_NOT_FOUND` before the existing health test can run.

## Validation
- `npm test -w apps/api`
- `npm run build -w apps/web`
- `git diff --check`

## Demo
Short demo GIF: https://github.com/snkk2x-collab/bug-bounty/releases/download/pr-7916-demo/pr-7916-api-test-script.gif

The demo shows the API workspace test script running the real test file glob successfully.
