### PR TITLE
fix: strip caller-controlled id from proposal creation

### DIFF
--- a/apps/api/src/middleware/stripProposalId.js
+++ b/apps/api/src/middleware/stripProposalId.js
@@ -1,0 +1,1 @@
+export const stripProposalId=(req,_res,next)=>{delete req.body?.id;delete req.body?.status;delete req.body?.createdAt;return next();};


### PR DESCRIPTION
Closes #8045