### PR TITLE
Reject public admin registration

### DIFF
--- a/apps/api/src/tests/auth-validation.test.js
+++ b/apps/api/src/tests/auth-validation.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects public admin role assignment", () => {
+  const result = registerSchema.safeParse({
+    email: "owner@example.com",
+    password: "password123",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerSchema preserves client default role", () => {
+  const result = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(result.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #8040

## Summary
- Restrict public registration roles to `client` and `freelancer`.
- Preserve the default `client` role.
- Add focused schema coverage for admin rejection and default behavior.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.