### PR TITLE
fix: normalize payment currency to lowercase before intent creation

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,7 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: (payload.currency ?? "usd").toLowerCase(),
     provider: "stripe"
   };
 }


### PR DESCRIPTION
## Summary
- Apply `.toLowerCase()` to currency before storing/passing to Stripe
- Stripe requires lowercase ISO 4217 currency codes (e.g. `usd` not `USD`)
- Prevents payment failures from case-sensitive currency mismatches

Fixes #8042

Author: borjamoskv