### PR TITLE
fix: add stricter 20-req/15min rate limiter for auth routes (#9069)

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,16 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+/**
+ * Stricter rate limiter for authentication endpoints.
+ * Allows 20 requests per 15-minute window to limit brute-force
+ * and credential-stuffing attacks on register/login/refresh.
+ */
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
+
+authRoutes.use(authLimiter);
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);


### PR DESCRIPTION
## Summary

Closes #9069

Adds a dedicated `authLimiter` (20 req / 15 min) applied to all `/api/auth` routes, replacing the permissive global limiter (200 req / 15 min) for credential endpoints.

## Vulnerability

Auth endpoints shared the global `apiLimiter` which allows 200 requests per 15-minute window — far too permissive for credential operations. An attacker could attempt ~800 login attempts per hour against a single IP before being throttled, enabling practical brute-force and credential-stuffing attacks.

## Fix

```js
// rateLimit.js — new auth-specific limiter
export const authLimiter = rateLimit({
  windowMs: 15 * 60 * 1000,
  limit: 20,          // was 200
  standardHeaders: 'draft-7',
  legacyHeaders: false,
  message: { error: 'Too many requests, please try again later.' }
});
```

Applied via `authRoutes.use(authLimiter)` so `POST /register`, `POST /login`, and `POST /refresh` all share the tighter limit.