### PR TITLE
Require authentication for payment creation

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const paymentRoutesPath = new URL("../routes/paymentRoutes.js", import.meta.url);
+
+test("payment creation route requires authentication", async () => {
+  const source = await readFile(paymentRoutesPath, "utf8");
+
+  assert.match(source, /import\s+\{\s*authMiddleware\s*\}\s+from\s+["']\.\.\/middleware\/auth\.js["'];/);
+  assert.match(source, /paymentRoutes\.post\(\s*["']\/["']\s*,\s*authMiddleware\s*,\s*createPayment\s*\)/);
+});


### PR DESCRIPTION
Closes #10952.

This protects POST /api/payments with the existing bearer-token uthMiddleware before payment creation runs, so anonymous callers can no longer create payment intent records.

Added focused coverage that verifies the route imports uthMiddleware and registers it before createPayment.

Verification:
- node --check apps/api/src/routes/paymentRoutes.js
- node --check apps/api/src/tests/paymentRoutes.test.js
- node --test apps/api/src/tests/paymentRoutes.test.js
- git diff --check