### PR TITLE
fix: prevent admin role self-assignment on registration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,14 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration payload", 400);
+  }
+
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(url, body) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return { response, payload: await response.json() };
+}
+
+test("POST /api/auth/register defaults public registrations to client role", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "client@example.com",
+      password: "password123"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "client");
+
+    const token = verifyAccessToken(payload.data.token);
+    assert.equal(token.role, "client");
+  });
+});
+
+test("POST /api/auth/register allows freelancer public registrations", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "freelancer@example.com",
+      password: "password123",
+      role: "freelancer"
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "freelancer");
+
+    const token = verifyAccessToken(payload.data.token);
+    assert.equal(token.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/register rejects admin self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postJson(`${baseUrl}/api/auth/register`, {
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid registration payload");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
- Restrict public registration to `client` and `freelancer` roles so callers cannot self-assign `admin`.
- Return a focused 400 response for invalid registration payloads before token creation.
- Add API regression tests for default client registration, freelancer registration, and rejected admin self-assignment.
- Fix the API test script so the committed `src/tests/*.test.js` regression suite is actually discovered by `node --test`.

Closes #10598
/claim #743

## Validation
- `npm test`

## Demo / Evidence
Before this change, `POST /api/auth/register` accepted `{ "role": "admin" }` and returned a token signed with `role: "admin"`. The new regression test posts the same payload and verifies a 400 response with no token creation.