### PR TITLE
Require auth for payments and proposals

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);

--- a/apps/api/src/tests/auth-required.test.js
+++ b/apps/api/src/tests/auth-required.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function jsonPost(body, token) {
+  return {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(body)
+  };
+}
+
+test("POST /api/payments requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/payments`,
+      jsonPost({
+        amount: 1200,
+        currency: "usd"
+      })
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/payments accepts a valid access token", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "user_1", role: "client" });
+    const response = await fetch(
+      `${baseUrl}/api/payments`,
+      jsonPost(
+        {
+          amount: 1200,
+          currency: "usd"
+        },
+        token
+      )
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.amount, 1200);
+    assert.equal(payload.data.currency, "usd");
+  });
+});
+
+test("GET /api/proposals requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/proposals requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(
+      `${baseUrl}/api/proposals`,
+      jsonPost({
+        jobId: "job_1",
+        freelancerId: "user_2",
+        coverLetter: "I can help ship this safely.",
+        bidAmount: 800
+      })
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.message, "Unauthorized");
+
+});
+});


### PR DESCRIPTION
Summary:
- Require auth for POST /api/payments.
- Require auth for GET/POST /api/proposals.
- Add regression tests for unauthenticated access and valid payment creation.

Tests:
- npm test -w apps/api

Fixes #TU_NUMERO_DE_ISSUE
Refs #743