### PR TITLE
fix: return 400 when upload endpoint receives no file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,6 @@
-import { ok } from "../utils/response.js";
-
-export async function uploadFile(req, res) {
-  return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
-  }, 201);
+import{ok,fail}from"../utils/response.js";
+export async function uploadFile(req,res){
+  if(!req.file)
+    return fail(res,"No file provided — include a file field in the request",400);
+  return ok(res,{filename:req.file.originalname,status:"uploaded"},201);
 }


### PR DESCRIPTION
Closes #8367

Rejects requests with no file field with 400 instead of returning misleading 201 with status: no-file.