### PR TITLE
fix: validate PORT env before starting server

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,14 @@
+function parsePort(raw, defaultPort = 4000) {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
+    return defaultPort;
+  }
+  return parsed;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Summary

Invalid `PORT` values (e.g. `PORT=abc`) no longer crash the API. A `parsePort` helper validates the value is an integer in the legal range and falls back to the default port otherwise.

## Changes

- `apps/api/src/config/env.js`: Added `parsePort()` helper that returns the default port for invalid values.

## Acceptance Criteria

- [x] Invalid PORT values fall back to default
- [x] Valid explicit ports (0, 8080) are preserved

Closes #9051