### PR TITLE
fix: reject unsupported provider names in OAuth callback

### DIFF
--- a/apps/api/src/middleware/oauthProviderCheck.js
+++ b/apps/api/src/middleware/oauthProviderCheck.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";const SUPPORTED=new Set(["google","github","facebook"]);export const oauthProviderCheck=(req,res,next)=>{const p=(req.params?.provider||req.query?.provider||"").toLowerCase();if(!SUPPORTED.has(p))return fail(res,`OAuth provider "${p}" not supported`,400);return next();};


### PR DESCRIPTION
Closes #1133

Single focused fix addressing the linked issue. Follows existing code patterns. Ready for review.