### PR TITLE
fix(api): restrict cors origins

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -15,11 +15,25 @@ import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
 
+const DEFAULT_CORS_ORIGINS = ["http://localhost:3000", "http://localhost:5173"];
+
+function getAllowedCorsOrigins() {
+  const configured = process.env.CORS_ORIGIN ?? process.env.FRONTEND_URL;
+  if (!configured) {
+    return DEFAULT_CORS_ORIGINS;
+  }
+
+  return configured
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({ origin: getAllowedCorsOrigins() }));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/tests/cors.test.js
+++ b/apps/api/src/tests/cors.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(app, run) {
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("CORS allows the configured frontend origin", async () => {
+  process.env.CORS_ORIGIN = "https://app.example.com";
+  try {
+    const app = createApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://app.example.com" }
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("access-control-allow-origin"), "https://app.example.com");
+    });
+  } finally {
+    delete process.env.CORS_ORIGIN;
+  }
+});
+
+test("CORS omits allow-origin for unlisted origins", async () => {
+  process.env.CORS_ORIGIN = "https://app.example.com";
+  try {
+    const app = createApp();
+
+    await withServer(app, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`, {
+        headers: { Origin: "https://evil.example.com" }
+      });
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("access-control-allow-origin"), null);
+    });
+  } finally {
+    delete process.env.CORS_ORIGIN;
+  }
+});


### PR DESCRIPTION
Fixes #10818
/claim #743

## Summary
- Restrict API CORS responses to configured frontend origins instead of reflecting every origin with `*`.
- Support `CORS_ORIGIN` or `FRONTEND_URL`, with local development defaults for the existing web app ports.
- Add API regression coverage for allowed and unlisted origins.

## Validation / Demo
- `node --test apps\api\src\tests\cors.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `git diff --cached --check`

The CORS regression demonstrates the behavior change directly:
- configured origin `https://app.example.com` receives `Access-Control-Allow-Origin: https://app.example.com`
- unlisted origin `https://evil.example.com` receives no allow-origin header

## Scope
Focused on API CORS configuration and tests for scoped child issue #10818 under parent bounty #743.
