### PR TITLE
Fix review id collisions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${randomUUID()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview generates unique ids for same-millisecond reviews", async (t) => {
+  const originalDateNow = Date.now;
+  t.after(() => {
+    Date.now = originalDateNow;
+  });
+
+  Date.now = () => 1234567890;
+
+  const first = await createReview({ rating: 5, comment: "great" });
+  const second = await createReview({ rating: 4, comment: "good" });
+
+  assert.match(first.id, /^rev_/);
+  assert.match(second.id, /^rev_/);
+  assert.notEqual(first.id, second.id);
+});


### PR DESCRIPTION
/claim #743

## Summary

- Generate review ids with a server-owned `rev_` + UUID value instead of `Date.now()`.
- Preserve the existing `rev_` prefix while preventing same-millisecond collisions.
- Add focused review service regression coverage for two creates in the same millisecond.
- Update the API test script so the workspace test command executes `*.test.js` files directly.

## Verification

```sh
node --test ./src/tests/reviewService.test.js
npm test -w apps/api
git diff --check
```

Refs #10931
Parent bounty: #743
