### PR TITLE
fix: isolate rate-limit stores per app instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env.*
 coverage
 *.log
+.aider*

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test 'src/tests/**/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createRateLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,7 +21,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(createRateLimiter());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,15 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
+const defaultConfig = {
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
   legacyHeaders: false
-});
+};
+
+export function createRateLimiter() {
+  return rateLimit({ ...defaultConfig });
+}
+
+/** @deprecated Use createRateLimiter() for per-instance isolation */
+export const apiLimiter = rateLimit(defaultConfig);

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("rate-limit stores are isolated per app instance", async () => {
+  const app1 = createApp();
+  const app2 = createApp();
+
+  const server1 = app1.listen(0);
+  const server2 = app2.listen(0);
+
+  await Promise.all([
+    new Promise((resolve, reject) => {
+      server1.once("listening", resolve);
+      server1.once("error", reject);
+    }),
+    new Promise((resolve, reject) => {
+      server2.once("listening", resolve);
+      server2.once("error", reject);
+    })
+  ]);
+
+  const { port: port1 } = server1.address();
+  const { port: port2 } = server2.address();
+
+  // Exhaust rate limit on app1 (limit is 200, send 210)
+  const makeRequest = (port) =>
+    fetch(`http://127.0.0.1:${port}/health`).then((r) => r.status);
+
+  const results1 = await Promise.all(
+    Array.from({ length: 210 }, () => makeRequest(port1))
+  );
+
+  const got429 = results1.filter((s) => s === 429).length;
+  assert.ok(got429 >= 1, "Expected at least one 429 on first instance after exhausting limit");
+
+  // Second instance should still be fresh
+  const status2 = await makeRequest(port2);
+  assert.equal(status2, 200, "Second instance should not be rate-limited");
+
+  await Promise.all([
+    new Promise((resolve, reject) => {
+      server1.close((error) => (error ? reject(error) : resolve()));
+    }),
+    new Promise((resolve, reject) => {
+      server2.close((error) => (error ? reject(error) : resolve()));
+    })
+  ]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Closes #8270

## What changed
- **rateLimit.js**: Exported `createRateLimiter()` factory that returns a fresh rate-limit middleware instance each call. Kept `apiLimiter` as deprecated export for backward compat.
- **app.js**: Uses `createRateLimiter()` inside `createApp()` so each app instance gets its own isolated rate-limit store.
- **rateLimit.test.js**: New regression test that exhausts 210 requests on app1 (limit=200), confirms at least one 429, then verifies app2 still returns 200.
- **package.json**: Fixed test script glob to work with Node v25 (`src/tests/**/*.test.js`).

## Acceptance criteria
1. ✅ Rate limiter factory exported instead of module-level singleton
2. ✅ New limiter instance mounted inside `createApp()`
3. ✅ Regression test: exhaust app1, verify app2 still accepts
4. ✅ `npm test` runs all test files (both pass)