### PR TITLE
fix: deduplicate skill entries on job creation

### DIFF
--- a/apps/api/src/middleware/jobDedupeSkills.js
+++ b/apps/api/src/middleware/jobDedupeSkills.js
@@ -1,0 +1,1 @@
+export const jobDedupeSkills=(req,_,next)=>{if(Array.isArray(req.body?.skills)){req.body.skills=[...new Set(req.body.skills.map(s=>String(s).trim().toLowerCase()).filter(Boolean))];}return next();};


### PR DESCRIPTION
Closes #990

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.