### PR TITLE
fix: ignore caller-controlled id and status in job creation

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,8 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const { id, status, ...rest } = payload;
+  const job = { ...rest, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
## Fix
Strip `id` and `status` from client payload before creating the job object. Server always generates `id` and sets `status: "open"`, preventing clients from injecting arbitrary ids or bypassing workflow state.

Fixes #8023

Author: borjamoskv