### PR TITLE
fix: resolve freelancer profile from mock data instead of placeholder

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer with username <strong>{params.username}</strong> was found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Username: <strong>{freelancer.username}</strong></p>
+      <p>Rate: {freelancer.rate}</p>
+      <p>Skills: {freelancer.skills.join(", ")}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Look up the freelancer from `lib/mock.ts` using the `username` route parameter and render their profile data (username, rate, skills) instead of showing a static placeholder. Shows a not-found message for unknown usernames.

Fixes #7986

Author: borjamoskv