### PR TITLE
Fix API test file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #9467

## Summary
- Updates the API workspace test script to target existing `src/tests/*.test.js` files.
- Fixes Node's test runner treating `src/tests` as a module entrypoint.

## Validation
- Reproduced the original failure: `npm test -w apps/api` reported `MODULE_NOT_FOUND` for `apps/api/src/tests`.
- Passed after the change: `npm test -w apps/api`.
