### PR TITLE
fix(auth): add admin role authorization check on admin routes (#1764)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-auth.test.js
+++ b/apps/api/src/tests/admin-auth.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+
+const JWT_SECRET = "test-secret";
+
+function signToken(payload) {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: "15m" });
+}
+
+test("requireAdmin passes for admin role", async () => {
+  const { requireAdmin } = await import("../middleware/auth.js");
+  let nextCalled = false;
+  const req = { user: { role: "admin" } };
+  const res = {};
+  const next = () => { nextCalled = true; };
+  
+  requireAdmin(req, res, next);
+  assert.equal(nextCalled, true);
+});
+
+test("requireAdmin rejects client role with 403", async () => {
+  const { requireAdmin } = await import("../middleware/auth.js");
+  let statusCode = null;
+  let body = null;
+  const req = { user: { role: "client" } };
+  const res = {
+    status(code) { statusCode = code; return res; },
+    json(data) { body = data; return res; }
+  };
+  const next = () => { throw new Error("next should not be called"); };
+  
+  requireAdmin(req, res, next);
+  assert.equal(statusCode, 403);
+  assert.equal(body.success, false);
+  assert.equal(body.message, "Forbidden");
+});
+
+test("requireAdmin rejects freelancer role with 403", async () => {
+  const { requireAdmin } = await import("../middleware/auth.js");
+  let statusCode = null;
+  const req = { user: { role: "freelancer" } };
+  const res = {
+    status(code) { statusCode = code; return res; },
+    json() { return res; }
+  };
+  const next = () => { throw new Error("next should not be called"); };
+  
+  requireAdmin(req, res, next);
+  assert.equal(statusCode, 403);
+});


### PR DESCRIPTION
Closes #1764

## Changes
- Added `requireAdmin` middleware in `apps/api/src/middleware/auth.js` that checks `req.user.role === 'admin'` and returns 403 Forbidden otherwise
- Applied `requireAdmin` to admin routes in `apps/api/src/routes/adminRoutes.js` after `authMiddleware`
- Any non-admin authenticated user now receives 403 when accessing admin endpoints

## Testing
- [x] 3 new tests verify admin access is granted and non-admin roles (client, freelancer) are rejected with 403
- [x] Existing health test still passes