### PR TITLE
Reject empty search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = String(req.query.q ?? "").trim();
+  if (!query) {
+    return fail(res, "Search query is required", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects missing query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /query/i);
+  });
+});
+
+test("GET /api/search rejects blank query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /query/i);
+  });
+});
+
+test("GET /api/search rejects whitespace-only query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /query/i);
+  });
+});
+
+test("GET /api/search returns results for valid query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=developer`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "developer");
+    assert.deepEqual(payload.data.users, []);
+    assert.deepEqual(payload.data.jobs, []);
+    assert.deepEqual(payload.data.freelancers, []);
+  });
+});


### PR DESCRIPTION
Closes #8068

/claim #743

## Summary
- Reject missing, blank, and whitespace-only `q` values for `GET /api/search`.
- Trim valid search queries before dispatching to the search service.
- Add focused API regression coverage for invalid empty queries and valid query behavior.

## Validation
- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/*.test.js` (5 passing tests)
- `git diff --check`
- `npm run lint` (repo placeholder: no root lint configured)

## Demo
Short demo video: https://github.com/ram-devv1/bug-bounty/releases/download/pr-8070-demo/pr8070-search-demo.mp4

The demo shows missing, blank, and whitespace-only search queries returning HTTP 400 while `/api/search?q=developer` still returns HTTP 200.
