### PR TITLE
fix: add user validation to prevent admin role self-assignment

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
-export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+export async function postUser(req, res, next) {
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (err) {
+    return next(err);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      error: "Validation error",
+      details: err.errors.map((e) => ({
+        path: e.path.join("."),
+        message: e.message,
+      })),
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/users.test.js
+++ b/apps/api/src/tests/users.test.js
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function startServer(app) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0);
+    server.once("listening", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function url(server, path) {
+  const { port } = server.address();
+  return `http://127.0.0.1:${port}${path}`;
+}
+
+async function postJSON(server, path, body) {
+  const response = await fetch(url(server, path), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const payload = await response.json();
+  return { response, payload };
+}
+
+test("POST /api/users rejects payloads with missing email", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+
+  const { response, payload } = await postJSON(server, "/api/users", {
+    fullName: "No Email",
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.error, "Validation error");
+  assert.ok(payload.details.some((d) => d.path === "email"));
+
+  await stopServer(server);
+});
+
+test("POST /api/users rejects admin role assignment", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+
+  const { response, payload } = await postJSON(server, "/api/users", {
+    email: "admin@evil.com",
+    fullName: "Hacker",
+    role: "admin",
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.error, "Validation error");
+  assert.ok(payload.details.some((d) => d.path === "role"));
+
+  await stopServer(server);
+});
+
+test("POST /api/users accepts valid client payload", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+
+  const { response, payload } = await postJSON(server, "/api/users", {
+    email: "client@example.com",
+    fullName: "Valid Client",
+    role: "client",
+  });
+
+  assert.equal(response.status, 201);
+  assert.ok(payload.success);
+  const user = payload.data;
+  assert.equal(user.email, "client@example.com");
+  assert.equal(user.role, "client");
+  assert.ok(user.id);
+
+  await stopServer(server);
+});
+
+test("POST /api/users accepts valid payload with default role", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+
+  const { response, payload } = await postJSON(server, "/api/users", {
+    email: "freelancer@example.com",
+    fullName: "Default Role",
+  });
+
+  assert.equal(response.status, 201);
+  assert.ok(payload.success);
+  const user = payload.data;
+  assert.equal(user.email, "freelancer@example.com");
+  assert.equal(user.role, "client");
+  assert.ok(user.id);
+
+  await stopServer(server);
+});
+
+test("POST /api/users rejects freelancer with empty email", async () => {
+  const app = createApp();
+  const server = await startServer(app);
+
+  const { response, payload } = await postJSON(server, "/api/users", {
+    fullName: "Bad Freelancer",
+    role: "freelancer",
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.error, "Validation error");
+  assert.ok(payload.details.some((d) => d.path === "email"));
+
+  await stopServer(server);
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().min(1),
+  role: z.enum(["client", "freelancer"]).default("client"),
+  bio: z.string().optional(),
+});
+
+export const updateUserSchema = createUserSchema.partial();


### PR DESCRIPTION
/claim #743

## Summary

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue **Low Handing Fruit Automation#743** for more information.

---

## Fix

**Bug:** `POST /api/users` currently accepts `req.body` raw without any Zod validation. This allows any caller to inject `role: "admin"` when creating a user, bypassing the auth registration flow that restricts admin role assignment.

### Changes

1. **New file: `validators/user.js`** — Added `createUserSchema` with:
   - `email`: required, valid email format
   - `fullName`: required, non-empty
   - `role`: enum restricted to `["client", "freelancer"]`, defaults to `"client"`
   - `bio`: optional

2. **Modified: `controllers/userController.js`** — Added `createUserSchema.parse(req.body)` inside try/catch with `next(err)` fallthrough to error handler

3. **Modified: `middleware/errorHandler.js`** — Added `ZodError` handling that returns `400` with structured `{ success: false, error: "Validation error", details: [...] }` instead of generic 500

4. **New file: `tests/users.test.js`** — 5 regression tests:
   - Rejects missing email → 400
   - Rejects `role: "admin"` → 400
   - Accepts valid client payload → 201
   - Defaults missing role to client → 201
   - Rejects empty email with valid role → 400

### Test Results
```
# tests 5
# pass 5
# fail 0
```