### PR TITLE
fix: require JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -5,3 +5,8 @@ export const env = {
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };
+
+// Fail fast in production if JWT_SECRET is not set
+if (env.nodeEnv === "production" && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is required in production");
+}


### PR DESCRIPTION
## Summary

Production startup now fails fast when `JWT_SECRET` is missing. The development fallback (`development-secret`) is only available outside production.

## Changes

- `apps/api/src/config/env.js`: Added a runtime check that throws when `NODE_ENV=production` and `JWT_SECRET` is not set.

## Acceptance Criteria

- [x] Production startup fails fast when JWT_SECRET is missing
- [x] Development fallback still works outside production

Closes #9048