### PR TITLE
fix: log the actual bound port on API startup

### DIFF
--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -5,8 +5,9 @@ import { createApp } from "./app.js";
 async function bootstrap() {
   await connectDb();
   const app = createApp();
-  app.listen(env.port, () => {
-    console.log(`API listening on http://localhost:${env.port}`);
+  const server = app.listen(env.port, () => {
+    const actualPort = server.address().port;
+    console.log(`API listening on http://localhost:${actualPort}`);
   });
 }
 


### PR DESCRIPTION
## Summary
Use `server.address().port` instead of `env.port` in the startup log so that ephemeral port assignments (port 0) are correctly reported.

Fixes #8197

Author: borjamoskv