### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,10 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postNotification(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/notifications`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/notifications rejects missing required fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      userId: "user_1",
+      body: "Missing title"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications rejects blank notification body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      userId: "user_1",
+      title: "Update",
+      body: "   "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/notifications preserves server-owned fields", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postNotification(baseUrl, {
+      id: "ntf_caller",
+      read: true,
+      userId: "user_1",
+      title: "Update",
+      body: "Your proposal changed"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^ntf_/);
+    assert.notEqual(payload.data.id, "ntf_caller");
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.userId, "user_1");
+    assert.equal(payload.data.title, "Update");
+    assert.equal(payload.data.body, "Your proposal changed");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  body: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary

Validates notification creation payloads before writing to the service layer and preserves server-owned notification fields. Fixes #8076.

## Changes

- Added a focused notification creation Zod schema requiring `userId`, `title`, and `body`.
- Returned structured HTTP 400 responses for invalid notification payloads.
- Ensured generated `ntf_*` ids and `read: false` cannot be overwritten by request bodies.
- Added route regression tests for missing fields, blank body, and caller-supplied internal fields.

## Testing

- `node --test apps/api/src/tests/notification.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`