### PR TITLE
fix(api): restrict cors to frontend origin

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -17,9 +17,19 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 
 export function createApp() {
   const app = express();
+  const frontendOrigin = process.env.FRONTEND_ORIGIN ?? "http://localhost:3000";
+  const corsOptions = {
+    origin(origin, callback) {
+      if (!origin || origin === frontendOrigin) {
+        return callback(null, frontendOrigin);
+      }
+
+      return callback(null, false);
+    }
+  };
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(corsOptions));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS allows the configured frontend origin", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { origin: "http://localhost:3000" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get("access-control-allow-origin"),
+      "http://localhost:3000"
+    );
+  });
+});
+
+test("CORS does not reflect untrusted origins", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { origin: "http://evil.example" }
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
+  });
+});


### PR DESCRIPTION
Restricts CORS to the frontend origin used by the web app and verifies the API only reflects that trusted origin. Includes regression coverage for allowed and untrusted origins.