### PR TITLE
Preserve generated job fields

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob preserves generated fields over payload values", async () => {
+  const job = await createJob({
+    id: "client_supplied_id",
+    status: "closed",
+    title: "Build dashboard",
+    description: "Create a freelancer analytics dashboard",
+    budgetMin: 500,
+    budgetMax: 1000,
+    categoryId: "analytics"
+  });
+
+  assert.notEqual(job.id, "client_supplied_id");
+  assert.equal(job.id.startsWith("job_"), true);
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build dashboard");
+});


### PR DESCRIPTION
Closes #9544

## Summary
- Prevents job payloads from overriding server-owned generated fields.
- Keeps generated `job_` ids and defaults new jobs to `status: "open"`.
- Adds a focused regression test for client-supplied `id` and `status` values.

## Validation
- Red: `node --test apps/api/src/tests/jobService.test.js` failed because payload `id` overrode the generated id.
- Green: `node --test apps/api/src/tests/jobService.test.js`.
- Full direct API test discovery: `node --test "apps/api/src/tests/*.test.js"`.
