### PR TITLE
Job service should return defensive snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,12 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map(job => structuredClone(job));
 }
 
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
-  jobs.push(job);
-  return job;
+  jobs.push(structuredClone(job));
+  return structuredClone(job);
 }
+

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("Unit Test: job service returns defensive snapshots", async () => {
+  // 1. Create a job
+  const jobPayload = {
+    title: "Software Engineer",
+    description: "Write clean and elegant JS code",
+    budgetMin: 50,
+    budgetMax: 100,
+    categoryId: "tech",
+    skills: ["javascript", "nodejs"]
+  };
+  
+  const createdJob = await createJob(jobPayload);
+  
+  // 2. Modify properties on the returned createdJob object
+  createdJob.status = "corrupted";
+  createdJob.skills.push("malicious");
+  
+  // 3. Retrieve jobs listing
+  const jobsList1 = await listJobs();
+  
+  assert.equal(jobsList1.length, 1);
+  assert.equal(jobsList1[0].status, "open");
+  assert.deepEqual(jobsList1[0].skills, ["javascript", "nodejs"]);
+  
+  // 4. Modify the returned jobs list array and nested object
+  jobsList1.push({ id: "injected_job", status: "open" });
+  jobsList1[0].status = "hacked";
+  jobsList1[0].skills[0] = "corrupted";
+  
+  // 5. Retrieve jobs listing again and verify internal state remains intact
+  const jobsList2 = await listJobs();
+  
+  assert.equal(jobsList2.length, 1);
+  assert.equal(jobsList2[0].status, "open");
+  assert.deepEqual(jobsList2[0].skills, ["javascript", "nodejs"]);
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,21 @@
+# Operations Guide - Defensive Snapshots
+
+This document describes the design, configuration, and testing procedures for defensive snapshots in the Job Service.
+
+## Defensive Snapshots
+
+The application implements defensive snapshotting in `apps/api/src/services/jobService.js` to protect internal in-memory databases from accidental side-channel mutations.
+
+### Design
+
+By default, JavaScript objects and arrays are passed by reference. If a service returns its backing collection directly to route controllers or business logic, any caller can mutate the returned array or modify properties of nested items (like updating `job.status` or modifying the `skills` array), which silently corrupts the database state.
+
+To prevent this:
+1. **Array Cloning**: `listJobs()` maps over the backing array, cloning each element.
+2. **Deep Copying**: Utilizes the native `structuredClone()` API to create complete, independent deep copies of job objects (including nested arrays like `skills`) before storing them and before returning them to callers.
+
+### Testing
+
+The implementation is verified by tests in `apps/api/src/tests/job.test.js`:
+- **Object Mutation Protection**: Confirms that changing the status or modifying `skills` on a returned job does not alter subsequent lookups.
+- **Array Mutation Protection**: Confirms that adding elements to the list returned by `listJobs()` does not alter the service state.


### PR DESCRIPTION
## Summary

This PR resolves the issue where job listings and creation results are exposed by reference, allowing route controllers or external logic to inadvertently mutate the internal job storage collection or nested arrays (such as `skills`).

## Changes

- **Defensive Snapshots**: Refactored `listJobs()` and `createJob()` in `apps/api/src/services/jobService.js` to return deep copies using `structuredClone()`, ensuring caller mutations do not leak back into the service database.
- **Tests**: Created a new regression test suite in `apps/api/src/tests/job.test.js` verifying that object, array, and nested array properties remain isolated from external modification.
- **Documentation**: Documented defensive snapshots in `docs/OPERATIONS.md`.

Closes #8552