### PR TITLE
fix(api): preserve server-owned proposal id

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal preserves the server-owned id", async () => {
+  const proposal = await createProposal({
+    id: "client_supplied_id",
+    jobId: "job_123",
+    freelancerId: "usr_freelancer",
+    coverLetter: "I can complete this safely.",
+    amount: 750
+  });
+
+  assert.match(proposal.id, /^prp_\d+$/);
+  assert.notEqual(proposal.id, "client_supplied_id");
+  assert.equal(proposal.jobId, "job_123");
+  assert.equal(proposal.freelancerId, "usr_freelancer");
+  assert.equal(proposal.coverLetter, "I can complete this safely.");
+  assert.equal(proposal.amount, 750);
+});


### PR DESCRIPTION
## Summary

- Fixes #9125 by making proposal creation keep the server-generated proposal id after applying caller payload fields.
- Adds focused service regression coverage proving a caller-provided id cannot override the generated value while normal proposal fields are preserved.

/claim #743

## Validation

- node --test src/tests/proposalService.test.js from apps/api passed.
- git diff --check passed.

## Notes

This PR intentionally stays at the proposal service layer so it remains compatible with parallel route-auth submissions under the same parent bounty.