### PR TITLE
fix: ignore client-controlled id and read in notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id, read, ...rest } = payload;
+  const notification = { ...rest, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
## Fix
Strip `id` and `read` from the client payload before creating the notification object. Server now always generates the `id` and sets `read: false`, preventing clients from injecting arbitrary ids or marking notifications as already read.

Fixes #8226

Author: borjamoskv