### PR TITLE
Normalize search query parameter shape

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,19 @@
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+function normalizeSearchQuery(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const firstStringValue = value.find((entry) => typeof entry === "string");
+    return firstStringValue ?? "";
+  }
+
+  return "";
+}
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  return ok(res, await globalSearch(normalizeSearchQuery(req.query.q)));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getSearchQuery(baseUrl, queryString) {
+  const response = await fetch(`${baseUrl}/api/search${queryString}`);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  return payload.data.query;
+}
+
+test("GET /api/search normalizes query parameter shape", async () => {
+  await withServer(async (baseUrl) => {
+    assert.equal(await getSearchQuery(baseUrl, "?q=alpha"), "alpha");
+    assert.equal(await getSearchQuery(baseUrl, "?q=alpha&q=beta"), "alpha");
+    assert.equal(await getSearchQuery(baseUrl, "?q[x]=beta"), "");
+    assert.equal(await getSearchQuery(baseUrl, ""), "");
+  });
+});


### PR DESCRIPTION
/claim #743

## Summary

- Normalize the `q` query parameter before calling `globalSearch()`.
- Preserve ordinary string queries, use the first string from repeated `q` values, and fall back to an empty string for nested or missing values.
- Add focused route coverage for normal, repeated, nested, and missing search query inputs.

Fixes #10919
Refs #743

## Validation

- `node --test apps/api/src/tests/search.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

No payout, wallet, credential, or off-platform payment details are included.