### PR TITLE
fix(service): prevent client-controlled field injection on job and message creation

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,7 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = { ...payload, id: `msg_${Date.now()}`, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/spreadPreservation.test.js
+++ b/apps/api/src/tests/spreadPreservation.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+import { sendMessage } from "../services/messageService.js";
+
+test("Job & Message creation field preservation", async (t) => {
+  await t.test("createJob ignores client-controlled id and status", async () => {
+    const job = await createJob({
+      title: "Backend Engineer Needed",
+      id: "job_INJECTED",
+      status: "closed"
+    });
+    assert.notEqual(job.id, "job_INJECTED");
+    assert.ok(job.id.startsWith("job_"));
+    assert.equal(job.status, "open");
+  });
+
+  await t.test("sendMessage ignores client-controlled id and sentAt", async () => {
+    const message = await sendMessage({
+      content: "hello",
+      id: "msg_INJECTED",
+      sentAt: "2099-01-01T00:00:00Z"
+    });
+    assert.notEqual(message.id, "msg_INJECTED");
+    assert.ok(message.id.startsWith("msg_"));
+    assert.notEqual(message.sentAt, "2099-01-01T00:00:00Z");
+  });
+});


### PR DESCRIPTION
closes #9807
closes #9034
closes #9036
closes #9139
/claim #9807
/claim #9034
/claim #9036
/claim #9139