### PR TITLE
fix: handle Zod validation errors in job controller with structured 400 response

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -6,7 +6,14 @@ export async function getJobs(req, res) {
   return ok(res, await listJobs());
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (err) {
+    if (err.name === "ZodError") {
+      return fail(res, err.errors, 400);
+    }
+    return next(err);
+  }
 }

--- a/apps/api/src/tests/jobs.test.js
+++ b/apps/api/src/tests/jobs.test.js
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+function jsonPost(port, path, body) {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function startApp() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return { server, port };
+}
+
+test("POST /api/jobs → 201 with valid payload", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, "/api/jobs", {
+    title: "Senior React Developer",
+    description: "Build a real-time dashboard with WebSocket integration",
+    budgetMin: 3000,
+    budgetMax: 6000,
+    categoryId: "cat-web",
+    skills: ["React", "TypeScript", "D3.js"],
+  });
+  const body = await res.json();
+  assert.equal(res.status, 201);
+  assert.equal(body.success, true);
+  assert.ok(body.data.id.startsWith("job_"));
+});
+
+test("POST /api/jobs → 400 when title is too short", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, "/api/jobs", {
+    title: "JS",
+    description: "Build something",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "cat-web",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  // Zod errors array should contain the title validation error
+  assert.ok(Array.isArray(body.message));
+  const titleErr = body.message.find(
+    (e) => e.path && e.path.includes("title")
+  );
+  assert.ok(titleErr);
+});
+
+test("POST /api/jobs → 400 when description is too short", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, "/api/jobs", {
+    title: "Valid Job Title",
+    description: "short",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "cat-web",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(Array.isArray(body.message));
+});
+
+test("POST /api/jobs → 400 when budgetMin is negative", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, "/api/jobs", {
+    title: "Valid Job Title",
+    description: "A proper job description here",
+    budgetMin: -100,
+    budgetMax: 500,
+    categoryId: "cat-web",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+});
+
+test("POST /api/jobs → 400 when required fields are missing", async () => {
+  const { port } = await startApp();
+  const res = await jsonPost(port, "/api/jobs", {
+    title: "Half-filled Job",
+  });
+  const body = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(body.success, false);
+  assert.ok(Array.isArray(body.message));
+});


### PR DESCRIPTION
/claim #743

Closes #11004

This issue is limited only to the creator of this issue. This means that only the issue author can attempt to solve this issue. If you would like to work on it, please create another issue with the same contents and refer to issue #743 for more information.

## Bug

`postJob()` called `createJobSchema.parse(req.body)` synchronously without try/catch. Zod validation failures propagated as unhandled exceptions → generic 500 "Unexpected server error" instead of 400 with field-level validation details.

## Fix

### `apps/api/src/controllers/jobController.js`
- Wrapped `.parse()` in try/catch
- `ZodError` → `fail(res, err.errors, 400)` with structured validation details
- Non-Zod errors → `next(err)` to error handler

### `apps/api/src/tests/jobs.test.js` (NEW)
- 5 regression tests:
  1. Valid payload → 201 with job id
  2. Title too short → 400 with Zod error array
  3. Description too short → 400
  4. Negative budgetMin → 400
  5. Missing required fields → 400

## Test Results

```
✔ POST /api/jobs → 201 with valid payload
✔ POST /api/jobs → 400 when title is too short
✔ POST /api/jobs → 400 when description is too short
✔ POST /api/jobs → 400 when budgetMin is negative
✔ POST /api/jobs → 400 when required fields are missing

# tests 5
# pass 5
# fail 0
```