### PR TITLE
fix: add bcrypt password hashing and login verification

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "test": "node --test src/tests"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,31 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
-export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+export async function register(req, res, next) {
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err.status) {
+      return fail(res, err.message, err.status);
+    }
+    return next(err);
+  }
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err.status) {
+      return fail(res, err.message, err.status);
+    }
+    return next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {
@@ -22,6 +36,7 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const userId = req.user?.sub ?? "usr_unknown";
+  const result = await refreshToken(userId);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,51 @@
+import bcrypt from "bcryptjs";
 import { signAccessToken } from "../utils/jwt.js";
+import { createUser, findUserByEmail } from "./userService.js";
+
+const SALT_ROUNDS = 12;
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const existing = await findUserByEmail(payload.email);
+  if (existing) {
+    throw Object.assign(new Error("Email already registered"), { status: 409 });
+  }
+
+  const hashedPassword = await bcrypt.hash(payload.password, SALT_ROUNDS);
+  const id = `usr_${Date.now()}`;
+
+  const user = await createUser({
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: hashedPassword
+  });
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const user = await findUserByEmail(payload.email);
+  if (!user) {
+    throw Object.assign(new Error("Invalid email or password"), { status: 401 });
+  }
+
+  const valid = await bcrypt.compare(payload.password, user.password);
+  if (!valid) {
+    throw Object.assign(new Error("Invalid email or password"), { status: 401 });
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(userId) {
+  return { token: signAccessToken({ sub: userId, role: "client" }) };
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,16 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map(({ password, ...rest }) => rest);
+}
+
+export async function findUserByEmail(email) {
+  return users.find(u => u.email === email) ?? null;
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const id = `usr_${Date.now()}`;
+  const user = { id, ...payload };
   users.push(user);
   return user;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
     "apps/api": {
       "name": "@freelanceflow/api",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",
@@ -793,6 +794,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {


### PR DESCRIPTION
Closes #11011

Changes:
- Add bcryptjs password hashing (12 salt rounds) during registration
- Verify password hash on login (previously accepted any credentials)
- Add findUserByEmail to userService for login lookup
- Add duplicate email check during registration
- Fix Date.now() called twice causing ID/token mismatch
- Add error handling in auth controller (401/409)

/bounty 