### PR TITLE
fix: add authentication middleware to upload routes (#1771)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);


### PR DESCRIPTION
Closes #1771

## Changes
- Added `authMiddleware` to `apps/api/src/routes/uploadRoutes.js`
- All upload endpoints now require a valid JWT Bearer token
- Unauthenticated requests will receive a 401 Unauthorized response

## Testing
- [x] Existing tests pass