### PR TITLE
fix(api): generate unique job ids

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${randomUUID()}`, status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -7,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${randomUUID()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${randomUUID()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -17,3 +17,10 @@ test("createJob generates unique ids for same-millisecond creates", async () => 
     Date.now = originalNow;
   }
 });
+
+test("createJob ignores client-supplied id", async () => {
+  const job = await createJob({ id: "job_client_supplied", title: "Client id job" });
+
+  assert.match(job.id, /^job_/);
+  assert.notEqual(job.id, "job_client_supplied");
+});

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob } from "../services/jobService.js";
+
+test("createJob generates unique ids for same-millisecond creates", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1720000000000;
+
+  try {
+    const first = await createJob({ title: "First job" });
+    const second = await createJob({ title: "Second job" });
+
+    assert.match(first.id, /^job_/);
+    assert.match(second.id, /^job_/);
+    assert.notEqual(first.id, second.id);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #10846
/claim #743

## Summary
- Generate job IDs with Node's built-in UUID support instead of timestamp-only `Date.now()` values.
- Keep job IDs server-owned even if a caller supplies an `id` field in the request payload.
- Preserve the existing `job_` prefix and server-owned `status: "open"` behavior.
- Add focused regression coverage for same-millisecond creates and client-supplied ID override attempts.

## Validation / Demo
- `node --test apps\api\src\tests\jobService.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `node --test apps\api\src\tests\jobService.test.js apps\api\src\tests\health.test.js`
- `git diff --check`

## Scope
Focused on job creation ID generation and tests for scoped child issue #10846 under parent bounty #743.
