### PR TITLE
Protect notification internal fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...safePayload } = payload;
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-controlled internal fields", async () => {
+  const notification = await createNotification({
+    id: "caller_id",
+    read: true,
+    title: "New proposal",
+    message: "A freelancer sent a proposal."
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "caller_id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.title, "New proposal");
+  assert.equal(notification.message, "A freelancer sent a proposal.");
+});


### PR DESCRIPTION
## Summary
- ignore caller-provided `id` and `read` fields when creating notifications
- keep generated notification ids and the default unread state authoritative
- add focused service coverage for caller-controlled internal fields

## Validation
- `node --test "apps/api/src/tests/*.test.js"`

Fixes #8004

Disclosure: prepared with AI-assisted development and manually validated with the command above.
