### PR TITLE
fix: enforce 5MB maximum file size on upload endpoint

### DIFF
--- a/apps/api/src/middleware/uploadSizeLimit.js
+++ b/apps/api/src/middleware/uploadSizeLimit.js
@@ -1,0 +1,2 @@
+import multer from"multer";
+export const upload=multer({storage:multer.memoryStorage(),limits:{fileSize:5*1024*1024,files:1}});


### PR DESCRIPTION
Closes #7739