### PR TITLE
fix(api): validate review payloads

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,21 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(
+      res,
+      "Review payload must include targetUserId, jobId, and rating from 1 to 5",
+      400
+    );
+  }
+
+  return ok(res, await createReview(payload.data), 201);
 }

--- a/apps/api/src/tests/review.test.js
+++ b/apps/api/src/tests/review.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/reviews rejects empty payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /targetUserId/i);
+  });
+});
+
+test("POST /api/reviews accepts a valid review", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        targetUserId: "usr_123",
+        jobId: "job_123",
+        rating: 5,
+        comment: "Great work"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.targetUserId, "usr_123");
+    assert.equal(payload.data.rating, 5);
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetUserId: z.string().min(1),
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().optional()
+});


### PR DESCRIPTION
Adds a review Zod schema with required targetUserId, jobId, and rating (1-5), wires it into the review controller, and returns 400 for invalid review payloads. Includes a route test for both invalid and valid requests.