### PR TITLE
Fix registration token subject mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs an access token for the returned user id", async () => {
+  const originalNow = Date.now;
+  let calls = 0;
+  Date.now = () => {
+    calls += 1;
+    return calls === 1 ? 1710000000000 : 1710000000001;
+  };
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      password: "correct horse battery staple",
+      role: "client"
+    });
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1710000000000");
+    assert.equal(decoded.sub, result.id);
+    assert.equal(decoded.role, "client");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743

Closes #7941

## Summary
- generate the registration user id once in `registerUser`
- sign the access token with the same id in the JWT `sub` claim
- add a regression test that forces consecutive `Date.now()` calls to diverge and verifies the decoded token subject equals the returned id

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/authService.test.js`
- `git diff --check`
