### PR TITLE
fix: strip caller-controlled id from review creation

### DIFF
--- a/apps/api/src/middleware/stripId.js
+++ b/apps/api/src/middleware/stripId.js
@@ -1,0 +1,1 @@
+export const stripId=(req,_res,next)=>{delete req.body?.id;delete req.body?.createdAt;delete req.body?.updatedAt;return next();};


### PR DESCRIPTION
Closes #8047