### PR TITLE
fix: strip password from user listing response

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(({ password, ...rest }) => rest);
 }
 
 export async function createUser(payload) {


### PR DESCRIPTION
Fixes #4616

/claim #743

## What changed
- `listUsers()` now maps users without the password field before returning

## Validation
- `node --check apps/api/src/services/userService.js` passes
- `node --test apps/api/src/tests/health.test.js` passes