### PR TITLE
Fix API test script to use glob pattern for file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Running `npm test -w apps/api` fails on Node v24 because the script passes the directory `src/tests` to `node --test`, which expects file paths or globs.

The error:
```
Error: Cannot find module ".../apps/api/src/tests"
✖ src\tests
```

The fix changes the test script from:
```
"test": "node --test src/tests"
```
to:
```
"test": "node --test \"src/tests/*.test.js\""
```

This makes the Node test runner discover test files via glob matching instead of trying to resolve `src/tests` as a module.

Closes #8346