### PR TITLE
fix: resolve freelancer profile by username from mock data

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,30 @@
+import { freelancers } from "@/lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((f) => f.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer Not Found</h2>
+        <p>No freelancer found with username <strong>{params.username}</strong>.</p>
+        <a href="/freelancers/search">Browse freelancers</a>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <h2>{freelancer.username}</h2>
+      <p>Hourly Rate: <strong>{freelancer.rate}</strong></p>
+      <div>
+        <h3>Skills</h3>
+        <ul>
+          {freelancer.skills.map((skill) => (
+            <li key={skill}>{skill}</li>
+          ))}
+        </ul>
+      </div>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

- Imports freelancers from `apps/web/lib/mock.ts` and looks up the profile by username.
- Displays matching freelancer details including skills and hourly rate.
- Renders a clear not-found fallback for unknown usernames.

## Problem

The `/freelancers/[username]` route only rendered placeholder text with the requested username. It did not look up the freelancer from mock data, so known profiles like `maya-dev` and `jordan-ux` showed generic text instead of their actual skills and rates.

## Fix

Updated `apps/web/app/freelancers/[username]/page.tsx` to:
1. Import `freelancers` from `@/lib/mock`.
2. Find the matching freelancer by username.
3. Display skills and rate for known profiles.
4. Show a "Not Found" card with a link to browse freelancers for unknown usernames.

Closes #2849