### PR TITLE
fix: remove admin from self-assignable roles at registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #7973

## Problem
The registration validator allowed `role: "admin"` to be submitted by any user, granting themselves full administrative privileges on sign-up — a critical privilege-escalation vulnerability.

## Fix
Restrict the Zod enum in `registerSchema` to `["client", "freelancer"]` only. Admin accounts must be provisioned through a separate, privileged path.

## Files changed
- `apps/api/src/validators/auth.js`

## Demo
A screen-capture walkthrough has been recorded (`demo_admin_role.mp4`) showing the vulnerable payload and how the fix blocks it.

## Checklist
- [x] `role=admin` in registration body is now rejected by Zod
- [x] Default role remains `client`
- [x] `client` and `freelancer` still accepted normally