### PR TITLE
fix: strip client-controlled id from review creation

### DIFF
--- a/apps/api/src/middleware/stripReviewId.js
+++ b/apps/api/src/middleware/stripReviewId.js
@@ -1,0 +1,1 @@
+export const stripReviewId=(req,_,next)=>{["id","createdAt","updatedAt"].forEach(f=>delete req.body?.[f]);return next();};


### PR DESCRIPTION
Closes #6843