### PR TITLE
fix: require admin role on /api/admin/metrics endpoint (#9071)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,15 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user) {
+      return fail(res, "Unauthorized", 401);
+    }
+    if (!roles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary

Closes #9071

Adds a `requireRole('admin')` middleware guard to all `/api/admin` routes so that only users with `role: 'admin'` in their JWT can access admin endpoints.

## Vulnerability

`adminRoutes` previously only applied `authMiddleware`, which validates that a JWT is present and signed correctly — but does **not** check the user's role. Any authenticated user (freelancer, client) could call `GET /api/admin/metrics` and receive sensitive platform-wide data.

## Fix

Added a reusable `requireRole(...roles)` middleware factory to `auth.js`:

```js
adminRoutes.use(authMiddleware);
adminRoutes.use(requireRole('admin')); // new — 403 for non-admin users
adminRoutes.get('/metrics', metrics);
```

Non-admin authenticated users now receive `403 Forbidden`.