### PR TITLE
fix: user creation accepts empty payloads and client-controlled ids

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,10 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  if (!payload || Object.keys(payload).length === 0) {
+    throw new Error("Payload cannot be empty");
+  }
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
Fixes #1766 by throwing an error if the payload is empty, and ensuring the server-generated `id` overrides any client-provided `id`.