### PR TITLE
Add The Quiet Handshake poem

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,26 @@
+# The Quiet Handshake
+
+A client pins a problem to the board,
+a ticket trimmed with budget, scope, and need.
+The worker reads the edges of the road
+and turns the ask into a tested seed.
+
+A branch begins where guesses used to drift,
+with small commits that keep their promise plain.
+Each diff is proof, each comment is a lift,
+each failing case a flare against the rain.
+
+The review walks slowly through the gate,
+not hunting noise, but trust in what has changed.
+It checks the paths where users might create,
+then leaves the code a little less estranged.
+
+When green lights gather, escrow learns the name
+of hands that made the platform safer run.
+The merge is quiet, but it marks the claim:
+clear work completed, clear accounting done.
+
+So FreelanceFlow keeps faith in every thread,
+from posted need to payout, line by line.
+A market breathes because the proof is read,
+and craft becomes a contract people sign.


### PR DESCRIPTION
/claim #76

## Summary

- Added a root-level `POEM.md` with an original five-stanza poem titled "The Quiet Handshake".
- The poem is written for FreelanceFlow and centers on the trust loop from posted work to review, merge, and payout.

## Creative note

I chose a quiet handoff tone because the review, escrow, merge, and payout flow reads like a chain of accountable trust between clients and contributors.

## Demo

Markdown-only content change: `POEM.md` renders directly in GitHub from this branch.

## Validation

- `POEM.md` is in the project root.
- The poem has five stanzas, above the three-stanza minimum.
- Verified the committed raw file content after pushing to the fork.