### PR TITLE
Cap and validate GET /api/search query length

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return fail(res, "Invalid search query", 400);
+  }
+  return ok(res, await globalSearch(parsed.data.q ?? ""));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/search returns existing shape for valid query", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  const response = await fetch(`${baseUrl}/api/search?q=node`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.query, "node");
+  assert.deepEqual(payload.data.users, []);
+  assert.deepEqual(payload.data.jobs, []);
+  assert.deepEqual(payload.data.freelancers, []);
+
+  await close(server);
+});
+
+test("GET /api/search treats missing query as empty string", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  const response = await fetch(`${baseUrl}/api/search`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.query, "");
+
+  await close(server);
+});
+
+test("GET /api/search trims surrounding whitespace", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  const response = await fetch(`${baseUrl}/api/search?q=%20%20node%20%20`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.query, "node");
+
+  await close(server);
+});
+
+test("GET /api/search rejects query longer than 200 characters", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  const longQuery = "a".repeat(201);
+  const response = await fetch(`${baseUrl}/api/search?q=${encodeURIComponent(longQuery)}`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Invalid search query");
+
+  await close(server);
+});
+
+test("GET /api/search rejects array query input", async () => {
+  const app = createApp();
+  const { server, baseUrl } = await listen(app);
+
+  const response = await fetch(`${baseUrl}/api/search?q=foo&q=bar`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Invalid search query");
+
+  await close(server);
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const MAX_QUERY_LENGTH = 200;
+
+export const searchQuerySchema = z.object({
+  q: z
+    .string()
+    .transform((s) => s.trim())
+    .pipe(z.string().max(MAX_QUERY_LENGTH))
+    .optional()
+});


### PR DESCRIPTION

Parent bounty: #743
Creator-limited issue: #8516
## Summary

Adds input validation for the `GET /api/search` query parameter so oversized or malformed query values are rejected before reaching the search path.

## Changes

- Normalizes valid string search queries by trimming surrounding whitespace.
- Rejects array or multi-value `q` inputs with a client error.
- Rejects non-string `q` inputs with a client error.
- Rejects search queries longer than 200 characters.
- Preserves existing behavior for normal valid queries.
- Adds focused regression coverage for valid, missing, trimmed, oversized, and multi-value query inputs.

## Tests

Command run (from `apps/api`):

```bash
node --test 'src/tests/**/*.test.js'
```

Result:

```text
✔ GET /health returns ok payload
✔ GET /api/search returns existing shape for valid query
✔ GET /api/search treats missing query as empty string
✔ GET /api/search trims surrounding whitespace
✔ GET /api/search rejects query longer than 200 characters
✔ GET /api/search rejects array query input
ℹ tests 6
ℹ pass 6
ℹ fail 0
```

## Scope

This PR is intentionally limited to the search query validation boundary. It does not refactor search internals, change unrelated endpoints, or perform live probing.

## Bounty

Parent bounty: #743
Creator-limited issue: #8516

