### PR TITLE
fix(api): return defensive list snapshots

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.slice();
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.slice();
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.slice();
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.slice();
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.slice();
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.slice();
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/serviceCopies.test.js
+++ b/apps/api/src/tests/serviceCopies.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import {
+  createNotification,
+  listNotifications,
+} from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertFreshArrays(label, createFn, listFn, payload) {
+  const created = await createFn(payload);
+  const first = await listFn();
+  const second = await listFn();
+
+  assert.notStrictEqual(first, second, `${label} should return a fresh array`);
+  assert.ok(
+    second.some((item) => item.id === created.id),
+    `${label} should include the created item`
+  );
+}
+
+test("list services return defensive snapshots", async () => {
+  await assertFreshArrays("users", createUser, listUsers, {
+    name: "Snapshot User",
+  });
+  await assertFreshArrays("jobs", createJob, listJobs, {
+    title: "Snapshot Job",
+  });
+  await assertFreshArrays("proposals", createProposal, listProposals, {
+    jobId: "job_snapshot",
+    userId: "usr_snapshot",
+  });
+  await assertFreshArrays("messages", sendMessage, listMessages, {
+    fromUserId: "usr_snapshot",
+    toUserId: "usr_snapshot",
+    body: "hello",
+  });
+  await assertFreshArrays("notifications", createNotification, listNotifications, {
+    userId: "usr_snapshot",
+    body: "ping",
+  });
+  await assertFreshArrays("reviews", createReview, listReviews, {
+    targetUserId: "usr_snapshot",
+    jobId: "job_snapshot",
+    rating: 5,
+  });
+});


### PR DESCRIPTION
Returns shallow copies from all list services so callers cannot mutate the in-memory store through shared references. Includes a test that asserts each list call returns a fresh array and still contains the created item.