### PR TITLE
fix: omit password fields from user creation response

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -7,5 +7,6 @@ export async function listUsers() {
 export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
-  return user;
+  const { password, passwordHash, ...safeUser } = user;
+  return safeUser;
 }


### PR DESCRIPTION
## Summary
Strip `password` and `passwordHash` from the user object returned by `createUser` to prevent credential leakage in API responses.

Fixes #8215

Author: borjamoskv