### PR TITLE
Require proposal estimated duration

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +6,9 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
+  if (typeof req.body?.estimatedDuration !== "string" || req.body.estimatedDuration.trim() === "") {
+    return fail(res, "estimatedDuration is required");
+  }
+
   return ok(res, await createProposal(req.body), 201);
 }

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jobId: "job_1", coverLetter: "I can help." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "estimatedDuration is required"
+    });
+  });
+});
+
+test("POST /api/proposals accepts valid estimatedDuration", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jobId: "job_1",
+        coverLetter: "I can help.",
+        estimatedDuration: "2 weeks"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.estimatedDuration, "2 weeks");
+  });
+});


### PR DESCRIPTION
Fixes #8011

## Summary
- Validate proposal creation payloads for a non-empty `estimatedDuration`.
- Return a 400 validation response when the field is missing or blank.
- Add focused API coverage for missing and valid duration payloads.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.