### PR TITLE
Handle invalid login payloads

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,15 @@
+import { ZodError } from "zod";
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+function invalidRequestBody(res, error) {
+  if (error instanceof ZodError) {
+    return fail(res, "Invalid request body", 400);
+  }
+
+  throw error;
+}
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -9,7 +18,13 @@ export async function register(req, res) {
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
+  let payload;
+  try {
+    payload = loginSchema.parse(req.body);
+  } catch (error) {
+    return invalidRequestBody(res, error);
+  }
+
   const result = await loginUser(payload);
   return ok(res, result);
 }

--- a/apps/api/src/tests/loginValidation.test.js
+++ b/apps/api/src/tests/loginValidation.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { login } from "../controllers/authController.js";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+test("login returns 400 for invalid request bodies", async () => {
+  const res = createResponse();
+
+  await login(
+    {
+      body: {
+        email: "not-an-email",
+        password: "short"
+      }
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Invalid request body"
+  });
+});


### PR DESCRIPTION
Closes #9698

## Summary
- Converts invalid login request bodies into the existing JSON error shape.
- Handles `ZodError` from `loginSchema.parse` with a `400` response.
- Adds a focused login controller regression test.

## Validation
- Red: `node --test apps/api/src/tests/loginValidation.test.js` failed because `ZodError` escaped the controller.
- Green: `node --test apps/api/src/tests/loginValidation.test.js`.
