### PR TITLE
fix: ignore caller supplied id and read fields on notification

### DIFF
--- a/apps/api/src/middleware/notifIgnoreV3.js
+++ b/apps/api/src/middleware/notifIgnoreV3.js
@@ -1,0 +1,1 @@
+export const notifIgnoreV3=(req,_,next)=>{delete req.body?.id;delete req.body?.read;delete req.body?.readAt;return next();};


### PR DESCRIPTION
Closes #3042