### PR TITLE
fix: list services return defensive snapshots, prevent id/status injection (#7878)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,12 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return [...jobs].map(item => ({...item}));
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id: _id, status: _status, ...safePayload } = payload;
+  const job = { id: `job_${Date.now()}`, status: "open", ...safePayload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages].map(item => ({...item}));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return [...notifications].map(item => ({...item}));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals].map(item => ({...item}));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews].map(item => ({...item}));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users].map(item => ({...item}));
 }
 
 export async function createUser(payload) {


### PR DESCRIPTION
Fixes #7878

Each list service (userService, jobService, proposalService, reviewService, messageService, notificationService) now returns `[...array].map(item => ({...item}))` instead of the raw internal array, so callers cannot mutate stored state via the returned reference.

Also fixes `createJob` to destructure and discard `id` and `status` from the incoming payload before spreading, preventing callers from injecting server-controlled fields.