### PR TITLE
fix(api): restrict admin metrics to admins

### DIFF
--- a/apps/api/src/middleware/roles.js
+++ b/apps/api/src/middleware/roles.js
@@ -1,0 +1,15 @@
+import { fail } from "../utils/response.js";
+
+export function requireRole(...allowedRoles) {
+  return (req, res, next) => {
+    if (!req.user?.role) {
+      return fail(res, "Unauthorized", 401);
+    }
+
+    if (!allowedRoles.includes(req.user.role)) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireRole } from "../middleware/roles.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-metrics-access.test.js
+++ b/apps/api/src/tests/admin-metrics-access.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/admin/metrics rejects client tokens", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /forbidden/i);
+  });
+});
+
+test("GET /api/admin/metrics allows admin tokens", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});


### PR DESCRIPTION
Adds a reusable role-check middleware, applies it to /api/admin/metrics, and covers both client rejection and admin success with API tests.