### PR TITLE
Limit in-memory upload size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,29 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+export const MAX_UPLOAD_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_UPLOAD_FILE_SIZE_BYTES }
+});
+
+function handleSingleFileUpload(req, res, next) {
+  return upload.single("file")(req, res, (error) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "Uploaded file is too large", 413);
+    }
+
+    if (error) {
+      return next(error);
+    }
+
+    return next();
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", handleSingleFileUpload, uploadFile);

--- a/apps/api/src/tests/upload-limit.test.js
+++ b/apps/api/src/tests/upload-limit.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from "../routes/uploadRoutes.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run("http://127.0.0.1:" + port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects files larger than the in-memory limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set(
+      "file",
+      new Blob([new Uint8Array(MAX_UPLOAD_FILE_SIZE_BYTES + 1)]),
+      "oversized.bin"
+    );
+
+    const response = await fetch(baseUrl + "/api/uploads", {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Uploaded file is too large"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #8331

/claim #743

- add a 5 MiB size limit to the in-memory multer upload route
- convert Multer `LIMIT_FILE_SIZE` errors into an explicit 413 response
- add an integration-style test for oversized multipart uploads

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` coverage in `apps/api/src/tests/upload-limit.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
