### PR TITLE
Require refresh token for auth refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
-import { registerSchema, loginSchema } from "../validators/auth.js";
+import { registerSchema, loginSchema, refreshSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const parsed = refreshSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Refresh token is required", 400);
+  }
+
+  try {
+    const result = await refreshToken(parsed.data);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,14 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: userId, role: payload.role })
   };
 }
 
@@ -14,10 +16,12 @@ export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: "usr_existing", role: "client" }),
+    refreshToken: signRefreshToken({ sub: "usr_existing", role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(payload) {
+  const decoded = verifyRefreshToken(payload.refreshToken);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/login returns an access token and refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.token, "string");
+    assert.equal(typeof payload.data.refreshToken, "string");
+  });
+});
+
+test("POST /api/auth/refresh requires a refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/refresh", {});
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Refresh token is required"
+    });
+  });
+});
+
+test("POST /api/auth/refresh rejects access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const loginPayload = await loginResponse.json();
+
+    const response = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: loginPayload.data.token
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid refresh token"
+    });
+  });
+});
+
+test("POST /api/auth/refresh mints a new access token from a refresh token", async () => {
+  await withServer(async (baseUrl) => {
+    const loginResponse = await postJson(baseUrl, "/api/auth/login", {
+      email: "client@example.com",
+      password: "password123"
+    });
+    const loginPayload = await loginResponse.json();
+
+    const response = await postJson(baseUrl, "/api/auth/refresh", {
+      refreshToken: loginPayload.data.refreshToken
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.token, "string");
+    assert.equal(payload.data.refreshToken, undefined);
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,19 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, tokenType: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
+  const decoded = jwt.verify(token, env.jwtSecret);
+  if (decoded?.tokenType !== "refresh") {
+    throw new Error("Invalid refresh token");
+  }
+
+  return decoded;
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -10,3 +10,7 @@ export const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8)
 });
+
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1)
+});


### PR DESCRIPTION
/claim #743

Closes #7920

## Summary
- issue refresh tokens from register/login responses with an explicit refresh token marker
- require `POST /api/auth/refresh` to submit a valid refresh token before minting a new access token
- reject missing refresh tokens with 400 and access/invalid tokens with 401
- add focused API coverage for login token issuance and refresh success/failure paths

## Root Cause
`refreshToken()` always minted a client access token with no input, so any caller could hit `/api/auth/refresh` and receive a valid token without presenting a refresh credential.

## Validation
- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test apps/api/src/tests/*.test.js`
- `env PATH=/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/tools/npm-package/bin:$PATH /Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node /Users/sun/Documents/Codex/2026-06-18/goal-chrome-200/work/tools/npm-package/bin/npm-cli.js run build -w apps/web`
- `git diff --check`

## Demo
Short demo GIF: https://github.com/snkk2x-collab/bug-bounty/releases/download/pr-7921-demo/pr-7921-auth-refresh-token.gif

The demo shows login refresh-token issuance, missing-token rejection, access-token rejection, and successful refresh with a valid refresh token.

## Note
The web build passed, but it regenerated `apps/web/next-env.d.ts` from the tracked dev route path to the production route path. That generated file change was intentionally left out of this PR because it is covered by a separate scoped issue.
