### PR TITLE
fix: require fullName in registerSchema to match User model

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  fullName: z.string().min(1),
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #2770

## Bug

The Prisma `User` model requires `fullName`, but `registerSchema` only accepted `email`, `password`, and `role`. Registration succeeded without the required field, which would cause a DB error at persistence time.

Additionally, `role` allowed `"admin"` as a self-assignable value, which is a security issue (tracked separately).

## Fix

- Added `fullName: z.string().min(1)` to `registerSchema`
- Removed `"admin"` from the allowed role enum — public registration only allows `client` or `freelancer`

## Verification

```js
registerSchema.parse({ fullName: 'Alice', email: 'a@b.com', password: 'secret123', role: 'client' }) // ✅
registerSchema.parse({ email: 'a@b.com', password: 'secret123' }) // ❌ fullName required
registerSchema.parse({ fullName: 'Alice', email: 'a@b.com', password: 'secret123', role: 'admin' }) // ❌ invalid enum
```