### PR TITLE
Ignore notification internal fields from payload

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,12 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id, read, ...notificationPayload } = payload;
+  const notification = {
+    ...notificationPayload,
+    id: `ntf_${Date.now()}`,
+    read: false
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification ignores caller-controlled internal fields", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1234;
+
+  try {
+    const notification = await createNotification({
+      id: "caller_id",
+      read: true,
+      userId: "usr_1",
+      message: "New proposal"
+    });
+
+    assert.equal(notification.id, "ntf_1234");
+    assert.equal(notification.read, false);
+    assert.equal(notification.userId, "usr_1");
+    assert.equal(notification.message, "New proposal");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8013

## Summary
- Ignore caller-provided `id` and `read` fields during notification creation.
- Preserve ordinary notification payload fields.
- Add direct service coverage for the internal-field override case.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.