### PR TITLE
fix(api): require auth for search

### DIFF
--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);

--- a/apps/api/src/tests/search-auth.test.js
+++ b/apps/api/src/tests/search-auth.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search requires authentication", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=test`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unauthorized/i);
+  });
+});
+
+test("GET /api/search works for authenticated callers", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_searcher", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=test`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.query, "test");
+  });
+});


### PR DESCRIPTION
Adds authMiddleware to GET /api/search and covers anonymous rejection plus authenticated search responses with API tests.