### PR TITLE
fix(api): run test files explicitly

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #8346

## Summary

- Update the API workspace test script to target `src/tests/*.test.js` explicitly.
- Keep the change limited to test discovery; no runtime API behavior changes.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
✔ GET /health returns ok payload
pass 1
fail 0
```