### PR TITLE
fix: return 400 for malformed JSON bodies instead of 500

### DIFF
--- a/apps/api/src/middleware/jsonErrorHandler.js
+++ b/apps/api/src/middleware/jsonErrorHandler.js
@@ -1,0 +1,8 @@
+import{fail}from"../utils/response.js";
+export function jsonErrorHandler(err,req,res,next){
+  if(err instanceof SyntaxError&&err.status===400&&"body"in err)
+    return fail(res,"Malformed JSON in request body",400);
+  if(err.type==="entity.too.large")
+    return fail(res,"Request body too large",413);
+  return next(err);
+}


### PR DESCRIPTION
Closes #8371

Adds jsonErrorHandler middleware catching SyntaxError from express.json() and body-parser. Returns 400 for malformed JSON, 413 for oversized bodies.