### PR TITLE
fix: validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+  if (Array.isArray(rawQuery) || typeof rawQuery !== "string") {
+    return fail(res, "search query must be a string", 400);
+  }
+
+  const query = rawQuery.trim();
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `search query must be ${MAX_QUERY_LENGTH} characters or fewer`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search-validation.test.js
+++ b/apps/api/src/tests/search-validation.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => { server.once("listening", resolve); server.once("error", reject); });
+  try { await assertions(`http://127.0.0.1:${server.address().port}`); }
+  finally { await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve())); }
+}
+
+test("GET /api/search rejects repeated q parameters", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "search query must be a string" });
+  });
+});
+
+test("GET /api/search rejects overly long queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"x".repeat(201)}`);
+    const payload = await response.json();
+    assert.equal(response.status, 400);
+    assert.match(payload.message, /200 characters/);
+  });
+});
+
+test("GET /api/search trims valid queries", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20api%20`);
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2833

Validates the search query before it reaches `globalSearch`: repeated/non-string query values are rejected, valid strings are trimmed, and input is capped at 200 chars.

## Test Plan
- `npm run test -w apps/api`

Result: all API tests passed.
