### PR TITLE
fix: payment endpoint lacks authentication

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
Fixes #1772 by securing the payment routes with `authMiddleware`.