### PR TITLE
fix: do not store GitHub token in origin URL in leaderboard workflow (#7773)

### DIFF
--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -36,7 +36,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
           git checkout "${DEFAULT_BRANCH}"
           git pull --ff-only origin "${DEFAULT_BRANCH}"
@@ -63,4 +63,4 @@ jobs:
 
           git commit -m "chore: update leaderboard for PR #${PR_NUMBER}"
           git pull --rebase origin "${DEFAULT_BRANCH}"
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${DEFAULT_BRANCH}"


### PR DESCRIPTION
Fixes #7773

The workflow was embedding the `GH_TOKEN` secret directly in the remote origin URL via `git remote set-url`, which causes the token to appear in git's remote config, process lists, and potentially runner logs.

Fix: set the origin URL to the token-less HTTPS form (`https://github.com/...`) and pass the token inline only at push time (`git push https://x-access-token:${GH_TOKEN}@...`). This keeps the credential out of the stored remote config while still authenticating the push.