### PR TITLE
fix: enforce default job status on creation (mass assignment)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
## Summary

Fixes mass assignment vulnerability in `createJob` where clients could override the job `status` field by sending it in the request body.

## The Bug

The spread operator `...payload` was applied **after** the default `status: "open"` field, meaning a client sending `{"status": "closed"}` would override the default.

```js
// Before (bug): payload overrides defaults
const job = { id: `job_${Date.now()}`, status: "open", ...payload };

// After (fix): defaults always win
const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
```

Root cause: mass assignment — raw `req.body` was spread directly into the object without sanitization.

## Testing

- Verified default `status: "open"` cannot be overridden
- Backward compatible — existing valid fields (title, description, budget) still work normally

Closes #8235
/bounty $700