### PR TITLE
fix(api): enforce admin role on admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,11 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware, authMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-rbac.test.js
+++ b/apps/api/src/tests/admin-rbac.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (port) => {
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${clientToken}` }
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 403);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "Forbidden");
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (port) => {
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${adminToken}` }
+    });
+
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.ok, true);
+    assert.equal(typeof payload.data, "object");
+  });
+});


### PR DESCRIPTION
Fixes missing RBAC on admin routes by requiring both:
- authenticated JWT (`authMiddleware`)
- admin role (`adminMiddleware`)

### Changes
- `apps/api/src/middleware/auth.js`
  - added `adminMiddleware` returning `403 Forbidden` when `req.user.role !== "admin"`
- `apps/api/src/routes/adminRoutes.js`
  - added `adminRoutes.use(adminMiddleware)` after auth middleware
- `apps/api/src/tests/admin-rbac.test.js`
  - regression tests for non-admin deny and admin allow on `/api/admin/metrics`

### Security behavior after patch
- missing/invalid token: `401`
- valid non-admin token: `403`
- valid admin token: `200`

### Validation
- Test file included for regression coverage.
- Local test execution in this workspace is currently blocked by missing dependencies in this cloned worktree (`cors` module not installed), so runtime verification requires `npm install` in `apps/api` before running tests.

Closes #1770