### PR TITLE
fix: restrict file upload size and type (fixes #10877)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,18 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  // Multer errors (file too large, wrong type, etc.)
+  if (err instanceof multer.MulterError || err.message === "Unsupported file type") {
+    const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;
+    return res.status(status).json({
+      success: false,
+      message: err.message
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,27 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Unsupported file type"));
+    }
+  }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Summary
Adds file size limits and MIME type validation to the `/api/uploads` endpoint.

## Changes
- `apps/api/src/routes/uploadRoutes.js`: Configured multer with `limits.fileSize` (5 MB) and `fileFilter` to accept only safe file types (images, PDFs, Word docs)
- `apps/api/src/middleware/errorHandler.js`: Added handler for multer errors (413 for file too large, 400 for unsupported type)

Fixes #10877
