### PR TITLE
Add auth route rate limiter

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,14 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: {
+    success: false,
+    message: "Too many authentication attempts"
+  }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);

--- a/apps/api/src/tests/auth-rate-limit.test.js
+++ b/apps/api/src/tests/auth-rate-limit.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login is capped by the auth-specific limiter", async () => {
+  await withServer(async (baseUrl) => {
+    const body = JSON.stringify({
+      email: "person@example.com",
+      password: "password123"
+    });
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const response = await fetch(`${baseUrl}/api/auth/login`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body
+      });
+
+      assert.equal(response.status, 200);
+    }
+
+    const limitedResponse = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body
+    });
+    const payload = await limitedResponse.json();
+
+    assert.equal(limitedResponse.status, 429);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Too many authentication attempts"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #7924
- Adds an auth-specific limiter of 20 requests per 15 minutes.
- Applies the stricter limiter to register, login, and refresh routes while leaving the existing global limiter in place.
- Adds an HTTP regression test proving the 21st login request returns 429.
- Updates the API test script so the current Node test runner executes `*.test.js` files directly.

## Bounty

/claim #743

## Validation

- `npm test -w apps/api`
- `git diff --check`

## Demo Video

- Demo clip: https://github.com/jaxassistant55/bug-bounty/releases/download/securebanana-20260618-demos/securebanana-pr-7925-demo.mp4
