### PR TITLE
Require authentication for message creation

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/tests/messageAuth.test.js
+++ b/apps/api/src/tests/messageAuth.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/messages rejects anonymous callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ recipientId: "usr_2", body: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/messages accepts authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({
+      sub: "user_message_auth",
+      role: "client"
+    });
+
+    const response = await fetch(`${baseUrl}/api/messages`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ recipientId: "usr_2", body: "hello" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.recipientId, "usr_2");
+    assert.equal(payload.data.body, "hello");
+    assert.match(payload.data.id, /^msg_/);
+  });
+});


### PR DESCRIPTION
﻿/claim #10913
/claim #743

## Summary
- Require the existing bearer-token `authMiddleware` before `POST /api/messages` reaches the message controller.
- Keep public `GET /api/messages` behavior unchanged.
- Add API regression coverage showing anonymous message creation is rejected while authenticated creation still works.

## Root Cause
`messageRoutes.post("/", postMessage)` exposed message creation without the authentication middleware used by protected API routes.

## Validation
- `node --test apps/api/src/tests/messageAuth.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
