### PR TITLE
fix(payment): normalize currency codes to lowercase and trim whitespace

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const rawCurrency = payload.currency ?? "usd";
+  const currency = typeof rawCurrency === "string" ? rawCurrency.trim().toLowerCase() : "usd";
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/currencyNormalize.test.js
+++ b/apps/api/src/tests/currencyNormalize.test.js
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent currency normalization", async () => {
+  const p1 = await createPaymentIntent({ amount: 100, currency: "USD" });
+  assert.equal(p1.currency, "usd");
+
+  const p2 = await createPaymentIntent({ amount: 200, currency: " eur " });
+  assert.equal(p2.currency, "eur");
+
+  const p3 = await createPaymentIntent({ amount: 300, currency: undefined });
+  assert.equal(p3.currency, "usd");
+});


### PR DESCRIPTION
closes #9775
closes #6108
closes #6104
closes #4778
/claim #9775
/claim #6108
/claim #6104
/claim #4778