### PR TITLE
fix: login endpoint verifies password against registered user store

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,23 +1,34 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    return next(err);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err.status) {
+      return fail(res, err.message, err.status);
+    }
+    return next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {
   return ok(res, {
     provider: req.params.provider,
-    status: "callback-received"
+    status: "callback-received",
   });
 }
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,46 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+// In-memory user store (TODO: replace with Prisma)
+const registeredUsers = [];
+
+export function storeUser(user) {
+  registeredUsers.push(user);
+}
+
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
-  return {
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    password: payload.password,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+  };
+  storeUser(user);
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role }),
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  // Look up registered user by email
+  const user = registeredUsers.find((u) => u.email === payload.email);
+  if (!user) {
+    const err = new Error("Invalid email or password");
+    err.status = 401;
+    throw err;
+  }
+  // Verify password matches the stored user record
+  if (user.password !== payload.password) {
+    const err = new Error("Invalid email or password");
+    err.status = 401;
+    throw err;
+  }
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role }),
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function jsonPost(port, path, body) {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function startApp() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return { server, port };
+}
+
+test("POST /api/auth/register → 201 with valid payload", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, `/api/auth/register`, {
+    email: "alice@test.com",
+    password: "secret12345",
+    role: "client",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+  assert.ok(body.data.token);
+  assert.equal(body.data.email, "alice@test.com");
+});
+
+test("POST /api/auth/login returns 200 with valid credentials after registration", async () => {
+  const { port } = await startApp();
+
+  // register first
+  await jsonPost(port, `/api/auth/register`, {
+    email: "bob@test.com",
+    password: "bobsecret99",
+    role: "freelancer",
+  });
+
+  const res = await jsonPost(port, `/api/auth/login`, {
+    email: "bob@test.com",
+    password: "bobsecret99",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  assert.ok(body.data.token);
+  assert.equal(body.data.email, "bob@test.com");
+});
+
+test("POST /api/auth/login returns 401 with wrong password", async () => {
+  const { port } = await startApp();
+
+  await jsonPost(port, `/api/auth/register`, {
+    email: "carol@test.com",
+    password: "rightpassword1",
+    role: "client",
+  });
+
+  const res = await jsonPost(port, `/api/auth/login`, {
+    email: "carol@test.com",
+    password: "wrongpassword",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 401);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Invalid email or password"));
+});
+
+test("POST /api/auth/login returns 401 for unregistered email", async () => {
+  const { port } = await startApp();
+
+  const res = await jsonPost(port, `/api/auth/login`, {
+    email: "ghost@test.com",
+    password: "anything123",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 401);
+  assert.equal(body.success, false);
+  assert.ok(body.message.includes("Invalid email or password"));
+});
+
+test("POST /api/auth/login token sub matches the registered user id", async () => {
+  const { port } = await startApp();
+
+  const regRes = await jsonPost(port, `/api/auth/register`, {
+    email: "dave@test.com",
+    password: "davepwd11111",
+    role: "client",
+  });
+  const regBody = await regRes.json();
+  const registeredId = regBody.data.id;
+
+  const loginRes = await jsonPost(port, `/api/auth/login`, {
+    email: "dave@test.com",
+    password: "davepwd11111",
+  });
+  const loginBody = await loginRes.json();
+
+  // Decode JWT payload without verification
+  const token = loginBody.data.token;
+  const payload = JSON.parse(
+    Buffer.from(token.split(".")[1], "base64url").toString("utf8")
+  );
+
+  assert.equal(payload.sub, registeredId);
+  assert.equal(payload.role, "client");
+});


### PR DESCRIPTION
/claim #743

Closes #11002

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.

## Bug

`loginUser()` in `apps/api/src/services/authService.js` returned a hardcoded JWT without verifying the provided password. Any caller could POST to `/api/auth/login` with any payload and receive a valid JWT, completely bypassing authentication.

## Fix

### `apps/api/src/services/authService.js`
- Added in-memory user store (`registeredUsers` array) with `storeUser()` helper
- `registerUser()` now stores the user (id, email, password, role) and signs JWT with the correct `sub` (user id)
- `loginUser()` looks up registered user by email, compares password, and throws 401 on mismatch or unknown email
- Returns JWT with correct `sub` and `role` for successful login

### `apps/api/src/controllers/authController.js`
- Wrapped `register()` and `login()` in try/catch to forward Zod parse errors and service-level auth errors
- `login()` catches `err.status` and returns `fail(res, err.message, err.status)` for 401 responses

### `apps/api/src/tests/auth.test.js` (NEW)
- 5 regression tests:
  1. `POST /api/auth/register` → 201 with valid payload
  2. `POST /api/auth/login` → 200 with valid credentials after registration
  3. `POST /api/auth/login` → 401 with wrong password
  4. `POST /api/auth/login` → 401 for unregistered email
  5. `POST /api/auth/login` → token `sub` matches registered user id

## Test Results

```
✔ POST /api/auth/register → 201 with valid payload
✔ POST /api/auth/login returns 200 with valid credentials after registration
✔ POST /api/auth/login returns 401 with wrong password
✔ POST /api/auth/login returns 401 for unregistered email
✔ POST /api/auth/login token sub matches the registered user id

# tests 5
# pass 5
# fail 0
```

Existing `health.test.js` remains passing.