### PR TITLE
fix(api): reject inverted job budget ranges (#2853)

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -7,6 +7,9 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ success: false, errors: parsed.error.flatten() });
+  }
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build landing page",
+  description: "Need a responsive marketing landing page.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "web"
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 500, budgetMax: 100 });
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].path.join("."), "budgetMax");
+});
+
+test("createJobSchema accepts an ordered budget range", () => {
+  assert.equal(createJobSchema.safeParse(validJob).success, true);
+});
+
+test("createJobSchema accepts an equal budget range", () => {
+  const result = createJobSchema.safeParse({ ...validJob, budgetMin: 250, budgetMax: 250 });
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted range when both bounds are present", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMin: 500, budgetMax: 100 }).success, false);
+});
+
+test("updateJobSchema allows a partial update with a single budget bound", () => {
+  assert.equal(updateJobSchema.safeParse({ budgetMax: 100 }).success, true);
+});
+
+test("POST /api/jobs returns 400 for an inverted budget range", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...validJob, budgetMin: 500, budgetMax: 100 })
+  });
+
+  assert.equal(response.status, 400);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobShape = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,14 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+// Reject inverted ranges. Tolerates missing fields so it also fits partial updates;
+// only enforces order when both bounds are present.
+const orderedBudget = (data) =>
+  data.budgetMin == null || data.budgetMax == null || data.budgetMax >= data.budgetMin;
+const orderedBudgetError = {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+};
+
+export const createJobSchema = jobShape.refine(orderedBudget, orderedBudgetError);
+export const updateJobSchema = jobShape.partial().refine(orderedBudget, orderedBudgetError);


### PR DESCRIPTION
## Summary

`createJobSchema` accepted payloads where `budgetMax < budgetMin`, producing invalid job records (e.g. a USD 500–100 range) that break filtering, sorting, and display assumptions.

## Changes

- **`apps/api/src/validators/job.js`** — extract the shared `jobShape` and add an `orderedBudget` refine to both `createJobSchema` and `updateJobSchema`. Building both from the base object avoids the `ZodEffects.partial()` pitfall (you cannot call `.partial()` on a refined schema). The check only enforces order when both bounds are present, so partial updates still validate correctly.
- **`apps/api/src/controllers/jobController.js`** — `postJob` now uses `safeParse` and returns **400** with field errors. Previously a thrown `ZodError` escaped the async handler, never reached the error middleware (which only emits 500), and would hang the request.
- **`apps/api/src/tests/job.test.js`** — tests for inverted / valid / equal ranges, partial-update validation, and the 400 endpoint response.

## Expected — all covered

- [x] Job creation rejects inverted budget ranges
- [x] Partial updates reject the same range when both budget fields are present
- [x] Existing valid ordered ranges continue to parse

## Testing

`node --test apps/api/src/tests/*.test.js` → **7/7 passing** (including the existing health test — no regression).

Closes #2853

/claim #2853