### PR TITLE
Require auth for core creation routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/core-post-auth.test.js
+++ b/apps/api/src/tests/core-post-auth.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const cases = [
+  {
+    path: "/api/proposals",
+    payload: {
+      jobId: "job_123",
+      freelancerId: "usr_freelancer",
+      coverLetter: "I can deliver this project quickly.",
+      amount: 1200
+    }
+  },
+  {
+    path: "/api/reviews",
+    payload: {
+      contractId: "ctr_123",
+      rating: 5,
+      comment: "Fast delivery and clear communication."
+    }
+  },
+  {
+    path: "/api/messages",
+    payload: {
+      senderId: "usr_client",
+      recipientId: "usr_freelancer",
+      body: "Can you share an updated timeline?"
+    }
+  },
+  {
+    path: "/api/notifications",
+    payload: {
+      userId: "usr_client",
+      type: "proposal",
+      text: "A new proposal has arrived."
+    }
+  }
+];
+
+for (const testCase of cases) {
+  test(`POST ${testCase.path} rejects missing token`, async () => {
+    await withServer(async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}${testCase.path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(testCase.payload)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 401);
+      assert.deepEqual(payload, {
+        success: false,
+        message: "Unauthorized"
+      });
+    });
+  });
+
+  test(`POST ${testCase.path} allows authenticated requests`, async () => {
+    await withServer(async (port) => {
+      const token = signAccessToken({ sub: "usr_auth", role: "client" });
+      const response = await fetch(`http://127.0.0.1:${port}${testCase.path}`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(testCase.payload)
+      });
+      const payload = await response.json();
+
+      assert.equal(response.status, 201);
+      assert.equal(payload.success, true);
+      assert.equal(typeof payload.data.id, "string");
+
+      for (const [key, value] of Object.entries(testCase.payload)) {
+        assert.deepEqual(payload.data[key], value);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Adds authentication and related validation coverage for the core creation routes.\n\nThis is a small, test-backed change limited to route middleware and its regression tests.