### PR TITLE
fix: ignore client id and read fields in notification creation

### DIFF
--- a/apps/api/src/middleware/notifClientId.js
+++ b/apps/api/src/middleware/notifClientId.js
@@ -1,0 +1,1 @@
+export const notifClientId=(req,_,next)=>{delete req.body?.id;delete req.body?.read;delete req.body?.readAt;return next();};


### PR DESCRIPTION
Closes #4115