### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job-validation.test.js
+++ b/apps/api/src/tests/job-validation.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API integration",
+  description: "Create a production API integration.",
+  budgetMin: 100,
+  budgetMax: 250,
+  categoryId: "development",
+  skills: ["node"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 250
+  });
+
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((issue) => issue.path.join(".") === "budgetMax"));
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const result = createJobSchema.safeParse(validJob);
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine((job) => job.budgetMin <= job.budgetMax, {
+  path: ["budgetMax"],
+  message: "budgetMax must be greater than or equal to budgetMin"
+});
+
+export const updateJobSchema = jobSchema.partial();


### PR DESCRIPTION
Fixes #8020

## Summary
- Add a cross-field validation rule requiring `budgetMin <= budgetMax`.
- Preserve the existing partial update schema behavior by keeping a base job schema.
- Add focused validation tests for inverted and ordered budget ranges.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.