### PR TITLE
fix(auth): align registration response ID and signed token subject

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/registrationMismatch.test.js
+++ b/apps/api/src/tests/registrationMismatch.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("Registration User ID Mismatch Protection", async (t) => {
+  // Stub Date.now to advance by 1 on every invocation
+  const originalDateNow = Date.now;
+  let count = 0;
+  Date.now = () => {
+    count += 1;
+    return 1000 + count;
+  };
+
+  t.after(() => {
+    Date.now = originalDateNow;
+  });
+
+  await t.test("registerUser aligns response id and signed token subject", async () => {
+    const payload = {
+      email: "test_mismatch@example.com",
+      password: "password123",
+      role: "client"
+    };
+
+    const result = await registerUser(payload);
+    
+    // Decode and verify the token sub
+    const decoded = verifyAccessToken(result.token);
+    
+    assert.equal(result.id, decoded.sub, `Expected response ID (${result.id}) and token subject (${decoded.sub}) to match`);
+  });
+});


### PR DESCRIPTION
closes #9763
closes #9749
closes #9731
/claim #9763
/claim #9749
/claim #9731