### PR TITLE
Validate review creation payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,11 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return fail(res, "Invalid review payload", 400);
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postReview(baseUrl, payload) {
+  return fetch(`${baseUrl}/api/reviews`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+}
+
+test("POST /api/reviews rejects missing targetId", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      reviewerId: "user_reviewer",
+      rating: 5,
+      comment: "Excellent work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid review payload" });
+  });
+});
+
+test("POST /api/reviews rejects ratings outside the accepted range", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      reviewerId: "user_reviewer",
+      targetId: "user_target",
+      rating: 6,
+      comment: "Excellent work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid review payload" });
+  });
+});
+
+test("POST /api/reviews preserves generated ids over caller supplied ids", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postReview(baseUrl, {
+      id: "rev_client",
+      reviewerId: "user_reviewer",
+      targetId: "user_target",
+      rating: 5,
+      comment: "Excellent work"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^rev_\d+$/);
+    assert.notEqual(payload.data.id, "rev_client");
+    assert.equal(payload.data.reviewerId, "user_reviewer");
+    assert.equal(payload.data.targetId, "user_target");
+    assert.equal(payload.data.rating, 5);
+    assert.equal(payload.data.comment, "Excellent work");
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  reviewerId: z.string().trim().min(1),
+  targetId: z.string().trim().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1)
+});


### PR DESCRIPTION
## Summary
- add a focused review creation schema for reviewer, target, rating, and comment fields
- return a structured 400 response for invalid review payloads
- restrict ratings to the accepted 1-5 range
- preserve server-generated rev_* ids when callers submit an id field
- cover missing target, invalid rating, and caller-supplied id override cases

Fixes #8082

## Validation
- node --test apps/api/src/tests/review.test.js
- node --test apps/api/src/tests/*.test.js
- git diff --check