### PR TITLE
fix(api): trim job validation fields

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/jobValidation.test.js
+++ b/apps/api/src/tests/jobValidation.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a useful API endpoint",
+  budgetMin: 100,
+  budgetMax: 200,
+  categoryId: "backend",
+  skills: ["node"]
+};
+
+test("job validation rejects whitespace-only title", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    title: "    "
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job validation rejects whitespace-only description", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    description: "          "
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job validation rejects whitespace-only category id", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    categoryId: "   "
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job validation rejects whitespace-only skills", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    skills: ["node", "   "]
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("job validation trims accepted string fields", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    title: "  Build API  ",
+    description: "  Build a useful API endpoint  ",
+    categoryId: "  backend  ",
+    skills: ["  node  ", "  api  "]
+  });
+
+  assert.equal(result.success, true);
+  assert.deepEqual(result.data, {
+    ...validJob,
+    title: "Build API",
+    description: "Build a useful API endpoint",
+    categoryId: "backend",
+    skills: ["node", "api"]
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().trim().min(4),
+  description: z.string().trim().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: z.string().trim().min(1),
+  skills: z.array(z.string().trim().min(1)).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
/claim #743

## Summary

Fixes #8363.

This PR tightens job creation validation so whitespace-only job fields are rejected instead of being accepted as meaningful text.

## Root cause

`createJobSchema` used plain `z.string().min(...)` validation for `title`, `description`, `categoryId`, and individual `skills`. Because length was checked before trimming, values such as `"    "` or `"          "` satisfied the minimum-length constraints and could be stored as visually empty job data.

## Changes

- Trim job `title`, `description`, `categoryId`, and `skills` before length validation.
- Add focused regression tests for whitespace-only values.
- Add a positive regression test proving padded valid values are trimmed and accepted.
- Point the API test script at concrete `*.test.js` files so the Node test runner discovers the committed test files.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
tests 6
pass 6
fail 0
```

```bash
git diff --check
```

Result: passed.

## Demo evidence

The regression tests exercise the API schema directly:

- whitespace-only `title` is rejected;
- whitespace-only `description` is rejected;
- whitespace-only `categoryId` is rejected;
- whitespace-only `skills` are rejected;
- padded valid strings are trimmed and accepted.
