### PR TITLE
fix(api): validate proposal request body

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      error: "Invalid proposal payload",
+      details: parsed.error.flatten().fieldErrors
+    });
+  }
+
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects an empty body", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "Invalid proposal payload");
+    assert.ok(payload.details.jobId);
+    assert.ok(payload.details.rate);
+    assert.ok(payload.details.message);
+  });
+});
+
+test("POST /api/proposals accepts a valid proposal payload", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jobId: "job-1", rate: 100, message: "I can help." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.jobId, "job-1");
+    assert.equal(payload.data.rate, 100);
+    assert.equal(payload.data.message, "I can help.");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  rate: z.number().positive(),
+  message: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- Adds a Zod validator for `POST /api/proposals` request bodies.
- Requires `jobId`, positive numeric `rate`, and non-empty `message` before calling `createProposal`.
- Returns `400` with field-level validation details for invalid payloads.
- Adds regression tests for empty and valid proposal payloads.

## Test Plan
- `npm install`
- `npm test` - 3 tests passed

Closes #9263