### PR TITLE
fix: add proposal validation, require estimatedDuration, preserve server-owned ids

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}`, status: "pending" };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estimatedDuration: z.number().int().positive()
+});


### PR DESCRIPTION
## Summary
- Create Zod schema (`createProposalSchema`) requiring `jobId`, `coverLetter`, `bidAmount`, and `estimatedDuration`
- Validate proposal input in controller before passing to service layer
- Move server-owned fields (`id`, `status`) after payload spread to prevent client override
- Previously proposals accepted arbitrary unvalidated bodies and clients could inject their own `id`

Fixes #8003
Fixes #8035

Author: borjamoskv