### PR TITLE
fix: reject empty upload submissions

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+const EMPTY_FILE_MESSAGE = "file is required and must not be empty";
 
 export async function uploadFile(req, res) {
+  if (!req.file || !req.file.buffer || req.file.size <= 0) {
+    return fail(res, EMPTY_FILE_MESSAGE, 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    mimetype: req.file.mimetype,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects missing file submissions", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: new FormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "file is required and must not be empty"
+    });
+  });
+});
+
+test("POST /api/uploads rejects empty file submissions", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob([""]), "empty.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "file is required and must not be empty"
+    });
+  });
+});
+
+test("POST /api/uploads accepts non-empty file submissions", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.deepEqual(payload.data, {
+      filename: "hello.txt",
+      mimetype: "text/plain",
+      size: 11,
+      status: "uploaded"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2850

Rejects upload requests that do not contain a file or contain a zero-byte file instead of returning a successful `uploaded`/`no-file` response.

## Changes
- Add explicit missing/empty file validation in `uploadFile`.
- Preserve success response for non-empty uploads.
- Add focused `node:test` coverage for:
  - missing file field → 400
  - empty file → 400
  - non-empty file → 201

## Test Plan
- `npm install --include-workspace-root --ignore-scripts`
- `npm run test -w apps/api`

Result: 4/4 tests passed.
