### PR TITLE
fix: reject blank production env secrets

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+function requireProductionValue(name) {
+  const value = process.env[name] ?? "";
+
+  if (nodeEnv === "production" && value.trim() === "") {
+    throw new Error(`${name} must be set in production`);
+  }
+
+  return value;
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  stripeSecretKey: requireProductionValue("STRIPE_SECRET_KEY"),
+  databaseUrl: requireProductionValue("DATABASE_URL")
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const envModuleUrl = new URL("../config/env.js", import.meta.url);
+const trackedEnvKeys = ["NODE_ENV", "STRIPE_SECRET_KEY", "DATABASE_URL"];
+
+async function loadEnv(overrides) {
+  const previousValues = Object.fromEntries(
+    trackedEnvKeys.map((key) => [key, process.env[key]])
+  );
+
+  for (const key of trackedEnvKeys) {
+    if (Object.hasOwn(overrides, key)) {
+      const value = overrides[key];
+
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  try {
+    return await import(`${envModuleUrl.href}?case=${Date.now()}-${Math.random()}`);
+  } finally {
+    for (const key of trackedEnvKeys) {
+      if (previousValues[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousValues[key];
+      }
+    }
+  }
+}
+
+test("development keeps blank database and Stripe config compatible", async () => {
+  const { env } = await loadEnv({
+    NODE_ENV: "development",
+    STRIPE_SECRET_KEY: "",
+    DATABASE_URL: "   "
+  });
+
+  assert.equal(env.nodeEnv, "development");
+  assert.equal(env.stripeSecretKey, "");
+  assert.equal(env.databaseUrl, "   ");
+});
+
+test("test imports keep missing database and Stripe config compatible", async () => {
+  const { env } = await loadEnv({
+    NODE_ENV: "test",
+    STRIPE_SECRET_KEY: undefined,
+    DATABASE_URL: undefined
+  });
+
+  assert.equal(env.nodeEnv, "test");
+  assert.equal(env.stripeSecretKey, "");
+  assert.equal(env.databaseUrl, "");
+});
+
+test("production rejects a missing database URL", async () => {
+  await assert.rejects(
+    loadEnv({
+      NODE_ENV: "production",
+      STRIPE_SECRET_KEY: "sk_live_123",
+      DATABASE_URL: undefined
+    }),
+    /DATABASE_URL must be set in production/
+  );
+});
+
+test("production rejects a blank database URL", async () => {
+  await assert.rejects(
+    loadEnv({
+      NODE_ENV: "production",
+      STRIPE_SECRET_KEY: "sk_live_123",
+      DATABASE_URL: "   "
+    }),
+    /DATABASE_URL must be set in production/
+  );
+});
+
+test("production rejects a missing Stripe secret", async () => {
+  await assert.rejects(
+    loadEnv({
+      NODE_ENV: "production",
+      STRIPE_SECRET_KEY: undefined,
+      DATABASE_URL: "postgres://db"
+    }),
+    /STRIPE_SECRET_KEY must be set in production/
+  );
+});
+
+test("production rejects a blank Stripe secret", async () => {
+  await assert.rejects(
+    loadEnv({
+      NODE_ENV: "production",
+      STRIPE_SECRET_KEY: "   ",
+      DATABASE_URL: "postgres://db"
+    }),
+    /STRIPE_SECRET_KEY must be set in production/
+  );
+});
+
+test("production accepts non-blank database and Stripe config", async () => {
+  const { env } = await loadEnv({
+    NODE_ENV: "production",
+    STRIPE_SECRET_KEY: "sk_live_123",
+    DATABASE_URL: "postgres://db"
+  });
+
+  assert.equal(env.nodeEnv, "production");
+  assert.equal(env.stripeSecretKey, "sk_live_123");
+  assert.equal(env.databaseUrl, "postgres://db");
+});


### PR DESCRIPTION
/claim #743

Fixes #9075
Related prior scope: #7212

## Summary
- Add production startup validation for `DATABASE_URL` and `STRIPE_SECRET_KEY` in `apps/api/src/config/env.js`.
- Reject missing or whitespace-only values only when `NODE_ENV=production`.
- Preserve development/test compatibility with the lightweight local setup.
- Add focused config import tests for missing and blank values for both critical production variables.

## Demo / validation
- `node --test src/tests/health.test.js src/tests/env.test.js` - passed.
- `npm exec -w apps/api -- node --test src/tests/env.test.js` - passed.
- `git diff --check` - passed.

Note: `npm test --workspace apps/api` currently fails in this Windows checkout because the existing script invokes `node --test src/tests`, which this Node runtime treats as a module path rather than expanding test files. The focused test command above validates this patch directly.