### PR TITLE
Reject uploads without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required");
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload-controller.test.js
+++ b/apps/api/src/tests/upload-controller.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { uploadFile } from "../controllers/uploadController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    }
+  };
+}
+
+test("uploadFile rejects requests without a file", async () => {
+  const res = createResponse();
+
+  await uploadFile({}, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.payload, {
+    success: false,
+    message: "File is required"
+  });
+});
+
+test("uploadFile accepts uploaded files", async () => {
+  const res = createResponse();
+
+  await uploadFile({ file: { originalname: "brief.pdf" } }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(res.payload, {
+    success: true,
+    data: {
+      filename: "brief.pdf",
+      status: "uploaded"
+    }
+  });
+});


### PR DESCRIPTION
Fixes #8021

## Summary
- Return a 400 validation response when upload requests do not include a file.
- Preserve the existing successful upload response shape.
- Add focused controller coverage for missing and present file cases.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.