### PR TITLE
fix: use single Date.now() call so token sub matches returned user id (#7941)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const now = Date.now();
   return {
-    id: `usr_${Date.now()}`,
+    id: `usr_${now}`,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: `usr_${now}`, role: payload.role })
   };
 }
 


### PR DESCRIPTION
/claim #7941

## Problem

In `registerUser`, `Date.now()` was called twice — once for the returned `id` and once inside `signAccessToken` for the JWT `sub` claim. Because each call can return a different millisecond, the token `sub` could differ from the user `id`, breaking token-to-user mapping.

## Fix

Capture `Date.now()` once into a `const now` variable and use it for both the `id` and the `sub` claim, guaranteeing they are always identical.

Fixes #7941