### PR TITLE
Reuse registered user id for token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/auth-service.test.js
+++ b/apps/api/src/tests/auth-service.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser uses returned user id as access token subject", async () => {
+  const originalNow = Date.now;
+  const times = [1000, 1001];
+  Date.now = () => times.shift() ?? 1001;
+
+  try {
+    const user = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+    const claims = verifyAccessToken(user.token);
+
+    assert.equal(user.id, "usr_1000");
+    assert.equal(claims.sub, user.id);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8012

## Summary
- Generate the registration user id once.
- Reuse that exact id for the access token `sub` claim.
- Add focused service coverage for a cross-millisecond `Date.now()` sequence.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.