### PR TITLE
fix: prevent client-controlled field injection via object spread

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary

- Reorders object spread in `messageService.js`, `jobService.js`, and `userService.js` so server-controlled fields (`id`, `status`, `sentAt`) come after the payload spread.
- Prevents clients from overriding server-generated fields.

## Problem

`sendMessage()`, `createJob()`, and `createUser()` used object spread like `{ id: ..., ...payload }`, allowing clients to override server-generated fields. For example, a client could send `{"id":"msg_INJECTED"}` or `{"status":"closed"}` and the server would accept those values.

## Fix

Changed the pattern to `{ ...payload, id: ..., status: ... }` so that server-controlled fields always take precedence over client input.

Closes #9034