### PR TITLE
fix: ignore caller-owned read and timestamp fields in message

### DIFF
--- a/apps/api/src/middleware/msgReadonly.js
+++ b/apps/api/src/middleware/msgReadonly.js
@@ -1,0 +1,1 @@
+export const msgReadonly=(req,_,next)=>{delete req.body?.read;delete req.body?.readAt;delete req.body?.sentAt;delete req.body?.id;return next();};


### PR DESCRIPTION
Closes #1158

Single focused fix addressing the linked issue. Follows existing code patterns. Ready for review.