### PR TITLE
fix: align registration token subject with user id

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/register-token.test.js
+++ b/apps/api/src/tests/register-token.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser access token subject matches returned user id", async () => {
+  const result = await registerUser({
+    email: "new-client@example.com",
+    password: "password123",
+    role: "client"
+  });
+
+  const decoded = verifyAccessToken(result.token);
+
+  assert.equal(typeof result.id, "string");
+  assert.equal(decoded.sub, result.id);
+  assert.equal(decoded.role, result.role);
+});


### PR DESCRIPTION
## Summary
Closes #2845

Fixes `registerUser` so the generated user id is reused for the JWT subject instead of calling `Date.now()` a second time for the token payload.

## Changes
- Generate the registration user id once.
- Return that id in the response.
- Sign the access token with the same id as `sub`.
- Add regression coverage proving `decoded.sub === result.id`.

## Test Plan
- `npm install --include-workspace-root --ignore-scripts`
- `npm run test -w apps/api`

Result: all API tests passed.
