### PR TITLE
Protect review ids

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id, ...reviewPayload } = payload;
+  const review = {
+    ...reviewPayload,
+    id: `rev_${Date.now()}`
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review-id-service.test.js
+++ b/apps/api/src/tests/review-id-service.test.js
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview ignores caller-controlled id", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 7890;
+
+  try {
+    const review = await createReview({
+      id: "caller_rev",
+      reviewerId: "usr_1",
+      revieweeId: "usr_2",
+      rating: 5
+    });
+
+    assert.equal(review.id, "rev_7890");
+    assert.equal(review.rating, 5);
+    assert.equal(review.revieweeId, "usr_2");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #8047

## Summary
- Ignore caller-provided review ids during creation.
- Keep generated review ids authoritative while preserving ordinary review payload fields.
- Add focused service coverage for id override attempts.

## Validation
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

AI-assisted implementation, reviewed before submission.