### PR TITLE
fix(api): isolate rate limiter per app instance

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test --test-isolation=none \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,7 +21,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(createApiLimiter());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export function createApiLimiter() {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    standardHeaders: "draft-7",
+    legacyHeaders: false
+  });
+}

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function search(baseUrl) {
+  const response = await fetch(`${baseUrl}/api/search?q=limiter`);
+  await response.text();
+  return response;
+}
+
+test("createApp instances keep rate-limit state isolated", async (t) => {
+  const first = await startServer();
+  const second = await startServer();
+
+  t.after(async () => {
+    await Promise.all([closeServer(first.server), closeServer(second.server)]);
+  });
+
+  for (let request = 0; request < 200; request += 1) {
+    const response = await search(first.baseUrl);
+    assert.notEqual(response.status, 429);
+  }
+
+  const limited = await search(first.baseUrl);
+  assert.equal(limited.status, 429);
+
+  const freshInstanceResponse = await search(second.baseUrl);
+  assert.equal(freshInstanceResponse.status, 200);
+});


### PR DESCRIPTION
/claim #743

Fixes #8270

## Summary

- Create a fresh API rate limiter for each `createApp()` call instead of reusing one module-level middleware instance.
- Add a regression test that exhausts one app instance and verifies a second app instance still accepts requests.
- Update the API test script to target concrete test files so the new regression test is exercised by `npm test`.

## Demo

- https://github.com/aqin236/bug-bounty/releases/download/rate-limit-demo-8271/demo-rate-limit-8271.gif

## Tests

- `npm test`