### PR TITLE
fix: validate and trim search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 500;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const raw = req.query.q;
+  const q = typeof raw === "string" ? raw.trim() : "";
+  if (q.length > MAX_QUERY_LENGTH) {
+    return res.status(400).json({ success: false, message: "Query too long" });
+  }
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Summary

`GET /api/search` now coerces `q` to a string, trims whitespace, and rejects queries longer than 500 characters with 400.

## Changes

- `apps/api/src/controllers/searchController.js`: Coerce `req.query.q` to string, trim, enforce max length of 500.

## Acceptance Criteria

- [x] coerce to a string
- [x] trim surrounding whitespace
- [x] reject overly long input with 400
- [x] keep empty or omitted queries safe

Closes #9050