### PR TITLE
fix: add types and exports fields to @freelanceflow/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
 }


### PR DESCRIPTION
## Summary
Add `types` and `exports` fields to the `@freelanceflow/ui` package.json so TypeScript and bundlers can resolve the package entry point correctly.

Fixes #7982

Author: borjamoskv