### PR TITLE
Admin metrics route should require admin role

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,16 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user) {
+      return fail(res, "Unauthorized", 401);
+    }
+    if (req.user.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}
+

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);
+

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Admin Route: /api/admin/metrics access control", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/admin/metrics`;
+
+  try {
+    // 1. Unauthenticated request (no header)
+    const resp1 = await fetch(baseUrl);
+    assert.equal(resp1.status, 401);
+    const payload1 = await resp1.json();
+    assert.equal(payload1.message, "Unauthorized");
+
+    // 2. Authenticated but non-admin request (client role)
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const resp2 = await fetch(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${clientToken}`
+      }
+    });
+    assert.equal(resp2.status, 403);
+    const payload2 = await resp2.json();
+    assert.equal(payload2.message, "Forbidden");
+
+    // 3. Authenticated admin request
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const resp3 = await fetch(baseUrl, {
+      headers: {
+        Authorization: `Bearer ${adminToken}`
+      }
+    });
+    assert.equal(resp3.status, 200);
+    const payload3 = await resp3.json();
+    assert.ok(payload3.success);
+    assert.ok(payload3.data.hasOwnProperty("openJobs"));
+    assert.ok(payload3.data.hasOwnProperty("activeFreelancers"));
+    assert.equal(payload3.data.openJobs, 42);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,24 @@
+# Operations Guide - Admin Authorization
+
+This document describes the design, configuration, and testing procedures for role-based authorization on admin routes.
+
+## Admin Role Verification
+
+The application implements role-based access control (RBAC) middleware in `apps/api/src/middleware/auth.js` to protect administrative endpoints.
+
+### Design
+
+1. **Token Authentication**: All requests to `/api/admin/*` must pass through `authMiddleware` which decodes and verifies a JSON Web Token (JWT) provided in the `Authorization` header. If the token is missing, expired, or invalid, the API rejects the request with a `401 Unauthorized` status.
+2. **Role Enforcing**: The custom `requireRole(role)` middleware asserts that the authenticated user's token contains the designated role (e.g. `admin`). If a user is authenticated but has a different role (such as `client` or `freelancer`), the API rejects the request with a `403 Forbidden` status.
+
+### Testing
+
+The implementation is verified by tests in `apps/api/src/tests/admin.test.js`:
+- **Unauthenticated**: Verifies that requests without a token are rejected with `401`.
+- **Unauthorized Role**: Verifies that authenticated requests containing a non-admin role are rejected with `403`.
+- **Authorized Admin**: Verifies that authenticated requests containing the `admin` role successfully access the metrics payload with status `200`.
+
+Run the tests:
+```bash
+npm run test
+```


### PR DESCRIPTION
## Summary

This PR fixes the security vulnerability where the `/api/admin/metrics` endpoint is protected by `authMiddleware` but does not enforce role-based access control. Any authenticated user (including non-admins) can fetch admin metrics.

## Changes

- **Authorization Middleware**: Implemented `requireRole(role)` middleware in `apps/api/src/middleware/auth.js` to assert that the authenticated user has the specified role.
- **Route Enforcing**: Applied `requireRole("admin")` on all routes under `adminRoutes` in `apps/api/src/routes/adminRoutes.js`.
- **Tests**: Created a new test suite in `apps/api/src/tests/admin.test.js` verifying that:
  - Requests without a token are rejected with `401 Unauthorized`.
  - Authenticated requests with non-admin roles are rejected with `403 Forbidden`.
  - Authenticated admin requests return `200 OK` along with the metrics.
- **Documentation**: Documented role-based verification design in `docs/OPERATIONS.md`.

Closes #8554