### PR TITLE
fix(api): preserve server-owned review id

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${Date.now()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview preserves the server-owned id", async () => {
+  const review = await createReview({
+    id: "client_supplied_id",
+    jobId: "job_123",
+    reviewerId: "usr_reviewer",
+    rating: 5,
+    comment: "Great delivery and communication."
+  });
+
+  assert.match(review.id, /^rev_\d+$/);
+  assert.notEqual(review.id, "client_supplied_id");
+  assert.equal(review.jobId, "job_123");
+  assert.equal(review.reviewerId, "usr_reviewer");
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, "Great delivery and communication.");
+});


### PR DESCRIPTION
## Summary

- Fixes #9133 by making review creation keep the server-generated review id after applying caller payload fields.
- Adds focused service regression coverage proving a caller-provided id cannot override the generated value while normal review fields are preserved.

/claim #743

## Validation

- node --test src/tests/reviewService.test.js from apps/api passed.
- git diff --check passed.

## Notes

This PR stays at the review service layer so it can be reviewed independently of parallel route-auth submissions under the same parent bounty.