### PR TITLE
fix: enforce admin role authorization on admin routes (fixes #10879)

### DIFF
--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,12 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Middleware that verifies the authenticated user has an admin role.
+ * Must be used after authMiddleware (req.user must be populated).
+ */
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Description
Adds an admin role verification middleware to admin API routes. Previously, only JWT validity was checked — any authenticated user could access admin endpoints.

## Changes
- Created `apps/api/src/middleware/admin.js` — verifies `req.user.role === 'admin'`
- Applied `authMiddleware` + `adminMiddleware` to all routes in `adminRoutes.js`

## Related Issue
Closes #10879