### PR TITLE
fix: add max length validation on search query to prevent resource exhaustion (#2833)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = req.query.q ?? "";
+  if (q.length > MAX_QUERY_LENGTH) {
+    return ok(res, { error: "Query too long", maxLength: MAX_QUERY_LENGTH }, 400);
+  }
+  return ok(res, await globalSearch(q));
 }


### PR DESCRIPTION
## Bug
GET /api/search passes req.query.q directly to the search service without validation or length limits. Attackers can send extremely long query strings to consume resources.

## Fix
Add MAX_QUERY_LENGTH = 200 limit. Return 400 with error message when query exceeds limit.

Closes #2833