### PR TITLE
Fix #2853: Job validation should reject inverted budget ranges

### DIFF
--- a/src/schemas/job.schema.test.ts
+++ b/src/schemas/job.schema.test.ts
@@ -1,0 +1,131 @@
+# Fix for Issue #2853: Job validation should reject inverted budget ranges
+
+import { describe, it, expect } from 'vitest';
+import { createJobSchema, updateJobSchema, patchJobSchema } from './job.schema';
+
+describe('createJobSchema', () => {
+  const validJobPayload = {
+    title: 'Senior Software Engineer',
+    description: 'We are looking for an experienced software engineer.',
+    budgetMin: 100,
+    budgetMax: 500,
+    currency: 'USD',
+    category: 'Engineering',
+    tags: ['javascript', 'typescript'],
+  };
+
+  it('should accept valid job with correct budget range', () => {
+    const result = createJobSchema.safeParse(validJobPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept job where budgetMin equals budgetMax', () => {
+    const payload = { ...validJobPayload, budgetMin: 500, budgetMax: 500 };
+    const result = createJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject job with inverted budget range (budgetMax < budgetMin)', () => {
+    const payload = { ...validJobPayload, budgetMin: 500, budgetMax: 100 };
+    const result = createJobSchema.safeParse(payload);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const budgetMaxError = result.error.issues.find(
+        (issue) => issue.path.includes('budgetMax')
+      );
+      expect(budgetMaxError).toBeDefined();
+      expect(budgetMaxError?.message).toBe(
+        'Budget maximum must be greater than or equal to budget minimum'
+      );
+    }
+  });
+
+  it('should reject negative budget values', () => {
+    const payload = { ...validJobPayload, budgetMin: -100, budgetMax: 500 };
+    const result = createJobSchema.safeParse(payload);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path.includes('budgetMin'))).toBe(true);
+    }
+  });
+
+  it('should reject missing required fields', () => {
+    const payload = { title: 'Test Job' };
+    const result = createJobSchema.safeParse(payload);
+    
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateJobSchema', () => {
+  it('should accept partial update with valid budget range', () => {
+    const payload = { budgetMin: 100, budgetMax: 500 };
+    const result = updateJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject partial update with inverted budget range', () => {
+    const payload = { budgetMin: 500, budgetMax: 100 };
+    const result = updateJobSchema.safeParse(payload);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const budgetMaxError = result.error.issues.find(
+        (issue) => issue.path.includes('budgetMax')
+      );
+      expect(budgetMaxError).toBeDefined();
+      expect(budgetMaxError?.message).toBe(
+        'Budget maximum must be greater than or equal to budget minimum'
+      );
+    }
+  });
+
+  it('should accept update with only budgetMin (no cross-field validation needed)', () => {
+    const payload = { budgetMin: 500 };
+    const result = updateJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept update with only budgetMax (no cross-field validation needed)', () => {
+    const payload = { budgetMax: 100 };
+    const result = updateJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept update with non-budget fields only', () => {
+    const payload = { title: 'Updated Title', description: 'Updated description' };
+    const result = updateJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('patchJobSchema', () => {
+  it('should accept patch with valid budget range when both fields present', () => {
+    const payload = { budgetMin: 200, budgetMax: 800 };
+    const result = patchJobSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject patch with inverted budget range', () => {
+    const payload = { budgetMin: 800, budgetMax: 200 };
+    const result = patchJobSchema.safeParse(payload);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path.includes('budgetMax') &&
+            issue.message.includes('greater than or equal')
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('should accept empty patch payload', () => {
+    const result = patchJobSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/schemas/job.schema.ts
+++ b/src/schemas/job.schema.ts
@@ -1,0 +1,66 @@
+# Fix for Issue #2853: Job validation should reject inverted budget ranges
+
+import { z } from 'zod';
+
+/**
+ * Base job fields schema without cross-field validation
+ */
+const jobFieldsSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
+  description: z.string().min(1, 'Description is required').max(5000, 'Description must be 5000 characters or less'),
+  budgetMin: z.number().positive('Budget minimum must be a positive number'),
+  budgetMax: z.number().positive('Budget maximum must be a positive number'),
+  currency: z.enum(['USD', 'EUR', 'GBP']).default('USD'),
+  category: z.string().min(1, 'Category is required'),
+  tags: z.array(z.string()).optional().default([]),
+  deadline: z.string().datetime().optional(),
+  remote: z.boolean().optional().default(true),
+});
+
+/**
+ * Validates that budgetMax is greater than or equal to budgetMin
+ */
+const validateBudgetRange = <T extends { budgetMin?: number; budgetMax?: number }>(
+  data: T,
+  ctx: z.RefinementCtx
+): void => {
+  if (
+    data.budgetMin !== undefined &&
+    data.budgetMax !== undefined &&
+    data.budgetMax < data.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Budget maximum must be greater than or equal to budget minimum',
+      path: ['budgetMax'],
+    });
+  }
+};
+
+/**
+ * Schema for creating a new job posting
+ * Enforces that budgetMax >= budgetMin
+ */
+export const createJobSchema = jobFieldsSchema.superRefine(validateBudgetRange);
+
+/**
+ * Schema for partial job updates
+ * All fields are optional, but if both budget fields are present,
+ * validates that budgetMax >= budgetMin
+ */
+export const updateJobSchema = jobFieldsSchema
+  .partial()
+  .superRefine(validateBudgetRange);
+
+/**
+ * Schema for patching specific job fields
+ * Validates budget range only when both fields are provided in the patch
+ */
+export const patchJobSchema = jobFieldsSchema
+  .partial()
+  .superRefine(validateBudgetRange);
+
+// Type exports for use in handlers/services
+export type CreateJobInput = z.infer<typeof createJobSchema>;
+export type UpdateJobInput = z.infer<typeof updateJobSchema>;
+export type PatchJobInput = z.infer<typeof patchJobSchema>;


### PR DESCRIPTION
Closes #2853

## Summary

Add a Zod refinement to the `createJobSchema` that validates `budgetMax` is greater than or equal to `budgetMin` when both fields are present, and apply the same validation to partial update schemas.

## Changes

## Summary

This PR fixes a validation bug where the job creation and update endpoints would accept payloads with inverted budget ranges (e.g., `budgetMin: 500, budgetMax: 100`). Such invalid records break filtering, sorting, and display assumptions downstream.

## Changes

### Schema Validation (`src/schemas/job.schema.ts`)

- Added a `validateBudgetRange` refinement function that checks if `budgetMax >= budgetMin` when both fields are present
- Applied the refinement to `createJobSchema` for new job creation
- Applied the same refinement to `updateJobSchema` and `patchJobSchema` for partial updates
- The validation only triggers when **both** budget fields are provided, allowing single-field updates without false positives

### Test Coverage (`src/schemas/job.schema.test.ts`)

- Added comprehensive tests for valid budget ranges
- Added tests confirming rejection of inverted ranges with appropriate error messages
- Added edge case tests for equal min/max values (valid)
- Added tests for partial updates with only one budget field (should pass)

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `budgetMin: 100, budgetMax: 500` | ✅ Accepted | ✅ Accepted |
| `budgetMin: 500, budgetMax: 500` | ✅ Accepted | ✅ Accepted |
| `budgetMin: 500, budgetMax: 100` | ✅ Accepted (bug) | ❌ Rejected |
| Partial update with only `budgetMin` | ✅ Accepted | ✅ Accepted |

## Related Issues

Fixes #743
Related to #2835