### PR TITLE
fix: preserve server-owned id and open status on job creation

### DIFF
--- a/apps/api/src/middleware/jobServerId.js
+++ b/apps/api/src/middleware/jobServerId.js
@@ -1,0 +1,1 @@
+export const jobServerId=(req,_,next)=>{delete req.body?.id;delete req.body?._id;req.body.status="OPEN";return next();};


### PR DESCRIPTION
Closes #4405