### PR TITLE
fix: reject empty payloads and client-controlled IDs in user creation (#1766)

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z
+  .object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    role: z.enum(["client", "freelancer"]).default("client")
+  })
+  .strict();


### PR DESCRIPTION
Closes #1766

## Changes
- Created `apps/api/src/validators/user.js` with strict Zod schema for user creation
- Schema uses `.strict()` to reject unknown fields (prevents client-controlled `id`)
- Requires valid `name` (non-empty string), `email` (valid format)
- Restricts `role` to public roles only (`client`, `freelancer`) — excludes `admin`
- Updated controller to parse and validate request body before creating user
- Server-generated ID remains authoritative (client cannot override it)

## Testing
- [x] Existing tests pass
- [x] Schema correctly rejects empty payloads
- [x] Schema correctly rejects payloads with `id` field