### PR TITLE
fix(api): preserve server-owned message fields

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,11 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}`,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages preserves server-owned id and sentAt", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client_supplied_id",
+        sentAt: "2000-01-01T00:00:00.000Z",
+        threadId: "thread_123",
+        recipientId: "usr_recipient",
+        body: "Hello from the regression test"
+      })
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^msg_\d+$/);
+    assert.notEqual(payload.data.id, "client_supplied_id");
+    assert.notEqual(payload.data.sentAt, "2000-01-01T00:00:00.000Z");
+    assert.equal(payload.data.threadId, "thread_123");
+    assert.equal(payload.data.recipientId, "usr_recipient");
+    assert.equal(payload.data.body, "Hello from the regression test");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #9123 by making message creation preserve server-owned id and sentAt fields after applying caller payload fields.
- Adds focused API regression coverage proving caller-provided id and sentAt cannot override generated values while ordinary message fields are preserved.

/claim #743

## Validation

- node --test src/tests/health.test.js src/tests/message.test.js from apps/api passed.
- git diff --check passed.

## Notes

The root npm test / package script still targets node --test src/tests, which fails on this checkout because Node treats the directory path as a module entry. That pre-existing script issue is already covered by other scoped submissions, so this PR keeps scope limited to message field ownership.