### PR TITLE
fix: verify refresh tokens before issuing access tokens

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,15 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const token = req.body?.refreshToken;
+  if (!token || typeof token !== "string") {
+    return fail(res, "refreshToken is required", 401);
+  }
+
+  try {
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,28 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, signRefreshToken, verifyRefreshToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role }),
+    refreshToken: signRefreshToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
   // TODO: verify password hash against stored user record
+  const user = { id: "usr_existing", role: "client" };
   return {
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    token: signAccessToken({ sub: user.id, role: user.role }),
+    refreshToken: signRefreshToken({ sub: user.id, role: user.role })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  const decoded = verifyRefreshToken(refreshTokenValue);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, signRefreshToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects requests without refreshToken", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({})
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "refreshToken is required" });
+  });
+});
+
+test("POST /api/auth/refresh rejects access tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const accessToken = signAccessToken({ sub: "usr_existing", role: "client" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken: accessToken })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "invalid refresh token" });
+  });
+});
+
+test("POST /api/auth/refresh accepts valid refresh tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const refreshToken = signRefreshToken({ sub: "usr_existing", role: "client" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ refreshToken })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    const decoded = verifyAccessToken(payload.data.token);
+    assert.equal(decoded.sub, "usr_existing");
+    assert.equal(decoded.role, "client");
+  });
+});
+
+test("POST /api/auth/login returns access and refresh tokens", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "client@example.com", password: "password123" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(typeof payload.data.token, "string");
+    assert.equal(typeof payload.data.refreshToken, "string");
+  });
+});

--- a/apps/api/src/utils/jwt.js
+++ b/apps/api/src/utils/jwt.js
@@ -5,6 +5,18 @@ export function signAccessToken(payload) {
   return jwt.sign(payload, env.jwtSecret, { expiresIn: "15m" });
 }
 
+export function signRefreshToken(payload) {
+  return jwt.sign({ ...payload, type: "refresh" }, env.jwtSecret, { expiresIn: "7d" });
+}
+
 export function verifyAccessToken(token) {
   return jwt.verify(token, env.jwtSecret);
+}
+
+export function verifyRefreshToken(token) {
+  const decoded = jwt.verify(token, env.jwtSecret);
+  if (decoded.type !== "refresh") {
+    throw new Error("invalid refresh token type");
+  }
+  return decoded;
 }


### PR DESCRIPTION
## Summary
Closes #2847

Requires callers to submit a real refresh token before `/api/auth/refresh` mints a new access token.

## Changes
- Adds dedicated `signRefreshToken` and `verifyRefreshToken` helpers.
- Login/register responses now include a refresh token alongside the access token.
- Refresh controller returns 401 for missing, malformed, or access-token inputs.
- Adds focused regression coverage for missing tokens, access-token misuse, valid refresh flow, and login token pair issuance.

## Test Plan
- `npm install --include-workspace-root --ignore-scripts`
- `npm run test -w apps/api`

Result: 5/5 tests passed.
