### PR TITLE
fix: protect job creation route with authMiddleware

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
/claim #7974

## Problem
The `POST /jobs` endpoint had no authentication middleware. Any anonymous HTTP client could create job listings, opening the door to spam, fraudulent postings, and data pollution.

## Fix
Import `authMiddleware` from `../middleware/auth.js` and insert it into the `POST /` route chain before the `postJob` handler.

## Files changed
- `apps/api/src/routes/jobRoutes.js`

## Demo
A screen-capture walkthrough has been recorded (`demo_job_auth.mp4`) showing an unauthenticated POST before and after the fix.

## Checklist
- [x] Unauthenticated `POST /jobs` now returns HTTP 401
- [x] Authenticated requests still reach `postJob` handler
- [x] `GET /jobs` remains publicly accessible (unchanged)