### PR TITLE
fix: resolve job detail from mock data instead of placeholder

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,21 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job with ID <strong>{params.id}</strong> was found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: {job.budget}</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Look up the job from `lib/mock.ts` using the `id` route parameter and render the job title and budget instead of a static placeholder. Shows a not-found message for unknown IDs.

Fixes #7985

Author: borjamoskv