### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/middleware/validateBudgetV4.js
+++ b/apps/api/src/middleware/validateBudgetV4.js
@@ -1,0 +1,2 @@
+import{fail}from"../utils/response.js";
+export const validateBudgetV4=(req,res,next)=>{const b=req.body?.budget;if(b&&typeof b.min==="number"&&typeof b.max==="number"&&b.min>=b.max)return fail(res,"budget.max must exceed budget.min",400);return next();};


### PR DESCRIPTION
Closes #6995