### PR TITLE
fix(auth): secure refresh token route and forward caller credentials

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -21,7 +21,11 @@ export async function oauthCallback(req, res) {
   });
 }
 
-export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+export async function refresh(req, res, next) {
+  try {
+    const result = await refreshToken(req.user);
+    return ok(res, result);
+  } catch (error) {
+    next(error);
+  }
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub || user.id, role: user.role }) };
 }

--- a/apps/api/src/tests/refresh.test.js
+++ b/apps/api/src/tests/refresh.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+test("Token Refresh Authentication", async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const token = signAccessToken({ sub: "usr_custom_caller_123", role: "expert" });
+
+  t.after(() => {
+    server.close();
+  });
+
+  await t.test("POST /api/auth/refresh blocks unauthenticated request", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST"
+    });
+    assert.equal(response.status, 401);
+  });
+
+  await t.test("POST /api/auth/refresh issues token containing caller sub and role", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${token}`
+      }
+    });
+    assert.equal(response.status, 200);
+    const result = await response.json();
+    assert.equal(result.success, true);
+
+    const decoded = verifyAccessToken(result.data.token);
+    assert.equal(decoded.sub, "usr_custom_caller_123");
+    assert.equal(decoded.role, "expert");
+  });
+});


### PR DESCRIPTION
closes #9733
closes #9278
closes #9577
/claim #9733
/claim #9278
/claim #9577