### PR TITLE
fix: reject admin role in public registration schema

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Fix
Remove `admin` from the allowed roles enum in `registerSchema`. Public registration now only accepts `client` and `freelancer` roles, preventing privilege escalation via self-assigned admin.

Fixes #8040

Author: borjamoskv