### PR TITLE
fix: add authentication middleware to payment routes (#1772)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
Closes #1772

## Changes
- Added `authMiddleware` to `apps/api/src/routes/paymentRoutes.js`
- All payment endpoints now require a valid JWT Bearer token
- Unauthenticated requests will receive a 401 Unauthorized response

## Testing
- [x] Existing tests pass