### PR TITLE
Patch Multer upload DoS advisories

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "zod": "^3.23.8"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-rate-limit": "^7.4.0",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
-        "multer": "^2.1.1",
+        "multer": "^2.2.0",
         "zod": "^3.23.8"
       }
     },
@@ -1519,10 +1519,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
-      "license": "MIT",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",


### PR DESCRIPTION
﻿/claim #743

Closes #9759

## Summary

Upgrade the API direct `multer` dependency from `^2.1.1` to `^2.2.0` so the installed dependency leaves the vulnerable range reported by npm audit for Multer upload DoS advisories.

## Why

Before the patch, `npm audit --json` reported one high-severity vulnerability through direct `multer@2.1.1`:

- GHSA-72gw-mp4g-v24j: Multer denial of service via deeply nested field names.
- GHSA-3p4h-7m6x-2hcm: incomplete cleanup of aborted uploads.

After the patch, `npm audit --json` reports `high: 0`. Remaining moderate audit findings are unrelated to this focused Multer patch.

## Scope

Changed only:

- `apps/api/package.json`
- `package-lock.json`

## Validation

- `npm audit --json` confirms high vulnerabilities dropped from 1 to 0.
- `npm test --workspace apps/api` passes.
- `npm run build --workspace apps/web` passes.
- `git diff --check` passes.

## Notes

No payout, contact, credential, wallet, or off-platform payment details are included in this PR.
