### PR TITLE
fix: enforce server-owned unread state on message creation

### DIFF
--- a/apps/api/src/middleware/msgUnreadServer.js
+++ b/apps/api/src/middleware/msgUnreadServer.js
@@ -1,0 +1,1 @@
+export const msgUnreadServer=(req,_,next)=>{delete req.body?.id;delete req.body?.read;delete req.body?.readAt;delete req.body?.createdAt;req.body.read=false;return next();};


### PR DESCRIPTION
Closes #1007

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.