### PR TITLE
fix(api): wrap health response in success envelope

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,6 +14,7 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { ok } from "./utils/response.js";
 
 export function createApp() {
   const app = express();
@@ -24,7 +25,7 @@ export function createApp() {
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
-    res.status(200).json({ ok: true, service: "api" });
+    return ok(res, { service: "api" });
   });
 
   app.use("/api/auth", authRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -16,7 +16,7 @@ test("GET /health returns ok payload", async () => {
   const payload = await response.json();
 
   assert.equal(response.status, 200);
-  assert.deepEqual(payload, { ok: true, service: "api" });
+  assert.deepEqual(payload, { success: true, data: { service: "api" } });
 
   await new Promise((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()));


### PR DESCRIPTION
## Summary
- return the `/health` payload through the shared `ok()` helper
- keep the status code at 200
- update the health regression test to assert the shared `{ success, data }` response envelope

Closes #4600

## Validation
- `node --test src/tests/health.test.js`