### PR TITLE
fix(jobs): preserve generated fields over payload values

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob preserves generated id and open status over payload values", async () => {
+  const job = await createJob({
+    id: "client_supplied_id",
+    status: "closed",
+    title: "Build dashboard",
+    description: "Create a freelancer analytics dashboard",
+    budgetMin: 500,
+    budgetMax: 1000,
+    categoryId: "analytics"
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.equal(job.status, "open");
+  assert.equal(job.title, "Build dashboard");
+});


### PR DESCRIPTION
Fixes #9632

/claim #9632

## Summary
- ensure createJob keeps its generated job id and open status after spreading caller payload
- add a focused regression test for payload override attempts
- keep caller-provided business fields such as title and budget intact

## Validation
- Not run locally in this environment; expected command: node --test apps/api/src/tests/jobService.test.js

Note: submitted by usmmrs0002-hub via Codex-assisted workflow.