### PR TITLE
fix(api): validate message request body

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: "Invalid message payload",
+      details: parsed.error.flatten().fieldErrors
+    });
+  }
+
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/message-validation.test.js
+++ b/apps/api/src/tests/message-validation.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects an empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "Invalid message payload");
+    assert.ok(payload.details.to);
+    assert.ok(payload.details.text);
+  });
+});
+
+test("POST /api/messages accepts a valid message payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ to: "user-1", text: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.to, "user-1");
+    assert.equal(payload.data.text, "hello");
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  to: z.string().min(1),
+  text: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- Adds a Zod validator for `POST /api/messages` request bodies.
- Requires non-empty `to` and `text` fields before calling `sendMessage`.
- Returns `400` with field-level validation details for invalid payloads.
- Adds regression tests for empty and valid message payloads.

## Test Plan
- `npm install`
- `npm test` - 3 tests passed

Closes #9264