### PR TITLE
fix: return 400 for malformed JSON and Zod validation errors

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,29 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  // Handle malformed JSON (body-parser parse errors)
+  if (err.type === 'entity.parse.failed' || err.status === 400) {
+    console.warn("Malformed JSON request:", err.message);
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON in request body"
+    });
+  }
+
+  // Handle Zod validation errors
+  if (err.name === 'ZodError' && err.issues) {
+    console.warn("Validation error:", err.issues);
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
+  // Generic server error
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { catchAsync } from "../utils/catchAsync.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", catchAsync(register));
+authRoutes.post("/login", catchAsync(login));
+authRoutes.get("/oauth/:provider/callback", catchAsync(oauthCallback));
+authRoutes.post("/refresh", catchAsync(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { catchAsync } from "../utils/catchAsync.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", catchAsync(getJobs));
+jobRoutes.post("/", catchAsync(postJob));

--- a/apps/api/src/tests/errorHandling.test.js
+++ b/apps/api/src/tests/errorHandling.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/login with malformed JSON returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{bad json"
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.toLowerCase().includes("malformed") || payload.message.toLowerCase().includes("json"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/auth/register with invalid payload returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.toLowerCase().includes("validation") || payload.issues);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/jobs with missing required fields returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/catchAsync.js
+++ b/apps/api/src/utils/catchAsync.js
@@ -1,0 +1,9 @@
+/**
+ * Wraps an async route handler so that any thrown error
+ * (including ZodError) is forwarded to the Express error handler.
+ */
+export function catchAsync(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
/claim #9025
/claim #9026

## Summary
- Updated `errorHandler` to recognize body-parser parse errors (`entity.parse.failed`) and return HTTP 400 with `{ success: false, message }` shape
- Added ZodError recognition in errorHandler returning 400 with structured `issues` array
- Added `catchAsync` utility to forward async errors to Express error handler
- Wrapped auth and job route handlers with `catchAsync`
- Added regression tests for malformed JSON, invalid registration, and missing fields

## Test Results
```
# tests 4
# pass 4
# fail 0
```

## Validation
```
git diff --check: passed
npm test: all 4 tests pass
```

Ref: #743