### PR TITLE
fix(api): require auth for token refresh

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/authRefresh.test.js
+++ b/apps/api/src/tests/authRefresh.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postRefresh(baseUrl, token) {
+  const headers = {};
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+    method: "POST",
+    headers
+  });
+
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("POST /api/auth/refresh rejects anonymous callers", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await postRefresh(baseUrl);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/auth/refresh preserves authenticated subject and role", async () => {
+  await withServer(async (baseUrl) => {
+    const originalToken = signAccessToken({ sub: "usr_refresh", role: "freelancer" });
+    const { response, payload } = await postRefresh(baseUrl, originalToken);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+
+    const decoded = verifyAccessToken(payload.data.token);
+    assert.equal(decoded.sub, "usr_refresh");
+    assert.equal(decoded.role, "freelancer");
+  });
+});


### PR DESCRIPTION
﻿﻿/claim #10894

## Summary
- Protect `POST /api/auth/refresh` with the existing bearer-token auth middleware.
- Refresh tokens from the authenticated caller's `sub` and `role` instead of hard-coding `usr_existing`.
- Add API regression coverage for anonymous rejection and authenticated refresh behavior.

## Verification
- RED: `node --test apps\\api\\src\\tests\\authRefresh.test.js` failed before the fix because anonymous refresh returned 200 and authenticated refresh returned `usr_existing`.
- GREEN: `node --test apps\\api\\src\\tests\\authRefresh.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\health.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\*.test.js`
- GREEN: `git diff --check`

Closes #10894
References #743
