### PR TITLE
Reject blank search queries

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = typeof req.query.q === "string" ? req.query.q.trim() : "";
+
+  if (!query) {
+    return fail(res, "Search query is required");
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(t) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test("GET /api/search rejects a missing query", async (t) => {
+  const baseUrl = await withServer(t);
+  const response = await fetch(`${baseUrl}/api/search`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, { success: false, message: "Search query is required" });
+});
+
+test("GET /api/search rejects a blank query", async (t) => {
+  const baseUrl = await withServer(t);
+  const response = await fetch(`${baseUrl}/api/search?q=`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, { success: false, message: "Search query is required" });
+});
+
+test("GET /api/search rejects a whitespace-only query", async (t) => {
+  const baseUrl = await withServer(t);
+  const response = await fetch(`${baseUrl}/api/search?q=%20%20%20`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(payload, { success: false, message: "Search query is required" });
+});
+
+test("GET /api/search accepts and trims a valid query", async (t) => {
+  const baseUrl = await withServer(t);
+  const response = await fetch(`${baseUrl}/api/search?q=%20designer%20`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload, {
+    success: true,
+    data: {
+      query: "designer",
+      users: [],
+      jobs: [],
+      freelancers: []
+    }
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #8069.

## Summary

- Reject missing, empty, and whitespace-only `q` values on `GET /api/search`.
- Trim valid search queries before passing them to `globalSearch`.
- Add focused API regression tests for missing, blank, whitespace-only, and valid query behavior.

## Validation

- `/Users/sun/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test "src/tests/*.test.js"` from `apps/api`
- `git diff --check`
