### PR TITLE
fix: patch multer upload DoS vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
Updates multer from ^2.1.1 to ^2.2.0 to fix two security advisories:

- GHSA-72gw-mp4g-v24j: deeply nested field names causing DoS
- GHSA-3p4h-7m6x-2hcm: incomplete cleanup of aborted uploads

Verified with npm audit that no Multer vulnerabilities remain after the update.

Fixes #7930

Signed-off-by: Gautam Kumar <gautamkumarofficial@users.noreply.github.com>