### PR TITLE
fix: return defensive snapshot from listProposals

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return [...proposals];
 }
 
 export async function createProposal(payload) {


### PR DESCRIPTION
## Summary
Return `[...proposals]` instead of the internal array reference to prevent callers from mutating the in-memory store.

Fixes #8213

Author: borjamoskv