### PR TITLE
fix: reject empty file uploads with 400 (#2850)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Problem

`uploadFile()` accepts empty file uploads (no file attached) and returns 201 with status no-file. Should reject with 400 instead.

## Fix

Check `req.file` and return 400 Bad Request when no file is provided.

## Changes

- `apps/api/src/controllers/uploadController.js` -- Return 400 on empty file