### PR TITLE
fix: prevent userId/token sub mismatch in registerUser (#2845)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Problem

 calls  twice for the user record uid=197609(ThinkPad) gid=197121 groups=197121 and JWT  claim, causing potential mismatch.

## Fix

Single  call, reused for both id and sub.

## Changes

-  — Single Date.now() call in registerUser()