### PR TITLE
fix(api): redact passwords from user listings

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(({ password, ...user }) => user);
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers omits stored password values", async () => {
+  const email = `redacted-${Date.now()}@example.com`;
+
+  await createUser({
+    email,
+    name: "Redacted User",
+    password: "s3cret"
+  });
+
+  const users = await listUsers();
+  const listed = users.find((user) => user.email === email);
+
+  assert.ok(listed);
+  assert.equal(listed.name, "Redacted User");
+  assert.equal(Object.hasOwn(listed, "password"), false);
+});


### PR DESCRIPTION
## Summary
- omit `password` from records returned by `listUsers()`
- preserve all other user fields in list responses
- add a regression test for a stored user payload that includes a password

Closes #4616

## Validation
- `node --test src/tests/userService.test.js src/tests/health.test.js`