### PR TITLE
Require authentication for payment and proposal endpoints

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);
+

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);
+

--- a/apps/api/src/tests/auth_routes.test.js
+++ b/apps/api/src/tests/auth_routes.test.js
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("Authentication middleware enforcement on payments and proposals", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(() => {
+    return new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const validToken = signAccessToken({ id: "usr_123", email: "test@example.com" });
+
+  await t.test("GET /api/proposals returns 401 Unauthorized when unauthenticated", async () => {
+    const response = await fetch(`${baseUrl}/api/proposals`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Unauthorized/i);
+  });
+
+  await t.test("POST /api/proposals returns 401 Unauthorized when unauthenticated", async () => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "New Proposal" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Unauthorized/i);
+  });
+
+  await t.test("POST /api/payments returns 401 Unauthorized when unauthenticated", async () => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Unauthorized/i);
+  });
+
+  await t.test("GET /api/proposals returns 200 OK when authenticated with a valid token", async () => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      headers: {
+        "Authorization": `Bearer ${validToken}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(Array.isArray(payload.data));
+  });
+
+  await t.test("POST /api/proposals returns 201 Created when authenticated with a valid token", async () => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${validToken}`
+      },
+      body: JSON.stringify({ title: "New Proposal", amount: 1000 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+  });
+
+  await t.test("POST /api/payments returns 201 Created when authenticated with a valid token", async () => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${validToken}`
+      },
+      body: JSON.stringify({ amount: 1000 })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.paymentId);
+  });
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,38 @@
+# Operations Guide - Authentication Enforcements
+
+This document outlines the authentication and security enforcements for proposals and payments in the API service.
+
+## Enforced Authentication Gates
+
+To secure proposal and payment creation, all requests to payments and proposals endpoints require a valid access token in the `Authorization` header.
+
+### Secured Endpoints
+The following endpoints reject unauthenticated requests with `401 Unauthorized`:
+
+| Endpoint Path | HTTP Method | Required Role | Default Response (Unauthenticated) |
+| :--- | :--- | :---: | :--- |
+| `/api/payments` | `POST` | User | `401 Unauthorized` |
+| `/api/proposals` | `GET` | User | `401 Unauthorized` |
+| `/api/proposals` | `POST` | User | `401 Unauthorized` |
+
+### Expected Request Format
+
+Authenticated requests must include a valid bearer token:
+
+```http
+Authorization: Bearer <your_jwt_access_token>
+```
+
+#### Example Valid Proposal Request (POST)
+```bash
+curl -X POST http://127.0.0.1:4000/api/proposals \
+  -H "Authorization: Bearer <valid_jwt>" \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Website Development", "amount": 1500}'
+```
+
+#### Example Blocked Request (No Header)
+```bash
+curl -X GET http://127.0.0.1:4000/api/proposals
+# Returns: {"success":false,"message":"Unauthorized"}
+```


### PR DESCRIPTION
## Summary

This PR secures the payments and proposals endpoints by enforcing token-based authentication. Unauthenticated requests to these paths are rejected with a `401 Unauthorized` response.

## Changes

- **Route Authentication Middleware**: Registered `authMiddleware` on `paymentRoutes` and `proposalRoutes` to protect:
  - `POST /api/payments`
  - `GET /api/proposals`
  - `POST /api/proposals`
- **Regression Tests**: Added `apps/api/src/tests/auth_routes.test.js` to assert that unauthenticated requests to the target endpoints fail with `401` (asserting `success: false`), and valid Bearer tokens allow requests to pass with `200` or `201`.
- **Documentation**: Created `docs/OPERATIONS.md` outlining the secured paths and authentication request examples.

Closes #8792