### PR TITLE
fix(ui): forward native button props

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, style, type = "button", ...props }: ButtonProps) {
   return (
     <button
+      type={type}
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}


### PR DESCRIPTION
/claim #743

Closes #10933

## Summary
- Forward native `button` props from the shared `Button` component.
- Default the component to `type="button"` to avoid accidental form submission when consumers omit a type.
- Preserve the existing inline visual styles while allowing caller-provided styles to extend or override them.

## Validation
- `git diff --check`

Note: I could not run the web build in this local environment because `npm`/`corepack` are not available on PATH; this patch is scoped to TypeScript component props and a native button attribute default.