### PR TITLE
Require auth for user listing

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/user-routes.test.js
+++ b/apps/api/src/tests/user-routes.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/users requires authentication", async () => {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
Fixes #8039

## Summary
- Add `authMiddleware` to the users collection GET route.
- Keep user creation behavior unchanged.
- Add focused route coverage for unauthenticated user listing.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.