### PR TITLE
fix: return defensive snapshot from listUsers

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return [...users];
 }
 
 export async function createUser(payload) {


### PR DESCRIPTION
## Summary
Return `[...users]` instead of the internal array reference to prevent callers from mutating the in-memory store.

Fixes #8022

Author: borjamoskv