### PR TITLE
fix: add input validation to search endpoint

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = (req.query.q ?? "").trim();
+  if (query.length === 0) {
+    return fail(res, "Query parameter 'q' is required");
+  }
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query parameter 'q' must be at most ${MAX_QUERY_LENGTH} characters`);
+  }
+  return ok(res, await globalSearch(query));
 }


### PR DESCRIPTION
## Summary
- Rejects empty queries on `/api/search`
- Enforces max length of 200 characters to prevent resource exhaustion

## Issue
Closes #2833

## Files Changed
- `apps/api/src/controllers/searchController.js`