### PR TITLE
Run API rate limiter before JSON parsing

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/app.test.js
+++ b/apps/api/src/tests/app.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("api limiter is registered before JSON body parsing", async () => {
+  const source = await readFile(new URL("../app.js", import.meta.url), "utf8");
+
+  assert.ok(
+    source.indexOf("app.use(apiLimiter)") < source.indexOf("app.use(express.json())"),
+    "apiLimiter must run before express.json() so rate limits apply before body parsing"
+  );
+});


### PR DESCRIPTION
## Summary
- move the API rate limiter before `express.json()` so requests are throttled before JSON body parsing
- add a focused regression test that guards the middleware registration order

## Validation
- `node --test "apps/api/src/tests/*.test.js"`

Fixes #8002

Disclosure: prepared with AI-assisted development and manually validated with the command above.
