### PR TITLE
fix(api): require auth for message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/message-auth.test.js
+++ b/apps/api/src/tests/message-auth.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages rejects anonymous clients", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/messages rejects anonymous clients", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("authenticated clients can create and list messages", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    };
+
+    const createResponse = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ body: "authenticated message" })
+    });
+    const createPayload = await createResponse.json();
+
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.success, true);
+    assert.equal(createPayload.data.body, "authenticated message");
+    assert.match(createPayload.data.id, /^msg_/);
+    assert.ok(createPayload.data.sentAt);
+
+    const listResponse = await fetch(`${baseUrl}/api/messages`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const listPayload = await listResponse.json();
+
+    assert.equal(listResponse.status, 200);
+    assert.equal(listPayload.success, true);
+    assert.ok(
+      listPayload.data.some((message) => message.id === createPayload.data.id),
+      "created authenticated message should appear in the message list"
+    );
+  });
+});


### PR DESCRIPTION
/claim #743

Scoped issue: #9147

## Summary
- require the existing bearer-token `authMiddleware` before all `/api/messages` routes
- keep authenticated message list/create behavior working
- add focused route regression tests for anonymous 401s and authenticated success

## Validation
- `npm ci`
- `npm test -w apps/api`

Validation output summary:
```text
# tests 4
# pass 4
# fail 0
```

- `git diff --check`

Short demo video: https://github.com/HaroldTheAI/bug-bounty-harold/releases/download/securebanana-9147-message-auth-demo/securebanana-9147-message-auth-demo.mp4

No payout, contact, credential, wallet, or off-platform payment details are included.
