### PR TITLE
Enforce upload file size limit

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,16 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err?.code === "LIMIT_FILE_SIZE") {
+    return res.status(413).json({
+      success: false,
+      message: "File too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }
+});
 
 export const uploadRoutes = Router();
 

--- a/apps/api/src/tests/upload-size-limit.test.js
+++ b/apps/api/src/tests/upload-size-limit.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function makeFormData(sizeInBytes) {
+  const form = new FormData();
+  form.append(
+    "file",
+    new Blob([Buffer.alloc(sizeInBytes, "a")]),
+    "upload.bin"
+  );
+  return form;
+}
+
+test("POST /api/uploads accepts small files", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: makeFormData(1024)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "upload.bin");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});
+
+test("POST /api/uploads rejects files larger than the configured limit", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: makeFormData(5 * 1024 * 1024 + 1)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, { success: false, message: "File too large" });
+  });
+});


### PR DESCRIPTION
Adds a 5 MiB upload cap on the API upload route and covers both successful small uploads and oversized upload rejection with regression tests.