### PR TITLE
fix: return defensive snapshot from listReviews

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return [...reviews];
 }
 
 export async function createReview(payload) {


### PR DESCRIPTION
## Summary
Return `[...reviews]` instead of the internal array reference to prevent callers from mutating the in-memory store.

Fixes #8025

Author: borjamoskv