### PR TITLE
fix(api): target concrete test files to resolve Node 22 MODULE_NOT_FOUND

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Resolves #10980

The API workspace test script previously passed the `src/tests` directory directly to Node's test runner. On Node 22, this is treated as a module entrypoint instead of a directory to scan, resulting in a MODULE_NOT_FOUND error that prevents the test suite from running.

Updated the test script to target explicit glob.