### PR TITLE
fix: add auth middleware to Proposal routes auth (closes #10576)

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
+proposalRoutes.use(authMiddleware);
 proposalRoutes.get("/", getProposals);
 proposalRoutes.post("/", postProposal);


### PR DESCRIPTION
/claim #743\n\nCloses #10576

Adds authMiddleware to the Proposal routes auth routes to require authentication for all endpoints.

## Changes
- Import authMiddleware
- Add `router.use(authMiddleware)` before route handlers
