### PR TITLE
Prevent admin role self-registration

### DIFF
--- a/apps/api/src/tests/auth-validation.test.js
+++ b/apps/api/src/tests/auth-validation.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role for public signup", () => {
+  const result = registerSchema.safeParse({
+    email: "admin@example.com",
+    password: "password123",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerSchema accepts public roles", () => {
+  assert.equal(
+    registerSchema.safeParse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    }).success,
+    true
+  );
+  assert.equal(
+    registerSchema.safeParse({
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    }).success,
+    true
+  );
+});
+
+test("registerSchema defaults public signup to client", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #8327

/claim #743

- remove `admin` from the public registration role enum
- keep public signup defaulting to `client`
- add regression tests for admin rejection, allowed public roles, and default role behavior

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` schema coverage in `apps/api/src/tests/auth-validation.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
