### PR TITLE
fix: enforce admin role check on admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary

- Adds an `adminMiddleware` that verifies the authenticated user has the `admin` role, returning 403 Forbidden otherwise.
- Applies it to `/api/admin` routes alongside `authMiddleware`.

## Problem

The `/api/admin` routes only applied `authMiddleware`, which verifies the JWT is valid but does not check if the user has an admin role. Any authenticated user (client, freelancer) could access admin-only endpoints like `/api/admin/metrics`, causing a privilege escalation vulnerability.

## Fix

1. Added `adminMiddleware` in `apps/api/src/middleware/auth.js` that checks `req.user.role === "admin"`.
2. Applied `adminMiddleware` after `authMiddleware` in `apps/api/src/routes/adminRoutes.js`.

Closes #1770