### PR TITLE
fix(api): return client errors for JSON body failures

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "JSON request body is too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/jsonBodyErrors.test.js
+++ b/apps/api/src/tests/jsonBodyErrors.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return a 400 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{\"title\":"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});
+
+test("oversized JSON request bodies return a 413 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const oversizedPayload = JSON.stringify({ body: "x".repeat(110 * 1024) });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: oversizedPayload
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "JSON request body is too large"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary

Fixes #8371.

Malformed JSON bodies now return a 400 client error, and oversized JSON bodies now return a 413 client error, instead of both falling through to the generic 500 path.

## Root cause

`express.json()` forwards body-parser errors to the global error handler with typed error metadata such as `entity.parse.failed` and `entity.too.large`. The existing handler did not inspect those client-error types and always returned a 500 response for parser failures.

## Changes

- Handle `entity.parse.failed` with a clear 400 JSON response.
- Handle `entity.too.large` with a clear 413 JSON response.
- Keep unexpected errors on the existing 500 response path.
- Add focused API regression tests for malformed and oversized JSON request bodies.
- Point the API test script at concrete `*.test.js` files so Node discovers the committed tests reliably.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
tests 3
pass 3
fail 0
```

```bash
git diff --check
```

Result: passed.