### PR TITLE
fix(web): expose current navigation state

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 const links = [
   ["/", "Home"],
@@ -8,16 +11,32 @@ const links = [
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
   ["/admin", "Admin"]
-];
+] as const;
 
 export function Navigation() {
+  const pathname = usePathname();
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
-      {links.map(([href, label]) => (
-        <Link key={href} href={href} className="card" style={{ padding: "0.5rem 0.8rem" }}>
-          {label}
-        </Link>
-      ))}
+      {links.map(([href, label]) => {
+        const isCurrent = pathname === href || (href !== "/" && pathname.startsWith(`${href}/`));
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className="card"
+            aria-current={isCurrent ? "page" : undefined}
+            style={{
+              padding: "0.5rem 0.8rem",
+              borderColor: isCurrent ? "#8ea2ff" : undefined,
+              background: isCurrent ? "#202b52" : undefined
+            }}
+          >
+            {label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }


### PR DESCRIPTION
/claim #743

Closes #10973

## Summary
- Convert the shared navigation to read the current pathname.
- Add `aria-current="page"` to the matching navigation link.
- Keep nested routes associated with their parent nav item, such as `/jobs/job-101` marking `Jobs` as current.
- Add a small active visual treatment without changing the route list.

## Validation
- `git diff --check`

Note: I could not run the web build in this local environment because `npm`/`corepack` are not available on PATH. The change is scoped to one Next navigation component.