### PR TITLE
Return defensive copies from list services

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,7 +1,7 @@
 const jobs = [];
 
 export async function listJobs() {
-  return jobs;
+  return jobs.map((job) => ({ ...job }));
 }
 
 export async function createJob(payload) {

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,7 +1,7 @@
 const messages = [];
 
 export async function listMessages() {
-  return messages;
+  return messages.map((message) => ({ ...message }));
 }
 
 export async function sendMessage(payload) {

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,7 +1,7 @@
 const notifications = [];
 
 export async function listNotifications() {
-  return notifications;
+  return notifications.map((notification) => ({ ...notification }));
 }
 
 export async function createNotification(payload) {

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,7 +1,7 @@
 const proposals = [];
 
 export async function listProposals() {
-  return proposals;
+  return proposals.map((proposal) => ({ ...proposal }));
 }
 
 export async function createProposal(payload) {

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,7 +1,7 @@
 const reviews = [];
 
 export async function listReviews() {
-  return reviews;
+  return reviews.map((review) => ({ ...review }));
 }
 
 export async function createReview(payload) {

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/listServices.test.js
+++ b/apps/api/src/tests/listServices.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+import { sendMessage, listMessages } from "../services/messageService.js";
+import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createProposal, listProposals } from "../services/proposalService.js";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createUser, listUsers } from "../services/userService.js";
+
+async function assertDefensiveList({ create, list, payload, field }) {
+  const record = await create(payload);
+  const firstList = await list();
+  const baselineLength = firstList.length;
+  const returnedRecord = firstList.find((item) => item.id === record.id);
+
+  assert.ok(returnedRecord);
+
+  firstList.push({ id: "client-injected-record" });
+  returnedRecord[field] = "client-mutated-value";
+
+  const secondList = await list();
+  const storedRecord = secondList.find((item) => item.id === record.id);
+
+  assert.equal(secondList.length, baselineLength);
+  assert.equal(storedRecord[field], payload[field]);
+}
+
+test("list services do not expose mutable backing arrays or records", async () => {
+  await assertDefensiveList({
+    create: createUser,
+    list: listUsers,
+    payload: { name: "Ada" },
+    field: "name"
+  });
+
+  await assertDefensiveList({
+    create: createJob,
+    list: listJobs,
+    payload: {
+      title: "Build API",
+      description: "Create a stable marketplace API",
+      budgetMin: 100,
+      budgetMax: 300,
+      categoryId: "backend",
+      skills: ["node"]
+    },
+    field: "title"
+  });
+
+  await assertDefensiveList({
+    create: createProposal,
+    list: listProposals,
+    payload: { jobId: "job_1", freelancerId: "usr_1", coverLetter: "I can help" },
+    field: "coverLetter"
+  });
+
+  await assertDefensiveList({
+    create: createReview,
+    list: listReviews,
+    payload: { jobId: "job_1", reviewerId: "usr_1", rating: 5, comment: "Great work" },
+    field: "comment"
+  });
+
+  await assertDefensiveList({
+    create: sendMessage,
+    list: listMessages,
+    payload: { from: "usr_1", to: "usr_2", body: "Hello" },
+    field: "body"
+  });
+
+  await assertDefensiveList({
+    create: createNotification,
+    list: listNotifications,
+    payload: { userId: "usr_1", message: "New update" },
+    field: "message"
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #10958.

## Summary

- Return cloned records from the in-memory list service functions instead of exposing backing arrays directly.
- Cover users, jobs, proposals, reviews, messages, and notifications.
- Add a focused regression test proving callers cannot mutate service state by pushing into a returned list or editing a returned record.

## Root cause

The list service functions returned their module-level arrays directly. Any caller holding a list response could mutate that array or a returned record object without going through the service layer.

## Validation

- `node --test apps/api/src/tests/listServices.test.js`
- `node --test apps/api/src/tests/*.test.js`
- `git diff --check`

No payout, wallet, private credentials, or payment information is included.