### PR TITLE
fix(api): validate search query input

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,22 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(rawQuery) {
+  if (Array.isArray(rawQuery)) {
+    return String(rawQuery[0] ?? "").trim();
+  }
+
+  return String(rawQuery ?? "").trim();
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = normalizeSearchQuery(req.query.q);
+
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(res, "Search query is too long", 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims surrounding query whitespace", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20banana%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "banana");
+  });
+});
+
+test("GET /api/search keeps omitted query safe", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "");
+  });
+});
+
+test("GET /api/search rejects overly long query strings", async () => {
+  await withServer(async (baseUrl) => {
+    const query = "x".repeat(201);
+    const response = await fetch(`${baseUrl}/api/search?q=${query}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is too long"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Summary

Fixes #8520.

GET /api/search now trims query input, keeps omitted or empty queries safe, and rejects overly long query strings before they reach the search service.

Root cause

The controller passed req.query.q directly into globalSearch without normalization or a length guard. That allowed whitespace-only or oversized query strings to flow into service work as noisy raw values.

Changes

- Normalize q by coercing it to a string and trimming whitespace.
- Preserve safe empty-query behavior when q is omitted.
- Reject queries longer than 200 characters with a 400 response.
- Add focused API tests for trimming, omitted query, and overlong query rejection.
- Point the API test script at concrete test files so Node discovers committed tests reliably.

Validation

npm test -w apps/api
Result: tests 4, pass 4, fail 0

git diff --check
Result: passed.