### PR TITLE
Protect proposal ids

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,11 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...proposalPayload } = payload;
+  const proposal = {
+    ...proposalPayload,
+    id: `prp_${Date.now()}`
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal-id-service.test.js
+++ b/apps/api/src/tests/proposal-id-service.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal ignores caller-controlled id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 5678;
+
+  try {
+    const proposal = await createProposal({
+      id: "caller_prp",
+      jobId: "job_1",
+      freelancerId: "usr_1"
+    });
+
+    assert.equal(proposal.id, "prp_5678");
+    assert.equal(proposal.jobId, "job_1");
+    assert.equal(proposal.freelancerId, "usr_1");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8045

## Summary
- Ignore caller-provided proposal ids during creation.
- Keep generated proposal ids authoritative while preserving ordinary payload fields.
- Add focused service coverage for id override attempts.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.