### PR TITLE
fix(auth): prevent admin role self-assignment during registration (#1755)

### DIFF
--- a/apps/api/src/tests/register-role.test.js
+++ b/apps/api/src/tests/register-role.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.success, false);
+});
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "freelancer");
+});
+
+test("registerSchema defaults to client when role omitted", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #1755

## Changes
- Removed `admin` from the registration role enum in `apps/api/src/validators/auth.js`
- Registration now only accepts `client` and `freelancer` roles
- Default role remains `client` when omitted
- Added focused test coverage proving `admin` is rejected and normal roles still work

## Testing
- [x] All 4 new validation tests pass
- [x] Existing health test passes
- [x] Linting passes (no linter configured)