### PR TITLE
Fix invalid API port fallback

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,24 @@
+export function parsePort(value, defaultPort = 4000) {
+  if (value === undefined || value === null) {
+    return defaultPort;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return defaultPort;
+  }
+
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port < 0 || port >= 65536) {
+    return defaultPort;
+  }
+
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parsePort } from "../config/env.js";
+
+test("parsePort falls back to the default when PORT is missing or invalid", () => {
+  assert.equal(parsePort(undefined), 4000);
+  assert.equal(parsePort("abc"), 4000);
+  assert.equal(parsePort(""), 4000);
+  assert.equal(parsePort("1.5"), 4000);
+  assert.equal(parsePort("-1"), 4000);
+  assert.equal(parsePort("65536"), 4000);
+});
+
+test("parsePort preserves valid explicit ports", () => {
+  assert.equal(parsePort("0"), 0);
+  assert.equal(parsePort("8080"), 8080);
+  assert.equal(parsePort(3000), 3000);
+});


### PR DESCRIPTION
## Summary

Fixes #9237.

- Add a `parsePort` helper that falls back to the default port for missing, blank, non-integer, negative, or out-of-range `PORT` values.
- Preserve valid explicit ports including `0` and `8080`.
- Add focused regression tests for valid and invalid port parsing.
- Update the API test script so the Node test runner executes the test files directly.

## Validation

- `npm run test -w apps/api`

All 3 API tests passed locally.

## Notes

The issue asks for `python3 build.py` and generated `diagnostic/` artifacts, but this repository checkout does not contain `build.py`, `.github/pull_request_template.md`, or an existing `diagnostic/` directory. I validated the scoped API change with the available package test command instead.
