### PR TITLE
fix(api): enforce admin role on metrics

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function requireRoleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminRoleGuard.test.js
+++ b/apps/api/src/tests/adminRoleGuard.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getMetrics(baseUrl, token) {
+  const headers = {};
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers });
+  return {
+    response,
+    payload: await response.json()
+  };
+}
+
+test("GET /api/admin/metrics still rejects anonymous callers", async () => {
+  await withServer(async (baseUrl) => {
+    const { response, payload } = await getMetrics(baseUrl);
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("GET /api/admin/metrics rejects non-admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const clientToken = signAccessToken({ sub: "usr_client", role: "client" });
+    const { response, payload } = await getMetrics(baseUrl, clientToken);
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Forbidden"
+    });
+  });
+});
+
+test("GET /api/admin/metrics allows admin users", async () => {
+  await withServer(async (baseUrl) => {
+    const adminToken = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const { response, payload } = await getMetrics(baseUrl, adminToken);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.openJobs, 42);
+  });
+});


### PR DESCRIPTION
﻿﻿/claim #10896

## Summary
- Add a reusable role guard middleware for authenticated routes.
- Require the `admin` role on `/api/admin/metrics` after bearer-token authentication.
- Add API regression coverage for anonymous, non-admin, and admin access.

## Verification
- RED: `node --test apps\\api\\src\\tests\\adminRoleGuard.test.js` failed before the fix because a `client` token could read `/api/admin/metrics`.
- GREEN: `node --test apps\\api\\src\\tests\\adminRoleGuard.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\health.test.js`
- GREEN: `node --test apps\\api\\src\\tests\\*.test.js`
- GREEN: `git diff --check`

Closes #10896
References #743
