### PR TITLE
fix: return 400/413 for malformed and oversized JSON request bodies

### DIFF
--- a/apps/api/src/middleware/jsonErrorHandler.js
+++ b/apps/api/src/middleware/jsonErrorHandler.js
@@ -1,0 +1,8 @@
+import{fail}from"../utils/response.js";
+export function jsonErrorHandler(err,req,res,next){
+  if(err instanceof SyntaxError&&err.status===400&&"body"in err)
+    return fail(res,"Malformed JSON in request body",400);
+  if(err.type==="entity.too.large")
+    return fail(res,"Request payload too large",413);
+  return next(err);
+}


### PR DESCRIPTION
Closes #8365

Adds jsonErrorHandler catching SyntaxError (400) and entity.too.large (413) before 500 handler.