### PR TITLE
Search endpoint should validate and trim query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,25 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  let q = req.query.q;
+
+  // Keep empty or omitted queries safe
+  if (q === undefined || q === null) {
+    q = "";
+  }
+
+  // Coerce to a string
+  q = String(q);
+
+  // Trim surrounding whitespace
+  q = q.trim();
+
+  // Reject overly long input with 400 (setting 100 characters max limit)
+  if (q.length > 100) {
+    return fail(res, "Query parameter is too long", 400);
+  }
+
+  return ok(res, await globalSearch(q));
 }
+

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Search Route: GET /api/search input normalization and validation", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/search`;
+
+  try {
+    // 1. Normal query
+    const resp1 = await fetch(`${baseUrl}?q=  banana  `);
+    assert.equal(resp1.status, 200);
+    const payload1 = await resp1.json();
+    assert.equal(payload1.data.query, "banana"); // must be trimmed
+
+    // 2. Omitted/empty query
+    const resp2 = await fetch(baseUrl);
+    assert.equal(resp2.status, 200);
+    const payload2 = await resp2.json();
+    assert.equal(payload2.data.query, "");
+
+    // 3. Non-string query coercion (number)
+    const resp3 = await fetch(`${baseUrl}?q=12345`);
+    assert.equal(resp3.status, 200);
+    const payload3 = await resp3.json();
+    assert.equal(payload3.data.query, "12345");
+
+    // 4. Overly long query (101 characters)
+    const longQuery = "a".repeat(101);
+    const resp4 = await fetch(`${baseUrl}?q=${longQuery}`);
+    assert.equal(resp4.status, 400);
+    const payload4 = await resp4.json();
+    assert.equal(payload4.success, false);
+    assert.equal(payload4.message, "Query parameter is too long");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,27 @@
+# Operations Guide - Search Query Validation
+
+This document describes the design, configuration, and testing procedures for the search query validation feature.
+
+## Search Query Normalization & Validation
+
+The application implements query parameter validation in the `/api/search` endpoint controller to protect downstream search services.
+
+### Design
+
+1. **Omitted and Empty Inputs**: If the query query-parameter (`req.query.q`) is omitted, undefined, or null, it defaults safely to an empty string `""` without failing.
+2. **String Coercion**: Values are coerced to string objects to prevent type issues.
+3. **Whitespace Trimming**: Surrounding whitespace is stripped from the search term using `.trim()`.
+4. **Length Restriction**: Overly long query values are rejected immediately with a `400 Bad Request` code. The maximum length limit is set to `100` characters.
+
+### Testing
+
+The implementation is verified by tests in `apps/api/src/tests/search.test.js`:
+- **Trimming Validation**: Asserts that query values with surrounding spaces are trimmed correctly.
+- **Empty Query Gracefulness**: Asserts that empty/omitted inputs default to `""` and resolve with code `200`.
+- **String Coercion**: Asserts that numeric search queries are coerced to strings.
+- **Overly Long Validation**: Asserts that inputs exceeding `100` characters fail with status code `400`.
+
+Run the tests:
+```bash
+npm run test
+```


### PR DESCRIPTION
## Summary

This PR resolves the issue where the search query parameter (`q`) on the `GET /api/search` endpoint was passed directly to the search service without validation, coercion, trimming, or length constraints, leading to noisy data and potential overload.

## Changes

- **Search query validation and normalization**: Updated `search` in `apps/api/src/controllers/searchController.js` to:
  - Coerce inputs to strings.
  - Safe-default omitted/undefined inputs to empty string `""`.
  - Trim leading and trailing whitespace.
  - Enforce a maximum query string length of 100 characters, returning `400 Bad Request` on failure.
- **Tests**: Created a new test suite in `apps/api/src/tests/search.test.js` covering normal queries, default/empty values, string coercion, and length limit rejections.
- **Documentation**: Documented search query parameter validation in `docs/OPERATIONS.md`.

Closes #8677