### PR TITLE
fix(auth): parse Bearer scheme case-insensitively in authMiddleware

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -3,7 +3,7 @@ import { verifyAccessToken } from "../utils/jwt.js";
 
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
     return fail(res, "Unauthorized", 401);
   }
 

--- a/apps/api/src/tests/authScheme.test.js
+++ b/apps/api/src/tests/authScheme.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("GET /api/admin/metrics scheme case-insensitivity", async (t) => {
+  process.env.JWT_SECRET = "testsecret";
+  const { createApp } = await import("../app.js");
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  t.after(async () => {
+    if (typeof server.closeAllConnections === "function") {
+      server.closeAllConnections();
+    }
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  const token = signAccessToken({ userId: "usr_123", role: "admin" });
+
+  await t.test("allows exact 'Bearer ' scheme", async () => {
+    const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    assert.equal(res.status, 200);
+  });
+
+  await t.test("allows lowercase 'bearer ' scheme", async () => {
+    const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `bearer ${token}` }
+    });
+    assert.equal(res.status, 200);
+  });
+
+  await t.test("allows uppercase 'BEARER ' scheme", async () => {
+    const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `BEARER ${token}` }
+    });
+    assert.equal(res.status, 200);
+  });
+
+  await t.test("rejects Basic scheme with 401", async () => {
+    const res = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Basic ${token}` }
+    });
+    assert.equal(res.status, 401);
+  });
+});


### PR DESCRIPTION
closes #9817
closes #6330
closes #6330
/claim #9817
/claim #6330