### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/middleware/validateBudgetInvert.js
+++ b/apps/api/src/middleware/validateBudgetInvert.js
@@ -1,0 +1,7 @@
+import{fail}from"../utils/response.js";
+export function validateBudget(req,res,next){
+  const b=req.body?.budget;
+  if(b&&typeof b.min==="number"&&typeof b.max==="number"&&b.min>=b.max)
+    return fail(res,"budget.max must be greater than budget.min",400);
+  return next();
+}


### PR DESCRIPTION
Closes #8078