### PR TITLE
fix: add authMiddleware to job creation endpoint (#9286)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
## Problem

`POST /api/jobs` had no authentication, allowing anyone to create jobs without being authenticated.

## Fix

Add `authMiddleware` to the POST route while keeping GET /api/jobs public.

## Changes

- `apps/api/src/routes/jobRoutes.js` -- Import authMiddleware and apply to POST

Closes #9286