### PR TITLE
fix(api): validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,19 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
+function normalizeSearchQuery(query) {
+  return query.trim().slice(0, MAX_SEARCH_QUERY_LENGTH);
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = req.query;
+
+  if (Array.isArray(q)) {
+    return fail(res, "Search query must be a single string", 400);
+  }
+
+  const query = typeof q === "string" ? q : "";
+  return ok(res, await globalSearch(normalizeSearchQuery(query)));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects repeated q values", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/search?q=hello&q=world`
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /single string/i);
+  });
+});
+
+test("GET /api/search trims and caps the query", async () => {
+  await withServer(async (port) => {
+    const input = `  ${"x".repeat(250)}  `;
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/search?q=${encodeURIComponent(input)}`
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "x".repeat(200));
+  });
+});


### PR DESCRIPTION
Validates array query params with 400 and normalizes the search query by trimming and capping to 200 chars. Scope stays within apps/api/src/controllers/searchController.js.