### PR TITLE
fix(api): reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary
Fixes #2853 and #2835.

The `createJobSchema` validator in `apps/api/src/validators/job.js` accepted jobs where `budgetMin > budgetMax`, allowing inverted budget ranges to persist in the database.

## Changes
Added a `.refine()` validation to the Zod schema that enforces `budgetMax >= budgetMin`, rejecting any payload where the budget range is inverted.

## Impact
- Prevents invalid job data from entering the system
- Returns a clear validation error on the `budgetMax` path

Author: borjamoskv