### PR TITLE
fix: protect refresh endpoint with auth middleware

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const app = createApp();
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function baseUrl(server) {
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test("POST /api/auth/refresh without token returns 401", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/auth/refresh`, {
+      method: "POST",
+    });
+    const body = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(body.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh with invalid token returns 401", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: "Bearer invalid-token-here" },
+    });
+    const body = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(body.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/auth/refresh preserves subject and role from token", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ sub: "usr_test42", role: "freelancer" });
+
+    const res = await fetch(`${baseUrl(server)}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.equal(body.success, true);
+
+    const jwt = await import("jsonwebtoken");
+    const decoded = jwt.default.decode(body.data.token);
+    assert.equal(decoded.sub, "usr_test42", "refreshed token must preserve subject");
+    assert.equal(decoded.role, "freelancer", "refreshed token must preserve role");
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
## Problem

\POST /api/auth/refresh\ issues a fresh access token without checking the requester at all. The service signs the token for a hard-coded subject \usr_existing\ with role \client\, so even an authenticated caller does not get a token for their own subject and role.

## Fix

1. Added \uthMiddleware\ to the refresh route in \uthRoutes.js\
2. Pass \eq.user\ (the verified JWT payload) to \efreshToken()\
3. Sign the refreshed token with the authenticated user's \sub\ and \ole\

## Tests added

- \without token returns 401\ — unauthenticated requests are rejected
- \with invalid token returns 401\ — malformed tokens are rejected
- \preserves subject and role from token\ — the refreshed token retains the original caller's identity

Closes #9398