### PR TITLE
fix(api): validate job budget ranges

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build checkout flow",
+  description: "Create a polished checkout flow for clients.",
+  budgetMin: 500,
+  budgetMax: 750,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 900,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, false);
+  assert.equal(result.error.issues[0].message, "budgetMin must be less than or equal to budgetMax");
+  assert.deepEqual(result.error.issues[0].path, ["budgetMax"]);
+});
+
+test("createJobSchema allows equal budget endpoints", () => {
+  const result = createJobSchema.safeParse({
+    ...validJob,
+    budgetMin: 500,
+    budgetMax: 500
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("updateJobSchema rejects inverted ranges only when both endpoints are present", () => {
+  const inverted = updateJobSchema.safeParse({
+    budgetMin: 900,
+    budgetMax: 500
+  });
+  const partial = updateJobSchema.safeParse({
+    budgetMin: 900
+  });
+
+  assert.equal(inverted.success, false);
+  assert.equal(partial.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBudgetRange = (payload) =>
+  payload.budgetMin === undefined ||
+  payload.budgetMax === undefined ||
+  payload.budgetMin <= payload.budgetMax;
+
+const budgetRangeMessage = {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
+};
+
+const jobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +19,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobSchema.refine(jobBudgetRange, budgetRangeMessage);
+
+export const updateJobSchema = jobSchema.partial().refine(jobBudgetRange, budgetRangeMessage);


### PR DESCRIPTION
## Summary

- Fixes #9137 by rejecting job payloads where budgetMin is greater than budgetMax.
- Keeps equal budget endpoints valid and allows partial updates when only one budget endpoint is present.
- Adds focused validator regression coverage for createJobSchema and updateJobSchema.

/claim #743

## Validation

- node --test src/tests/jobValidator.test.js from apps/api passed.
- git diff --check passed.

## Notes

This PR stays focused on the job validator so it can be reviewed independently of route-auth and service-field ownership submissions under the same parent bounty.