### PR TITLE
fix(admin): add admin role authorization check on metrics endpoint (#1764)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: admin role required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+adminRoutes.get("/metrics", requireAdmin, metrics);


### PR DESCRIPTION
## Description

Adds role-based access control to the admin metrics endpoint, ensuring only users with an `admin` role can access sensitive admin data.

### Changes

- **apps/api/src/middleware/auth.js**: Added `requireAdmin` middleware function that checks `req.user.role === "admin"` and returns a 403 response if the user lacks admin privileges.
- **apps/api/src/routes/adminRoutes.js**: Applied the new `requireAdmin` middleware to the `GET /metrics` endpoint, after the existing `authMiddleware` authentication check.

### Rationale

Previously, the admin metrics endpoint only verified that the request had a valid JWT token (`authMiddleware`), but did not check whether the authenticated user held the `admin` role. This meant any authenticated user (client or freelancer) could access sensitive admin metrics. The fix adds a second layer of authorization that enforces the admin role requirement.

Closes #1764