### PR TITLE
fix: ensure createApp instances do not share rate-limit counters

### DIFF
--- a/apps/api/src/middleware/rateLimitPerInstance.js
+++ b/apps/api/src/middleware/rateLimitPerInstance.js
@@ -1,0 +1,2 @@
+import rateLimit from"express-rate-limit";
+export const createApiLimiter=()=>rateLimit({windowMs:15*60*1000,max:100,standardHeaders:true,legacyHeaders:false,keyGenerator:(req)=>req.ip||"unknown"});


### PR DESCRIPTION
Closes #5159