### PR TITLE
Omit passwords from created users

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...publicPayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...publicPayload };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-service-password.test.js
+++ b/apps/api/src/tests/user-service-password.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser omits password fields from public users", async () => {
+  const user = await createUser({
+    email: "safe@example.com",
+    fullName: "Safe User",
+    password: "password123"
+  });
+  const users = await listUsers();
+
+  assert.equal("password" in user, false);
+  assert.ok(users.some((storedUser) => storedUser.email === "safe@example.com"));
+  assert.equal(users.some((storedUser) => "password" in storedUser), false);
+});


### PR DESCRIPTION
Fixes #8043

## Summary
- Exclude `password` from user objects created by `createUser()`.
- Keep ordinary public profile fields in the response.
- Add focused service coverage for returned and stored user objects.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.