### PR TITLE
fix(api): resolve metrics auth, proposal validation, and rate limit order

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,8 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  estimatedDuration: z.union([z.string(), z.number()]).optional(),
+  estDuration: z.union([z.string(), z.number()]).optional(),
+}).refine(data => data.estimatedDuration !== undefined || data.estDuration !== undefined, {
+  message: "Estimated duration is required",
+  path: ["estimatedDuration"]
+});


### PR DESCRIPTION
# Fix API Security: Metrics, Proposal Validation, and Rate Limiting Order

This PR addresses multiple secondary API security vulnerabilities:

1. **Admin Metrics Auth**: Added `adminMiddleware` to restrict access to `/api/admin/metrics` strictly to admin users (Fixes #1764).
2. **Proposal Estimated Duration Validation**: Added `createProposalSchema` validator to enforce that `estimatedDuration` or `estDuration` is provided during proposal creation (Fixes #1739).
3. **Rate Limiter Order**: Reordered application middleware so `apiLimiter` runs before `express.json()`, ensuring malformed JSON requests are properly counted by the rate limiter (Fixes #1735).

Payment Info: PayPal: https://paypal.me/sureshc26