### PR TITLE
fix: add auth middleware to User routes auth (closes #10574)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
/claim #743\n\nCloses #10574

Adds authMiddleware to the User routes auth routes to require authentication for all endpoints.

## Changes
- Import authMiddleware
- Add `router.use(authMiddleware)` before route handlers
