### PR TITLE
[codex] validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build an API",
+  description: "Create a reliable project API",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "development"
+};
+
+test("create job validation accepts ordered and equal budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(
+    createJobSchema.safeParse({ ...validJob, budgetMax: validJob.budgetMin }).success,
+    true
+  );
+});
+
+test("create job validation rejects an inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+  assert.equal(
+    result.error.issues[0].message,
+    "budgetMax must be greater than or equal to budgetMin"
+  );
+});
+
+test("partial job validation rejects an inverted range when both values are present", () => {
+  const result = updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 100 });
+
+  assert.equal(result.success, false);
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("partial job validation accepts either budget value by itself", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,20 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+function validateBudgetRange(payload, ctx) {
+  if (
+    payload.budgetMin !== undefined &&
+    payload.budgetMax !== undefined &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+}
+
+export const createJobSchema = jobSchema.superRefine(validateBudgetRange);
+
+export const updateJobSchema = jobSchema.partial().superRefine(validateBudgetRange);


### PR DESCRIPTION
## What changed

- add one shared budget-range refinement for job schemas
- reject `budgetMax < budgetMin` on job creation
- enforce the same rule on partial updates when both values are supplied
- preserve equal/ordered ranges and single-field partial updates
- add focused regression coverage for all four cases

## Why

The schemas validated each budget independently as non-negative, but did not validate their relationship. That allowed invalid records such as a USD 500-100 range, breaking consumers that assume `budgetMin <= budgetMax`.

## Validation

```text
node --test apps/api/src/tests/health.test.js apps/api/src/tests/jobValidator.test.js
5 tests passed, 0 failed
```

Short demo video: https://github.com/micrc2/bounty-evidence/releases/download/job-budget-range-8072/job-budget-range-demo.mp4

Fixes #8072

/claim #743
