### PR TITLE
fix(auth): protect refresh route with auth middleware and pass verified user

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }


### PR DESCRIPTION
## Summary

Fixes two issues with `POST /api/auth/refresh`:

1. **Missing auth guard**: Route now applies `authMiddleware` so unauthenticated requests are rejected with `401`
2. **Hard-coded subject**: `refreshToken()` now accepts the verified user payload and signs the refreshed token for that user's `sub` and `role`

### Changes
- `authRoutes.js`: added `authMiddleware` to the refresh route
- `authController.js`: passes `req.user` from the middleware into `refreshToken`
- `authService.js`: `refreshToken(user)` signs the token for the given user's sub and role

Fixes #9748
Closes #2847