### PR TITLE
fix: admin routes lack role-based access control

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Fixes #1770 by adding `adminMiddleware` to the admin routes for proper role-based access control.