### PR TITLE
fix: validate refresh token before minting access token (#7920)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
+import { verifyAccessToken } from "../utils/jwt.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,19 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { refreshToken: token } = req.body;
+  if (!token) {
+    return res.status(401).json({ error: "Refresh token required" });
+  }
+  let decoded;
+  try {
+    decoded = verifyAccessToken(token);
+  } catch {
+    return res.status(401).json({ error: "Invalid or expired refresh token" });
+  }
+  if (decoded.type !== "refresh") {
+    return res.status(401).json({ error: "Invalid token type" });
+  }
+  const result = await refreshToken(decoded.sub);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,27 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const sub = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: sub,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub, role: payload.role }),
+    refreshToken: signRefreshToken({ sub, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const sub = "usr_existing";
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub, role: "client" }),
+    refreshToken: signRefreshToken({ sub, role: "client" })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(sub) {
+  return { token: signAccessToken({ sub, role: "client" }) };
 }

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,10 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, type: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
 }


### PR DESCRIPTION
Fixes #7920

- Added `signRefreshToken(payload)` to `jwt.js` (7-day expiry, `type: "refresh"` claim)
- Updated `registerUser()` and `loginUser()` in `authService.js` to return a `refreshToken` field alongside the access token
- Updated `refreshToken(sub)` service to accept a `sub` param instead of always using a hardcoded subject
- Updated `refresh()` controller to read `req.body.refreshToken`, verify it with `verifyAccessToken`, check `decoded.type === "refresh"`, and return 401 if the token is missing, invalid, or expired