### PR TITLE
fix: prevent DoS on search endpoint via query length limit

### DIFF
--- a/apps/api/src/middleware/searchDoS.js
+++ b/apps/api/src/middleware/searchDoS.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";export const searchDoS=(req,res,next)=>{const q=String(req.query.q||" ").trim();if(!q)return fail(res,"q required",400);if(q.length>200)return fail(res,"q exceeds 200 character limit",400);req.query.q=q;return next();};


### PR DESCRIPTION
Closes #1881