### PR TITLE
Fix API test script file matching

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Fixes the API workspace test script so Node's test runner targets test files instead of treating `src/tests` as a module entrypoint.

## Change

- Updated `apps/api/package.json`
- Changed `node --test src/tests` to `node --test "src/tests/**/*.test.js"`

## Validation

Before:

```text
Error: Cannot find module '.../apps/api/src/tests'
```

After:

```text
✔ GET /health returns ok payload
ℹ pass 1
ℹ fail 0
```

Closes #10945
