### PR TITLE
Return message list snapshots

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/tests/message-service.test.js
+++ b/apps/api/src/tests/message-service.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { listMessages, sendMessage } from "../services/messageService.js";
+
+test("listMessages returns a defensive array snapshot", async () => {
+  await sendMessage({ fromUserId: "usr_1", toUserId: "usr_2", body: "Hello" });
+
+  const firstResult = await listMessages();
+  firstResult.length = 0;
+  firstResult.push({ id: "injected" });
+
+  const secondResult = await listMessages();
+
+  assert.ok(secondResult.some((message) => message.body === "Hello"));
+  assert.equal(secondResult.some((message) => message.id === "injected"), false);
+});


### PR DESCRIPTION
Fixes #8024

## Summary
- Return a defensive array snapshot from `listMessages()`.
- Prevent callers from mutating internal message service state through list results.
- Add focused service coverage for mutation isolation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.