### PR TITLE
Validate payment creation payloads

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
+import { createPaymentSchema } from "../validators/payment.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const result = createPaymentSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Invalid request body", 400, result.error.issues);
+  }
+
+  return ok(res, await createPaymentIntent(result.data), 201);
 }

--- a/apps/api/src/tests/payment-validation.test.js
+++ b/apps/api/src/tests/payment-validation.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/payments rejects invalid payment bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: -10, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+    assert.ok(payload.issues.some((issue) => issue.path === "amount"));
+  });
+});
+
+test("POST /api/payments accepts valid payment bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 125, currency: "usd" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.amount, 125);
+    assert.equal(payload.data.currency, "usd");
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,14 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, issues) {
+  const payload = { success: false, message };
+  if (issues) {
+    payload.issues = issues.map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message
+    }));
+  }
+
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().trim().length(3).toLowerCase().default("usd")
+});


### PR DESCRIPTION
/claim #743

## Summary
- add a Zod schema for POST /api/payments payloads
- reject missing or non-positive payment amounts with a 400 response
- normalize accepted payment input before creating the payment intent placeholder

Closes #9303

## Verification
- node --test --test-reporter spec src/tests/payment-validation.test.js
