### PR TITLE
fix: require auth on GET /api/users (#7922)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
Fixes #7922

- Added `authMiddleware` import to `userRoutes.js`
- Applied `authMiddleware` guard to `GET /` route so unauthenticated callers receive 401 instead of the full user list