### PR TITLE
Normalize payment intent currency before creation

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,14 @@
 export async function createPaymentIntent(payload) {
+  const normalizedCurrency =
+    typeof payload.currency === "string" && payload.currency.trim()
+      ? payload.currency.trim().toLowerCase()
+      : "usd";
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency: normalizedCurrency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent normalizes provided currency", async () => {
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: " USD "
+  });
+
+  assert.equal(intent.currency, "usd");
+});
+
+test("createPaymentIntent defaults blank currency to usd", async () => {
+  const intent = await createPaymentIntent({
+    amount: 125,
+    currency: "   "
+  });
+
+  assert.equal(intent.currency, "usd");
+});


### PR DESCRIPTION
Fixes #10869

/claim #743

## Summary

- Normalize submitted payment intent currency values with trim/lowercase handling.
- Preserve the existing `"usd"` fallback for missing or blank currency values.
- Add focused service-level regression tests for mixed-case/whitespace currency and blank currency fallback.

## Validation

- `node --test apps/api/src/tests/paymentService.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `npm run build --workspace apps/web`

Note: `npm test --workspace apps/api` fails locally on Windows/Node v24 because the package script runs `node --test src/tests`, which this runtime treats as a missing module path. The explicit test glob above passes.

## Demo

This is a service-level change; the regression tests in this PR demonstrate the normalized output for `" USD "` and the blank-currency fallback.