### PR TITLE
fix(api): normalize payment currency

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
+  const currency = (payload.currency ?? "usd").trim().toLowerCase();
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const intent = await createPaymentIntent({ amount: 2500 });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent normalizes currency to lowercase", async () => {
+  const intent = await createPaymentIntent({ amount: 2500, currency: "USD" });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent trims whitespace before normalizing currency", async () => {
+  const intent = await createPaymentIntent({ amount: 2500, currency: "  GbP  " });
+
+  assert.equal(intent.currency, "gbp");
+});


### PR DESCRIPTION
## Summary
- normalize payment intent currency codes by trimming whitespace and converting to lowercase
- keep the existing default currency as `usd`
- add regression coverage for default, uppercase, and whitespace-padded currency inputs

Closes #4624

## Validation
- `node --test src/tests/paymentService.test.js src/tests/health.test.js`