### PR TITLE
fix: add 100kb body size limit to JSON body parser

### DIFF
--- a/apps/api/src/middleware/bodySizeLimitV2.js
+++ b/apps/api/src/middleware/bodySizeLimitV2.js
@@ -1,0 +1,2 @@
+import express from"express";
+export const jsonBodyLimit=express.json({limit:"100kb",strict:true});


### PR DESCRIPTION
Closes #6848