### PR TITLE
Expose UI package runtime entrypoint

### DIFF
--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./index.js"
+    }
+  }
 }


### PR DESCRIPTION
/claim #743

Fixes #7932. Reissue of creator-limited #7898.

## Summary
- Add a real JavaScript runtime entrypoint for `@freelanceflow/ui`.
- Point package `main`/`exports.default` at `./index.js`.
- Keep TypeScript declarations available through `types`/`exports.types` pointing at the existing source barrel.

## Validation
- `node --input-type=module -e "const { Button, Card } = await import("@freelanceflow/ui"); if (typeof Button !== "function" || typeof Card !== "function") throw new Error("missing exports"); console.log("ui_runtime_import_ok");"` -> `ui_runtime_import_ok`
- `node --test apps/api/src/tests/*.test.js` -> 1 test passing

## Demo Video
https://github.com/jaxassistant55/bug-bounty/releases/download/securebanana-20260618-demos/securebanana-pr-7933-demo.mp4