### PR TITLE
fix(api): add strict auth route limiter

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,11 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { success: false, message: "Too many authentication requests" }
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);

--- a/apps/api/src/tests/auth-rate-limit.test.js
+++ b/apps/api/src/tests/auth-rate-limit.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("auth routes return 429 after 20 requests in a 15-minute window", async () => {
+  await withServer(async (baseUrl) => {
+    let response;
+    for (let index = 0; index < 20; index += 1) {
+      response = await fetch(`${baseUrl}/api/auth/refresh`, { method: "POST" });
+      assert.equal(response.status, 200);
+    }
+
+    response = await fetch(`${baseUrl}/api/auth/refresh`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 429);
+    assert.equal(payload.message, "Too many authentication requests");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an auth-specific rate limiter capped at 20 requests per 15-minute window.
- Applies it to `POST /api/auth/register`, `POST /api/auth/login`, and `POST /api/auth/refresh`.
- Leaves OAuth callback routes unchanged.
- Adds regression coverage verifying the 21st auth request returns `429`.

## Test Plan
- `npm install`
- `npm test` - 2 tests passed

Closes #9170