### PR TITLE
Codex Card component should forward native section props

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,19 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+const defaultCardStyle: React.CSSProperties = {
+  border: "1px solid #ddd",
+  borderRadius: 8,
+  padding: "1rem"
+};
+
+export function Card({ title, children, style, ...sectionProps }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section {...sectionProps} style={{ ...defaultCardStyle, ...style }}>
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
## Summary
- Allow the shared `Card` component to accept native section props (`className`, `id`, `aria-*`, `data-*`, event handlers, etc.).
- Preserve the existing title/children markup and default border/radius/padding styling.
- Merge caller-provided `style` after defaults so consumers can extend or override Card presentation.

Closes #10960

/claim #10960
/claim #743

## Validation
- `npx tsc --noEmit --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --lib dom,dom.iterable,esnext --esModuleInterop --skipLibCheck packages/ui/src/Card.tsx`
- `git diff --check`

## Demo note
This is a shared component typing/prop-forwarding fix rather than a visible page-flow change. The focused TypeScript compile above demonstrates that `Card` still compiles with the widened native section prop surface.