### PR TITLE
fix: reject empty payloads and client-controlled ids on user creation

### DIFF
--- a/apps/api/src/schemas/userNoEmpty.js
+++ b/apps/api/src/schemas/userNoEmpty.js
@@ -1,0 +1,1 @@
+import{z}from"zod";import{fail}from"../utils/response.js";const s=z.object({name:z.string().min(1).max(100).trim(),email:z.string().email(),password:z.string().min(8).max(128)});export const userNoEmpty=(req,res,next)=>{delete req.body?.id;const r=s.safeParse(req.body);if(!r.success)return fail(res,"Invalid user data",400);return next();};


### PR DESCRIPTION
Closes #979

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.