### PR TITLE
fix(auth): prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/tests/auth-validator.test.js
+++ b/apps/api/src/tests/auth-validator.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { registerSchema } from "../validators/auth.js";
+
+const baseRegistration = {
+  email: "person@example.com",
+  password: "password123"
+};
+
+test("registerSchema defaults omitted role to client", () => {
+  const payload = registerSchema.parse(baseRegistration);
+
+  assert.equal(payload.role, "client");
+});
+
+test("registerSchema accepts public registration roles", () => {
+  assert.equal(
+    registerSchema.parse({ ...baseRegistration, role: "client" }).role,
+    "client",
+  );
+  assert.equal(
+    registerSchema.parse({ ...baseRegistration, role: "freelancer" }).role,
+    "freelancer",
+  );
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  assert.throws(
+    () => registerSchema.parse({ ...baseRegistration, role: "admin" }),
+    ZodError,
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #9563

## Summary
- restrict public registration roles to `client` and `freelancer`
- keep omitted registration roles defaulting to `client`
- add focused validator coverage for default, allowed roles, and rejected `admin`
- make the API test script target test files explicitly

## Validation
- `npm run test -w apps/api`