### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,26 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
+export function normalizeSearchQuery(value) {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  const query = String(candidate ?? "").trim();
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return {
+      error: `Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer`
+    };
+  }
+
+  return { query };
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { error, query } = normalizeSearchQuery(req.query.q);
+  if (error) {
+    return fail(res, error, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("listening", resolve);
+      server.once("error", reject);
+    });
+
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search treats omitted query as an empty safe search", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "");
+  });
+});
+
+test("GET /api/search trims query input before searching", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20freelancer%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "freelancer");
+  });
+});
+
+test("GET /api/search rejects queries longer than 200 characters", async () => {
+  const longQuery = "a".repeat(201);
+
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Search query must be 200 characters or fewer");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #8312.
Refs #743.

Normalizes and bounds the `/api/search` query parameter before it reaches the search service.

## Changes

- Added `normalizeSearchQuery()` to coerce missing input safely, trim whitespace, and enforce a 200-character maximum.
- Return `400` for oversized search queries instead of passing them into the service layer.
- Added API tests for omitted query, trimmed query, and oversized query rejection.
- Updated the API test script so `npm test` runs the actual `*.test.js` files consistently.

## Validation

- `npm test`
  - 4 tests passed.

## Security Impact

Oversized query strings are rejected early, reducing unnecessary service work and avoiding inconsistent whitespace-only search behavior.