### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      ...options.headers
+    }
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/notifications rejects invalid creation payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const before = await requestJson(`${baseUrl}/api/notifications`);
+    const invalidPayloads = [
+      {},
+      { userId: "", title: "New proposal", body: "You have a new proposal" },
+      { userId: "usr_1", title: "", body: "You have a new proposal" },
+      { userId: "usr_1", title: "New proposal", body: "   " },
+      { userId: "usr_1", title: "New proposal", body: 42 }
+    ];
+
+    for (const payload of invalidPayloads) {
+      const result = await requestJson(`${baseUrl}/api/notifications`, {
+        method: "POST",
+        body: JSON.stringify(payload)
+      });
+
+      assert.equal(result.response.status, 400);
+      assert.equal(result.payload.success, false);
+    }
+
+    const after = await requestJson(`${baseUrl}/api/notifications`);
+    assert.equal(after.payload.data.length, before.payload.data.length);
+  });
+});
+
+test("POST /api/notifications preserves server-owned id and read defaults", async () => {
+  await withServer(async (baseUrl) => {
+    const result = await requestJson(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      body: JSON.stringify({
+        id: "ntf_client_supplied",
+        userId: "usr_1",
+        title: "New proposal",
+        body: "You have a new proposal",
+        read: true
+      })
+    });
+
+    assert.equal(result.response.status, 201);
+    assert.equal(result.payload.success, true);
+    assert.match(result.payload.data.id, /^ntf_/);
+    assert.notEqual(result.payload.data.id, "ntf_client_supplied");
+    assert.equal(result.payload.data.read, false);
+    assert.equal(result.payload.data.userId, "usr_1");
+    assert.equal(result.payload.data.title, "New proposal");
+    assert.equal(result.payload.data.body, "You have a new proposal");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const requiredString = z.string().trim().min(1);
+
+export const createNotificationSchema = z.object({
+  userId: requiredString,
+  title: requiredString,
+  body: requiredString
+});


### PR DESCRIPTION
## Summary
- add Zod validation for notification creation payloads (`userId`, `title`, `body`)
- return HTTP 400 for missing, blank, or incorrectly typed notification fields
- preserve server-owned `id` and `read` values even when clients try to override them
- fix the API test script so the Node test runner targets test files on Windows

## Validation
- RED: `node --test apps/api/src/tests/notification.test.js` failed with 201 instead of 400 and accepted client-supplied `id`
- GREEN: `npm run test -w apps/api` (3 tests, 0 failures)
- `git diff --check`

Closes #8063
Parent bounty: #743