### PR TITLE
fix: patch PostCSS audit advisory via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1672,9 +1672,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1691,9 +1691,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -9,5 +9,10 @@
     "build": "echo \"Run package-specific builds (e.g. npm run build -w apps/web)\"",
     "lint": "echo \"No root lint configured\"",
     "test": "npm run test -w apps/api"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "8.5.10"
+    }
   }
 }


### PR DESCRIPTION
/claim #7961

## Summary
- Add a root npm override pinning Next's PostCSS dependency to `8.5.10`.
- Refresh the lockfile `node_modules/postcss` entry to the patched release while keeping `next@16.2.6` unchanged.

## Verification
- `npm ci --ignore-scripts`
- `npm audit --omit=dev` now reports only unrelated `multer` and `qs` advisories; the PostCSS GHSA-qx2v-qp2m-jg93 / Next-via-PostCSS advisory is gone.
- `node -p require('./node_modules/postcss/package.json').version` -> `8.5.10`
- `npm run build -w apps/web` passes
- `git diff --check`

Note: `npm ls postcss --all` shows `postcss@8.5.10` under `next@16.2.6`, but npm exits with `ELSPROBLEMS` because Next's published package metadata still declares the exact `postcss@8.4.31` dependency. The install, audit target, and web build pass with the override/lockfile resolution.