### PR TITLE
fix: add JavaScript runtime entrypoint for @freelanceflow/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,23 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
The UI package previously pointed main at src/index.ts (TypeScript source), which failed when imported from workspace consumers.

Changes:
- Added build script to compile TypeScript to JavaScript
- Updated main to point to dist/index.js
- Added types field for TypeScript consumers
- Added exports field for modern module resolution
- Added tsconfig.json for compilation

After this change, `import("@freelanceflow/ui")` works from workspace consumers and exposes Button and Card from a JavaScript runtime entrypoint.

Fixes #7932

Signed-off-by: Gautam Kumar <gautamkumarofficial@users.noreply.github.com>