### PR TITLE
fix(api): require auth for post routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/tests/post-route-auth.test.js
+++ b/apps/api/src/tests/post-route-auth.test.js
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(port, path, body, token) {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST routes require authentication", async () => {
+  await withServer(async (port) => {
+    const responses = await Promise.all([
+      postJson(port, "/api/users", { fullName: "Test User" }),
+      postJson(port, "/api/notifications", { body: "hello" }),
+      postJson(port, "/api/payments", { amount: 1 })
+    ]);
+    const payloads = await Promise.all(responses.map((response) => response.json()));
+
+    for (const response of responses) {
+      assert.equal(response.status, 401);
+    }
+
+    for (const payload of payloads) {
+      assert.equal(payload.success, false);
+      assert.match(payload.message, /unauthorized/i);
+    }
+  });
+});
+
+test("authenticated callers can still create records", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await postJson(port, "/api/users", { fullName: "Test User" }, token);
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.fullName, "Test User");
+  });
+});


### PR DESCRIPTION
Adds authMiddleware to POST /api/users, /api/notifications, and /api/payments, and covers both anonymous rejection and authenticated creation paths with API tests.