### PR TITLE
fix: add auth middleware to notification routes (closes #10585)

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
+
+notificationRoutes.use(authMiddleware);
 
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
/claim #743\n\nCloses #10585

Adds authMiddleware to the notification routes.
