### PR TITLE
fix(search): validate query parameter and enforce max length limit

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q;
+  if (!query || typeof query !== "string" || query.trim() === "") {
+    return fail(res, "Search query is required and cannot be blank", 400);
+  }
+  if (query.length > 200) {
+    return fail(res, "Search query exceeds maximum length of 200 characters", 400);
+  }
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/searchVerify.test.js
+++ b/apps/api/src/tests/searchVerify.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("GET /api/search query validations", async (t) => {
+  process.env.JWT_SECRET = "testsecret";
+  const { createApp } = await import("../app.js");
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  await t.test("rejects missing query parameter q with 400", async () => {
+    const res = await fetch(`${baseUrl}/api/search`);
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.success, false);
+  });
+
+  await t.test("rejects empty/blank query parameter q with 400", async () => {
+    const res = await fetch(`${baseUrl}/api/search?q=%20%20%20`);
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.success, false);
+  });
+
+  await t.test("rejects queries exceeding 200 characters with 400", async () => {
+    const longQuery = "a".repeat(201);
+    const res = await fetch(`${baseUrl}/api/search?q=${longQuery}`);
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.success, false);
+  });
+
+  await t.test("allows valid query with 200", async () => {
+    const res = await fetch(`${baseUrl}/api/search?q=valid`);
+    assert.equal(res.status, 200);
+  });
+});


### PR DESCRIPTION
closes #9771
closes #9735
closes #9686
/claim #9771
/claim #9735
/claim #9686