### PR TITLE
fix(search): enforce non-blank query validation and 200-char length limit

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,28 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
-export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+const MAX_QUERY_LENGTH = 200;
+
+export async function search(req, res, next) {
+  try {
+    const q = req.query.q;
+
+    if (!q || typeof q !== "string" || q.trim() === "") {
+      return res.status(400).json({
+        success: false,
+        error: "Query parameter 'q' is required and cannot be blank"
+      });
+    }
+
+    if (q.length > MAX_QUERY_LENGTH) {
+      return res.status(400).json({
+        success: false,
+        error: `Query parameter 'q' exceeds maximum length of ${MAX_QUERY_LENGTH} characters`
+      });
+    }
+
+    return ok(res, await globalSearch(q));
+  } catch (error) {
+    next(error);
+  }
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("Search Validation & Query Length Limit", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  t.after(() => {
+    server.close();
+  });
+
+  await t.test("GET /api/search rejects missing query parameter", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search`);
+    assert.equal(response.status, 400);
+    const data = await response.json();
+    assert.equal(data.success, false);
+  });
+
+  await t.test("GET /api/search rejects blank query parameter", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=%20%20`);
+    assert.equal(response.status, 400);
+    const data = await response.json();
+    assert.equal(data.success, false);
+  });
+
+  await t.test("GET /api/search rejects query parameter longer than 200 characters", async () => {
+    const longQuery = "a".repeat(201);
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${longQuery}`);
+    assert.equal(response.status, 400);
+    const data = await response.json();
+    assert.equal(data.success, false);
+    assert.match(data.error, /exceeds maximum length/);
+  });
+
+  await t.test("GET /api/search accepts query parameter <= 200 characters", async () => {
+    const validQuery = "a".repeat(200);
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=${validQuery}`);
+    assert.equal(response.status, 200);
+    const data = await response.json();
+    assert.equal(data.success, true);
+  });
+});


### PR DESCRIPTION
closes #9735
closes #9686
/claim #9735
/claim #9686