### PR TITLE
fix: reject inverted job budget ranges in createJobSchema and updateJobSchema

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().superRefine((data, ctx) => {
+  if (
+    data.budgetMin !== undefined &&
+    data.budgetMax !== undefined &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+});


### PR DESCRIPTION
Closes #2853
Closes #2835
Closes #2827

## Bug

`createJobSchema` accepted payloads where `budgetMax < budgetMin`, creating invalid records like a $500–$100 range.

## Fix

- Added `.refine()` to `createJobSchema` to reject inverted budget ranges
- Extended `updateJobSchema` with `.superRefine()` to catch the same case when both budget fields are present in a partial update
- Valid ordered ranges and partial updates with only one budget field continue to parse successfully

## Verification

```js
createJobSchema.parse({ ..., budgetMin: 100, budgetMax: 500 }) // ✅ valid
createJobSchema.parse({ ..., budgetMin: 500, budgetMax: 100 }) // ❌ ZodError: budgetMax must be >= budgetMin
updateJobSchema.parse({ budgetMin: 200, budgetMax: 100 })      // ❌ rejected
updateJobSchema.parse({ budgetMax: 100 })                      // ✅ partial ok
```