### PR TITLE
fix(api): validate GET /api/search query + tests

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = searchQuerySchema.parse(req.query);
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,32 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
+  const errorSummary =
+    err instanceof Error
+      ? {
+          name: err.name,
+          message: err.message,
+          stack: err.stack
+        }
+      : {
+          message: String(err)
+        };
+
+  console.error("Unhandled API error:", errorSummary);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues.map((issue) => ({
+        path: issue.path.join("."),
+        code: issue.code,
+        message: issue.message
+      }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/search-validation.test.js
+++ b/apps/api/src/tests/search-validation.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    server.closeIdleConnections?.();
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects oversized query with 400", async () => {
+  await withServer(async (port) => {
+    const tooLong = "a".repeat(201);
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${tooLong}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Validation failed");
+  });
+});
+
+test("GET /api/search trims and accepts query <= 200 chars", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=%20%20hello%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "hello");
+  });
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.object({
+  q: z.string().trim().max(200).optional().default("")
+});


### PR DESCRIPTION
Implements input validation and query length guard for `GET /api/search`.

### Changes
- `apps/api/src/validators/search.js`
  - new schema: `q` is optional string, trimmed, max 200 chars, default `""`
- `apps/api/src/controllers/searchController.js`
  - applies `searchQuerySchema.parse(req.query)` and passes sanitized `q` to service
- `apps/api/src/middleware/errorHandler.js`
  - maps `ZodError` to `400 Validation failed` so invalid query input returns 400
- `apps/api/src/tests/search-validation.test.js`
  - verifies oversized query -> 400
  - verifies valid query is trimmed and accepted -> 200

### Security impact
- prevents unbounded query payloads from flowing into search path
- enforces consistent normalized input behavior

### Validation note
Local runtime tests in this worktree still require dependency install first (`cors` unresolved until install), but regression test coverage is included in patch.
