### PR TITLE
[codex] Fix API test discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

- pass the API test files to Node's test runner explicitly
- make the documented root `npm test` command execute the existing suite
- preserve the workspace-level test command

## Root cause

The script passed the `src/tests` directory to `node --test`. Current Node.js releases resolve that argument as a module path instead of discovering test files under the directory, so the command failed with `MODULE_NOT_FOUND` before running any test.

## Impact

Contributors and CI can use the repository's standard test command again. The change is limited to test discovery and does not affect runtime behavior.

## Validation

- `npm test` (1 passed)
- `npm run test -w apps/api` (1 passed)
- `git diff --check` (passed)

Closes #8102

## Bounty scope

This resolves scoped issue #8102 under parent bounty #743.

/claim #743
