### PR TITLE
Normalize payment currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,13 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const currency = typeof payload.currency === "string" && payload.currency.trim()
+    ? payload.currency.trim().toLowerCase()
+    : "usd";
+
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/payment-service.test.js
+++ b/apps/api/src/tests/payment-service.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes currency casing", async () => {
+  const payment = await createPaymentIntent({ amount: 1000, currency: " USD " });
+
+  assert.equal(payment.currency, "usd");
+});
+
+test("createPaymentIntent defaults missing currency to usd", async () => {
+  const payment = await createPaymentIntent({ amount: 1000 });
+
+  assert.equal(payment.currency, "usd");
+});


### PR DESCRIPTION
Fixes #8042

## Summary
- Normalize provided payment currency values with trim and lowercase.
- Preserve the existing `usd` default for missing or blank currencies.
- Add focused service coverage for normalization and default behavior.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.