### PR TITLE
Require estimated duration for proposals

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { proposalCreateSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = proposalCreateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid proposal payload",
+      errors: parsed.error.flatten().fieldErrors
+    });
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        coverLetter: "I can help with this work."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.deepEqual(payload.errors.estimatedDuration, ["Required"]);
+  });
+});
+
+test("POST /api/proposals accepts estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_1",
+        freelancerId: "usr_1",
+        coverLetter: "I can help with this work.",
+        estimatedDuration: "2 weeks"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.estimatedDuration, "2 weeks");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const proposalCreateSchema = z
+  .object({
+    estimatedDuration: z.string().trim().min(1)
+  })
+  .passthrough();


### PR DESCRIPTION
## Summary
- add proposal creation validation requiring a non-empty `estimatedDuration`
- return a 400 validation response before persisting invalid proposal payloads
- add focused API coverage for missing and valid duration payloads

## Validation
- `node --test "apps/api/src/tests/*.test.js"`

Fixes #8003

Disclosure: prepared with AI-assisted development and manually validated with the command above.
