### PR TITLE
fix: validate and sanitise search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { ok, badRequest } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+
+  if (q !== undefined && typeof q !== "string") {
+    return badRequest(res, "Query parameter 'q' must be a string.");
+  }
+
+  const trimmed = (q ?? "").trim();
+
+  if (trimmed.length > 200) {
+    return badRequest(res, "Query parameter 'q' must not exceed 200 characters.");
+  }
+
+  return ok(res, await globalSearch(trimmed));
 }


### PR DESCRIPTION
/claim #7972

## Problem
The `GET /search` endpoint accepted `req.query.q` without any validation. Non-string values (arrays, objects) could crash the service, and unbounded strings could cause downstream performance issues or ReDoS-style amplification.

## Fix
- Reject non-string values for `q` with **HTTP 400**
- Trim whitespace before forwarding to the search service
- Enforce a **200-character** maximum length

## Files changed
- `apps/api/src/controllers/searchController.js`

## Demo
A screen-capture walkthrough has been recorded (`demo_search_validation.mp4`) showing the before/after behaviour.

## Checklist
- [x] Non-string input returns 400
- [x] Whitespace is trimmed
- [x] Input > 200 chars returns 400
- [x] Valid input still passes through to `globalSearch`