### PR TITLE
fix: validate PORT env before passing to app.listen (#8831)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,16 @@
+/**
+ * Safely parse a PORT env value.
+ * Returns `defaultVal` when the value is missing, NaN, or out of range.
+ */
+function parsePort(val, defaultVal = 4000) {
+  const port = Number(val);
+  if (Number.isInteger(port) && port >= 0 && port < 65536) return port;
+  return defaultVal;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT, 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Fix: Invalid PORT env crashes API startup

Closes #8831

### Problem
`Number(process.env.PORT ?? 4000)` produces `NaN` when `PORT` is set to an invalid value like `abc`, causing `app.listen(NaN)` to throw `ERR_SOCKET_BAD_PORT`.

### Fix
Added a `parsePort` helper that validates the port is an integer in the valid range (0–65535) before passing to `app.listen`. Invalid or missing values fall back to the default port (4000).

### Changes
- `apps/api/src/config/env.js` — Added `parsePort()` helper, replaced direct `Number()` call

### Testing
- `PORT=abc` → uses 4000 (was: crash)
- `PORT=0` → uses 0 (ephemeral port, valid)
- `PORT=8080` → uses 8080 (unchanged)
- No `PORT` set → uses 4000 (unchanged)
