### PR TITLE
fix: require fullName and ignore client-controlled id in user creation (#9318)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,11 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { fullName, email, role } = payload;
+  if (!fullName) {
+    throw new Error("fullName is required");
+  }
+  const user = { id: `usr_${Date.now()}`, fullName, email, role };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Destructure only allowed fields (fullName, email, role). Require fullName. Ignore client-controlled id.

Changes:
- `apps/api/src/services/userService.js` — Destructure fields, require fullName