### PR TITLE
fix(middleware): catch body-parser malformed JSON SyntaxErrors and respond with status 400

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,24 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
+  }
+
+  if (err instanceof SyntaxError && err.status === 400 && "body" in err) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid JSON payload"
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+test("POST with malformed JSON payload", async (t) => {
+  process.env.JWT_SECRET = "testsecret";
+  const { createApp } = await import("../app.js");
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  await t.test("returns 400 Bad Request on malformed JSON payload", async () => {
+    const res = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: "{ invalid json"
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.success, false);
+    assert.ok(body.message.toLowerCase().includes("json") || body.message.toLowerCase().includes("malformed") || body.message.toLowerCase().includes("invalid"));
+  });
+});


### PR DESCRIPTION
closes #9803
closes #9052
closes #8877
closes #8863
/claim #9803
/claim #9052
/claim #8877
/claim #8863