### PR TITLE
fix(web): use comma separator for freelancer skills

### DIFF
--- a/apps/web/app/freelancers/search/page.tsx
+++ b/apps/web/app/freelancers/search/page.tsx
@@ -9,7 +9,7 @@ export default function FreelancerSearchPage() {
         {freelancers.map((freelancer) => (
           <article className="card" key={freelancer.username}>
             <h3>{freelancer.username}</h3>
-            <p>{freelancer.skills.join(" · ")}</p>
+            <p>{freelancer.skills.join(", ")}</p>
             <p>{freelancer.rate}</p>
             <Link href={`/freelancers/${freelancer.username}`}>Open profile</Link>
           </article>


### PR DESCRIPTION
﻿﻿## Summary
- Use an ASCII comma separator for freelancer search skills to avoid separator mojibake risk.

Closes #10938

## Claims
/claim #10938
/claim #743

## Verification
- Failing-first check before the change: `Select-String` assertion for `skills.join(", ")` failed on the old page source.
- `Select-String -LiteralPath apps\web\app\freelancers\search\page.tsx -SimpleMatch 'skills.join(", ")' -Quiet`
- `npm run build -w apps/web`
- `git diff --check`

## Scope
- Only `apps/web/app/freelancers/search/page.tsx` changed.
