### PR TITLE
Require authentication for proposal creation

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposalAuth.test.js
+++ b/apps/api/src/tests/proposalAuth.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects anonymous callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jobId: "job_1", coverLetter: "I can help." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/proposals accepts authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({
+      sub: "user_proposal_auth",
+      role: "freelancer"
+    });
+
+    const response = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ jobId: "job_1", coverLetter: "I can help." })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.jobId, "job_1");
+    assert.equal(payload.data.coverLetter, "I can help.");
+    assert.match(payload.data.id, /^prp_/);
+  });
+});


### PR DESCRIPTION
﻿/claim #10915
/claim #743

## Summary
- Require the existing bearer-token `authMiddleware` before `POST /api/proposals` reaches the proposal controller.
- Keep public `GET /api/proposals` behavior unchanged.
- Add API regression coverage showing anonymous proposal creation is rejected while authenticated creation still works.

## Root Cause
`proposalRoutes.post("/", postProposal)` exposed proposal creation without the authentication middleware used by protected API routes.

## Validation
- `node --test apps/api/src/tests/proposalAuth.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
