### PR TITLE
fix: add input validation to user creation endpoint

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createUserSchema } from "../validators/user.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,6 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  fullName: z.string().min(1).max(100),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
## Summary

- Adds a Zod validation schema for the `POST /api/users` endpoint that validates email, password, fullName, and role fields.
- Prevents arbitrary or malicious data from being persisted as user records.

## Problem

The `POST /api/users` endpoint passed `req.body` directly to the service layer without any validation. This allowed arbitrary data to be stored as user records, similar to how auth and job routes use proper Zod validation.

## Fix

1. Created `apps/api/src/validators/user.js` with a `createUserSchema` requiring valid email, 8+ character password, non-empty fullName, and role restricted to `["client", "freelancer"]`.
2. Applied `createUserSchema.parse(req.body)` in `apps/api/src/controllers/userController.js` before passing data to the service.

Closes #1773