### PR TITLE
fix: add stricter rate limit for auth endpoints

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,11 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { success: false, message: "Too many authentication attempts, please try again later" }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
+authRoutes.use(authLimiter);
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);


### PR DESCRIPTION
## Summary

- Adds `authLimiter` with 20 requests per 15-minute window for `/api/auth` routes.
- Prevents brute-force attacks on login, registration, and refresh endpoints.

## Problem

Authentication endpoints shared the global API limiter (200 requests per 15 minutes), which was too permissive for credential and token endpoints. This allowed potential brute-force attacks.

## Fix

1. Added `authLimiter` in `apps/api/src/middleware/rateLimit.js` with a 20-request limit per 15-minute window.
2. Applied it to `/api/auth` routes in `apps/api/src/routes/authRoutes.js`.

Closes #9069