### PR TITLE
fix(api): keep notification fields server-owned

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,14 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { message, type, userId } = payload;
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    read: false,
+    message,
+    type,
+    userId
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification keeps server-owned fields", async () => {
+  const notification = await createNotification({
+    id: "client-id",
+    read: true,
+    message: "Hello",
+    type: "info",
+    userId: "usr_123"
+  });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Hello");
+  assert.equal(notification.type, "info");
+  assert.equal(notification.userId, "usr_123");
+});


### PR DESCRIPTION
Updates createNotification to ignore client-controlled id/read fields and keeps message, type, and userId as the only accepted payload fields. Includes a focused service regression test.