### PR TITLE
Protect job internal fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,12 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id, status, ...jobPayload } = payload;
+  const job = {
+    ...jobPayload,
+    id: `job_${Date.now()}`,
+    status: "open"
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service.test.js
+++ b/apps/api/src/tests/job-service.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob ignores caller-controlled id and status", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 4321;
+
+  try {
+    const job = await createJob({
+      id: "caller_job",
+      status: "closed",
+      title: "Build landing page",
+      budgetMin: 100,
+      budgetMax: 200
+    });
+
+    assert.equal(job.id, "job_4321");
+    assert.equal(job.status, "open");
+    assert.equal(job.title, "Build landing page");
+    assert.equal(job.budgetMin, 100);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8023

## Summary
- Ignore caller-provided `id` and `status` fields during job creation.
- Keep generated job ids and the default `open` status authoritative.
- Add focused service coverage for the internal-field override case.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.