### PR TITLE
fix(api): preserve server-owned job fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob preserves server-owned id and status", async () => {
+  const job = await createJob({
+    id: "client_supplied_id",
+    status: "closed",
+    title: "Build a landing page",
+    description: "Create a polished landing page for a launch.",
+    budgetMin: 500,
+    budgetMax: 750,
+    categoryId: "web",
+    skills: ["react", "copywriting"]
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "client_supplied_id");
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build a landing page");
+  assert.equal(job.description, "Create a polished landing page for a launch.");
+  assert.equal(job.budgetMin, 500);
+  assert.equal(job.budgetMax, 750);
+  assert.equal(job.categoryId, "web");
+  assert.deepEqual(job.skills, ["react", "copywriting"]);
+});


### PR DESCRIPTION
## Summary

- Fixes #9139 by making job creation keep the server-generated job id and initial open status after applying caller payload fields.
- Adds focused service regression coverage proving caller-provided id and status cannot override server-owned values while normal job fields are preserved.

/claim #743

## Validation

- node --test src/tests/jobService.test.js from apps/api passed.
- git diff --check passed.

## Notes

This PR stays focused on the job service so it can be reviewed independently of validator and route-auth submissions under the same parent bounty.