### PR TITLE
fix: reject inverted budget ranges in POST /api/jobs

### DIFF
--- a/apps/api/src/middleware/budgetInvV24.js
+++ b/apps/api/src/middleware/budgetInvV24.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";export const budgetInvV24=(req,res,next)=>{const b=req.body?.budget;if(b&&typeof b.min==="number"&&typeof b.max==="number"&&b.min>=b.max)return fail(res,"budget.max must exceed budget.min",400);return next();};


### PR DESCRIPTION
Closes #1374