### PR TITLE
Require admin role for admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return (req, res, next) => {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/auth-middleware.test.js
+++ b/apps/api/src/tests/auth-middleware.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { requireRole } from "../middleware/auth.js";
+
+function createResponse() {
+  return {
+    body: null,
+    statusCode: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("requireRole allows users with the required role", () => {
+  const req = { user: { role: "admin" } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireRole("admin")(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body, null);
+});
+
+test("requireRole rejects authenticated users without the required role", () => {
+  const req = { user: { role: "client" } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireRole("admin")(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});
+
+test("requireRole rejects requests without a user", () => {
+  const req = {};
+  const res = createResponse();
+  let nextCalled = false;
+
+  requireRole("admin")(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { success: false, message: "Forbidden" });
+});


### PR DESCRIPTION
## Summary

Fixes #8329

/claim #743

- add a reusable `requireRole` middleware
- apply `requireRole("admin")` to admin routes after token authentication
- add regression tests for allowed admin users, rejected non-admin users, and missing user context

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` middleware coverage in `apps/api/src/tests/auth-middleware.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
