### PR TITLE
fix: require authentication on payment endpoint

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
## Summary

- Adds `authMiddleware` to `/api/payments` routes to ensure only authenticated users can create payment intents.

## Problem

The `/api/payments` route did not require authentication. Anyone could create payment intents without being logged in, exposing a financial endpoint without access control.

## Fix

Added `paymentRoutes.use(authMiddleware)` in `apps/api/src/routes/paymentRoutes.js`.

Closes #1772