### PR TITLE
Validate user creation input

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userValidator.test.js
+++ b/apps/api/src/tests/userValidator.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
+
+const validUser = {
+  email: "client@example.com",
+  fullName: "Client Example"
+};
+
+test("createUserSchema accepts valid user creation payloads", () => {
+  const result = createUserSchema.safeParse(validUser);
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});
+
+test("createUserSchema rejects caller-controlled id fields", () => {
+  const result = createUserSchema.safeParse({
+    ...validUser,
+    id: "caller-controlled-id"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("createUserSchema rejects admin role assignment", () => {
+  const result = createUserSchema.safeParse({
+    ...validUser,
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "role");
+});
+
+test("createUser preserves server-owned id", async () => {
+  const result = await createUser({
+    ...validUser,
+    id: "caller-controlled-id"
+  });
+
+  assert.match(result.id, /^usr_/);
+  assert.notEqual(result.id, "caller-controlled-id");
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+}).strict();


### PR DESCRIPTION
## Summary

- Add a strict user creation schema for `email`, `fullName`, and public roles.
- Parse user creation input in the controller before calling the service.
- Preserve server-owned generated ids even if callers provide an `id` field.

Fixes #3615
Parent bounty: #743
Source issue: #1766

## Tests

- `node --test apps/api/src/tests/userValidator.test.js`
  - pass: 4
- `node --test apps/api/src/tests/*.test.js`
  - pass: 13
- `npm test`
  - currently fails before executing tests because `apps/api/package.json` passes `src/tests` as a module path under Node v26; left out of this PR because a separate open PR appears to cover the test-script glob.
