### PR TITLE
Expose the DB package workspace entrypoint

### DIFF
--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.js
+++ b/packages/db/index.js
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Summary

- Add explicit `main`, `types`, and `exports` metadata for `@freelanceflow/db`.
- Add a runtime `index.js` entrypoint that re-exports `@prisma/client`.
- Add matching declarations for TypeScript consumers.

Fixes #3608
Parent bounty: #743
Source issue: #2775

## Tests

- `node -e "import('@freelanceflow/db').then(m=>console.log('imported', Object.keys(m).length))"`
  - pass: `imported 3`
- `node --check packages/db/index.js`
  - pass
