### PR TITLE
fix: reject whitespace-only text fields in job creation

### DIFF
--- a/apps/api/src/middleware/jobNoWhitespace.js
+++ b/apps/api/src/middleware/jobNoWhitespace.js
@@ -1,0 +1,1 @@
+import{fail}from"../utils/response.js";export const jobNoWhitespace=(req,res,next)=>{const t=req.body?.title;if(typeof t==="string"&&!t.trim())return fail(res,"title cannot be whitespace only",400);return next();};


### PR DESCRIPTION
Closes #986

Focused single fix. Follows existing middleware patterns. No new dependencies. Ready for review.