### PR TITLE
fix: update API test script to target test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

- Fixed the API workspace test script that was failing with MODULE_NOT_FOUND error
- Changed test script from `node --test src/tests` to `node --test "src/tests/*.test.js"`
- The Node test runner requires explicit file glob patterns, not directory paths

## Test plan

- Confirmed `npm test -w apps/api` fails with MODULE_NOT_FOUND before the fix
- Updated only `apps/api/package.json`
- Confirmed `npm test -w apps/api` runs `src/tests/health.test.js` successfully
- Ran `git diff --check` - no issues

## Evidence

Before fix:
```
Error: Cannot find module '/Users/avalok/work/makemoney/sbl-7959/apps/api/src/tests'
```

After fix:
```
> test
> node --test "src/tests/*.test.js"
ok 1 - GET /health returns ok payload
# tests 1, pass 1
```

Resolves #7959 (reissue via #743)