### PR TITLE
Preserve generated notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves generated fields over payload values", async () => {
+  const notification = await createNotification({
+    id: "client_supplied_id",
+    read: true,
+    message: "Proposal received"
+  });
+
+  assert.notEqual(notification.id, "client_supplied_id");
+  assert.equal(notification.id.startsWith("ntf_"), true);
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "Proposal received");
+});


### PR DESCRIPTION
Closes #9542

## Summary
- Prevents notification payloads from overriding server-owned generated fields.
- Keeps generated `ntf_` ids and defaults new notifications to `read: false`.
- Adds a focused regression test for client-supplied `id` and `read` values.

## Validation
- Red: `node --test apps/api/src/tests/notificationService.test.js` failed because payload `id` overrode the generated id.
- Green: `node --test apps/api/src/tests/notificationService.test.js`.
- Full direct API test discovery: `node --test "apps/api/src/tests/*.test.js"`.
