### PR TITLE
Require JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,16 @@
+function getRequiredEnv(key, fallback) {
+  const value = process.env[key];
+  if (process.env.NODE_ENV === "production" && !value) {
+    throw new Error(`Environment variable ${key} is required in production`);
+  }
+  return value ?? fallback;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: getRequiredEnv("JWT_SECRET", "development-secret"),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("env.js configuration tests", async (t) => {
+  const originalEnv = { ...process.env };
+
+  t.afterEach(() => {
+    // Reset process.env and NODE_ENV
+    process.env = { ...originalEnv };
+  });
+
+  await t.test("falls back to 'development-secret' when NODE_ENV is not production and JWT_SECRET is unset", async () => {
+    delete process.env.NODE_ENV;
+    delete process.env.JWT_SECRET;
+    
+    const { env } = await import(`../config/env.js?t=${Date.now()}`);
+    assert.equal(env.jwtSecret, "development-secret");
+  });
+
+  await t.test("uses custom JWT_SECRET when provided in development", async () => {
+    delete process.env.NODE_ENV;
+    process.env.JWT_SECRET = "my-custom-dev-secret";
+    
+    const { env } = await import(`../config/env.js?t=${Date.now() + 1}`);
+    assert.equal(env.jwtSecret, "my-custom-dev-secret");
+  });
+
+  await t.test("throws an error when NODE_ENV is production and JWT_SECRET is missing", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.JWT_SECRET;
+    
+    await assert.rejects(
+      async () => {
+        await import(`../config/env.js?t=${Date.now() + 2}`);
+      },
+      (err) => {
+        assert(err instanceof Error);
+        assert.match(err.message, /JWT_SECRET is required in production/);
+        return true;
+      }
+    );
+  });
+
+  await t.test("accepts JWT_SECRET when provided in production", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "strong-prod-secret";
+    
+    const { env } = await import(`../config/env.js?t=${Date.now() + 3}`);
+    assert.equal(env.jwtSecret, "strong-prod-secret");
+  });
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,31 @@
+# Operations Guide - Production Environment Requirements
+
+This document outlines the environment requirements for deploying and running the api service in production environments.
+
+## Environment Variables Configuration
+
+### Production Enforcements
+When running in a production environment (`NODE_ENV=production`), the application enforces security-critical configurations on startup. Missing required variables will cause the service to crash immediately rather than falling back to insecure defaults.
+
+| Environment Variable | Mode | Required in Production | Description / Default |
+| :--- | :--- | :---: | :--- |
+| `NODE_ENV` | All | No | The execution environment (e.g. `development`, `production`). Defaults to `development`. |
+| `PORT` | All | No | The port the server listens on. Defaults to `4000`. |
+| `JWT_SECRET` | Production | **Yes** | Secret key used to sign and verify JSON Web Tokens. In development, defaults to `development-secret`. |
+| `STRIPE_SECRET_KEY` | All | No | Secret key used for Stripe payment gateway communication. Defaults to `""`. |
+| `DATABASE_URL` | All | No | Connection string for the database. Defaults to `""`. |
+
+### Starting the Application in Production
+Ensure `JWT_SECRET` is set in the environment before booting:
+
+```bash
+# Valid production start
+export NODE_ENV=production
+export JWT_SECRET=yoursupersecuresecretkeyhere123!
+npm start
+
+# Insecure/invalid production start (Will crash on boot)
+export NODE_ENV=production
+unset JWT_SECRET
+npm start
+```


### PR DESCRIPTION
## Summary

This PR ensures the API configuration fails startup fast in production if the security-sensitive `JWT_SECRET` environment variable is missing, while safely falling back to the `"development-secret"` default outside of production.

## Changes

- **Environment Variable Guard**: Added a `getRequiredEnv(key, fallback)` helper in `apps/api/src/config/env.js` that throws a startup-blocking error if `process.env.NODE_ENV === "production"` and the variable is missing.
- **Regression Tests**: Added `apps/api/src/tests/env.test.js` to cover the development fallback, customized development secret, production enforcement crash, and valid production secret initialization.
- **Documentation**: Created `docs/OPERATIONS.md` describing environment requirements and production startup instructions.

Closes #8693