### PR TITLE
[codex] Log the actual ephemeral API port

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -5,8 +5,10 @@ import { createApp } from "./app.js";
 async function bootstrap() {
   await connectDb();
   const app = createApp();
-  app.listen(env.port, () => {
-    console.log(`API listening on http://localhost:${env.port}`);
+  const server = app.listen(env.port, () => {
+    const address = server.address();
+    const port = typeof address === "object" && address !== null ? address.port : env.port;
+    console.log(`API listening on http://localhost:${port}`);
   });
 }
 

--- a/apps/api/src/tests/server.test.js
+++ b/apps/api/src/tests/server.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+const apiRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+test("server reports the actual port selected for PORT=0", async () => {
+  const child = spawn(process.execPath, ["src/server.js"], {
+    cwd: apiRoot,
+    env: { ...process.env, NODE_ENV: "test", PORT: "0" },
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  let exited = false;
+  let stderr = "";
+  let stdout = "";
+  child.once("exit", () => {
+    exited = true;
+  });
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  try {
+    const port = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Timed out waiting for startup log. stderr: ${stderr}`));
+      }, 5000);
+
+      child.once("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.once("exit", (code, signal) => {
+        clearTimeout(timeout);
+        reject(new Error(`Server exited before startup (code ${code}, signal ${signal}). stderr: ${stderr}`));
+      });
+
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk;
+        const match = stdout.match(/API listening on http:\/\/localhost:(\d+)/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(Number(match[1]));
+        }
+      });
+    });
+
+    assert.ok(port > 0, `expected an ephemeral port, received ${port}`);
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(response.status, 200, "the reported port should accept API requests");
+  } finally {
+    if (!exited) {
+      child.kill();
+      await once(child, "exit");
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- log the actual bound port returned by `server.address()` after API startup
- preserve the configured port as a fallback for non-TCP server addresses
- add a regression test that starts with `PORT=0`, checks the reported port is positive, and reaches `/health` through that exact port

## Validation

- `node --test apps/api/src/tests/*.test.js` (2 passed)
- `npm run build -w apps/web` (passed)
- `git diff --check` (passed)

## Demo

A short demo video showing ephemeral-port startup, the reachable health endpoint, and the passing regression test is attached in the PR comments.

Closes #8074


## Bounty scope

This resolves scoped issue #8074 under parent bounty #743.

/claim #743