### PR TITLE
Fix API test script to discover test files via glob pattern

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
The API workspace test script passes the test directory (`src/tests`) directly to `node --test`. On Node v24 this fails with:

```
Error: Cannot find module ".../apps/api/src/tests"
```

Node treats the argument as a file path, not a directory to scan. Switching to a glob (`src/tests/*.test.js`) makes the runner discover each test file individually.

**Before:**
```json
"test": "node --test src/tests"
```

**After:**
```json
"test": "node --test \"src/tests/*.test.js\""
```

Verified locally:
```
npm test -w apps/api
✔ GET /health returns ok payload
pass 1
fail 0
```

Refs #8346