### PR TITLE
Fix API test script file discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md — bug-bounty
+
+> 墨子 Harness · 自动生成于 2026-07-06
+
+---
+
+## 项目说明
+
+- **项目名称**: bug-bounty
+- **仓库地址**: https://github.com/SecureBananaLabs/bug-bounty.git
+- **技术栈**: Node.js
+- **目标**: 父 bounty #743 下独立发现并修复一个低风险 bug；PR 前需创建自己的限定 issue
+- **Bounty链接**: https://github.com/SecureBananaLabs/bug-bounty/issues/743
+
+---
+
+## 禁止操作
+
+1. **不要 push 到 main/master** — 始终在 feature 分支工作
+2. **不要 force push** — `git push --force` 绝对禁止，`--force-with-lease` 也不行
+3. **不要修改 CI/CD 配置** — `.github/workflows/`、`Makefile`、`Dockerfile` 不碰
+4. **不要装来路不明的包** — 不新增 npm/pip/cargo 依赖，除非 bounty 明确需要
+5. **不要删别人的代码** — 不删除或重构非自己写的代码
+6. **不要加后门/遥测** — 不插任何数据收集、网络请求、环境变量窃取代码
+7. **不要 `sudo`** — 不执行需要提权的命令
+8. **不要 `curl`/`wget` 下载外部脚本** — 所有依赖通过包管理器
+
+---
+
+## 完成定义
+
+**以下四条命令，退出码必须全部为 0，才算完成：**
+
+1. **类型检查** — `echo '(跳过，非 TS 项目)'`
+2. **测试** — `npm test`
+3. **Lint** — `npm run lint`
+4. **构建** — `npm run build`
+
+**额外要求**:
+- [ ] 本地手动验证功能正常
+- [ ] PR 描述清晰：改了什么、为什么、怎么测的
+- [ ] 截图/GIF 附在 PR 里（如有 UI 变更）
+- [ ] PROGRESS.md 已更新

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,34 @@
+# PROGRESS.md — bug-bounty
+
+> 墨子 Harness · 自动生成于 2026-07-06
+
+---
+
+## ✅ 已完成
+
+- 初始化墨子 Harness
+- 确认父 bounty #743 可参与；跳过 #10940，因为该 issue 限定仅创建者可解
+- 创建自己的限定 issue：#10942
+- 修复 API workspace test script，使其执行 `src/tests/*.test.js`
+- Harness 四条命令全绿：type-check / test / lint / build
+- `git diff --check` 通过
+
+---
+
+## 🔄 进行中
+
+- 准备提交、push、开 PR
+
+---
+
+## 📋 待办
+
+- 提交当前分支
+- push 到 fork/origin
+- 创建 PR 关联 #10942 和父 bounty #743
+
+---
+
+## ⚠️ 已知问题
+
+- 无

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# 墨子 Harness · 环境锁定脚本
+# 项目: bug-bounty
+# 生成: 2026-07-06
+# ============================================================
+
+echo "🔍 检查环境..."
+
+# --- Node 版本锁定 ---
+REQUIRED_NODE_MAJOR="22"
+CURRENT_NODE=$(node -v 2>/dev/null || echo "not-installed")
+
+if [ "$CURRENT_NODE" = "not-installed" ]; then
+  echo "❌ Node.js 未安装"
+  exit 1
+fi
+
+CURRENT_MAJOR=$(echo "$CURRENT_NODE" | sed 's/v//' | cut -d. -f1)
+if [ "$CURRENT_MAJOR" != "$REQUIRED_NODE_MAJOR" ]; then
+  echo "❌ 需要 Node v${REQUIRED_NODE_MAJOR}.x，当前 $CURRENT_NODE"
+  echo "   建议: nvm install $REQUIRED_NODE_MAJOR && nvm use $REQUIRED_NODE_MAJOR"
+  exit 1
+fi
+echo "  ✅ Node: $CURRENT_NODE"
+
+# --- 包管理器锁定 ---
+PACKAGE_MANAGER="npm"
+
+# --- 依赖安装（锁定版本）---
+echo "📦 安装依赖..."
+
+case "$PACKAGE_MANAGER" in
+  pnpm)
+    if ! command -v pnpm &>/dev/null; then
+      echo "  安装 pnpm..."
+      npm install -g pnpm
+    fi
+    echo "  pnpm: $(pnpm --version)"
+    
+    if [ -f "pnpm-lock.yaml" ]; then
+      pnpm install --frozen-lockfile
+    else
+      echo "  ⚠️ 未找到 pnpm-lock.yaml，生成中..."
+      pnpm install
+    fi
+    ;;
+    
+  npm)
+    if [ -f "package-lock.json" ]; then
+      npm ci
+    else
+      echo "  ⚠️ 未找到 package-lock.json，生成中..."
+      npm install
+    fi
+    ;;
+    
+  yarn)
+    if [ -f "yarn.lock" ]; then
+      yarn install --frozen-lockfile
+    else
+      echo "  ⚠️ 未找到 yarn.lock，生成中..."
+      yarn install
+    fi
+    ;;
+    
+  *)
+    echo "❌ 未知包管理器: $PACKAGE_MANAGER"
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "✅ 环境准备完成"
+echo ""
+echo "下一步:"
+echo "  1. 确认 AGENTS.md 已配置"
+echo "  2. git checkout -b feature/xxx 创建开发分支"
+echo "  3. 开始写代码"
+echo "  4. 跑 Harness: echo '(跳过，非 TS 项目)' && npm test && npm lint && npm build"
+echo "  5. 全绿后 git commit && git push origin feature/xxx"


### PR DESCRIPTION
## Summary
- Fix the API workspace test script to execute existing test files with `src/tests/*.test.js` instead of passing the test directory as a module entrypoint.
- Add Harness project tracking files for the bounty workflow.

## Issue
Fixes #10942
Parent bounty: #743

## Validation
- `echo '(跳过，非 TS 项目)'`
- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`