### PR TITLE
Display freelancer details on profile page

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,23 @@
+import { freelancers } from "../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <p>Profile: <strong>{freelancer.username}</strong></p>
+      <p>Skills: <strong>{freelancer.skills.join(", ")}</strong></p>
+      <p>Rate: <strong>{freelancer.rate}</strong></p>
     </section>
   );
 }


### PR DESCRIPTION
Fixes #2849

This PR updates the freelancer profile route to resolve mock profiles by username from `apps/web/lib/mock.ts`.

- Known freelancer usernames now render the matching mock profile details (skills and hourly rate).
- Unknown usernames render a clear "Freelancer Not Found" fallback.
- The profile page now exposes useful skills/rate context instead of generic placeholder copy.