### PR TITLE
Apply rate limiter before JSON parser

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/app-middleware-order.test.js
+++ b/apps/api/src/tests/app-middleware-order.test.js
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("apiLimiter is registered before JSON body parsing", async () => {
+  const source = await readFile(new URL("../app.js", import.meta.url), "utf8");
+
+  assert.ok(source.indexOf("app.use(apiLimiter)") < source.indexOf("app.use(express.json())"));
+});


### PR DESCRIPTION
Fixes #8010

## Summary
- Move `apiLimiter` before `express.json()` so rate limiting runs before body parsing.
- Add a focused source-order regression test for the middleware registration order.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

Note: `npm test -w apps/api` currently fails because the existing script invokes `node --test src/tests`, which this Node version treats as a module path rather than discovering test files. This PR leaves that separate issue untouched.

AI-assisted implementation, reviewed before submission.