### PR TITLE
Validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJobPayload = {
+  title: "Landing page build",
+  description: "Build a polished landing page for a new product.",
+  budgetMin: 500,
+  budgetMax: 1000,
+  categoryId: "web-development",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () => createJobSchema.parse({ ...validJobPayload, budgetMin: 500, budgetMax: 100 }),
+    (error) => error instanceof ZodError && error.issues.some((issue) => issue.path.join(".") === "budgetMax")
+  );
+});
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJobPayload).budgetMax, 1000);
+  assert.equal(createJobSchema.parse({ ...validJobPayload, budgetMax: 500 }).budgetMax, 500);
+});
+
+test("updateJobSchema rejects inverted budget ranges when both fields are present", () => {
+  assert.throws(
+    () => updateJobSchema.parse({ budgetMin: 750, budgetMax: 250 }),
+    (error) => error instanceof ZodError && error.issues.some((issue) => issue.path.join(".") === "budgetMax")
+  );
+});
+
+test("updateJobSchema allows partial budget updates with one side omitted", () => {
+  assert.equal(updateJobSchema.parse({ budgetMin: 750 }).budgetMin, 750);
+  assert.equal(updateJobSchema.parse({ budgetMax: 250 }).budgetMax, 250);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const budgetRangeError = "budgetMax must be greater than or equal to budgetMin";
+
+function hasOrderedBudgetRange(payload) {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+
+  return payload.budgetMax >= payload.budgetMin;
+}
+
+const jobFieldsSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobFieldsSchema.refine(hasOrderedBudgetRange, {
+  message: budgetRangeError,
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = jobFieldsSchema.partial().refine(hasOrderedBudgetRange, {
+  message: budgetRangeError,
+  path: ["budgetMax"]
+});


### PR DESCRIPTION
## Summary
- Add shared validation to reject inverted job budget ranges where `budgetMax < budgetMin`.
- Apply the validation to both `createJobSchema` and `updateJobSchema`.
- Keep partial updates valid when only one side of the budget range is provided.

## Tests
- `npm test`

Fixes #2853