### PR TITLE
fix: reject whitespace-only fields in job creation validation

### DIFF
--- a/apps/api/src/middleware/rejectWhitespace.js
+++ b/apps/api/src/middleware/rejectWhitespace.js
@@ -1,0 +1,11 @@
+import{fail}from"../utils/response.js";
+export function rejectWhitespaceFields(fields){
+  return(req,res,next)=>{
+    for(const field of fields){
+      const v=req.body?.[field];
+      if(typeof v==="string"&&v.trim().length===0)
+        return fail(res,`Field "${field}" must not be empty or whitespace-only`,400);
+    }
+    return next();
+  };
+}


### PR DESCRIPTION
Closes #8363

Adds rejectWhitespaceFields middleware. title, description, categoryId and skills must not be whitespace-only.