### PR TITLE
Validate user creation payloads

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,16 @@
 import { ok } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
+import { createUserSchema } from "../validators/user.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
-export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+export async function postUser(req, res, next) {
+  try {
+    const payload = createUserSchema.parse(req.body);
+    return ok(res, await createUser(payload), 201);
+  } catch (error) {
+    return next(error);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,22 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request body",
+      issues: err.issues.map((issue) => ({
+        path: issue.path,
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/user.test.js
+++ b/apps/api/src/tests/user.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users defaults valid users to client role", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "new-user@example.com",
+        fullName: "New User"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^usr_/);
+    assert.equal(payload.data.email, "new-user@example.com");
+    assert.equal(payload.data.fullName, "New User");
+    assert.equal(payload.data.role, "client");
+  });
+});
+
+test("POST /api/users rejects admin role self-assignment", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "admin-attempt@example.com",
+        fullName: "Admin Attempt",
+        role: "admin"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+  });
+});
+
+test("POST /api/users rejects invalid email payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/users`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "",
+        fullName: "Invalid Email"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+    assert.ok(payload.issues.some((issue) => issue.path.includes("email")));
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  email: z.string().email(),
+  fullName: z.string().trim().min(1),
+  role: z.enum(["client", "freelancer"]).default("client")
+});


### PR DESCRIPTION
Closes #11000

/claim #743

## Summary
- add a `createUserSchema` for `POST /api/users`
- require a valid email and non-empty full name
- default new users to `client` and reject `role: admin`
- map Zod validation failures to structured `400 Bad Request` responses
- add API regression coverage for valid defaults, admin-role rejection, and invalid email rejection

## Root cause
`postUser()` passed `req.body` directly into `createUser()`, so user creation accepted malformed payloads and privileged role values without validation.

## Validation
- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/user.test.js`
- `git diff --check`

## Payout
If accepted for reward under #743, @es3298 can provide payout details privately or use the platform payout flow. No private payout details are included in this public PR.