### PR TITLE
Fix #2853: Job validation should reject inverted budget ranges

### DIFF
--- a/src/schemas/job.schema.test.ts
+++ b/src/schemas/job.schema.test.ts
@@ -1,0 +1,154 @@
+# Fix for Issue #2853: Job validation should reject inverted budget ranges
+
+import { describe, it, expect } from 'vitest';
+import { createJobSchema, updateJobSchema, patchJobSchema } from './job.schema';
+
+describe('createJobSchema', () => {
+  const validJob = {
+    title: 'Software Engineer',
+    description: 'Building great software',
+    budgetMin: 100,
+    budgetMax: 500,
+    currency: 'USD',
+    contactEmail: 'hiring@example.com',
+  };
+
+  it('should accept valid job with correct budget range', () => {
+    const result = createJobSchema.safeParse(validJob);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept job where budgetMin equals budgetMax', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 500,
+      budgetMax: 500,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject job with inverted budget range (budgetMax < budgetMin)', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 500,
+      budgetMax: 100,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Budget maximum must be greater than or equal to budget minimum'
+      );
+      expect(result.error.issues[0].path).toContain('budgetMax');
+    }
+  });
+
+  it('should reject job with zero budgetMax and positive budgetMin', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 100,
+      budgetMax: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept job with zero budgetMin and positive budgetMax', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 0,
+      budgetMax: 100,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept job with both budgets at zero', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: 0,
+      budgetMax: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject negative budget values', () => {
+    const result = createJobSchema.safeParse({
+      ...validJob,
+      budgetMin: -100,
+      budgetMax: 500,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateJobSchema', () => {
+  it('should accept update with valid budget range', () => {
+    const result = updateJobSchema.safeParse({
+      budgetMin: 200,
+      budgetMax: 800,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject update with inverted budget range', () => {
+    const result = updateJobSchema.safeParse({
+      budgetMin: 800,
+      budgetMax: 200,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Budget maximum must be greater than or equal to budget minimum'
+      );
+    }
+  });
+
+  it('should accept update with only budgetMin (no cross-field validation needed)', () => {
+    const result = updateJobSchema.safeParse({
+      budgetMin: 500,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept update with only budgetMax (no cross-field validation needed)', () => {
+    const result = updateJobSchema.safeParse({
+      budgetMax: 500,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept update with no budget fields', () => {
+    const result = updateJobSchema.safeParse({
+      title: 'Updated Title',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept empty update object', () => {
+    const result = updateJobSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('patchJobSchema', () => {
+  it('should reject patch with inverted budget range', () => {
+    const result = patchJobSchema.safeParse({
+      budgetMin: 1000,
+      budgetMax: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept patch with valid budget range', () => {
+    const result = patchJobSchema.safeParse({
+      budgetMin: 100,
+      budgetMax: 1000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept patch with single budget field', () => {
+    const result = patchJobSchema.safeParse({
+      budgetMax: 1000,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/schemas/job.schema.ts
+++ b/src/schemas/job.schema.ts
@@ -1,0 +1,66 @@
+# Fix for Issue #2853: Job validation should reject inverted budget ranges
+
+import { z } from 'zod';
+
+/**
+ * Base job schema fields without cross-field validations
+ */
+const jobBaseFields = {
+  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
+  description: z.string().min(1, 'Description is required').max(5000, 'Description must be 5000 characters or less'),
+  budgetMin: z.number().nonnegative('Budget minimum must be non-negative'),
+  budgetMax: z.number().nonnegative('Budget maximum must be non-negative'),
+  currency: z.enum(['USD', 'EUR', 'GBP', 'CAD', 'AUD']).default('USD'),
+  tags: z.array(z.string().max(50)).max(10, 'Maximum 10 tags allowed').optional(),
+  deadline: z.string().datetime().optional(),
+  contactEmail: z.string().email('Invalid email address'),
+};
+
+/**
+ * Validates that budgetMax is not less than budgetMin when both are present
+ */
+function validateBudgetRange(data: { budgetMin?: number; budgetMax?: number }): boolean {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+}
+
+const budgetRangeError = {
+  message: 'Budget maximum must be greater than or equal to budget minimum',
+  path: ['budgetMax'],
+};
+
+/**
+ * Schema for creating a new job - all required fields must be present
+ */
+export const createJobSchema = z
+  .object(jobBaseFields)
+  .refine(validateBudgetRange, budgetRangeError);
+
+/**
+ * Schema for updating an existing job - all fields are optional
+ * Budget range validation applies when both budget fields are provided
+ */
+export const updateJobSchema = z
+  .object({
+    title: jobBaseFields.title.optional(),
+    description: jobBaseFields.description.optional(),
+    budgetMin: jobBaseFields.budgetMin.optional(),
+    budgetMax: jobBaseFields.budgetMax.optional(),
+    currency: jobBaseFields.currency.optional(),
+    tags: jobBaseFields.tags,
+    deadline: jobBaseFields.deadline,
+    contactEmail: jobBaseFields.contactEmail.optional(),
+  })
+  .refine(validateBudgetRange, budgetRangeError);
+
+/**
+ * Schema for partial job updates (PATCH) - same as update but explicitly partial
+ */
+export const patchJobSchema = updateJobSchema;
+
+// Type exports for use in controllers and services
+export type CreateJobInput = z.infer<typeof createJobSchema>;
+export type UpdateJobInput = z.infer<typeof updateJobSchema>;
+export type PatchJobInput = z.infer<typeof patchJobSchema>;


### PR DESCRIPTION
Closes #2853

## Summary

Add a Zod refinement to the job validation schema that ensures `budgetMax` is greater than or equal to `budgetMin` when both fields are present, rejecting inverted budget ranges during job creation and partial updates.

## Changes

## Summary

Fixes job validation to properly reject inverted budget ranges where `budgetMax` is less than `budgetMin`.

## Problem

The `createJobSchema` was accepting payloads with invalid budget ranges (e.g., a USD 500-100 range). This creates malformed job records that can break:
- Budget filtering functionality
- Sorting by budget
- Display assumptions in the UI

## Solution

Added Zod refinement validation to ensure `budgetMax >= budgetMin` when both fields are present:

- **Job creation**: Rejects any payload where `budgetMax < budgetMin`
- **Job updates (PUT/PATCH)**: Validates budget range only when both budget fields are provided in the update payload
- **Single field updates**: Allows updating only `budgetMin` or only `budgetMax` without validation (the service layer should handle cross-referencing with existing values if needed)
- **Equal values**: Accepts cases where `budgetMin === budgetMax` (fixed-price jobs)

## Testing

Comprehensive test coverage added for:
- Valid budget ranges (min < max)
- Equal budget values (min === max)
- Inverted ranges (rejected)
- Zero values edge cases
- Partial updates with single budget field
- Empty update objects

## Related Issues

- Closes #743 (parent bounty)
- Related to #2835