### PR TITLE
fix(upload): add authentication to upload endpoint (#1771)

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
+uploadRoutes.use(authMiddleware);
 uploadRoutes.post("/", upload.single("file"), uploadFile);


### PR DESCRIPTION
## Summary
Added authentication middleware to the upload endpoint.

## Changes
- Added authMiddleware import from ../middleware/auth.js
- Applied authMiddleware via router.use() so all upload routes require authentication

## Issue
Closes #1771 — Upload endpoint authentication ($430 Bounty)

## Testing
- Upload endpoint now requires a valid Bearer token
- Unauthenticated requests receive 401 Unauthorized
- Pattern matches existing protected routes (e.g. adminRoutes)