### PR TITLE
fix: ignore caller-controlled id in message creation

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id, ...rest } = payload;
+  const message = { ...rest, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }


### PR DESCRIPTION
## Fix
Strip `id` from client payload and always generate server-side `id` in `sendMessage`, preventing IDOR via client-supplied identifiers.

Fixes #8046

Author: borjamoskv