### PR TITLE
fix: add adminMiddleware to enforce role-based access (#9285)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Problem

`/api/admin` routes only checked for a valid JWT (authMiddleware) but did not verify the admin role. Any authenticated user could access admin endpoints.

## Fix

Create `adminMiddleware` that checks `req.user.role === "admin"` and returns 403 Forbidden for non-admin users. Apply after authMiddleware.

## Changes

- `apps/api/src/middleware/auth.js` -- Add adminMiddleware function
- `apps/api/src/routes/adminRoutes.js` -- Import and apply adminMiddleware

Closes #9285