### PR TITLE
Expose UI runtime entrypoint

### DIFF
--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,5 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Button(props: { children: ReactNode }): ReactElement;
+
+export declare function Card(props: { title: string; children: ReactNode }): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  }
 }


### PR DESCRIPTION
Closes #7936
/claim #743

## Summary
- Adds a runtime ESM entrypoint for `@freelanceflow/ui` so workspace consumers can import the package directly.
- Adds package `exports`, `types`, and `type: module` metadata pointing at the runtime JS and declaration files.
- Adds matching TypeScript declarations for the exported `Button` and `Card` components.

## Root cause
`packages/ui/package.json` pointed `main` at `src/index.ts`, whose extensionless TS re-exports are not directly loadable by Node/workspace runtime imports. A consumer import of `@freelanceflow/ui` failed with `ERR_MODULE_NOT_FOUND` before reaching the components.

## Demo
![demo](https://github.com/snkk2x-collab/bug-bounty/releases/download/pr-7936-demo/pr-7936-ui-runtime-entrypoint.gif)

## Validation
- `node -e "import('@freelanceflow/ui').then(m=>{ console.log(Object.keys(m).sort().join(',')); })"` -> `Button,Card`
- `node --input-type=module -e "import { Button, Card } from '@freelanceflow/ui'; console.log(typeof Button, typeof Card);"` -> `function function`
- `tsc --noEmit --jsx react-jsx --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck tmp-ui-type-check.mts`
- `next build apps/web`
- `git diff --check`
