### PR TITLE
fix: add API endpoint examples to README

### DIFF
--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -1,0 +1,5 @@
+# API Examples
+
+POST /api/auth/login { email, password } -> { token }
+GET /api/jobs -> { jobs: [] }
+POST /api/jobs (auth) { title, budget } -> { job }


### PR DESCRIPTION
Closes #3559