### PR TITLE
Return proposal list snapshots

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/tests/proposal-list-service.test.js
+++ b/apps/api/src/tests/proposal-list-service.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("listProposals returns a defensive array snapshot", async () => {
+  await createProposal({ jobId: "job_1", freelancerId: "usr_1" });
+
+  const firstResult = await listProposals();
+  firstResult.length = 0;
+  firstResult.push({ id: "injected" });
+
+  const secondResult = await listProposals();
+
+  assert.ok(secondResult.some((proposal) => proposal.jobId === "job_1"));
+  assert.equal(secondResult.some((proposal) => proposal.id === "injected"), false);
+});


### PR DESCRIPTION
Fixes #8044

## Summary
- Return a defensive array snapshot from `listProposals()`.
- Prevent callers from mutating internal proposal service state through list results.
- Add focused service coverage for mutation isolation.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.