### PR TITLE
fix(messages): require authentication for message routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/tests/message-routes.test.js
+++ b/apps/api/src/tests/message-routes.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/messages requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("GET /api/messages allows authenticated users", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_1", role: "client" });
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(Array.isArray(payload.data), true);
+  });
+});


### PR DESCRIPTION
Fixes #9670

## Summary
- apply `authMiddleware` to `/api/messages` routes
- reject unauthenticated reads and writes to message endpoints
- add route coverage for unauthorized and authorized access

## Validation
- Not run locally in this shell because `node`/`npm` are not available on PATH