### PR TITLE
fix: ensure registration token subject matches returned user id

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { signAccessToken } from '../utils/jwt.js';
+
+// Mock Date.now() to test race condition
+describe('registerUser token subject matches returned id', () => {
+  let originalDateNow;
+  let callCount = 0;
+  
+  beforeEach(() => {
+    callCount = 0;
+    originalDateNow = Date.now;
+    // Simulate Date.now() returning different values on consecutive calls
+    Date.now = mock.fn(() => {
+      callCount++;
+      return 1000 + callCount; // Returns 1001, 1002, etc.
+    });
+  });
+  
+  it('should have matching id and token subject', async () => {
+    // Import after mocking Date.now
+    const { registerUser } = await import('../services/authService.js');
+    
+    const result = await registerUser({ email: 'test@example.com', role: 'client' });
+    
+    // Verify the id and token subject match
+    assert.ok(result.id, 'Should return user id');
+    assert.ok(result.token, 'Should return token');
+    
+    // Decode the JWT to verify the subject matches the returned id
+    const decoded = JSON.parse(Buffer.from(result.token.split('.')[1], 'base64').toString());
+    
+    // The key assertion: token subject must equal returned user id
+    assert.strictEqual(decoded.sub, result.id, 'Token subject must match returned user id');
+    assert.strictEqual(decoded.role, 'client', 'Token role must match provided role');
+  });
+  
+  it('should not have race condition between id and token subject', async () => {
+    const { registerUser } = await import('../services/authService.js');
+    
+    // Even with Date.now() returning different values each call,
+    // the id should still match the token subject
+    const result = await registerUser({ email: 'test@example.com', role: 'client' });
+    const decoded = JSON.parse(Buffer.from(result.token.split('.')[1], 'base64').toString());
+    
+    // This test would FAIL if Date.now() was called twice
+    assert.strictEqual(decoded.sub, result.id);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed race condition in `registerUser` where `Date.now()` was called twice
- Generated user id once and reused for both response and JWT `sub` claim
- Added regression test that verifies token subject equals returned user id
- Also fixed API test script glob pattern (included as dependency)

## Problem

`registerUser` called `Date.now()` twice: once for the returned `id` and again for the JWT `sub` claim. If the calls happened in different milliseconds, the API would return one user id while the access token authenticates as a different user id.

## Solution

Generate the registration user id once and sign the access token with that exact id as `sub`:

```javascript
const id = `usr_${Date.now()}`;
return {
  id,
  email: payload.email,
  role: payload.role,
  token: signAccessToken({ sub: id, role: payload.role })
};
```

## Test plan

- Added regression test that forces consecutive `Date.now()` calls to diverge
- Test verifies the decoded token subject equals the returned id
- All tests pass: `npm test -w apps/api`

```
# tests 3, pass 3
```

Resolves #7941 (reissue via #743)