### PR TITLE
fix: reject oversized credentials in auth password fields

### DIFF
--- a/apps/api/src/middleware/pwdOversize.js
+++ b/apps/api/src/middleware/pwdOversize.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";export const pwdOversize=(req,res,next)=>{const p=req.body?.password;if(typeof p==="string"&&p.length>128)return fail(res,"Password exceeds maximum allowed length",400);return next();};


### PR DESCRIPTION
Closes #2389