### PR TITLE
Patch Multer upload DoS advisories

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "zod": "^3.23.8"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-rate-limit": "^7.4.0",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
-        "multer": "^2.1.1",
+        "multer": "^2.2.0",
         "zod": "^3.23.8"
       }
     },
@@ -1519,9 +1519,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",


### PR DESCRIPTION
/claim #743

Fixes #7930.

## Summary
- Bump the API direct `multer` dependency from `^2.1.1` to `^2.2.0`.
- Refresh `package-lock.json` so the resolved upload middleware package is `multer@2.2.0`.
- Address the current Multer upload DoS audit findings while leaving upload route behavior unchanged.

## Demo Video
- https://github.com/jaxassistant55/bug-bounty/releases/download/securebanana-20260618-demos/securebanana-pr-7931-demo.mp4

## Validation
- `npm audit --omit=dev --audit-level=high` -> `found 0 vulnerabilities`
- `npm ls multer` -> `multer@2.2.0`
- `node --test apps/api/src/tests/*.test.js` -> 1 test passing

## Note
`npm test -w apps/api` still fails on upstream main because the script invokes `node --test src/tests` as a module path; the focused test file command above passes.