### PR TITLE
fix: expose UI workspace package entrypoint

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,17 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "type": "module",
+  "main": "src/index.js",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
 }

--- a/packages/ui/src/Button.js
+++ b/packages/ui/src/Button.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}

--- a/packages/ui/src/Card.js
+++ b/packages/ui/src/Card.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,0 +1,2 @@
+export * from "./Button.js";
+export * from "./Card.js";


### PR DESCRIPTION
## Summary
Closes #2787

Exposes a real JavaScript package entrypoint for `@freelanceflow/ui` while preserving TypeScript declarations.

## Test Plan
- `npm install --include-workspace-root --ignore-scripts`
- `node -e "import('@freelanceflow/ui').then(m => { if (!m.Button || !m.Card) throw new Error('missing exports') })"`

Result: import smoke test passed.
