### PR TITLE
fix: add authentication middleware to POST /api/notifications (#7866)

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);


### PR DESCRIPTION
## Summary

The `POST /api/notifications` route lacked authentication middleware, allowing unauthenticated users to create notifications.

## Fix

Added `authMiddleware` (the same auth guard used by other protected routes such as `adminRoutes`) to the `POST /` handler in `notificationRoutes.js`.

```js
// Before
notificationRoutes.post("/", postNotification);

// After
notificationRoutes.post("/", authMiddleware, postNotification);
```

## References

Closes #7866

/claim #7866