### PR TITLE
OpenAI Codex: keep registration JWT subject aligned

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs token subject with the returned user id", async () => {
+  const originalDateNow = Date.now;
+  const timestamps = [1710000000000, 1710000000001, 1710000000002];
+  let index = 0;
+
+  Date.now = () => timestamps[index++] ?? timestamps.at(-1);
+
+  try {
+    const result = await registerUser({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    });
+
+    const decoded = verifyAccessToken(result.token);
+
+    assert.equal(decoded.sub, result.id);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
/claim #10889

## Summary
- Reuse one generated registration user id for both the API response and JWT `sub` claim.
- Add a focused regression test that forces sequential `Date.now()` values and verifies the decoded token subject matches the returned user id.

## Verification
- `node --test apps\api\src\tests\authService.test.js`
- `node --test apps\api\src\tests\health.test.js`
- `node --test apps\api\src\tests\*.test.js`
- `git diff --check`

Closes #10889
References #743