### PR TITLE
fix(api): validate user payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = createUserSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "User payload must include fullName", 400);
+  }
+
+  return ok(res, await createUser(payload.data), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,13 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { fullName, email, role } = payload;
+  const user = {
+    id: `usr_${Date.now()}`,
+    fullName,
+    email,
+    role
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users rejects missing fullName", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /fullName/i);
+  });
+});
+
+test("POST /api/users ignores client-controlled ids", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: "client-id",
+        fullName: "Test User",
+        email: "test@example.com",
+        role: "freelancer"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_/);
+    assert.notEqual(payload.data.id, "client-id");
+    assert.equal(payload.data.fullName, "Test User");
+    assert.equal(payload.data.email, "test@example.com");
+    assert.equal(payload.data.role, "freelancer");
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  fullName: z.string().trim().min(1),
+  email: z.string().email().optional(),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});


### PR DESCRIPTION
Adds a Zod schema for POST /api/users, requires fullName, and ignores client-controlled ids in the returned user object. Includes regression coverage for missing fullName and id override attempts.