### PR TITLE
fix: add auth middleware to Payment routes auth (closes #10577)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
/claim #743\n\nCloses #10577

Adds authMiddleware to the Payment routes auth routes to require authentication for all endpoints.

## Changes
- Import authMiddleware
- Add `router.use(authMiddleware)` before route handlers
