### PR TITLE
Fix API workspace test target

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

- Update the API workspace test script to target existing test files explicitly.
- Avoid passing the `src/tests` directory itself to Node's test runner, which fails on current Node versions with `MODULE_NOT_FOUND`.

Closes #8359

## Validation

```bash
npm test -w apps/api
```

Result:

```text
✔ GET /health returns ok payload
pass 1
fail 0
```
