### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Build API",
+  description: "Build a production API",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "backend",
+  skills: ["node"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  assert.equal(createJobSchema.parse(validJob).budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(() => createJobSchema.parse({ ...validJob, budgetMin: 500, budgetMax: 100 }), /budgetMax/);
+});
+
+test("updateJobSchema rejects inverted ranges when both values are present", () => {
+  assert.throws(() => updateJobSchema.parse({ budgetMin: 900, budgetMax: 300 }), /budgetMax/);
+});
+
+test("updateJobSchema allows partial budget updates", () => {
+  assert.equal(updateJobSchema.parse({ budgetMax: 300 }).budgetMax, 300);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function hasOrderedBudgetRange(payload) {
+  if (payload.budgetMin === undefined || payload.budgetMax === undefined) {
+    return true;
+  }
+  return payload.budgetMax >= payload.budgetMin;
+}
+
+const jobShape = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +16,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobShape.refine(hasOrderedBudgetRange, {
+  path: ["budgetMax"],
+  message: "budgetMax must be greater than or equal to budgetMin"
+});
+
+export const updateJobSchema = jobShape.partial().refine(hasOrderedBudgetRange, {
+  path: ["budgetMax"],
+  message: "budgetMax must be greater than or equal to budgetMin"
+});


### PR DESCRIPTION
## Summary
Closes #2853

Rejects inverted job budget ranges in create/update validation.

## Test Plan
- `npm run test -w apps/api`

Result: all API tests passed.
