### PR TITLE
fix(auth): generate user ID once and reuse for JWT sub claim (#1758)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/register-id.test.js
+++ b/apps/api/src/tests/register-id.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import jwt from "jsonwebtoken";
+
+test("registerUser returns id matching token sub claim", async () => {
+  const result = await registerUser({
+    email: "test@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  assert.ok(result.id, "should have an id");
+  assert.ok(result.token, "should have a token");
+
+  const decoded = jwt.decode(result.token);
+  assert.equal(decoded.sub, result.id, "token sub should match returned id");
+});
+
+test("registerUser uses same id for both response and token", async () => {
+  const result = await registerUser({
+    email: "user2@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  const decoded = jwt.decode(result.token);
+  assert.equal(decoded.sub, result.id);
+  assert.ok(result.id.startsWith("usr_"), "id should start with usr_");
+});


### PR DESCRIPTION
Closes #1758

## Changes
- Fixed `apps/api/src/services/authService.js` to generate user ID once via a single `Date.now()` call
- The same `id` value is now reused for both the response object and the JWT `sub` claim
- This prevents the mismatch where `token.sub !== user.id` could occur on millisecond boundaries

## Testing
- [x] 2 new tests verify id/token.sub consistency
- [x] Existing health test still passes