### PR TITLE
fix(api): run tests via test file glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #9161

/claim #9161

## Summary
- update the API workspace test script to target src/tests/*.test.js files
- avoid passing the src/tests directory as a module entrypoint to the Node test runner
- keep the change scoped to apps/api/package.json

## Validation
- Not run locally in this environment; expected command: npm test -w apps/api

Note: submitted by usmmrs0002-hub via Codex-assisted workflow.