### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/validate.js
+++ b/apps/api/src/middleware/validate.js
@@ -1,0 +1,19 @@
+import { ZodError } from "zod";
+import { fail } from "../utils/response.js";
+
+export function validate(schema) {
+  return (req, res, next) => {
+    try {
+      req.body = schema.parse(req.body);
+      return next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const details = error.issues
+          .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+          .join("; ");
+        return fail(res, `Validation failed: ${details}`, 400);
+      }
+      return next(error);
+    }
+  };
+}

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { validate } from "../middleware/validate.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", validate(createReviewSchema), postReview);

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects missing targetId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_123",
+        rating: 5,
+        comment: "Excellent work and communication."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /targetId/);
+  });
+});
+
+test("POST /api/reviews rejects rating above five", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reviewerId: "usr_123",
+        targetId: "usr_456",
+        rating: 6,
+        comment: "Excellent work and communication."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /rating/);
+  });
+});
+
+test("POST /api/reviews preserves server generated id", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client_supplied_id",
+        reviewerId: "usr_123",
+        targetId: "usr_456",
+        rating: 5,
+        comment: "Excellent work and communication."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_/);
+    assert.notEqual(payload.data.id, "client_supplied_id");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().min(1),
+  targetId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(10)
+});


### PR DESCRIPTION
Closes #8050

## Summary
- adds a focused Zod schema for review creation payloads
- validates `POST /api/reviews` before persistence and returns structured 400 responses
- preserves the server generated `rev_*` id even when callers submit an `id`
- fixes the API workspace test script so the route regression tests are exercised

## Validation
- `npm run test -w apps/api`