### PR TITLE
fix: run rate limiter before JSON body parsing

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });


### PR DESCRIPTION
## Summary
Move `apiLimiter` middleware before `express.json()` so rate-limited requests are rejected before the server wastes resources parsing the request body.

Fixes #8002

Author: borjamoskv