### PR TITLE
fix: use same userId for id and JWT sub in registerUser (#2845)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 


### PR DESCRIPTION
## Bug
registerUser() builds the returned id and JWT sub with two separate Date.now() calls. If time advances between calls, the API returns one user id while signing the token for a different subject.

## Fix
Call Date.now() once and reuse the same userId for both the returned id and the JWT sub claim.

Closes #2845