### PR TITLE
Require authentication for notification creation

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/notifications rejects anonymous callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ userId: "usr_1", message: "New proposal" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/notifications accepts authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({
+      sub: "user_notification_auth",
+      role: "client"
+    });
+
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ userId: "usr_1", message: "New proposal" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.userId, "usr_1");
+    assert.equal(payload.data.message, "New proposal");
+    assert.equal(payload.data.read, false);
+    assert.match(payload.data.id, /^ntf_/);
+  });
+});


### PR DESCRIPTION
﻿/claim #10917
/claim #743

## Summary
- Require the existing bearer-token `authMiddleware` before `POST /api/notifications` reaches the notification controller.
- Keep public `GET /api/notifications` behavior unchanged.
- Add API regression coverage showing anonymous notification creation is rejected while authenticated creation still works.

## Root Cause
`notificationRoutes.post("/", postNotification)` exposed notification creation without the authentication middleware used by protected API routes.

## Validation
- `node --test apps/api/src/tests/notificationAuth.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`
