### PR TITLE
fix: fall back to port 4000 when PORT env is invalid (#7917)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,10 @@
+const _rawPort = process.env.PORT;
+const _parsedPort = _rawPort !== undefined ? parseInt(_rawPort, 10) : NaN;
+const _resolvedPort = (_rawPort === undefined || isNaN(_parsedPort) || _parsedPort < 0 || _parsedPort > 65535) ? 4000 : _parsedPort;
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: _resolvedPort,
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
Fixes #7917

- Changed port parsing in `env.js` to use `parseInt(rawPort, 10)` and validate the result
- Falls back to 4000 when `PORT` is undefined, non-numeric (e.g. `abc`), NaN, negative, or out of the valid 0–65535 range
- Eliminates the `ERR_SOCKET_BAD_PORT` crash when an invalid `PORT` value is set