### PR TITLE
fix: preserve server-owned notification fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _ignoredId, read: _ignoredRead, ...safePayload } = payload ?? {};
+  const notification = { ...safePayload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification-service.test.js
+++ b/apps/api/src/tests/notification-service.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "attacker-id",
+    read: true,
+    message: "New proposal",
+    type: "proposal"
+  });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.notEqual(notification.id, "attacker-id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "New proposal");
+  assert.equal(notification.type, "proposal");
+});


### PR DESCRIPTION
## Summary
Closes #2762

Ensures notification creation ignores caller-supplied `id` and `read`, keeping both server-owned.

## Test Plan
- `npm run test -w apps/api`

Result: all API tests passed.
