### PR TITLE
fix: preserve server-owned id and read state in notification creation (#9317)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { message, type, userId } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, message, type, userId };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Destructure only allowed fields from payload to prevent clients from overriding server-generated id and read state.

Changes:
- `apps/api/src/services/notificationService.js` — Destructure message, type, userId only