### PR TITLE
fix: return 400 for malformed JSON requests

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,17 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  // Handle malformed JSON parse errors from body-parser
+  if (err?.type === "entity.parse.failed" || err?.type === "entity.too.large") {
+    return res.status(400).json({
+      success: false,
+      message: err?.type === "entity.too.large" ? "Request body too large" : "Malformed JSON in request body"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"


### PR DESCRIPTION
## Summary

The error handler now recognizes body-parser parse errors (`entity.parse.failed`) and returns HTTP 400 instead of the generic 500.

## Changes

- `apps/api/src/middleware/errorHandler.js`: Added check for `entity.parse.failed` and `entity.too.large` error types, returning 400 with `{ success: false, message }`.

## Acceptance Criteria

- [x] malformed JSON returns HTTP 400, not 500
- [x] response uses `{ success: false, message }` shape
- [x] non-JSON server errors still go through the generic 500 path

Closes #9052