### PR TITLE
fix(api): reject blank DATABASE_URL and STRIPE_SECRET_KEY in production (resolves #9164)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,25 @@
+function requireNonBlank(value, name) {
+  if (value === undefined || value === null || value.trim() === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const isProduction = nodeEnv === "production";
+
+const databaseUrl = process.env.DATABASE_URL ?? "";
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY ?? "";
+
+if (isProduction) {
+  requireNonBlank(databaseUrl, "DATABASE_URL");
+  requireNonBlank(stripeSecretKey, "STRIPE_SECRET_KEY");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
+  stripeSecretKey,
+  databaseUrl
 };


### PR DESCRIPTION
Resolves #9164

## Bug

`apps/api/src/config/env.js` accepts absent or blank `DATABASE_URL` and `STRIPE_SECRET_KEY` config values, falling back to empty strings. In production, this lets the server start in a broken state.

## Fix

Added `requireNonBlank()` guard that throws immediately in production when `DATABASE_URL` or `STRIPE_SECRET_KEY` is missing or blank. Development and test environments remain unaffected.

## Scope

- `apps/api/src/config/env.js`