### PR TITLE
fix: require refresh token validation before issuing new tokens

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,7 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { verifyAccessToken } from "../utils/jwt.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +23,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { refreshToken: token } = req.body;
+  if (!token) {
+    return fail(res, "Refresh token is required", 400);
+  }
+  try {
+    verifyAccessToken(token);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
+export async function refreshToken(token) {
   return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
 }


### PR DESCRIPTION
## Summary

- Requires a valid refresh token in the request body for the `POST /api/auth/refresh` endpoint.
- Returns 400 Bad Request if no refresh token is provided.
- Returns 401 Unauthorized if the token is invalid.

## Problem

The refresh token endpoint issued new access tokens without validating the provided refresh token. Anyone could call the refresh endpoint without a valid token and receive a new access token, bypassing authentication.

## Fix

1. Updated `refresh()` in `apps/api/src/controllers/authController.js` to extract `refreshToken` from `req.body` and validate it before proceeding.
2. Returns 400 if token is missing, 401 if token is invalid.
3. Updated `refreshToken()` service function signature to accept the validated token.

Closes #1750