### PR TITLE
Validate job budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,9 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine((job) => job.budgetMax >= job.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
+});
+
+export const updateJobSchema = baseJobSchema.partial();


### PR DESCRIPTION
## Summary

Fixes #4605.

- Add a cross-field Zod validation for job budget ranges.
- Reject payloads where `budgetMax` is lower than `budgetMin`.
- Attach the validation error to the `budgetMax` path.
- Preserve the existing `updateJobSchema.partial()` behavior by refining a separate create schema.

## Validation

- `node --input-type=module -e "... createJobSchema.safeParse(...) ..."`
- `node --test apps/api/src/tests/*.test.js`

The schema validation check and existing API health test both passed locally.

## Notes

I kept the PR scoped to `apps/api/src/validators/job.js` as requested by the issue.
