### PR TITLE
fix: strip password from user listing response

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(({ password, ...rest }) => rest);
 }
 
 export async function createUser(payload) {


### PR DESCRIPTION
## What changed
`listUsers()` now maps users to omit the `password` field before returning the array.

## Criteria
- [x] `listUsers()` strips `password` from each user record
- [x] No changes to controller or routes
- [x] Existing behavior preserved for non-sensitive fields
- [x] Verified: password field is absent from returned objects

Closes #4616