### PR TITLE
fix: ensure registration token subject matches returned user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Fix
Generate the user `id` once and reuse it as both the returned `id` field and the JWT `sub` claim. Previously two separate `Date.now()` calls could produce different values, causing the token subject to mismatch the returned user id.

Fixes #8005

Author: borjamoskv