### PR TITLE
Require authentication for token refresh

### DIFF
--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run("http://127.0.0.1:" + port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects anonymous requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(baseUrl + "/api/auth/refresh", {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh accepts authenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_existing", role: "client" });
+    const response = await fetch(baseUrl + "/api/auth/refresh", {
+      method: "POST",
+      headers: { authorization: "Bearer " + token }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.token, "string");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #8333

/claim #743

- protect `POST /api/auth/refresh` with `authMiddleware`
- reject anonymous refresh attempts with 401
- add route tests for anonymous rejection and authenticated refresh success

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` coverage in `apps/api/src/tests/auth-refresh.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
