### PR TITLE
fix: reject inverted budget ranges in job validation (Closes #2853)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,20 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(
+  data => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Fix: Reject inverted budget ranges in job validation

### Bug
`createJobSchema` currently accepts payloads where `budgetMax` is lower than `budgetMin`. This creates invalid job records with inverted budget ranges.

### Fix
Added `.refine()` to both `createJobSchema` and `updateJobSchema` to ensure `budgetMax >= budgetMin`.

- **createJobSchema**: Refuse creation when budgetMax < budgetMin
- **updateJobSchema**: Refuse partial updates when both budget fields are present and inverted
- Valid ordered ranges continue to parse successfully

Closes #2853
