### PR TITLE
Protect message ids

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id, ...messagePayload } = payload;
+  const message = { id: `msg_${Date.now()}`, ...messagePayload, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-id-service.test.js
+++ b/apps/api/src/tests/message-id-service.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage ignores caller-controlled id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 6789;
+
+  try {
+    const message = await sendMessage({
+      id: "caller_msg",
+      fromUserId: "usr_1",
+      toUserId: "usr_2",
+      body: "Hello"
+    });
+
+    assert.equal(message.id, "msg_6789");
+    assert.equal(message.body, "Hello");
+    assert.ok(message.sentAt);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8046

## Summary
- Ignore caller-provided message ids during creation.
- Keep generated message ids authoritative while preserving ordinary payload fields and generated `sentAt`.
- Add focused service coverage for id override attempts.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.