### PR TITLE
fix: resolve job detail by id from mock data

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,22 @@
+import { jobs } from "@/lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((j) => j.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Not Found</h2>
+        <p>No job found with id <strong>{params.id}</strong>.</p>
+        <a href="/jobs">Browse jobs</a>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <h2>{job.title}</h2>
+      <p>Budget: <strong>{job.budget}</strong></p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

- Imports jobs from `apps/web/lib/mock.ts` and looks up the job by id.
- Displays matching job title and budget.
- Renders a clear not-found fallback for unknown job ids.

## Problem

The `/jobs/[id]` route only rendered placeholder text with the requested id. It did not look up the job from mock data, so known jobs like `job-101` showed generic text instead of their actual title and budget.

## Fix

Updated `apps/web/app/jobs/[id]/page.tsx` to:
1. Import `jobs` from `@/lib/mock`.
2. Find the matching job by id.
3. Display title and budget for known jobs.
4. Show a "Not Found" card with a link to browse jobs for unknown ids.

Closes #2760