### PR TITLE
fix: add Zod refine to reject budgetMax < budgetMin (#2853)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+}).refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be >= budgetMin", path: ["budgetMax"] }
+);
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Problem

`createJobSchema` allows `budgetMax < budgetMin`, which is semantically invalid for a budget range.

## Fix

Add `.refine()` to the Zod schema to enforce `budgetMax >= budgetMin` with a clear error message.

## Changes

- `apps/api/src/validators/job.js` -- Add Zod refine validation