### PR TITLE
Validate API PORT configuration

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,16 @@
+export function parsePort(value, fallback = 4000) {
+  const port = Number(value ?? fallback);
+
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    return fallback;
+  }
+
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parsePort } from "../config/env.js";
+
+test("parsePort falls back when PORT is not a valid listen port", () => {
+  assert.equal(parsePort("not-a-port"), 4000);
+  assert.equal(parsePort("65536"), 4000);
+  assert.equal(parsePort("-1"), 4000);
+});
+
+test("parsePort preserves valid explicit ports", () => {
+  assert.equal(parsePort("0"), 0);
+  assert.equal(parsePort("8080"), 8080);
+});


### PR DESCRIPTION
/claim #743

Closes #7917

## Summary
- add `parsePort` validation for API env configuration
- fall back to the default port when `PORT` is missing, non-numeric, out of range, or non-integer
- preserve valid explicit ports, including `0` for ephemeral test servers
- add focused Node test coverage for invalid and valid port inputs

## Root Cause
`Number(process.env.PORT ?? 4000)` can produce `NaN` when `PORT` is set to an invalid value, and that `NaN` is passed directly into `app.listen`, causing `ERR_SOCKET_BAD_PORT` during startup.

## Validation
- `node --test apps/api/src/tests/env.test.js`
- `PORT=abc node apps/api/src/server.js` starts on `http://localhost:4000` (then stopped)
- `npm run build -w apps/web`
- `git diff --check`

## Demo
Short demo GIF: https://github.com/snkk2x-collab/bug-bounty/releases/download/pr-7918-demo/pr-7918-validate-api-port.gif

The demo shows the focused PORT validation tests passing for invalid fallback and valid explicit ports.
