### PR TITLE
fix: normalize payment currency values

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -3,7 +3,13 @@ export async function createPaymentIntent(payload) {
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizeCurrency(payload.currency),
     provider: "stripe"
   };
+}
+
+function normalizeCurrency(currency) {
+  return typeof currency === "string" && currency.trim()
+    ? currency.trim().toLowerCase()
+    : "usd";
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes submitted currency values", async () => {
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: " USD "
+  });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent defaults blank currency values to usd", async () => {
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: "   "
+  });
+
+  assert.equal(intent.currency, "usd");
+});


### PR DESCRIPTION
## Summary

- Normalize submitted payment currency values by trimming whitespace and lowercasing them.
- Preserve the existing `usd` fallback for missing or blank currency values.
- Add focused payment service regression coverage.

## Validation

- `node --test apps/api/src/tests/paymentService.test.js`
- `npm test --workspace apps/api`
- `npm run build --workspace apps/web`
- `git diff --check`

## Bounty

/claim #743

Scoped issue: #10867
Closes #10867

Disclosure: this focused payment normalization patch was prepared with AI assistance and validated locally before PR submission.
