### PR TITLE
Preserve server-owned notification id and read state

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const result = await createNotification({
+    id: "client-controlled-id",
+    read: true,
+    message: "New proposal received"
+  });
+
+  assert.match(result.id, /^ntf_/);
+  assert.notEqual(result.id, "client-controlled-id");
+  assert.equal(result.read, false);
+  assert.equal(result.message, "New proposal received");
+});


### PR DESCRIPTION
## Summary

- Ensure notification creation overwrites caller-provided `id` and `read` values.
- Keep the rest of the notification payload intact.
- Add focused service coverage for server-owned notification fields.

Fixes #3612
Parent bounty: #743
Source issue: #2762

## Tests

- `node --test apps/api/src/tests/notificationService.test.js`
  - pass: 1
- `node --test apps/api/src/tests/*.test.js`
  - pass: 9
- `npm test`
  - currently fails before executing tests because `apps/api/package.json` passes `src/tests` as a module path under Node v26; left out of this PR because a separate open PR appears to cover the test-script glob.
