### PR TITLE
fix: return defensive snapshot from listMessages

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return [...messages];
 }
 
 export async function sendMessage(payload) {


### PR DESCRIPTION
## Summary
Return `[...messages]` instead of the internal array reference to prevent callers from mutating the in-memory store.

Fixes #8024

Author: borjamoskv