### PR TITLE
fix(api): target api test files explicitly

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Changes test script from `node --test src/tests` to `node --test "src/tests/*.test.js"` so Node test runner discovers test files instead of treating the directory as a module entry point.

Closes #9128.