### PR TITLE
fix: ignore caller-controlled id in review creation

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id, ...rest } = payload;
+  const review = { ...rest, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }


### PR DESCRIPTION
## Fix
Strip `id` from client payload and always generate server-side `id` in `createReview`, preventing IDOR via client-supplied identifiers.

Fixes #8047

Author: borjamoskv