### PR TITLE
Limit upload file size

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,15 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return fail(res, "Uploaded file is too large", 413);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,12 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024
+  }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects files larger than the upload limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const oversizedFile = new Blob([new Uint8Array(5 * 1024 * 1024 + 1)]);
+
+    form.append("file", oversizedFile, "oversized.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file is too large"
+    });
+  });
+});


### PR DESCRIPTION
Closes #8104
/claim #743

## Summary

- Add a 5 MB fileSize limit to the Multer memory upload middleware for /api/uploads.
- Convert Multer LIMIT_FILE_SIZE errors into the existing JSON failure envelope with HTTP 413.
- Add a focused regression test that posts an oversized multipart file and verifies the rejection path.

## Demo / validation evidence

The new regression test exercises the upload endpoint end-to-end by sending a 5 * 1024 * 1024 + 1 byte multipart file and asserting:

- HTTP status 413
- JSON body: success false, message "Uploaded file is too large"

Validation run locally:

- node --test src/tests/upload.test.js -> 1/1 pass
- node --test src/tests/*.test.js -> 2/2 pass
- git diff --check -> no whitespace errors

No payout or payment details are included in this PR.
