### PR TITLE
fix: user creation endpoint has no input validation

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,12 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { registerSchema } from "../validators/auth.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  const payload = registerSchema.parse(req.body);
+  return ok(res, await createUser(payload), 201);
 }


### PR DESCRIPTION
Fixes #1773 by importing and applying `registerSchema` validation to the user creation endpoint.