### PR TITLE
Fix API test file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #9469
Part of parent Algora bounty #743.

## Summary

- Update the API workspace test script to discover `src/tests/*.test.js` files.
- Keep the change limited to the test command, matching the issue's suggested fix.

## Validation

- Reproduced the original failure with:

```sh
node --test src/tests
```

- Verified the updated script after installing API dependencies in a temporary local validation environment:

```sh
pnpm --dir apps/api test
```

Result:

```text
✔ GET /health returns ok payload
tests 1
pass 1
fail 0
```
