### PR TITLE
Require authentication for file uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/uploadAuth.test.js
+++ b/apps/api/src/tests/uploadAuth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function createUploadBody() {
+  const formData = new FormData();
+  formData.set("file", new Blob(["sample upload"], { type: "text/plain" }), "sample.txt");
+  return formData;
+}
+
+test("POST /api/uploads rejects anonymous file uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: createUploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/uploads accepts authenticated file uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({
+      sub: "user_upload_auth",
+      role: "client"
+    });
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: createUploadBody()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: { filename: "sample.txt", status: "uploaded" }
+    });
+  });
+});


### PR DESCRIPTION
﻿/claim #10909
/claim #743

## Summary
- Require the existing bearer-token `authMiddleware` before `POST /api/uploads` reaches multer or the upload controller.
- Add API regression coverage showing anonymous multipart uploads are rejected while authenticated uploads still work.

## Root Cause
`uploadRoutes.post("/", upload.single("file"), uploadFile)` exposed file parsing and upload handling without the authentication middleware used by protected API routes.

## Validation
- `node --test apps/api/src/tests/uploadAuth.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
