### PR TITLE
OpenAI Codex [ Bug ] Fix API test script file discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
/claim #10883

## Summary
- Fix the API workspace test script so it targets actual test files instead of passing the `src/tests` directory to `node --test`.
- Keeps the change scoped to the test entrypoint for the issue created under the #743 low-hanging-fruit flow.

## Verification
- `npm test`

Closes #10883
References #743