### PR TITLE
Return 400 for Zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/error-handler.test.js
+++ b/apps/api/src/tests/error-handler.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError, z } from "zod";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    body: null,
+    statusCode: null,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("errorHandler returns 400 for Zod validation errors", () => {
+  const result = z.object({ email: z.string().email() }).safeParse({ email: "invalid" });
+  assert.equal(result.success, false);
+
+  const res = createResponse();
+  let nextCalled = false;
+
+  errorHandler(result.error, {}, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, "Validation failed");
+  assert.equal(Array.isArray(res.body.issues), true);
+});
+
+test("errorHandler delegates when headers were already sent", () => {
+  const res = createResponse();
+  res.headersSent = true;
+  const error = new ZodError([]);
+  let nextError = null;
+
+  errorHandler(error, {}, res, (err) => {
+    nextError = err;
+  });
+
+  assert.equal(nextError, error);
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body, null);
+});


### PR DESCRIPTION
## Summary

Fixes #8335

/claim #743

- handle `ZodError` in the global API error handler
- return HTTP 400 with validation details instead of a generic 500
- add regression coverage for Zod validation errors and headers-sent delegation

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` coverage in `apps/api/src/tests/error-handler.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
