### PR TITLE
Return client errors for invalid JSON bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,23 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
+  if (err?.type === "entity.too.large") {
+    return res.status(413).json({
+      success: false,
+      message: "Request body too large"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/jsonBodyErrors.test.js
+++ b/apps/api/src/tests/jsonBodyErrors.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("malformed JSON request bodies return a 400 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"email": "user@example.com"'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  });
+});
+
+test("oversized JSON request bodies return a 413 client error", async () => {
+  await withServer(async (baseUrl) => {
+    const largeBody = JSON.stringify({ value: "x".repeat(110 * 1024) });
+
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: largeBody
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Request body too large"
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #8877

Replacement for #8879/#8878 so this PR uses a fresh commit SHA and is not associated with the earlier failed `update-leaderboard` run from #8878.

## Summary
- Return `400` JSON responses for malformed JSON body parser errors.
- Return `413` JSON responses for oversized JSON body parser errors.
- Keep unexpected API errors on the existing `500` fallback path.
- Add focused API regression coverage for malformed and oversized request bodies.
- Make the API test script target `src/tests/*.test.js` explicitly so the workspace test command runs on this checkout.

## Root Cause
The shared API error handler treated body-parser client errors the same as unexpected server failures, so malformed JSON and payload-too-large errors fell through to the generic 500 response.

## Validation
- `npm test -w apps/api`
- `node --check apps/api/src/middleware/errorHandler.js`
- `node --check apps/api/src/tests/jsonBodyErrors.test.js`
- `git diff --check HEAD~1..HEAD`