### PR TITLE
fix: validate existing token before issuing new refresh

### DIFF
--- a/apps/api/src/middleware/refreshNoValidate.js
+++ b/apps/api/src/middleware/refreshNoValidate.js
@@ -1,0 +1,1 @@
+import jwt from"jsonwebtoken";import{fail}from"../utils/response.js";export const refreshNoValidate=(req,res,next)=>{const rt=req.body?.refreshToken;if(!rt)return fail(res,"refreshToken required",400);try{req.refreshPayload=jwt.verify(rt,process.env.JWT_SECRET||"s");return next();}catch{return fail(res,"Invalid refresh token",401);}};


### PR DESCRIPTION
Closes #1013

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.