### PR TITLE
fix: add auth middleware to Job routes auth (closes #10575)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
+jobRoutes.use(authMiddleware);
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);


### PR DESCRIPTION
/claim #743\n\nCloses #10575

Adds authMiddleware to the Job routes auth routes to require authentication for all endpoints.

## Changes
- Import authMiddleware
- Add `router.use(authMiddleware)` before route handlers
