### PR TITLE
fix: ignore caller-controlled id in proposal creation

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,8 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id, ...rest } = payload;
+  const proposal = { ...rest, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }


### PR DESCRIPTION
## Fix
Strip `id` from client payload and always generate server-side `id` in `createProposal`, preventing IDOR via client-supplied identifiers.

Fixes #8211

Author: borjamoskv