### PR TITLE
fix: require authentication for POST /api/jobs

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Fix
Add `authMiddleware` to the `POST /api/jobs` route so job creation requires a valid JWT.

Fixes #8038

Author: borjamoskv