### PR TITLE
fix: reject whitespace-only passwords in auth validators

### DIFF
--- a/apps/api/src/middleware/rejectWhitespacePwd.js
+++ b/apps/api/src/middleware/rejectWhitespacePwd.js
@@ -1,0 +1,2 @@
+import{fail}from"../utils/response.js";
+export const rejectWhitespacePwd=(req,res,next)=>{const p=req.body?.password;if(typeof p==="string"&&!p.trim())return fail(res,"Password must not be whitespace only",400);return next();};


### PR DESCRIPTION
Closes #6336