### PR TITLE
fix(api): validate write endpoint bodies

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed");
+  }
+
+  return ok(res, await sendMessage(result.data), 201);
 }

--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed");
+  }
+
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed");
+  }
+
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const result = createReviewSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, "Validation failed");
+  }
+
+  return ok(res, await createReview(result.data), 201);
 }

--- a/apps/api/src/tests/writeEndpointValidation.test.js
+++ b/apps/api/src/tests/writeEndpointValidation.test.js
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("write endpoints reject malformed request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const cases = [
+      {
+        path: "/api/proposals",
+        body: {
+          coverLetter: "I can help with this project.",
+          bidAmount: 0,
+          estDuration: "2 weeks",
+          jobId: "job_1",
+          freelancerId: "usr_1"
+        }
+      },
+      {
+        path: "/api/reviews",
+        body: {
+          rating: 6,
+          comment: "Great work",
+          reviewerId: "usr_1",
+          revieweeId: "usr_2"
+        }
+      },
+      {
+        path: "/api/messages",
+        body: {
+          body: "",
+          senderId: "usr_1",
+          receiverId: "usr_2"
+        }
+      },
+      {
+        path: "/api/notifications",
+        body: {
+          userId: "usr_1",
+          title: "",
+          body: "Payment received"
+        }
+      }
+    ];
+
+    for (const { path, body } of cases) {
+      const { response, payload } = await postJson(baseUrl, path, body);
+
+      assert.equal(response.status, 400, `${path} should reject malformed input`);
+      assert.equal(payload.success, false);
+      assert.equal(payload.message, "Validation failed");
+    }
+  });
+});
+
+test("write endpoints still accept valid request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const cases = [
+      {
+        path: "/api/proposals",
+        body: {
+          coverLetter: "I can help with this project.",
+          bidAmount: 1200,
+          estDuration: "2 weeks",
+          jobId: "job_1",
+          freelancerId: "usr_1"
+        },
+        idPrefix: "prp_"
+      },
+      {
+        path: "/api/reviews",
+        body: {
+          rating: 5,
+          comment: "Great work",
+          reviewerId: "usr_1",
+          revieweeId: "usr_2"
+        },
+        idPrefix: "rev_"
+      },
+      {
+        path: "/api/messages",
+        body: {
+          body: "Hello",
+          senderId: "usr_1",
+          receiverId: "usr_2"
+        },
+        idPrefix: "msg_"
+      },
+      {
+        path: "/api/notifications",
+        body: {
+          userId: "usr_1",
+          title: "Payment",
+          body: "Payment received"
+        },
+        idPrefix: "ntf_"
+      }
+    ];
+
+    for (const { path, body, idPrefix } of cases) {
+      const { response, payload } = await postJson(baseUrl, path, body);
+
+      assert.equal(response.status, 201, `${path} should accept valid input`);
+      assert.equal(payload.success, true);
+      assert.ok(payload.data.id.startsWith(idPrefix));
+    }
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  body: z.string().trim().min(1),
+  senderId: z.string().trim().min(1),
+  receiverId: z.string().trim().min(1)
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  body: z.string().trim().min(1)
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  coverLetter: z.string().trim().min(1),
+  bidAmount: z.number().positive(),
+  estDuration: z.string().trim().min(1),
+  jobId: z.string().trim().min(1),
+  freelancerId: z.string().trim().min(1)
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().trim().min(1),
+  reviewerId: z.string().trim().min(1),
+  revieweeId: z.string().trim().min(1)
+});


### PR DESCRIPTION
﻿﻿/claim #10892

## Summary
- Add Zod schemas for proposal, review, message, and notification creation bodies.
- Validate those POST request bodies before passing them into the in-memory services.
- Keep valid creation flows working while returning 400 Validation failed for malformed bodies.

## Verification
- RED: `node --test apps\\api\\src\\tests\\writeEndpointValidation.test.js` failed before the fix because `/api/proposals` returned 201 for malformed input.
- GREEN: `node --test apps\\api\\src\\tests\\writeEndpointValidation.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\health.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\*.test.js`
- GREEN: `git diff --check`

Closes #10892
References #743
