### PR TITLE
fix(#8226): keep notification id and read state server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications does not allow client-controlled id or read state", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client_supplied",
+        message: "Proposal update",
+        read: true
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "client_supplied");
+    assert.match(payload.data.id, /^ntf_/);
+    assert.equal(payload.data.read, false);
+    assert.equal(payload.data.message, "Proposal update");
+  });
+});


### PR DESCRIPTION
Fixes #8226

Refs #743
/claim #743

## Summary

- Prevent notification creation payloads from overriding server-owned `id` and `read` fields.
- Keep newly created notifications unread even if the request body includes `read: true`.
- Add a regression test for client-supplied `id` and `read` fields.

## Root cause

`createNotification` placed `id` and `read: false` before spreading the request payload, so caller-provided fields could overwrite those service-owned values.

## Testing

```bash
node --test apps/api/src/tests/*.test.js
```