### PR TITLE
fix(api): require auth for messages

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,13 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { recipientId, body } = payload;
+  const message = {
+    id: `msg_${Date.now()}`,
+    recipientId,
+    body,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message-auth.test.js
+++ b/apps/api/src/tests/message-auth.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages requires authentication", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        recipientId: "usr_456",
+        body: "hello"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unauthorized/i);
+  });
+});
+
+test("POST /api/messages accepts authenticated requests", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_123", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        recipientId: "usr_456",
+        body: "hello"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.body, "hello");
+  });
+});

--- a/apps/api/src/tests/message-auth.test.js
+++ b/apps/api/src/tests/message-auth.test.js
@@ -50,6 +50,7 @@ test("POST /api/messages accepts authenticated requests", async () => {
         authorization: `Bearer ${token}`
       },
       body: JSON.stringify({
+        id: "client-id",
         recipientId: "usr_456",
         body: "hello"
       })
@@ -58,6 +59,8 @@ test("POST /api/messages accepts authenticated requests", async () => {
 
     assert.equal(response.status, 201);
     assert.equal(payload.success, true);
+    assert.notEqual(payload.data.id, "client-id");
+    assert.match(payload.data.id, /^msg_/);
     assert.equal(payload.data.body, "hello");
   });
 });


### PR DESCRIPTION
Fixes #9321 and #9199.

Adds authMiddleware to POST /api/messages and prevents client-controlled message ids in the service. Includes regression coverage for unauthenticated rejection, authenticated requests, and id override prevention.