### PR TITLE
fix: keep web next-env stable after production build

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Align `apps/web/next-env.d.ts` with the route-types path generated by the production Next build.
- Prevent `npm run build -w apps/web` from leaving the tracked file dirty after a successful build.

Fixes #11020
Parent bounty: #743

## Verification
- `npm run build -w apps/web`
- `git status --short` after the build returned clean
