### PR TITLE
Fix invalid API port fallback

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,21 @@
+export function parsePort(rawPort, defaultPort = 4000) {
+  if (rawPort === undefined) {
+    return defaultPort;
+  }
+
+  const value = rawPort.trim();
+
+  if (!/^\d+$/.test(value)) {
+    return defaultPort;
+  }
+
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 0 && port < 65536 ? port : defaultPort;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parsePort } from "../config/env.js";
+
+test("parsePort preserves valid explicit ports", () => {
+  assert.equal(parsePort("0"), 0);
+  assert.equal(parsePort("8080"), 8080);
+});
+
+test("parsePort falls back to default for invalid ports", () => {
+  assert.equal(parsePort(undefined), 4000);
+  assert.equal(parsePort(""), 4000);
+  assert.equal(parsePort("abc"), 4000);
+  assert.equal(parsePort("12.5"), 4000);
+  assert.equal(parsePort("-1"), 4000);
+  assert.equal(parsePort("65536"), 4000);
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a `parsePort` helper for API config parsing
- fall back to the default port when `PORT` is missing, empty, non-numeric, non-integer, negative, or outside Node's listen range
- preserve valid explicit ports such as `0` and `8080`
- fix the API package test script so `npm test -w apps/api` runs the test files directly

## Root cause
`Number(process.env.PORT ?? 4000)` can produce `NaN` for invalid environment values such as `PORT=abc`, and that value can be passed to `app.listen`.

## Validation
- `npm test -w apps/api`

## Demo evidence
- Video demo: https://raw.githubusercontent.com/xixifusi1213-gif/bug-bounty/demo-pr-9257-port-video/securebanana-pr-9257-port-demo.webm
- Final state screenshot: https://raw.githubusercontent.com/xixifusi1213-gif/bug-bounty/demo-pr-9257-port-video/securebanana-pr-9257-port-demo.png
- The video shows the passing API validation run for this PR: valid explicit ports are preserved, invalid `PORT` values fall back safely, and the health route test still passes.

Closes #9256
