### PR TITLE
fix: reject upload requests that do not include a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded",
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const app = createApp();
+    const server = app.listen(0, () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function baseUrl(server) {
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test("POST /api/uploads without file returns 400", async () => {
+  const server = await startServer();
+  try {
+    const res = await fetch(`${baseUrl(server)}/api/uploads`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const body = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.equal(body.success, false);
+    assert.equal(body.message, "No file provided");
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test("POST /api/uploads with empty multipart returns 400", async () => {
+  const server = await startServer();
+  try {
+    const form = new FormData();
+    // No file field attached
+    form.append("description", "test upload");
+
+    const res = await fetch(`${baseUrl(server)}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const body = await res.json();
+
+    assert.equal(res.status, 400);
+    assert.equal(body.success, false);
+  } finally {
+    await closeServer(server);
+  }
+});


### PR DESCRIPTION
## Problem

POST /api/uploads returns 201 with success: true even when no file is included in the request. The response shows status: "no-file" but the HTTP status code indicates success.

## Fix

Check req.file before returning a success response. If absent, return 400 with { success: false, message: "No file provided" }. Successful uploads still return 201.

## Tests added

- without file returns 400 -- JSON body with no file field
- with empty multipart returns 400 -- multipart form with text fields but no file

Closes #9399