### PR TITLE
Fix registration token subject drift

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token for the returned user id", async () => {
+  const originalDateNow = Date.now;
+  let timestamp = 1_700_000_000_000;
+
+  Date.now = () => timestamp++;
+
+  try {
+    const result = await registerUser({
+      email: "new-user@example.com",
+      role: "client"
+    });
+
+    const tokenPayload = verifyAccessToken(result.token);
+
+    assert.equal(result.id, "usr_1700000000000");
+    assert.equal(tokenPayload.sub, result.id);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
/claim #743

## Summary

- Generate the registration user id once and reuse it for the returned `id` and JWT `sub`.
- Add a regression test that forces `Date.now()` to advance and verifies the token subject matches the returned user id.
- Update the API test script so the existing Node test runner executes the test files directly.

## Verification

```sh
npm test -w apps/api
```

Refs #10921
Parent bounty: #743
