### PR TITLE
fix: enforce request body size limit on JSON parser

### DIFF
--- a/apps/api/src/middleware/bodySizeLimit.js
+++ b/apps/api/src/middleware/bodySizeLimit.js
@@ -1,0 +1,2 @@
+import express from"express";
+export const jsonWithLimit=express.json({limit:"100kb"});


### PR DESCRIPTION
Closes #6850