### PR TITLE
fix: add role-based access control to admin routes (#1770)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Closes #1770

## Changes
- Added `adminMiddleware` in `apps/api/src/middleware/auth.js` that checks `req.user.role === "admin"`
- Applied `adminMiddleware` after `authMiddleware` in `apps/api/src/routes/adminRoutes.js`
- Non-admin authenticated users now receive a 403 Forbidden response
- Prevents privilege escalation where any authenticated user could access admin endpoints

## Testing
- [x] Existing tests pass