### PR TITLE
fix(api): run node tests via file glob

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

- Fix the API workspace test script to execute concrete test files instead of passing the `src/tests` directory as a module entrypoint.
- Preserve the existing Node test runner and API test suite.
- Keep the change scoped to `apps/api/package.json`.

## Validation

- `npm test`
- `npm run build -w apps/web`
- `git diff --check`

## Claim

/claim #743

Closes #10980
