### PR TITLE
fix(auth): add stricter auth route limiter

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,10 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: "draft-7",
+  legacyHeaders: false
+});

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authLimiter } from "../middleware/rateLimit.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", authLimiter, register);
+authRoutes.post("/login", authLimiter, login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authLimiter, refresh);


### PR DESCRIPTION
Fixes #9170

/claim #9170

## Summary
- add an auth-specific rate limiter with a 20 request limit per 15 minute window
- apply it to register, login, and refresh auth endpoints
- preserve the existing global API limiter for all routes

## Validation
- Not run locally in this environment; expected command: npm test -w apps/api

Note: submitted by usmmrs0002-hub via Codex-assisted workflow.