### PR TITLE
fix: reject client-controlled id field in message creation

### DIFF
--- a/apps/api/src/middleware/stripMsgClientId.js
+++ b/apps/api/src/middleware/stripMsgClientId.js
@@ -1,0 +1,1 @@
+export const stripMsgClientId=(req,_,next)=>{delete req.body?.id;delete req.body?.createdAt;return next();};


### PR DESCRIPTION
Closes #5939