### PR TITLE
Guard invalid API PORT env values

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,20 @@
+function parsePort(value) {
+  if (value === undefined || value === "") {
+    return 4000;
+  }
+
+  const port = Number(value);
+  if (Number.isInteger(port) && port > 0 && port <= 65535) {
+    return port;
+  }
+
+  console.warn(`Invalid PORT value "${value}", falling back to 4000`);
+  return 4000;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: parsePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
/claim #743

Closes #9540

## Summary

- Adds focused `PORT` parsing in `apps/api/src/config/env.js`.
- Falls back to `4000` when `PORT` is missing, invalid, non-integer, or outside the valid TCP port range.
- Logs a warning for invalid configured values instead of passing `NaN` / invalid values to `app.listen()`.

## Scope

Only `apps/api/src/config/env.js` was modified, matching the scoped issue.

## Validation

```sh
PORT=abc node --input-type=module -e "const mod = await import('./apps/api/src/config/env.js'); if (mod.env.port !== 4000) { throw new Error('expected fallback 4000 for abc'); }"
PORT=65536 node --input-type=module -e "const mod = await import('./apps/api/src/config/env.js'); if (mod.env.port !== 4000) { throw new Error('expected fallback 4000 for 65536'); }"
PORT=4321 node --input-type=module -e "const mod = await import('./apps/api/src/config/env.js'); if (mod.env.port !== 4321) { throw new Error('expected 4321'); }"
node --test apps/api/src/tests/*.test.js
git diff --check
```

Demo/evidence: the invalid-value commands print the fallback warning and exit successfully; the valid-value command exits successfully with `4321` preserved.
