### PR TITLE
fix: reject empty file uploads with 400 instead of 201 (#2850)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return ok(res, { status: "no-file" }, 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
## Bug
POST /api/uploads returns 201 with success:true even when no file field is included. Response reports status:no-file but HTTP status is still treated as success.

## Fix
Return HTTP 400 when req.file is missing instead of 201.

Closes #2850