### PR TITLE
fix: missing admin role authorization check on admin metrics endpoint

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", adminMiddleware, metrics);


### PR DESCRIPTION
Fixes #1764 by appending `adminMiddleware` to the admin metrics endpoint specifically, ensuring proper authorization.