### PR TITLE
Fix review id collisions

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${randomUUID()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview generates distinct server-owned ids in the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1720000000000;
+
+  try {
+    const first = await createReview({
+      id: "client_supplied",
+      reviewerId: "usr_a",
+      revieweeId: "usr_b",
+      rating: 5,
+      comment: "fast"
+    });
+    const second = await createReview({
+      reviewerId: "usr_c",
+      revieweeId: "usr_d",
+      rating: 4,
+      comment: "clear"
+    });
+
+    assert.match(first.id, /^rev_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^rev_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, second.id);
+    assert.notEqual(first.id, "client_supplied");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
/claim #743
/claim #10859

## Summary

- Replace timestamp-only `rev_${Date.now()}` review ids with `rev_${randomUUID()}`.
- Keep the existing `rev_` prefix while making the id server-owned and collision-resistant.
- Add focused regression coverage for same-millisecond review creation and client-supplied id override.

Closes #10859
Refs #743 and #10850

## Validation

```sh
node --test apps/api/src/tests/reviewService.test.js
node --test apps/api/src/tests/*.test.js
node --check apps/api/src/services/reviewService.js
node --check apps/api/src/tests/reviewService.test.js
git diff --check
```

