### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,11 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid message payload", 400);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postMessage(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/messages rejects missing receiverId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      senderId: "user_sender",
+      body: "Hello"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid message payload" });
+  });
+});
+
+test("POST /api/messages rejects blank body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      senderId: "user_sender",
+      receiverId: "user_receiver",
+      body: " "
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid message payload" });
+  });
+});
+
+test("POST /api/messages preserves generated ids over caller supplied ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postMessage(baseUrl, {
+      id: "msg_client",
+      senderId: "user_sender",
+      receiverId: "user_receiver",
+      body: "Hello"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^msg_\d+$/);
+    assert.notEqual(payload.data.id, "msg_client");
+    assert.equal(payload.data.senderId, "user_sender");
+    assert.equal(payload.data.receiverId, "user_receiver");
+    assert.equal(payload.data.body, "Hello");
+    assert.ok(payload.data.sentAt);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  senderId: z.string().trim().min(1),
+  receiverId: z.string().trim().min(1),
+  body: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary
- add a focused message creation schema for sender, receiver, and body fields
- return a structured 400 response before invalid message payloads reach the service
- preserve server-generated msg_* ids when callers submit an id field
- cover missing receiver, blank body, and caller-supplied id override cases

Fixes #8080

## Validation
- node --test apps/api/src/tests/message.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check