### PR TITLE
Keep registration token subject in sync

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
+
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser uses the returned user id as the token subject", async () => {
+  const user = await registerUser({
+    email: "client@example.com",
+    role: "client"
+  });
+
+  const tokenPayload = verifyAccessToken(user.token);
+
+  assert.equal(tokenPayload.sub, user.id);
+  assert.equal(tokenPayload.role, user.role);
+});


### PR DESCRIPTION
Closes #10948.

This fixes registration identity drift by generating the new user id once and reusing it for both the response id and JWT sub.

It also adds a regression test that verifies the decoded token subject matches the returned user id and role.

Verification:
- node --check apps/api/src/services/authService.js
- node --check apps/api/src/tests/authService.test.js

Note: full API tests could not run in this local environment because dependencies are not installed (jsonwebtoken / cors missing), and the existing npm test script treats src/tests as a module under Node 24 on Windows.