### PR TITLE
Reject empty search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  if (!query) {
+    return fail(res, "Search query is required");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search-controller.test.js
+++ b/apps/api/src/tests/search-controller.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { search } from "../controllers/searchController.js";
+
+function createResponse() {
+  return {
+    statusCode: undefined,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    }
+  };
+}
+
+test("search rejects empty queries", async () => {
+  const res = createResponse();
+
+  await search({ query: { q: "   " } }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.payload, {
+    success: false,
+    message: "Search query is required"
+  });
+});
+
+test("search trims and accepts non-empty queries", async () => {
+  const res = createResponse();
+
+  await search({ query: { q: "  react  " } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.data.query, "react");
+});


### PR DESCRIPTION
Fixes #8041

## Summary
- Return a 400 response when `q` is missing or blank.
- Trim accepted search queries before passing them to the service.
- Add focused controller coverage for rejected and accepted queries.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.