### PR TITLE
Fix: Reject inverted job budget ranges in create and partial-update validation

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("createJobSchema validates budget ranges", () => {
+  // Valid equal
+  const valid1 = createJobSchema.safeParse({
+    title: "Valid job",
+    description: "Valid description",
+    budgetMin: 500,
+    budgetMax: 500,
+    categoryId: "c1",
+    skills: ["s1"]
+  });
+  assert.equal(valid1.success, true);
+
+  // Valid ordered
+  const valid2 = createJobSchema.safeParse({
+    title: "Valid job",
+    description: "Valid description",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "c1",
+    skills: ["s1"]
+  });
+  assert.equal(valid2.success, true);
+
+  // Invalid inverted
+  const invalid = createJobSchema.safeParse({
+    title: "Valid job",
+    description: "Valid description",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "c1",
+    skills: ["s1"]
+  });
+  assert.equal(invalid.success, false);
+});
+
+test("updateJobSchema validates budget ranges", () => {
+  // Valid partial - only one budget field
+  const valid1 = updateJobSchema.safeParse({
+    budgetMin: 500
+  });
+  assert.equal(valid1.success, true);
+
+  // Valid partial - both fields ordered
+  const valid2 = updateJobSchema.safeParse({
+    budgetMin: 100,
+    budgetMax: 500
+  });
+  assert.equal(valid2.success, true);
+
+  // Invalid partial - inverted fields
+  const invalid = updateJobSchema.safeParse({
+    budgetMin: 500,
+    budgetMax: 100
+  });
+  assert.equal(invalid.success, false);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,24 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMin <= data.budgetMax, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z.object({
+  title: z.string().min(4),
+  description: z.string().min(10),
+  budgetMin: z.number().nonnegative(),
+  budgetMax: z.number().nonnegative(),
+  categoryId: z.string().min(1),
+  skills: z.array(z.string().min(1)).default([])
+}).partial().refine(data => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMin <= data.budgetMax;
+  }
+  return true;
+}, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
Resolves #8207