### PR TITLE
Return 400 for Zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/validation-errors.test.js
+++ b/apps/api/src/tests/validation-errors.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+import { createJobSchema } from "../validators/job.js";
+
+test("Zod validation failures return HTTP 400", () => {
+  let statusCode;
+  let payload;
+  const req = {};
+  const res = {
+    headersSent: false,
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(body) {
+      payload = body;
+      return this;
+    }
+  };
+  const next = () => assert.fail("next should not be called for validation errors");
+
+  const result = createJobSchema.safeParse({
+    title: "Bad",
+    description: "too short",
+    budgetMin: -1,
+    budgetMax: 100,
+    categoryId: ""
+  });
+  assert.equal(result.success, false);
+
+  errorHandler(result.error, req, res, next);
+
+  assert.equal(statusCode, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+  assert.ok(payload.issues.some((issue) => issue.path === "budgetMin"));
+});


### PR DESCRIPTION
Fixes #8019

## Summary
- Handle `ZodError` in the API error middleware as a client validation failure.
- Return HTTP 400 with stable validation issue details.
- Preserve existing 500 handling for unexpected errors.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.