### PR TITLE
Keep registration token subject consistent

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs a token for the returned user id", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  const tokenPayload = verifyAccessToken(result.token);
+
+  assert.match(result.id, /^usr_\d+$/);
+  assert.equal(tokenPayload.sub, result.id);
+  assert.equal(tokenPayload.role, "client");
+});


### PR DESCRIPTION
## Summary
- generate the registration user id once and reuse it for the JWT `sub` claim
- preserve the existing registration response shape
- add focused service coverage proving the token subject matches the returned id

## Validation
- `node --test "apps/api/src/tests/*.test.js"`

Fixes #8005

Disclosure: prepared with AI-assisted development and manually validated with the command above.
