### PR TITLE
fix: use glob pattern to discover test files recursively

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test 'src/**/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
Change the test script from `node --test src/tests` to `node --test 'src/**/*.test.js'` so that test files colocated with source files are discovered automatically.

Fixes #8195

Author: borjamoskv