### PR TITLE
fix(auth): prevent admin role self-assignment during registration (#2832)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,15 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  // Strip admin role to prevent self-assignment during registration
+  const safeRole = payload.role === "admin" ? "client" : payload.role;
+
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: safeRole,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role: safeRole })
   };
 }
 

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/closes #2832
/claim #2832

[agent]

## Summary
Prevent users from assigning themselves admin role during registration