### PR TITLE
fix: prevent users from reviewing themselves

### DIFF
--- a/apps/api/src/middleware/noSelfReviewV2.js
+++ b/apps/api/src/middleware/noSelfReviewV2.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";export const noSelfReviewV2=(req,res,next)=>{const uid=String(req.user?.id||req.user?.sub||"");const target=String(req.body?.targetId||"");if(uid&&target&&uid===target)return fail(res,"Cannot review yourself",400);return next();};


### PR DESCRIPTION
Closes #996

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.