### PR TITLE
feat: auth refresh endpoint should require authentication and sign correct user claims (resolves #9278)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);
+

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/auth_refresh.test.js
+++ b/apps/api/src/tests/auth_refresh.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+test("Auth refresh endpoint tests", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const url = `http://127.0.0.1:${port}/api/auth/refresh`;
+
+  await t.test("POST /api/auth/refresh without token returns 401 Unauthorized", async () => {
+    const response = await fetch(url, {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+
+  await t.test("POST /api/auth/refresh with invalid token returns 401", async () => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer invalidtokenhere"
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid token");
+  });
+
+  await t.test("POST /api/auth/refresh with valid token returns 200 and preserves user sub and role", async () => {
+    const initialToken = signAccessToken({ sub: "usr_custom_123", role: "freelancer" });
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${initialToken}`
+      }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.token);
+
+    // Verify the refreshed token contains the correct subject and role
+    const decoded = verifyAccessToken(payload.data.token);
+    assert.equal(decoded.sub, "usr_custom_123");
+    assert.equal(decoded.role, "freelancer");
+  });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
This PR implements route protection and correct token claims signing for the auth refresh route, satisfying the requirements of issue #9278:
- POST /api/auth/refresh requires authentication via the authMiddleware.
- Signs refreshed token with correct authenticated sub and role.
- Adds route-level unit tests in auth_refresh.test.js covering unauthorized rejection (no token, invalid token) and subject preservation.

Parent bounty: #743