### PR TITLE
fix(auth): prevent admin role self-assignment (#1426)

### DIFF
--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.success, false);
+});
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerSchema defaults to client when role not provided", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});
+
+test("registerSchema rejects invalid role", () => {
+  const result = registerSchema.safeParse({
+    email: "test@example.com",
+    password: "password123",
+    role: "superadmin"
+  });
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

- Removes `"admin"` from the allowed role enum in `registerSchema`, preventing users from self-assigning admin privileges during registration.
- The schema now only accepts `"client"` and `"freelancer"` roles, defaulting to `"client"`.

## Changes

- **`apps/api/src/validators/auth.js`**: Changed `z.enum(["client", "freelancer", "admin"])` to `z.enum(["client", "freelancer"])`.
- **`apps/api/src/tests/auth.test.js`**: Added 5 tests to verify that:
  - Admin role is rejected
  - Client role is accepted
  - Freelancer role is accepted
  - Default role is "client" when not provided
  - Invalid roles are rejected

## Testing

All 6 tests pass (5 new auth tests + 1 existing health test).

Closes #1426