### PR TITLE
Expose UI runtime entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "src/index.js",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.js"
+    }
+  }
 }

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/src/Card.js
+++ b/packages/ui/src/Card.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,2 @@
+export * from "./Button.js";
+export * from "./Card.js";


### PR DESCRIPTION
## Summary
- add an ESM runtime entrypoint for `@freelanceflow/ui`
- expose runtime JavaScript `Button` and `Card` modules for workspace consumers
- keep TypeScript declarations pointed at the existing `src/index.ts` source

Fixes #8089

## Validation
- `node -e "import('@freelanceflow/ui').then(m=>{console.log(Object.keys(m).sort().join(',')); if (!m.Button || !m.Card) process.exit(1);})"`
- `npm --workspace apps/web run build`
- `git diff --check`