### PR TITLE
fix(api): reject missing upload files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async baseUrl => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: new FormData(),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required",
+    });
+  });
+});
+
+test("POST /api/uploads accepts a valid file upload", async () => {
+  await withServer(async baseUrl => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #9141 by returning HTTP 400 when `POST /api/uploads` receives no file.
- Keeps successful uploads returning HTTP 201 with the uploaded filename.
- Adds focused API coverage for missing-file rejection and valid upload success.

/claim #743

## Validation

- `PATH=/Users/swn/dependencies/node/bin:$PATH node --test src/tests/upload.test.js` from `apps/api`: 2 passing.
- `PATH=/Users/swn/dependencies/node/bin:$PATH node --test src/tests/*.test.js` from `apps/api`: 3 passing.
- `git diff --check`: passed.

## Notes

The change is intentionally limited to upload request handling and upload route tests.