### PR TITLE
fix: generate user id once in registerUser to prevent JWT sub mismatch

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+
+test("registerUser returns id matching token subject", async () => {
+  const result = await registerUser({
+    email: "test@example.com",
+    password: "password123",
+    role: "client",
+  });
+
+  const decoded = jwt.decode(result.token);
+  assert.equal(decoded.sub, result.id, "JWT sub must match returned user id");
+});
+
+test("registerUser uses consistent id even under time pressure", async () => {
+  // Simulate many rapid registrations to expose any race between Date.now() calls
+  const results = await Promise.all(
+    Array.from({ length: 50 }, () =>
+      registerUser({
+        email: "race@example.com",
+        password: "password123",
+        role: "freelancer",
+      })
+    )
+  );
+
+  for (const result of results) {
+    const decoded = jwt.decode(result.token);
+    assert.equal(
+      decoded.sub,
+      result.id,
+      `JWT sub ${decoded.sub} does not match id ${result.id}`
+    );
+  }
+});


### PR DESCRIPTION
## Problem

egisterUser() calls Date.now() twice — once for the user id and once for the JWT sub. If time advances between those calls, the returned id and the signed token subject differ, causing downstream authenticated requests to identify a different user.

## Fix

Generate the user id once, return it, and pass the same value as sub to signAccessToken().

## Tests added

- egisterUser returns id matching token subject — verifies decoded.sub === result.id
- egisterUser uses consistent id even under time pressure — fires 50 parallel registrations and asserts all token subjects match their returned ids

Closes #9400