### PR TITLE
Fix API test script file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- Update the API test script to target concrete `*.test.js` files
- Avoid passing the `src/tests` directory as a module entrypoint to the Node test runner

## Test
- `pnpm --dir apps/api test` with Node runtime on PATH

Fixes #9290