### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,8 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  // Admin role is not self-assignable — must be granted by existing admin
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Removes `admin` from the allowed roles in the registration schema so users cannot self-assign admin privileges during signup.

### Changes
- registerSchema: role enum restricted to `client | freelancer` (admin removed)

Closes #2832

/claim #2832