### PR TITLE
Add Clear Merge Window poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,31 @@
+# Clear Merge Window
+
+In FreelanceFlow the brief begins
+as signal cut from noise:
+a client names the work in scope,
+a builder finds a choice.
+
+The ledger does not hurry trust;
+it writes the handoff down.
+Escrow holds the quiet line
+between the verb and noun.
+
+A proposal crosses like a patch
+through tests that keep their light.
+Each failing edge becomes a note,
+each passing check a right.
+
+The reviewer reads the diff of care,
+not only what was done:
+the contract, code, and context meet
+before the branch is one.
+
+Then merge is not a final door
+but proof that both sides saw:
+clear terms, clear work, clear payment rails,
+and maintenance with law.
+
+So let the marketplace be small
+and honest at its core:
+less fog around the promises,
+more signal at the door.


### PR DESCRIPTION
## Summary
- Add an original root-level `POEM.md` titled "Clear Merge Window".
- The poem is written specifically for FreelanceFlow and uses six short stanzas.

## Creative note
I chose a compact technical-lyric form where scope, escrow, tests, review, merge, and payment become visible marketplace handoffs.

/claim #76

## Validation
- Confirmed `POEM.md` exists in the project root.
- Confirmed the poem has more than three stanzas.
- PASS: `git diff --check`
