### PR TITLE
fix(api): require jwt secret in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,14 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET;
+
+if (nodeEnv === "production" && !jwtSecret?.trim()) {
+  throw new Error("JWT_SECRET is required in production");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: jwtSecret?.trim() ? jwtSecret : "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+async function importEnvWith(overrides) {
+  const previous = {
+    NODE_ENV: process.env.NODE_ENV,
+    JWT_SECRET: process.env.JWT_SECRET
+  };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    const moduleUrl = new URL(`../config/env.js?case=${Date.now()}-${Math.random()}`, import.meta.url);
+    return await import(moduleUrl.href);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("production config rejects missing JWT_SECRET", async () => {
+  await assert.rejects(
+    () => importEnvWith({ NODE_ENV: "production", JWT_SECRET: undefined }),
+    /JWT_SECRET is required in production/
+  );
+});
+
+test("production config rejects blank JWT_SECRET", async () => {
+  await assert.rejects(
+    () => importEnvWith({ NODE_ENV: "production", JWT_SECRET: "   " }),
+    /JWT_SECRET is required in production/
+  );
+});
+
+test("development config keeps JWT_SECRET fallback", async () => {
+  const { env } = await importEnvWith({ NODE_ENV: "development", JWT_SECRET: undefined });
+
+  assert.equal(env.jwtSecret, "development-secret");
+});


### PR DESCRIPTION
Fixes #10843
/claim #743

## Summary
- Reject production API configuration when `JWT_SECRET` is unset or blank.
- Preserve the existing `development-secret` fallback outside production.
- Add focused config regression coverage for production rejection and development fallback behavior.

## Validation / Demo
- `node --test apps\api\src\tests\env.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `node --test apps\api\src\tests\env.test.js apps\api\src\tests\health.test.js`
- `git diff --check`

## Scope
Focused on API environment configuration and tests for scoped child issue #10843 under parent bounty #743.
