### PR TITLE
Prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema defaults new users to the client role", () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123"
+  });
+
+  assert.equal(payload.role, "client");
+});
+
+test("registerSchema allows normal public registration roles", () => {
+  const payload = registerSchema.parse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+
+  assert.equal(payload.role, "freelancer");
+});
+
+test("registerSchema rejects public admin self-assignment", () => {
+  assert.throws(() =>
+    registerSchema.parse({
+      email: "admin@example.com",
+      password: "password123",
+      role: "admin"
+    })
+  );
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #10950.

This removes dmin from the public registration role enum so public signups can only request normal user roles. Omitted roles still default to client, and reelancer remains accepted.

Added focused schema coverage for:
- defaulting omitted role to client`n- accepting reelancer`n- rejecting dmin self-assignment

Verification:
- node --check apps/api/src/validators/auth.js
- node --check apps/api/src/tests/authValidator.test.js
- git diff --check

Note: full runtime tests require local dependencies (zod, etc.), which are not installed in this checkout.