### PR TITLE
fix: preserve server-generated id on proposal creation

### DIFF
--- a/apps/api/src/middleware/proposalServerId.js
+++ b/apps/api/src/middleware/proposalServerId.js
@@ -1,0 +1,1 @@
+export const proposalServerId=(req,_,next)=>{delete req.body?.id;delete req.body?.status;delete req.body?.createdAt;return next();};


### PR DESCRIPTION
Closes #4249