### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

- Removes `admin` from the allowed role enum in `registerSchema`, preventing users from self-assigning admin privileges during registration.

## Problem

The `POST /api/auth/register` endpoint accepted `role: "admin"` as a valid value, allowing any user to register with elevated admin privileges. This is a privilege escalation vulnerability.

## Fix

Changed `z.enum(["client", "freelancer", "admin"])` to `z.enum(["client", "freelancer"])` in `apps/api/src/validators/auth.js`.

Closes #1426