### PR TITLE
fix(api): target concrete test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #9290
/claim #743

## Summary
- Update the API workspace test script to target concrete test files.
- Keep the fix scoped to `apps/api/package.json`.

## Verification
- `npm test -w apps/api`
- `git diff --check`
