### PR TITLE
fix: validate provided refresh token before issuing new access token

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,10 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { refreshToken: token } = req.body;
+  if (!token || typeof token !== "string") {
+    return res.status(400).json({ error: "refreshToken is required" });
+  }
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,4 +1,4 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
@@ -18,6 +18,8 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  // Verify the provided token before issuing a new one
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }


### PR DESCRIPTION
## Summary

Fixes the refresh token endpoint to actually verify the provided refresh token instead of ignoring it.

### Changes
- Controller now extracts `refreshToken` from request body (returns 400 if missing)
- Service verifies the token with JWT secret
- New access token uses the verified user identity (sub, role)

Closes #1775

/claim #1775