### PR TITLE
fix: strip caller-owned read and timestamp fields from message

### DIFF
--- a/apps/api/src/middleware/msgCallerFields.js
+++ b/apps/api/src/middleware/msgCallerFields.js
@@ -1,0 +1,1 @@
+export const msgCallerFields=(req,_,next)=>{["id","read","readAt","sentAt","createdAt"].forEach(f=>delete req.body?.[f]);return next();};


### PR DESCRIPTION
Closes #1157

Single focused fix addressing the linked issue. Follows existing code patterns. Ready for review.