### PR TITLE
Validate message creation payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid request body", 400, result.error.issues);
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/tests/message-validation.test.js
+++ b/apps/api/src/tests/message-validation.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects invalid message bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ recipientId: "", body: "" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+    assert.ok(payload.issues.some((issue) => issue.path === "recipientId"));
+    assert.ok(payload.issues.some((issue) => issue.path === "body"));
+  });
+});
+
+test("POST /api/messages accepts valid message bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ recipientId: "usr_123", body: "Hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.recipientId, "usr_123");
+    assert.equal(payload.data.body, "Hello");
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,14 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, issues) {
+  const payload = { success: false, message };
+  if (issues) {
+    payload.issues = issues.map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message
+    }));
+  }
+
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().trim().min(1),
+  body: z.string().trim().min(1).max(5000)
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for POST /api/messages payloads
- reject missing/empty recipientId or body values with a 400 response
- keep accepted message payloads normalized before calling the message service

Closes #9300

## Verification
- node --test --test-reporter spec src/tests/message-validation.test.js
