### PR TITLE
fix(auth): secure token refresh route and preserve subject identity

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.id || user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/refreshVerify.test.js
+++ b/apps/api/src/tests/refreshVerify.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth/refresh", async (t) => {
+  // Hoist env variable check
+  process.env.JWT_SECRET = "testsecret";
+  const { createApp } = await import("../app.js");
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  await t.test("rejects unauthenticated refresh requests with 401", async () => {
+    const res = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST"
+    });
+    assert.equal(res.status, 401);
+  });
+
+  await t.test("accepts authenticated refresh requests and preserves subject identity", async () => {
+    const originalToken = signAccessToken({ sub: "usr_custom_123", role: "developer" });
+    const res = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${originalToken}`
+      }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.success);
+    assert.ok(body.data.token);
+
+    // Decode and verify the refreshed token
+    const { verifyAccessToken } = await import("../utils/jwt.js");
+    const decoded = verifyAccessToken(body.data.token);
+    assert.equal(decoded.sub, "usr_custom_123");
+    assert.equal(decoded.role, "developer");
+  });
+});


### PR DESCRIPTION
closes #9765
closes #9748
closes #9733
closes #9577
/claim #9765
/claim #9748
/claim #9733
/claim #9577