### PR TITLE
fix: add authMiddleware to upload endpoint (#9284)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
## Problem

`POST /api/uploads` had no authentication, allowing anyone to upload files without a valid JWT token.

## Fix

Add `authMiddleware` before the upload handler.

## Changes

- `apps/api/src/routes/uploadRoutes.js` -- Add authMiddleware import and apply to POST route

Closes #9284