### PR TITLE
Add billing and notifications navigation links

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -7,6 +7,8 @@ const links = [
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
Closes #9273

/claim #743

## Summary
- Add existing `/notifications` and `/billing` routes to the global web navigation.
- Preserve the current `Navigation` component structure and styling.
- Keep the change scoped to the route discoverability issue tracked in #9273.

## Validation
- `npm run build -w apps/web` passed.
- The production build output includes both `/billing` and `/notifications` routes.

## Demo evidence
- Video demo: https://raw.githubusercontent.com/xixifusi1213-gif/bug-bounty/demo-pr-9274-nav-video/securebanana-pr-9274-nav-demo.webm
- Final state screenshot: https://raw.githubusercontent.com/xixifusi1213-gif/bug-bounty/demo-pr-9274-nav-video/securebanana-pr-9274-billing-demo.png
- The recording opens the app, shows the new Notifications and Billing entries in the global navigation, then navigates to both pages.
