### PR TITLE
fix: add main, types, and exports fields to @freelanceflow/db

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Summary
Add `main`, `types`, and `exports` entrypoint fields to the `@freelanceflow/db` package.json so consumers in the monorepo can resolve the package correctly.

Fixes #7984

Author: borjamoskv