### PR TITLE
fix: reject duplicate email addresses at registration (#7771)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,10 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err.status) {
+    return res.status(err.status).json({ success: false, message: err.message });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,13 +1,18 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const registeredUsers = new Map(); // email -> user
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
-  };
+  const normalizedEmail = payload.email.toLowerCase().trim();
+  if (registeredUsers.has(normalizedEmail)) {
+    const err = new Error("Email already registered");
+    err.status = 409;
+    throw err;
+  }
+  const id = `usr_${Date.now()}`;
+  const user = { id, email: normalizedEmail, role: payload.role };
+  registeredUsers.set(normalizedEmail, user);
+  return { ...user, token: signAccessToken({ sub: id, role: payload.role }) };
 }
 
 export async function loginUser(payload) {


### PR DESCRIPTION
Fixes #7771

- Added an in-memory `registeredUsers` Map to `authService.js` keyed by normalized (lowercase-trimmed) email.
- `registerUser` now checks for an existing entry and throws a `409`-status error (`"Email already registered"`) before creating the account.
- Updated `errorHandler.js` to handle errors with an `err.status` property, forwarding the status code and message directly to the response — so the 409 surfaces correctly to the client.