### PR TITLE
fix: review service should generate collision-resistant server-owned ids (#10859)

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,8 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const { id: _clientProvidedId, ...rest } = payload;
+  const review = { id: `rev_${crypto.randomUUID()}`, ...rest };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview generates collision-resistant ids", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1720000000000;
+
+  try {
+    const review1 = await createReview({
+      reviewerId: "usr_a",
+      revieweeId: "usr_b",
+      rating: 5,
+      comment: "fast",
+    });
+    const review2 = await createReview({
+      reviewerId: "usr_c",
+      revieweeId: "usr_d",
+      rating: 4,
+      comment: "clear",
+    });
+
+    assert.ok(review1.id.startsWith("rev_"), "review1 id has rev_ prefix");
+    assert.ok(review2.id.startsWith("rev_"), "review2 id has rev_ prefix");
+    assert.notEqual(review1.id, review2.id, "ids must be distinct");
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("createReview ignores client-supplied id", async () => {
+  const review = await createReview({
+    id: "rev_hacked",
+    reviewerId: "usr_a",
+    revieweeId: "usr_b",
+    rating: 5,
+    comment: "fast",
+  });
+
+  assert.notEqual(review.id, "rev_hacked", "client id must not override server id");
+  assert.ok(review.id.startsWith("rev_"), "server id has rev_ prefix");
+});


### PR DESCRIPTION
## Summary

Closes #10859

Replace timestamp-only review id generation with collision-resistant server-owned ids using `crypto.randomUUID()`.

## Root Cause

`apps/api/src/services/reviewService.js` generates review ids with `Date.now()`:

```js
const review = { id: `rev_${Date.now()}`, ...payload };
```

This produces duplicate ids when two reviews are created in the same millisecond, and allows client-provided `id` to override the server-generated id because `...payload` is spread after `id`.

## Changes

| File | Change |
|------|--------|
| `apps/api/src/services/reviewService.js` | Use `crypto.randomUUID()` for collision-resistant ids; strip client id from payload before spreading |
| `apps/api/src/tests/reviewService.test.js` | Add regression tests for collision resistance and client id override prevention |

## Testing

- [x] `node --test apps/api/src/tests/reviewService.test.js` — 2 tests pass
- [x] Collision test: freeze `Date.now()`, create two rapid reviews, assert distinct ids
- [x] Override test: pass client `id` in payload, assert server id is used instead