### PR TITLE
fix: preserve server-owned id and read state in notification creation

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.parse(req.body);
+  return ok(res, await createNotification(payload), 201);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,13 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  // Server-owned fields take precedence — spread payload first, then override
+  const notification = {
+    ...payload,
+    id: `ntf_${Date.now()}`,
+    read: false,
+    createdAt: new Date().toISOString(),
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  title: z.string().min(1),
+  message: z.string().min(1),
+  type: z.enum(["info", "warning", "error"]).default("info"),
+}).strict(); // Strip extra fields like client-supplied id or read


### PR DESCRIPTION
## Summary

Fixes notification creation so that server-owned fields (id, read) cannot be overwritten by client-supplied values.

### Changes
- Added Zod validation schema with `.strict()` to strip extra fields
- Reordered service to spread payload first, then apply server defaults
- Added `createdAt` timestamp

Closes #2762

/claim #2762