### PR TITLE
Validate marketplace request bodies

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/marketplace.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.parse(req.body);
+  return ok(res, await sendMessage(payload), 201);
 }

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/marketplace.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = createPaymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/marketplace.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/marketplace.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/tests/marketplace-validation.test.js
+++ b/apps/api/src/tests/marketplace-validation.test.js
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createMessageSchema,
+  createPaymentSchema,
+  createProposalSchema,
+  createReviewSchema
+} from "../validators/marketplace.js";
+
+test("createProposalSchema rejects non-positive bid amounts", () => {
+  const result = createProposalSchema.safeParse({
+    coverLetter: "I can deliver this project",
+    bidAmount: -1,
+    estDuration: "1 week",
+    jobId: "job_1",
+    freelancerId: "user_1"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("createProposalSchema accepts a valid proposal payload", () => {
+  const result = createProposalSchema.safeParse({
+    coverLetter: "I can deliver this project",
+    bidAmount: 250,
+    estDuration: "1 week",
+    jobId: "job_1",
+    freelancerId: "user_1"
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createMessageSchema rejects blank bodies and self messages", () => {
+  assert.equal(
+    createMessageSchema.safeParse({
+      body: "   ",
+      senderId: "user_1",
+      receiverId: "user_2"
+    }).success,
+    false
+  );
+  assert.equal(
+    createMessageSchema.safeParse({
+      body: "Hello",
+      senderId: "user_1",
+      receiverId: "user_1"
+    }).success,
+    false
+  );
+});
+
+test("createMessageSchema accepts a valid message payload", () => {
+  const result = createMessageSchema.safeParse({
+    body: "Hello",
+    senderId: "user_1",
+    receiverId: "user_2"
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createPaymentSchema rejects non-positive payment amounts", () => {
+  const result = createPaymentSchema.safeParse({
+    amount: 0,
+    currency: "usd",
+    jobId: "job_1"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("createPaymentSchema accepts a valid payment payload", () => {
+  const result = createPaymentSchema.safeParse({
+    amount: 100,
+    jobId: "job_1"
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.currency, "usd");
+});
+
+test("createReviewSchema rejects out-of-range ratings and self reviews", () => {
+  assert.equal(
+    createReviewSchema.safeParse({
+      rating: 6,
+      comment: "Great",
+      reviewerId: "user_1",
+      revieweeId: "user_2"
+    }).success,
+    false
+  );
+  assert.equal(
+    createReviewSchema.safeParse({
+      rating: 5,
+      comment: "Great",
+      reviewerId: "user_1",
+      revieweeId: "user_1"
+    }).success,
+    false
+  );
+});
+
+test("createReviewSchema accepts a valid review payload", () => {
+  const result = createReviewSchema.safeParse({
+    rating: 5,
+    comment: "Great",
+    reviewerId: "user_1",
+    revieweeId: "user_2"
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/marketplace.js
+++ b/apps/api/src/validators/marketplace.js
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+const id = z.string().min(1);
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().min(10),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().min(1),
+  jobId: id,
+  freelancerId: id
+});
+
+export const createMessageSchema = z.object({
+  body: z.string().trim().min(1),
+  senderId: id,
+  receiverId: id
+}).refine((data) => data.senderId !== data.receiverId, {
+  message: "receiverId must be different from senderId",
+  path: ["receiverId"]
+});
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().trim().min(3).max(3).default("usd"),
+  jobId: id
+});
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1),
+  reviewerId: id,
+  revieweeId: id
+}).refine((data) => data.reviewerId !== data.revieweeId, {
+  message: "revieweeId must be different from reviewerId",
+  path: ["revieweeId"]
+});


### PR DESCRIPTION
## Summary

Fixes #8325

/claim #743

- add Zod schemas for proposal, message, payment, and review create payloads
- parse those request bodies in the corresponding controllers before calling services
- add regression coverage for invalid amounts, blank/self messages, invalid review ratings, self reviews, and representative valid payloads

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` schema coverage in `apps/api/src/tests/marketplace-validation.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
