### PR TITLE
Require auth for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/job-routes.test.js
+++ b/apps/api/src/tests/job-routes.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs requires authentication", async () => {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Build app",
+        description: "Build a useful app.",
+        budgetMin: 100,
+        budgetMax: 200,
+        categoryId: "development"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
Fixes #8038

## Summary
- Add `authMiddleware` to the job creation route.
- Keep public job listing behavior unchanged.
- Add focused route coverage for unauthenticated job creation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.