### PR TITLE
fix: return 400 for invalid auth request bodies

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,15 +1,24 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+import { ZodError } from "zod";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  const payload = parseAuthPayload(registerSchema, req.body, res);
+  if (!payload) {
+    return;
+  }
+
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
+  const payload = parseAuthPayload(loginSchema, req.body, res);
+  if (!payload) {
+    return;
+  }
+
   const result = await loginUser(payload);
   return ok(res, result);
 }
@@ -24,4 +33,17 @@ export async function oauthCallback(req, res) {
 export async function refresh(req, res) {
   const result = await refreshToken();
   return ok(res, result);
+}
+
+function parseAuthPayload(schema, body, res) {
+  try {
+    return schema.parse(body);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      fail(res, "Invalid request body", 400);
+      return null;
+    }
+
+    throw error;
+  }
 }

--- a/apps/api/src/tests/authValidation.test.js
+++ b/apps/api/src/tests/authValidation.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withTestServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register returns 400 for invalid request bodies", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "not-an-email",
+      password: "short"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request body"
+    });
+  });
+});
+
+test("POST /api/auth/login returns 400 for invalid request bodies", async () => {
+  await withTestServer(async (baseUrl) => {
+    const response = await postJson(`${baseUrl}/api/auth/login`, {
+      email: "not-an-email",
+      password: "short"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Invalid request body"
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Return the existing JSON 400 response for invalid register request bodies.
- Return the existing JSON 400 response for invalid login request bodies.
- Add focused API regression coverage for both invalid auth payload paths.

## Validation

- `node --test apps/api/src/tests/authValidation.test.js`
- `npm test --workspace apps/api`
- `npm run build --workspace apps/web`
- `git diff --check`

## Bounty

/claim #743

Scoped issue: #10314
Closes #10314

Disclosure: this focused API validation patch was prepared with AI assistance and validated locally before PR submission.
