### PR TITLE
fix: require auth for /api/payments POST (#2757)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);


### PR DESCRIPTION
## Bug
/api/payments allows unauthenticated callers to create payment intent records. Payment creation is account-scoped and should require auth.

## Fix
Add authMiddleware to paymentRoutes POST.

Closes #2757