### PR TITLE
fix(api): validate notification payloads

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const payload = createNotificationSchema.safeParse(req.body);
+
+  if (!payload.success) {
+    return fail(res, "Notification payload must include message and userId", 400);
+  }
+
+  return ok(res, await createNotification(payload.data), 201);
 }

--- a/apps/api/src/tests/notification-validation.test.js
+++ b/apps/api/src/tests/notification-validation.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects empty payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /message/i);
+  });
+});
+
+test("POST /api/notifications accepts valid payloads", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        message: "Hello",
+        userId: "usr_123",
+        type: "info"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.message, "Hello");
+    assert.equal(payload.data.userId, "usr_123");
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+const trimmedNonEmptyString = z.string().trim().min(1);
+
+export const createNotificationSchema = z.object({
+  message: trimmedNonEmptyString,
+  userId: trimmedNonEmptyString,
+  type: z.string().trim().min(1).optional()
+});


### PR DESCRIPTION
Adds a Zod schema for POST /api/notifications, requires message and userId, and returns 400 for invalid payloads. Includes regression coverage for missing fields and a valid request.