### PR TITLE
fix(api): preserve server-owned user id

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser } from "../services/userService.js";
+
+test("createUser preserves the server-owned id", async () => {
+  const user = await createUser({
+    id: "client_supplied_id",
+    email: "new.user@example.com",
+    name: "New User",
+    role: "freelancer"
+  });
+
+  assert.match(user.id, /^usr_\d+$/);
+  assert.notEqual(user.id, "client_supplied_id");
+  assert.equal(user.email, "new.user@example.com");
+  assert.equal(user.name, "New User");
+  assert.equal(user.role, "freelancer");
+});


### PR DESCRIPTION
## Summary

- Fixes #9135 by making user creation keep the server-generated user id after applying caller payload fields.
- Adds focused service regression coverage proving a caller-provided id cannot override the generated value while normal user fields are preserved.

/claim #743

## Validation

- node --test src/tests/userService.test.js from apps/api passed.
- git diff --check passed.

## Notes

This PR stays at the user service layer so it can be reviewed independently of parallel route-auth submissions under the same parent bounty.