### PR TITLE
Require JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,20 @@
+function requiredInProduction(name, fallback) {
+  const value = process.env[name];
+  if (value) {
+    return value;
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(name + " is required in production");
+  }
+
+  return fallback;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: requiredInProduction("JWT_SECRET", "development-secret"),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalJwtSecret = process.env.JWT_SECRET;
+
+function restoreEnv() {
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  if (originalJwtSecret === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = originalJwtSecret;
+  }
+}
+
+async function loadEnvForTest() {
+  return import("../config/env.js?test=" + Date.now() + Math.random());
+}
+
+test("env uses development JWT secret fallback outside production", async (t) => {
+  t.after(restoreEnv);
+  process.env.NODE_ENV = "development";
+  delete process.env.JWT_SECRET;
+
+  const { env } = await loadEnvForTest();
+
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("env uses configured JWT secret when provided", async (t) => {
+  t.after(restoreEnv);
+  process.env.NODE_ENV = "production";
+  process.env.JWT_SECRET = "configured-secret";
+
+  const { env } = await loadEnvForTest();
+
+  assert.equal(env.jwtSecret, "configured-secret");
+});
+
+test("env rejects missing JWT_SECRET in production", async (t) => {
+  t.after(restoreEnv);
+  process.env.NODE_ENV = "production";
+  delete process.env.JWT_SECRET;
+
+  await assert.rejects(loadEnvForTest(), /JWT_SECRET is required in production/);
+});


### PR DESCRIPTION
## Summary

Fixes #8337

/claim #743

- fail fast when `JWT_SECRET` is missing in production
- keep the local development fallback outside production
- add regression tests for development fallback, configured secret usage, and production missing-secret failure

## Validation

- Reviewed changed files through GitHub web editor and GitHub file fetches.
- Added focused `node:test` coverage in `apps/api/src/tests/env.test.js`.
- Local test execution was not run because this workflow is restricted to web/GitHub-only changes with no local disk writes.
