### PR TITLE
Make the UI package directly importable

### DIFF
--- a/packages/ui/Button.js
+++ b/packages/ui/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/Card.js
+++ b/packages/ui/Card.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,4 @@
+import type { ReactElement, ReactNode } from "react";
+
+export declare function Button({ children }: { children: ReactNode }): ReactElement;
+export declare function Card({ title, children }: { title: string; children: ReactNode }): ReactElement;

--- a/packages/ui/index.js
+++ b/packages/ui/index.js
@@ -1,0 +1,2 @@
+export { Button } from "./Button.js";
+export { Card } from "./Card.js";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Point `@freelanceflow/ui` at a runtime JavaScript entrypoint.
- Export `Button` and `Card` from ESM files that Node can import directly.
- Add package declarations so TypeScript consumers keep component types.

Fixes #3604
Parent bounty: #743
Source issue: #2787

## Tests

- `node -e "import('@freelanceflow/ui').then(m=>console.log(Object.keys(m).sort().join(',')))"`
  - pass: `Button,Card`
- `node --check packages/ui/index.js`
  - pass
- `node --check packages/ui/Button.js`
  - pass
- `node --check packages/ui/Card.js`
  - pass
