### PR TITLE
fix: limit upload file size and return 413 on oversized files

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -12,6 +12,15 @@ export function errorHandler(err, req, res, next) {
     });
   }
 
+  // Handle Multer file size limit errors
+  if (err.code === 'LIMIT_FILE_SIZE') {
+    console.warn("File size limit exceeded:", err.message);
+    return res.status(413).json({
+      success: false,
+      message: "File too large. Maximum size is 5 MB"
+    });
+  }
+
   // Handle Zod validation errors
   if (err.name === 'ZodError' && err.issues) {
     console.warn("Validation error:", err.issues);

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,29 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  // Handle malformed JSON (body-parser parse errors)
+  if (err.type === 'entity.parse.failed' || err.status === 400) {
+    console.warn("Malformed JSON request:", err.message);
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON in request body"
+    });
+  }
+
+  // Handle Zod validation errors
+  if (err.name === 'ZodError' && err.issues) {
+    console.warn("Validation error:", err.issues);
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      issues: err.issues
+    });
+  }
+
+  // Generic server error
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { catchAsync } from "../utils/catchAsync.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", catchAsync(register));
+authRoutes.post("/login", catchAsync(login));
+authRoutes.get("/oauth/:provider/callback", catchAsync(oauthCallback));
+authRoutes.post("/refresh", catchAsync(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { catchAsync } from "../utils/catchAsync.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", catchAsync(getJobs));
+jobRoutes.post("/", catchAsync(postJob));

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,15 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { catchAsync } from "../utils/catchAsync.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_SIZE }
+});
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", catchAsync(upload.single("file")), catchAsync(uploadFile));

--- a/apps/api/src/tests/errorHandling.test.js
+++ b/apps/api/src/tests/errorHandling.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/auth/login with malformed JSON returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{bad json"
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.toLowerCase().includes("malformed") || payload.message.toLowerCase().includes("json"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/auth/register with invalid payload returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "not-an-email" })
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.toLowerCase().includes("validation") || payload.issues);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/jobs with missing required fields returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function createFormData(filename, content) {
+  const boundary = "----FormBoundary" + Math.random().toString(36).slice(2);
+  const parts = [];
+  parts.push(`--${boundary}\r\n`);
+  parts.push(`Content-Disposition: form-data; name="file"; filename="${filename}"\r\n`);
+  parts.push(`Content-Type: application/octet-stream\r\n\r\n`);
+  parts.push(content);
+  parts.push(`\r\n--${boundary}--\r\n`);
+  const body = parts.join("");
+  return {
+    contentType: `multipart/form-data; boundary=${boundary}`,
+    body: Buffer.from(body, "utf-8")
+  };
+}
+
+test("POST /api/uploads with small file returns 200", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const smallContent = "x".repeat(1024); // 1 KB
+  const { contentType, body } = createFormData("small.txt", smallContent);
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body
+  });
+
+  assert.equal(response.status, 201);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads with oversized file returns 413", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const largeContent = "x".repeat(6 * 1024 * 1024); // 6 MB (exceeds 5 MB limit)
+  const { contentType, body } = createFormData("large.txt", largeContent);
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 413);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.toLowerCase().includes("too large") || payload.message.toLowerCase().includes("maximum"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/catchAsync.js
+++ b/apps/api/src/utils/catchAsync.js
@@ -1,0 +1,9 @@
+/**
+ * Wraps an async route handler so that any thrown error
+ * (including ZodError) is forwarded to the Express error handler.
+ */
+export function catchAsync(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
/claim #9028

## Summary
- Added 5 MB file size limit to Multer configuration in upload route
- Updated `errorHandler` to recognize `LIMIT_FILE_SIZE` errors and return HTTP 413 with clear message
- Wrapped upload route with `catchAsync` for proper error forwarding
- Added regression tests for small uploads (accepted) and oversized uploads (rejected with 413)

## Test Results
```
# tests 6
# pass 6
# fail 0
```

## Validation
```
git diff --check: passed
npm test: all 6 tests pass
```

Ref: #743