### PR TITLE
Fix API workspace test script target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #7959

/claim #743

## Summary
- update the API workspace test script to target concrete `src/tests/*.test.js` files
- keep the change scoped to `apps/api/package.json`

## Validation
- RED: `npm test -w apps/api` failed before the change with `MODULE_NOT_FOUND` for `apps/api/src/tests`
- GREEN: `npm test -w apps/api` now runs `src/tests/health.test.js` successfully: 1 test passed, 0 failed
- `git diff --check`

## Notes
This is my own reissue/fix attempt for the #743 parent bounty because #7915 is limited to its creator.
