### PR TITLE
fix: require authentication for GET /api/users

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
## Fix
Add `authMiddleware` to the `GET /api/users` route so user listing requires a valid JWT.

Fixes #8039

Author: borjamoskv