### PR TITLE
fix: add input validation and length limit to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -28,3 +28,27 @@ export async function search(req, res) {
 
   return ok(res, await globalSearch(result.data));
 }
+import { z } from "zod";
+import { ok, fail } from "../utils/response.js";
+import { globalSearch } from "../services/searchService.js";
+
+const searchQuerySchema = z.string().trim().min(1).max(200);
+
+export async function search(req, res) {
+  const raw = req.query.q;
+
+  if (typeof raw !== "string") {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  const result = searchQuerySchema.safeParse(raw);
+
+  if (!result.success) {
+    const message = raw.trim().length === 0
+      ? "Search query must not be empty"
+      : "Search query must be 200 characters or fewer";
+    return fail(res, message, 400);
+  }
+
+  return ok(res, await globalSearch(result.data));
+}

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -4,3 +4,27 @@ import { globalSearch } from "../services/searchService.js";
 export async function search(req, res) {
   return ok(res, await globalSearch(req.query.q ?? ""));
 }
+iimport { z } from "zod";
+import { ok, fail } from "../utils/response.js";
+import { globalSearch } from "../services/searchService.js";
+
+const searchQuerySchema = z.string().trim().min(1).max(200);
+
+export async function search(req, res) {
+  const raw = req.query.q;
+
+  if (typeof raw !== "string") {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  const result = searchQuerySchema.safeParse(raw);
+
+  if (!result.success) {
+    const message = raw.trim().length === 0
+      ? "Search query must not be empty"
+      : "Search query must be 200 characters or fewer";
+    return fail(res, message, 400);
+  }
+
+  return ok(res, await globalSearch(result.data));
+}


### PR DESCRIPTION
Closes #8269

/claim #743

This PR adds input validation to the search endpoint:
- Limits query length to 200 characters
- Rejects non-string input (e.g. repeated q params)
- Trims whitespace
- Returns clear error messages