### PR TITLE
fix(api): generate unique payment ids

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: `pay_${randomUUID()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent generates unique ids for same-millisecond requests", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1720000000000;
+
+  try {
+    const first = await createPaymentIntent({ amount: 1000 });
+    const second = await createPaymentIntent({ amount: 2500 });
+
+    assert.match(first.paymentId, /^pay_/);
+    assert.match(second.paymentId, /^pay_/);
+    assert.notEqual(first.paymentId, second.paymentId);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
Fixes #10848
/claim #743

## Summary
- Generate payment intent IDs with Node's built-in UUID support instead of timestamp-only `Date.now()` values.
- Preserve the existing `pay_` prefix and response shape.
- Add focused regression coverage that reproduces same-millisecond payment intent requests and proves the IDs differ.

## Validation / Demo
- `node --test apps\api\src\tests\paymentService.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `node --test apps\api\src\tests\paymentService.test.js apps\api\src\tests\health.test.js`
- `git diff --check`

## Scope
Focused on payment intent ID generation and tests for scoped child issue #10848 under parent bounty #743.
