### PR TITLE
fix: invalid PORT env crashes API startup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,13 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: (() => {
+    const p = Number(process.env.PORT ?? 4000);
+    if (!Number.isFinite(p) || p <= 0) {
+      console.warn(`[warn] Invalid PORT "${process.env.PORT}", falling back to 4000`);
+      return 4000;
+    }
+    return p;
+  })(),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
Closes #9150

## Bug
`Number(process.env.PORT ?? 4000)` returns `NaN` when PORT is set to a non-numeric value, crashing the API with `ERR_SOCKET_BAD_PORT`.

## Fix
Validate PORT after parsing — fallback to default 4000 with a warning when invalid.

## Scope
Only modifies `apps/api/src/config/env.js`.

## Tested cases
| PORT value | Result | Explanation |
|-----------|--------|-------------|
| `4000`   | 4000   | Valid value |
| `3000`   | 3000   | Valid custom port |
| `abc`    | 4000   | NaN → fallback |
| ``       | 4000   | Empty → fallback |
| `-1`     | 4000   | Negative → fallback |
| `0`      | 4000   | Unsafe → fallback |
| (none)    | 4000   | Default |

- [x] JS syntax valid (`node -c`)
- [x] All edge cases verified