### PR TITLE
fix: reject upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({ success: false, message: "No file uploaded" });
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Summary

`POST /api/uploads` now returns 400 when no file is attached, instead of returning 201 with `status: no-file`.

## Changes

- `apps/api/src/controllers/uploadController.js`: Return 400 with `{ success: false, message: "No file uploaded" }` when `req.file` is missing. Keep 201 for valid uploads.

## Acceptance Criteria

- [x] Return a 400 response when req.file is missing
- [x] Keep the existing 201 success response for valid uploads

Closes #9049