### PR TITLE
fix: require authentication on upload endpoint and reject missing files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 10 * 1024 * 1024 } });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);


### PR DESCRIPTION
## Summary

- Adds `authMiddleware` to `/api/uploads` routes to require authentication for file uploads.
- Adds 10MB file size limit via multer configuration.
- Returns 400 Bad Request when no file is provided in the upload request.

## Problem

The `/api/uploads` route did not apply `authMiddleware`, meaning anyone could upload files without being authenticated. Additionally, the endpoint accepted requests without a file and returned a success response with `status: "no-file"`.

## Fix

1. Added `uploadRoutes.use(authMiddleware)` in `apps/api/src/routes/uploadRoutes.js`.
2. Added `limits: { fileSize: 10 * 1024 * 1024 }` to multer configuration.
3. Updated `uploadFile` controller to return 400 when `req.file` is missing.

Closes #1771