### PR TITLE
fix: reject inverted budget ranges in job schema

### DIFF
--- a/apps/api/src/schemas/jobBudgetSchemaV2.js
+++ b/apps/api/src/schemas/jobBudgetSchemaV2.js
@@ -1,0 +1,2 @@
+import{z}from"zod";
+export const jobBudgetSchema=z.object({min:z.number().nonnegative(),max:z.number().positive()}).refine(b=>b.max>b.min,{message:"max must be greater than min"});


### PR DESCRIPTION
Closes #5124