### PR TITLE
fix: ignore caller-supplied ids on user creation

### DIFF
--- a/apps/api/src/middleware/userNoId.js
+++ b/apps/api/src/middleware/userNoId.js
@@ -1,0 +1,1 @@
+export const userNoId=(req,_,next)=>{delete req.body?.id;delete req.body?._id;delete req.body?.createdAt;return next();};


### PR DESCRIPTION
Closes #2534