### PR TITLE
fix(api/uploads): reject missing-file submissions with 400

### DIFF
--- a/apps/api/src/middleware/requireUploadFile.js
+++ b/apps/api/src/middleware/requireUploadFile.js
@@ -1,0 +1,16 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Route-level guard for upload endpoints.
+ *
+ * Rejects multipart requests that did not include the expected file field
+ * with a 400 response. This keeps 2xx upload responses reserved for
+ * requests that actually carried a file payload.
+ */
+export function requireUploadFile(req, res, next) {
+  if (req.file) {
+    next();
+    return;
+  }
+  fail(res, "Missing file field in multipart upload", 400);
+}

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { requireUploadFile } from "../middleware/requireUploadFile.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", upload.single("file"), requireUploadFile, uploadFile);

--- a/apps/api/src/tests/uploads.test.js
+++ b/apps/api/src/tests/uploads.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(callback) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  try {
+    await callback(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads with no file returns 400", async () => {
+  await withServer(async (base) => {
+    const form = new FormData();
+    const response = await fetch(`${base}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /file/i);
+  });
+});
+
+test("POST /api/uploads with a file returns 201 success payload", async () => {
+  await withServer(async (base) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+    const response = await fetch(`${base}/api/uploads`, {
+      method: "POST",
+      body: form,
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "hello.txt");
+    assert.equal(payload.data.status, "uploaded");
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/uploads` previously returned `201 { success: true, data: { status: "no-file" } }` for multipart requests that did not include a file field. This change adds a route-level guard that rejects those requests with a `400`, and reserves 2xx responses for requests that actually carried a file.

## Changes

- **New middleware `apps/api/src/middleware/requireUploadFile.js`** — checks `req.file` after `multer.single("file")` and returns `400 { success: false, message: "Missing file field in multipart upload" }` when no file was uploaded.
- **`apps/api/src/routes/uploadRoutes.js`** — wires the new middleware into the upload route between `multer.single("file")` and the controller.
- **`apps/api/src/tests/uploads.test.js`** — adds focused API test coverage for:
  1. `POST /api/uploads` with no file returns 400 and `success: false`.
  2. `POST /api/uploads` with a file returns 201 and `success: true` with `filename`/`status: "uploaded"`.

## Validation

- New and existing tests pass with the glob form of `node --test`:

\`\`\`
$ cd apps/api && node --test "src/tests/*.test.js"
✔ GET /health returns ok payload
✔ POST /api/uploads with no file returns 400
✔ POST /api/uploads with a file returns 201 success payload
ℹ tests 3
ℹ pass 3
ℹ fail 0
\`\`\`

> Note: the package's `"test": "node --test src/tests"` script is currently broken on Node 24 because `node --test` no longer accepts a directory argument directly — this is a separate pre-existing issue (#10945 / #10942) and intentionally out of scope for this fix.

Refs #11022.

/claim #11022
/claim #743
/bounty