### PR TITLE
fix(api): validate message payloads

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,21 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const payload = createMessageSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(
+      res,
+      "Message payload must include recipientId and body",
+      400
+    );
+  }
+
+  return ok(res, await sendMessage(payload.data), 201);
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects empty payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /recipientId/i);
+  });
+});
+
+test("POST /api/messages trims accepted payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        recipientId: "  usr_123  ",
+        body: "  hello there  "
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.recipientId, "usr_123");
+    assert.equal(payload.data.body, "hello there");
+    assert.ok(payload.data.sentAt);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+const trimmedNonEmptyString = z.string().trim().min(1);
+
+export const createMessageSchema = z.object({
+  recipientId: trimmedNonEmptyString,
+  body: trimmedNonEmptyString
+});


### PR DESCRIPTION
Adds a Zod schema for POST /api/messages, rejects missing or empty recipientId/body values with 400, and trims accepted payloads before they reach the message service. Includes route coverage for invalid and valid requests.