### PR TITLE
fix: ignore caller-owned id and read fields on notification

### DIFF
--- a/apps/api/src/middleware/stripNotifRO.js
+++ b/apps/api/src/middleware/stripNotifRO.js
@@ -1,0 +1,1 @@
+export const stripNotifRO=(req,_,next)=>{["id","read","readAt","createdAt"].forEach(f=>delete req.body?.[f]);return next();};


### PR DESCRIPTION
Closes #4866