### PR TITLE
fix: enforce server-controlled default status on job creation

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }


### PR DESCRIPTION
## Summary
- Move server-owned fields (`id`, `status`) after payload spread so client cannot override them
- Previously `{ id, status: 'open', ...payload }` allowed client to inject arbitrary status
- Now `{ ...payload, id, status: 'open' }` ensures server values always win

Fixes #8235

Author: borjamoskv