### PR TITLE
fix(api): point test script at test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
/claim #743

Resolves #9161

## Summary
- Update the API workspace test script to target the concrete `src/tests/*.test.js` files.
- This avoids Node treating `src/tests` as a module entrypoint and failing before test discovery.

## Validation
Reproduced before the fix:

```text
npm test -w apps/api
Error: Cannot find module '.../apps/api/src/tests'
node --test src/tests
```

Validated after the fix:

```text
npm test -w apps/api
✔ GET /health returns ok payload
ℹ tests 1
ℹ pass 1
ℹ fail 0
```
