### PR TITLE
fix: expose UI runtime entrypoint

### DIFF
--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,30 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+exports.Button = Button;
+exports.Card = Card;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "scripts": {
+    "test": "node --test test/runtime-entrypoint.test.js"
+  },
+  "main": "./index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./index.js"
+    }
+  }
 }

--- a/packages/ui/test/runtime-entrypoint.test.js
+++ b/packages/ui/test/runtime-entrypoint.test.js
@@ -1,0 +1,9 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+test("runtime entrypoint exposes UI components", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+});


### PR DESCRIPTION
/claim #743

Fixes #7936.

## Summary
- Add a real CommonJS runtime entrypoint for `@freelanceflow/ui` at `packages/ui/index.js`.
- Point `main` and package `exports.default` to the runtime JS entrypoint.
- Keep TypeScript declarations available through `types` and `exports.types` pointing at the existing source barrel.
- Add a focused Node test that dynamically imports `@freelanceflow/ui` and verifies `Button` and `Card` are exported as functions.

## Validation
- `npm install`
- `node -e "import('@freelanceflow/ui').then(m=>{ console.log(Object.keys(m).sort().join(',')); if(typeof m.Button!=='function'||typeof m.Card!=='function') throw new Error('missing runtime exports') })"`
  - Output included: `Button,Card,default,module.exports`
- `npm test -w packages/ui`
  - 1 test passed

## Note
- `npm test -w apps/api` still fails because the existing API package script invokes `node --test src/tests`, and `apps/api/src/tests` is not a resolvable module/directory in this checkout. That is unrelated to the UI runtime entrypoint change and matches the separate API test-script issue already present in the repo.