### PR TITLE
Build out settings page

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,8 +1,98 @@
+const account = {
+  name: "Maya Chen",
+  email: "maya@example.com",
+  avatar: "MC",
+  visibility: "Public freelancer profile"
+};
+
+const notifications = [
+  { label: "Email proposal updates", enabled: true },
+  { label: "Push message alerts", enabled: true },
+  { label: "In-app billing reminders", enabled: false }
+];
+
+const sessions = [
+  { device: "Chrome on macOS", location: "Santiago, CL", lastActive: "Active now" },
+  { device: "Safari on iPhone", location: "Valparaiso, CL", lastActive: "2 hours ago" }
+];
+
+const billingHistory = [
+  { id: "INV-1042", label: "Freelancer Plus", amount: "$29.00", status: "Paid" },
+  { id: "PAY-8821", label: "Payout to bank", amount: "$640.00", status: "Processing" }
+];
+
+function StatusPill({ enabled }: { enabled: boolean }) {
+  return (
+    <span style={{ color: enabled ? "#7dd3fc" : "#cbd5e1", fontWeight: 700 }}>
+      {enabled ? "On" : "Off"}
+    </span>
+  );
+}
+
 export default function SettingsPage() {
   return (
-    <section className="card">
-      <h2>Settings</h2>
-      <p>Account preferences, profile visibility, and security controls.</p>
-    </section>
+    <main>
+      <section className="card">
+        <h2>Settings</h2>
+        <p>Manage profile, notification, security, and billing preferences.</p>
+      </section>
+
+      <section className="card">
+        <h3>Account / Profile</h3>
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          <p><strong>Display name:</strong> {account.name}</p>
+          <p><strong>Email:</strong> {account.email}</p>
+          <p><strong>Avatar:</strong> {account.avatar}</p>
+          <p><strong>Visibility:</strong> {account.visibility}</p>
+        </div>
+      </section>
+
+      <section className="card">
+        <h3>Notifications</h3>
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          {notifications.map((item) => (
+            <p key={item.label}>
+              <strong>{item.label}:</strong> <StatusPill enabled={item.enabled} />
+            </p>
+          ))}
+        </div>
+      </section>
+
+      <section className="card">
+        <h3>Security</h3>
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          <p><strong>Password:</strong> Last changed 18 days ago</p>
+          <p><strong>Two-factor authentication:</strong> Enabled</p>
+          <div>
+            <strong>Active sessions:</strong>
+            <ul>
+              {sessions.map((session) => (
+                <li key={session.device}>
+                  {session.device} - {session.location} - {session.lastActive}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="card">
+        <h3>Billing / Payout</h3>
+        <div style={{ display: "grid", gap: "0.75rem" }}>
+          <p><strong>Payment method:</strong> Visa ending in 4242</p>
+          <p><strong>Payout details:</strong> Bank transfer ending in 1188</p>
+          <div>
+            <strong>Billing history:</strong>
+            <ul>
+              {billingHistory.map((entry) => (
+                <li key={entry.id}>
+                  {entry.id} - {entry.label} - {entry.amount} - {entry.status}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Closes #7993. Replaces the `/settings` placeholder with a full static settings page covering account/profile, notifications, security, and billing/payout information.

Parent bounty: #743

## Changes

- Adds mock account/profile details including display name, email, avatar initials, and visibility.
- Adds notification preference rows with on/off status.
- Adds security details for password, 2FA, and active sessions.
- Adds billing/payout details and billing history entries.
- Keeps the implementation dependency-free and aligned with the app's existing `card` styling.

## Testing

- `npm run build -w apps/web` — passed.

Note: Next.js emitted a workspace-root warning because multiple lockfiles exist in the wider local workspace, but the web app compiled, typechecked, and prerendered `/settings` successfully.