### PR TITLE
fix: ZodError returns 400 from error handler, wrap async auth routes (#7908)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,13 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({ success: false, message: "Validation error", errors: err.errors });
   }
 
   return res.status(500).json({

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -3,7 +3,9 @@ import { login, oauthCallback, refresh, register } from "../controllers/authCont
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+const wrap = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
+
+authRoutes.post("/register", wrap(register));
+authRoutes.post("/login", wrap(login));
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", wrap(refresh));


### PR DESCRIPTION
Fixes #7908

- Added `import { ZodError } from "zod"` to `errorHandler.js` and a check before the 500 catch-all: when `err instanceof ZodError`, responds with HTTP 400 and the structured `err.errors` array.
- Wrapped async auth route handlers (`register`, `login`, `refresh`) with a `wrap` helper so unhandled promise rejections propagate to Express error middleware instead of crashing the process.