### PR TITLE
Upload endpoint should reject requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }
+

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Upload Route: POST /api/uploads validation", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/api/uploads`;
+
+  try {
+    // 1. Invalid upload: Missing file
+    const formData1 = new FormData();
+    const resp1 = await fetch(baseUrl, {
+      method: "POST",
+      body: formData1
+    });
+    assert.equal(resp1.status, 400);
+    const payload1 = await resp1.json();
+    assert.equal(payload1.success, false);
+    assert.equal(payload1.message, "File is required");
+
+    // 2. Valid upload: With file
+    const formData2 = new FormData();
+    formData2.append(
+      "file",
+      new Blob(["dummy file contents"], { type: "text/plain" }),
+      "dummy.txt"
+    );
+    const resp2 = await fetch(baseUrl, {
+      method: "POST",
+      body: formData2
+    });
+    assert.equal(resp2.status, 201);
+    const payload2 = await resp2.json();
+    assert.equal(payload2.success, true);
+    assert.equal(payload2.data.filename, "dummy.txt");
+    assert.equal(payload2.data.status, "uploaded");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,24 @@
+# Operations Guide - Upload File Validation
+
+This document describes the design, configuration, and testing procedures for the file upload endpoint.
+
+## File Upload Validation
+
+The application implements a check on the file upload endpoint (`POST /api/uploads`) in `apps/api/src/controllers/uploadController.js` to prevent empty upload submissions.
+
+### Design
+
+1. **Multer Parsing**: The endpoint uses `multer` memory storage to parse incoming multipart/form-data requests.
+2. **File Check**: If the request body does not contain a valid `file` object (meaning `req.file` is undefined/missing), the endpoint rejects the request with a `400 Bad Request` status and a validation error message.
+3. **Success Response**: If a valid file is uploaded, the API successfully saves the file metadata and returns a `201 Created` status with the file properties.
+
+### Testing
+
+The implementation is verified by tests in `apps/api/src/tests/upload.test.js`:
+- **Missing File Verification**: Sends a POST request with an empty `FormData` payload and asserts that the API returns a `400` status with the correct error message.
+- **Valid File Verification**: Appends a dummy text Blob to a `FormData` payload as the `file` field, posts it, and asserts that the API returns a `201` status along with the matching file properties.
+
+Run the tests:
+```bash
+npm run test
+```


### PR DESCRIPTION
## Summary

This PR resolves the issue where the `POST /api/uploads` endpoint returns a `201 Created` status with `status: no-file` when the request does not upload any file.

## Changes

- **Upload Validation**: Modified `uploadFile` in `apps/api/src/controllers/uploadController.js` to return `400 Bad Request` if `req.file` is missing, utilizing the `fail` response wrapper.
- **Tests**: Created a new unit test suite in `apps/api/src/tests/upload.test.js` checking that requests without a file receive a `400` status, and valid file uploads receive `201`.
- **Documentation**: Documented file upload endpoint validation in `docs/OPERATIONS.md`.

Closes #8679