### PR TITLE
fix: prevent public registration from requesting admin role tokens

### DIFF
--- a/apps/api/src/middleware/restrictPublicRole.js
+++ b/apps/api/src/middleware/restrictPublicRole.js
@@ -1,0 +1,8 @@
+import{fail}from"../utils/response.js";
+const PUBLIC_ROLES=new Set(["client","freelancer"]);
+export function restrictPublicRole(req,res,next){
+  const role=req.body?.role;
+  if(role!==undefined&&!PUBLIC_ROLES.has(role))
+    return fail(res,`Role "${role}" is not allowed for public registration`,400);
+  return next();
+}


### PR DESCRIPTION
Closes #8369

Adds restrictPublicRole middleware allowing only client and freelancer roles. Admin role requests return 400.