### PR TITLE
fix(api): block admin self-registration

### DIFF
--- a/apps/api/src/tests/authRegistrationRole.test.js
+++ b/apps/api/src/tests/authRegistrationRole.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema defaults public registrations to client role", () => {
+  const parsed = registerSchema.parse({
+    email: "client@example.com",
+    password: "securepass"
+  });
+
+  assert.equal(parsed.role, "client");
+});
+
+test("registerSchema accepts freelancer public registrations", () => {
+  const parsed = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "securepass",
+    role: "freelancer"
+  });
+
+  assert.equal(parsed.role, "freelancer");
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const parsed = registerSchema.safeParse({
+    email: "admin@example.com",
+    password: "securepass",
+    role: "admin"
+  });
+
+  assert.equal(parsed.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
/claim #10903

## Summary
- restrict public registration roles to `client` and `freelancer`
- preserve the default `client` role for registrations that omit `role`
- add focused tests proving `admin` self-assignment is rejected while normal roles still work

## Verification
- RED: `node --test apps\api\src\tests\authRegistrationRole.test.js` failed because `role: admin` was accepted
- GREEN: `node --test apps\api\src\tests\authRegistrationRole.test.js`
- GREEN: `node --test apps\api\src\tests\health.test.js`
- GREEN: `node --test apps\api\src\tests\*.test.js`
- `git diff --check`

Closes #10903
References #743