### PR TITLE
Reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Create a polished landing page for launch.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects budget ranges where max is less than min", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("updateJobSchema accepts single budget field partial updates", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});
+
+test("job schemas accept ordered and equal budget ranges", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+  assert.equal(
+    createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 500,
+      budgetMax: 500
+    }).success,
+    true
+  );
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 100, budgetMax: 500 }).success, true);
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 500 }).success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const hasOrderedBudgetRange = (job) =>
+  job.budgetMin === undefined ||
+  job.budgetMax === undefined ||
+  job.budgetMax >= job.budgetMin;
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +14,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(hasOrderedBudgetRange, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobSchema.partial().refine(hasOrderedBudgetRange, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- reject create job payloads where `budgetMax` is less than `budgetMin`
- apply the same ordering rule to partial updates only when both budget fields are present
- add focused validator coverage for inverted, ordered, equal, and single-field partial budget updates

Fixes #8078
Refs #743
/claim #743

## Validation
- `node --test apps/api/src/tests/*.test.js` (using bundled Node 24.14.0)