### PR TITLE
Fix health route rate limiting

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -21,11 +21,12 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });
   });
+
+  app.use(apiLimiter);
 
   app.use("/api/auth", authRoutes);
   app.use("/api/users", userRoutes);

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,14 +2,26 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
-  const app = createApp();
+async function listen(app) {
   const server = app.listen(0);
 
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);
     server.once("error", reject);
   });
+
+  return server;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /health returns ok payload", async () => {
+  const app = createApp();
+  const server = await listen(app);
 
   const { port } = server.address();
   const response = await fetch(`http://127.0.0.1:${port}/health`);
@@ -18,7 +30,20 @@ test("GET /health returns ok payload", async () => {
   assert.equal(response.status, 200);
   assert.deepEqual(payload, { ok: true, service: "api" });
 
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
+  await close(server);
+});
+
+test("GET /health bypasses the shared API rate limiter", async () => {
+  const app = createApp();
+  const server = await listen(app);
+  const { port } = server.address();
+
+  try {
+    for (let i = 0; i < 205; i += 1) {
+      const response = await fetch(`http://127.0.0.1:${port}/health`);
+      assert.equal(response.status, 200);
+    }
+  } finally {
+    await close(server);
+  }
 });


### PR DESCRIPTION
Closes #10990
/claim #10990

## Summary
- register `/health` before the shared API rate limiter
- keep the limiter in place for the rest of the API routes
- add regression coverage proving repeated health probes continue returning 200

## Tests
- `node --test src/tests/*.test.js` from `apps/api`

Note: the current `npm test` script on `main` still points Node at `src/tests` as a directory; this PR keeps scope limited to #10990 and validates with Node's explicit test-file pattern.