### PR TITLE
Production env config rejects blank infrastructure secrets

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,20 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const isProduction = nodeEnv === "production";
+
+function readRequiredProductionEnv(name) {
+  const value = process.env[name] ?? "";
+
+  if (isProduction && value.trim() === "") {
+    throw new Error(`${name} must be set in production`);
+  }
+
+  return value;
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  stripeSecretKey: readRequiredProductionEnv("STRIPE_SECRET_KEY"),
+  databaseUrl: readRequiredProductionEnv("DATABASE_URL")
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const ORIGINAL_ENV = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY
+};
+
+let importCounter = 0;
+
+function setEnv({ databaseUrl, nodeEnv, stripeSecretKey }) {
+  if (nodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = nodeEnv;
+  }
+
+  if (databaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = databaseUrl;
+  }
+
+  if (stripeSecretKey === undefined) {
+    delete process.env.STRIPE_SECRET_KEY;
+  } else {
+    process.env.STRIPE_SECRET_KEY = stripeSecretKey;
+  }
+}
+
+function restoreEnv() {
+  setEnv({
+    databaseUrl: ORIGINAL_ENV.DATABASE_URL,
+    nodeEnv: ORIGINAL_ENV.NODE_ENV,
+    stripeSecretKey: ORIGINAL_ENV.STRIPE_SECRET_KEY
+  });
+}
+
+async function importFreshEnv() {
+  importCounter += 1;
+  return import(`../config/env.js?case=${importCounter}`);
+}
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test("development imports allow missing database and Stripe config", async () => {
+  setEnv({ databaseUrl: undefined, nodeEnv: "development", stripeSecretKey: undefined });
+
+  const { env } = await importFreshEnv();
+
+  assert.equal(env.databaseUrl, "");
+  assert.equal(env.stripeSecretKey, "");
+});
+
+test("test imports allow missing database and Stripe config", async () => {
+  setEnv({ databaseUrl: undefined, nodeEnv: "test", stripeSecretKey: undefined });
+
+  const { env } = await importFreshEnv();
+
+  assert.equal(env.databaseUrl, "");
+  assert.equal(env.stripeSecretKey, "");
+});
+
+test("production rejects missing database config", async () => {
+  setEnv({ databaseUrl: undefined, nodeEnv: "production", stripeSecretKey: "sk_live_test" });
+
+  await assert.rejects(importFreshEnv(), /DATABASE_URL must be set in production/);
+});
+
+test("production rejects blank database config", async () => {
+  setEnv({ databaseUrl: "   ", nodeEnv: "production", stripeSecretKey: "sk_live_test" });
+
+  await assert.rejects(importFreshEnv(), /DATABASE_URL must be set in production/);
+});
+
+test("production rejects missing Stripe config", async () => {
+  setEnv({ databaseUrl: "postgres://localhost/app", nodeEnv: "production", stripeSecretKey: undefined });
+
+  await assert.rejects(importFreshEnv(), /STRIPE_SECRET_KEY must be set in production/);
+});
+
+test("production rejects blank Stripe config", async () => {
+  setEnv({ databaseUrl: "postgres://localhost/app", nodeEnv: "production", stripeSecretKey: "\t" });
+
+  await assert.rejects(importFreshEnv(), /STRIPE_SECRET_KEY must be set in production/);
+});
+
+test("production accepts nonblank database and Stripe config", async () => {
+  setEnv({
+    databaseUrl: "postgres://localhost/app",
+    nodeEnv: "production",
+    stripeSecretKey: "sk_live_test"
+  });
+
+  const { env } = await importFreshEnv();
+
+  assert.equal(env.databaseUrl, "postgres://localhost/app");
+  assert.equal(env.stripeSecretKey, "sk_live_test");
+});


### PR DESCRIPTION
## Summary
- Fail fast in production when `DATABASE_URL` or `STRIPE_SECRET_KEY` is missing or blank.
- Preserve development/test compatibility by keeping empty-string fallbacks outside production.
- Add focused config tests for missing, blank, and valid production values.

Closes #9090

## Validation
- `node --test apps/api/src/tests/env.test.js --test-reporter=spec`
- `node --test "src/tests/*.test.js" --test-reporter=spec` from `apps/api`
- `node --check apps/api/src/config/env.js`
- `node --check apps/api/src/tests/env.test.js`
- `git diff --check`

Note: `npm test -w apps/api -- --test-reporter=spec` still fails on this Windows checkout because the existing package script passes the directory `src/tests` directly to Node, which Node resolves as a missing file on Windows. The equivalent explicit glob command above passes all 8 API tests.