### PR TITLE
fix: validate and limit search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  if (q.length === 0) {
+    return fail(res, "Query parameter 'q' is required", 400);
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Query must be ${MAX_QUERY_LENGTH} characters or fewer`, 400);
+  }
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Summary

- Requires a non-empty `q` query parameter for the search endpoint.
- Enforces a 200 character limit on the search query to prevent DoS attacks.

## Problem

The search endpoint accepted any query string including empty strings and extremely long queries. This allowed potential DoS attacks via oversized queries and returned empty results for missing queries without proper error handling.

## Fix

1. Added type check and trim for the `q` parameter.
2. Returns 400 if `q` is empty or missing.
3. Returns 400 if `q` exceeds 200 characters.

Closes #1777