### PR TITLE
OpenAI Codex [ Bug ] Validate payment intent amounts

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,8 +1,16 @@
 export async function createPaymentIntent(payload) {
+  const amount = Number(payload.amount);
+  if (!Number.isFinite(amount)) {
+    throw new Error("amount must be a finite number");
+  }
+  if (amount <= 0) {
+    throw new Error("amount must be positive");
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
+    amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
   };

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent rejects non-positive amounts", async () => {
+  for (const amount of [0, -1, "-5"]) {
+    await assert.rejects(
+      () => createPaymentIntent({ amount, currency: "usd" }),
+      /amount must be positive/
+    );
+  }
+});
+
+test("createPaymentIntent rejects non-numeric and non-finite amounts", async () => {
+  for (const amount of ["abc", Number.NaN, Number.POSITIVE_INFINITY]) {
+    await assert.rejects(
+      () => createPaymentIntent({ amount, currency: "usd" }),
+      /amount must be a finite number/
+    );
+  }
+});
+
+test("createPaymentIntent preserves valid positive amount", async () => {
+  const intent = await createPaymentIntent({ amount: "12.50", currency: "usd" });
+
+  assert.equal(intent.amount, 12.5);
+  assert.equal(intent.currency, "usd");
+  assert.equal(intent.provider, "stripe");
+  assert.match(intent.paymentId, /^pay_/);
+});


### PR DESCRIPTION
/claim #10886

## Summary
- Validate payment intent amounts before returning a payment intent.
- Reject non-numeric, non-finite, zero, and negative amounts with clear errors.
- Normalize valid positive numeric/string amounts to numbers while preserving the existing response shape.

## Verification
- `node --test apps\api\src\tests\paymentService.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `git diff --check`

Closes #10886
References #743