### PR TITLE
Keep health checks outside API rate limit

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/healthRateLimit.test.js
+++ b/apps/api/src/tests/healthRateLimit.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /health is not rate limited by the shared API limiter", async () => {
+  await withServer(async (baseUrl) => {
+    for (let attempt = 1; attempt <= 205; attempt += 1) {
+      const response = await fetch(`${baseUrl}/health`);
+      assert.equal(response.status, 200, `attempt ${attempt} returned ${response.status}`);
+      await response.body?.cancel();
+    }
+  });
+});


### PR DESCRIPTION
/claim #743

Fixes #10988

## Summary
- Register `GET /health` before the shared API rate limiter so uptime probes do not consume or trip the API quota.
- Keep `apiLimiter` in place for the remaining `/api/*` routes.
- Add regression coverage proving repeated health checks continue returning 200.

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/healthRateLimit.test.js`
- `git diff --check`