### PR TITLE
fix: strip caller-controlled id from message creation

### DIFF
--- a/apps/api/src/middleware/stripMsgId.js
+++ b/apps/api/src/middleware/stripMsgId.js
@@ -1,0 +1,1 @@
+export const stripMessageId=(req,_res,next)=>{delete req.body?.id;delete req.body?.sentAt;delete req.body?.createdAt;return next();};


### PR DESCRIPTION
Closes #8046