### PR TITLE
fix: prevent invalid PORT env from crashing API startup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,14 @@
+function parsePort(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 65535) {
+    return 4000;
+  }
+  return parsed;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Summary

- Adds a `parsePort` helper that validates the `PORT` environment variable and falls back to the default port 4000 for invalid values.
- Prevents `ERR_SOCKET_BAD_PORT` crashes on startup when `PORT` is set to a non-numeric value.

## Problem

The API config parsed PORT with `Number(process.env.PORT ?? 4000)`. If PORT is present but invalid (e.g., `PORT=abc`), the parsed port becomes `NaN` and the API crashes during startup with `ERR_SOCKET_BAD_PORT`.

## Fix

Added a `parsePort` helper that checks `Number.isFinite()` and range (0-65535), returning the default port 4000 for invalid values.

Closes #9051