### PR TITLE
fix(api): require JWT secret in production

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+function requireInProduction(name, value, nodeEnv) {
+  if (nodeEnv === "production" && !value) {
+    throw new Error(`${name} is required in production`);
+  }
+
+  return value;
+}
+
+export function createEnv(source = process.env) {
+  const nodeEnv = source.NODE_ENV ?? "development";
+  const jwtSecret = requireInProduction("JWT_SECRET", source.JWT_SECRET, nodeEnv);
+
+  return {
+    nodeEnv,
+    port: Number(source.PORT ?? 4000),
+    jwtSecret: jwtSecret ?? "development-secret",
+    stripeSecretKey: source.STRIPE_SECRET_KEY ?? "",
+    databaseUrl: source.DATABASE_URL ?? ""
+  };
+}
+
+export const env = createEnv();

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createEnv } from "../config/env.js";
+
+test("createEnv uses development JWT fallback outside production", () => {
+  const env = createEnv({ NODE_ENV: "development" });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.jwtSecret, "development-secret");
+});
+
+test("createEnv uses configured JWT secret in production", () => {
+  const env = createEnv({
+    NODE_ENV: "production",
+    JWT_SECRET: "configured-production-secret"
+  });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.jwtSecret, "configured-production-secret");
+});
+
+test("createEnv fails fast when production JWT secret is missing", () => {
+  assert.throws(
+    () => createEnv({ NODE_ENV: "production" }),
+    /JWT_SECRET is required in production/
+  );
+});


### PR DESCRIPTION
/claim #743

## Summary

Fixes #8506.

Production startup now fails fast when `JWT_SECRET` is missing, while local development still keeps the existing `development-secret` fallback.

## Root cause

The environment config always used `process.env.JWT_SECRET ?? development-secret`. That is convenient for local development but unsafe in production because a missing secret would silently sign access tokens with a public, predictable fallback.

## Changes

- Extract `createEnv()` so env behavior is testable without mutating global process state.
- Require `JWT_SECRET` when `NODE_ENV=production`.
- Preserve the development fallback outside production.
- Add focused regression tests for development fallback, configured production secret, and missing production secret failure.
- Point the API test script at concrete `*.test.js` files so Node discovers committed tests reliably.

## Validation

```bash
npm test -w apps/api
```

Result:

```text
tests 4
pass 4
fail 0
```

```bash
git diff --check
```

Result: passed.