### PR TITLE
feat: reject missing or blank search queries

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,10 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q;
+  if (q === undefined || q === null || q.trim() === "") {
+    return fail(res, "Search query is required and cannot be blank", 400);
+  }
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("GET /api/search with valid query returns 200 and search results", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/search?q=javascript`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.query, "javascript");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/search with missing query returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/search`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Search query is required and cannot be blank");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/search with blank query returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/search?q=%20%20%20`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Search query is required and cannot be blank");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves our search validation issue by ensuring that the search endpoint (`GET /api/search`) rejects missing, empty, or whitespace-only queries with a `400 Bad Request` and a descriptive message.

## Why This Change?

Allowing empty/blank queries wastes resources and makes client-side handling ambiguous.

## What Changed

- **Validation**: Added logic in `apps/api/src/controllers/searchController.js` to return `400` using the standard `fail` helper if query `q` is missing or blank.
- **Tests**: Created `apps/api/src/tests/search.test.js` to cover valid, missing, and whitespace-only query inputs.
- **Test Command**: Cleaned up the test command in `apps/api/package.json` to use Node's auto-discovery (`node --test`), which fixes test runs on Windows and other environments.

Closes #743