### PR TITLE
fix: restrict public registration roles to client and freelancer only

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- Removes `admin` from the public registration role enum
- Prevents self-assignment of admin privileges during registration

## Issue
Closes #2832

## Files Changed
- `apps/api/src/validators/auth.js`