### PR TITLE
Fix API test discovery script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Closes #7995. Updates the API workspace test script so Node's test runner receives the concrete test-file glob instead of the `src/tests` directory entrypoint.

Parent bounty: #743

## Changes

- Changes `apps/api/package.json` test script from `node --test src/tests` to `node --test "src/tests/*.test.js"`.
- Preserves the existing health test and workspace layout.

## Testing

- `npm test -w apps/api` — passed, 1 test.