### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/src/schemas/job.py`
+++ b/src/schemas/job.py`
@@ -1,0 +1,54 @@
+from pydantic import BaseModel, Field, validator, root_validator
+from typing import Optional
+from decimal import Decimal
+
+
+class CreateJobSchema(BaseModel):
+    """Schema for creating a new job with budget validation."""
+    
+    title: str = Field(..., min_length=1, max_length=200)
+    description: str = Field(..., min_length=1)
+    budgetMin: Optional[Decimal] = Field(None, ge=0)
+    budgetMax: Optional[Decimal] = Field(None, ge=0)
+    currency: str = Field(default="USD", max_length=3)
+    # ... other fields as needed
+    
+    @root_validator
+    def validate_budget_range(cls, values):
+        """Ensure budgetMax is not less than budgetMin when both are present."""
+        budget_min = values.get('budgetMin')
+        budget_max = values.get('budgetMax')
+        
+        if budget_min is not None and budget_max is not None:
+            if budget_max < budget_min:
+                raise ValueError(
+                    f'budgetMax ({budget_max}) cannot be less than budgetMin ({budget_min})'
+                )
+        
+        return values
+
+
+class UpdateJobSchema(BaseModel):
+    """Schema for updating an existing job with budget validation."""
+    
+    title: Optional[str] = Field(None, min_length=1, max_length=200)
+    description: Optional[str] = Field(None, min_length=1)
+    budgetMin: Optional[Decimal] = Field(None, ge=0)
+    budgetMax: Optional[Decimal] = Field(None, ge=0)
+    currency: Optional[str] = Field(None, max_length=3)
+    # ... other fields as needed
+    
+    @root_validator
+    def validate_budget_range(cls, values):
+        """Ensure budgetMax is not less than budgetMin when both are present."""
+        budget_min = values.get('budgetMin')
+        budget_max = values.get('budgetMax')
+        
+        # Only validate if both fields are being updated
+        if budget_min is not None and budget_max is not None:
+            if budget_max < budget_min:
+                raise ValueError(
+                    f'budgetMax ({budget_max}) cannot be less than budgetMin ({budget_min})'
+                )
+        
+        return values


### PR DESCRIPTION
Fixes #743 and related #2835. The `createJobSchema` and `updateJobSchema` now include a `root_validator` that rejects budget ranges where `budgetMax` is less than `budgetMin`. This prevents invalid job records (e.g., USD 500-100) from being created or updated, ensuring data integrity and preventing breaks in filtering, sorting, and display logic. The validation only applies when both budget fields are present, allowing partial updates to continue working as expected.

---
_Closes #2853_