### PR TITLE
fix(api): reject admin role during public registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const validRegistration = {
+  email: "user@example.com",
+  password: "correct-horse-battery-staple"
+};
+
+test("registerSchema defaults public signups to client role", () => {
+  const parsed = registerSchema.parse(validRegistration);
+
+  assert.equal(parsed.role, "client");
+});
+
+test("registerSchema allows freelancer public signups", () => {
+  const parsed = registerSchema.parse({
+    ...validRegistration,
+    role: "freelancer"
+  });
+
+  assert.equal(parsed.role, "freelancer");
+});
+
+test("registerSchema rejects admin role on public signup", () => {
+  const result = registerSchema.safeParse({
+    ...validRegistration,
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "role");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #743

## Summary

Fixes #8373.

Public registration no longer accepts `role: admin`. Normal public roles still validate, and omitted roles still default to `client`.

## Root cause

The public `registerSchema` allowed `client`, `freelancer`, and `admin`. Because the parsed role is passed through to `registerUser`, a public caller could request an admin-scoped registration path instead of being limited to ordinary public account roles.

## Changes

- Remove `admin` from the public registration role enum.
- Keep the default public role as `client`.
- Add focused validator regression tests for default client, allowed freelancer, and rejected admin role.
- Point the API test script at concrete `*.test.js` files so Node discovers the committed tests reliably.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
tests 4
pass 4
fail 0
```

```bash
git diff --check
```

Result: passed.