### PR TITLE
fix(api): add auth-specific rate limiting

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,10 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);

--- a/apps/api/src/tests/auth-rate-limit.test.js
+++ b/apps/api/src/tests/auth-rate-limit.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback("http://127.0.0.1:" + port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login is limited after 20 requests", async () => {
+  await withServer(async (baseUrl) => {
+    const request = () => fetch(baseUrl + "/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123"
+      })
+    });
+
+    for (let i = 0; i < 20; i += 1) {
+      const response = await request();
+      assert.equal(response.status, 200);
+    }
+
+    const limited = await request();
+    assert.equal(limited.status, 429);
+  });
+});


### PR DESCRIPTION
/claim #743

Resolves #9170

## Summary
- Add an auth-specific limiter with a 20-request / 15-minute window using the existing express-rate-limit dependency.
- Apply the limiter to POST /api/auth/register, POST /api/auth/login, and POST /api/auth/refresh.
- Add regression coverage proving the 21st login request returns 429.

## Validation

```text
node --test apps/api/src/tests/*.test.js
✔ POST /api/auth/login is limited after 20 requests
✔ GET /health returns ok payload
ℹ tests 2
ℹ pass 2
ℹ fail 0
```
