### PR TITLE
fix(api): unmatched routes return JSON 404 (resolves #9163)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -40,5 +40,11 @@ export function createApp() {
   app.use("/api/admin", adminRoutes);
 
   app.use(errorHandler);
+
+  // Catch-all: unmatched API routes return JSON 404
+  app.use((req, res) => {
+    res.status(404).json({ success: false, message: "Route not found" });
+  });
+
   return app;
 }


### PR DESCRIPTION
Resolves #9163

## Bug

The Express app has no catch-all 404 handler. Unmatched API routes return an HTML 404 page instead of a structured JSON error response.

## Fix

Added a catch-all middleware at the end of `app.js` that returns HTTP 404 with `{ success: false, message: "Route not found" }` for any unmatched route.

## Testing

Verified: `GET /api/nonexistent` now returns `{"success":false,"message":"Route not found"}` with status 404.