### PR TITLE
fix(api): require auth for uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload-auth.test.js
+++ b/apps/api/src/tests/upload-auth.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads requires authentication", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unauthorized/i);
+  });
+});
+
+test("POST /api/uploads accepts authenticated file uploads", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_uploader", role: "client" });
+    const form = new FormData();
+    form.append("file", new Blob(["hello"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "hello.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});


### PR DESCRIPTION
Adds authMiddleware to POST /api/uploads and covers unauthenticated rejection plus authenticated file upload success with API tests.