### PR TITLE
fix(api): run test files explicitly

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- Update the API workspace test script to target existing `*.test.js` files explicitly.
- Avoid Node v24+/v25 trying to execute `apps/api/src/tests` as a module.

## Validation
- Before: `npm.cmd test -w apps/api` failed with `Cannot find module '.../apps/api/src/tests'`.
- After: `npm.cmd test -w apps/api` passed (`1` test, `0` failures).

Closes #8355
Refs #743
/claim #743