### PR TITLE
Malformed JSON requests should return client errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,8 +4,25 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  // Handle express.json / body-parser parse failure
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  // Handle express.json / body-parser too large failure
+  if (err.status === 413 || err.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request entity too large"
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"
   });
 }
+

--- a/apps/api/src/tests/json_parser.test.js
+++ b/apps/api/src/tests/json_parser.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("JSON parsing and limit validation error handler tests", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(() => {
+    return new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  await t.test("POST with malformed JSON body returns 400 Bad Request", async () => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"malformed": ' // Invalid JSON syntax
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Malformed JSON request body/i);
+  });
+
+  await t.test("POST with oversized body returns 413 Payload Too Large", async () => {
+    // Construct a payload larger than 100kb default limit
+    const largeString = "a".repeat(110 * 1024);
+    const body = JSON.stringify({ data: largeString });
+
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Request entity too large/i);
+  });
+});

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,17 @@
+# Operations Guide - JSON Parsing Error Mappings
+
+This document outlines the API error mappings for malformed JSON request bodies and oversized request payloads.
+
+## Error Code Mapping
+
+The API body parser enforces strict client error formatting to ensure malformed requests and oversized payloads receive standard HTTP status codes instead of generic server errors.
+
+| Failure Condition | Parser Error Property | HTTP Status | Response Payload |
+| :--- | :--- | :---: | :--- |
+| **Malformed JSON** | `err instanceof SyntaxError && err.status === 400` | `400 Bad Request` | `{"success":false,"message":"Malformed JSON request body"}` |
+| **Payload Too Large** | `err.status === 413 \|\| err.type === "entity.too.large"` | `413 Payload Too Large` | `{"success":false,"message":"Request entity too large"}` |
+| **Other Errors** | All other uncaught exceptions | `500 Internal Server Error` | `{"success":false,"message":"Unexpected server error"}` |
+
+### Configuration Enforcement
+* The default body parser size limit is configured at `100kb`.
+* Any request containing invalid JSON syntax will be rejected immediately at the parser level with a 400 status.


### PR DESCRIPTION
## Summary

This PR catches Express body parser errors (malformed JSON syntax and payload size limit exceeded) in the global error handler and returns the correct client-side HTTP status codes (`400 Bad Request` and `413 Payload Too Large`), preventing them from escalating to generic 500 server errors.

## Changes

- **Error Handler Middleware**: Updated `errorHandler` in `apps/api/src/middleware/errorHandler.js` to inspect error status, syntax instances, and entity size conditions.
- **Regression Tests**: Added `apps/api/src/tests/json_parser.test.js` checking that malformed requests return 400 and requests exceeding the 100kb default limit receive 413.
- **Documentation**: Documented JSON error mapping configuration in `docs/OPERATIONS.md`.

Closes #8863