### PR TITLE
fix: strip caller-controlled id and status from job creation

### DIFF
--- a/apps/api/src/middleware/stripJobServerFields.js
+++ b/apps/api/src/middleware/stripJobServerFields.js
@@ -1,0 +1,1 @@
+export const stripJobServerFields=(req,_res,next)=>{["id","status","createdAt","updatedAt","authorId"].forEach(f=>delete req.body?.[f]);return next();};


### PR DESCRIPTION
Closes #8023