### PR TITLE
Validate notification creation payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid notification payload", 400);
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects invalid payloads", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "", body: "" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid notification payload"
+    });
+  });
+});
+
+test("POST /api/notifications accepts valid payloads", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        userId: "usr_123",
+        title: "Ticket updated",
+        body: "A support ticket changed status."
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.userId, "usr_123");
+    assert.equal(payload.data.title, "Ticket updated");
+    assert.equal(payload.data.body, "A support ticket changed status.");
+    assert.equal(payload.data.read, false);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  title: z.string().min(1),
+  body: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
- Add Zod validation for notification creation payloads
- Require `userId`, `title`, and `body` before creating notifications
- Add tests for invalid and valid notification creation requests

## Test
- `node --test src/tests/*.test.js`

Fixes #9306