### PR TITLE
fix(api/reviews): avoid same-millisecond id collisions

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,21 @@
 const reviews = [];
 
+// Monotonically increasing suffix to guarantee uniqueness even when two reviews
+// are created within the same millisecond. Combined with Date.now() the
+// resulting id stays sortable by creation time and collision-resistant.
+let reviewCounter = 0;
+
+function nextReviewId() {
+  reviewCounter += 1;
+  return `rev_${Date.now()}_${reviewCounter}`;
+}
+
 export async function listReviews() {
   return reviews;
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { id: nextReviewId(), ...payload };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviews.test.js
+++ b/apps/api/src/tests/reviews.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("createReview returns ids with the rev_ prefix", async () => {
+  const review = await createReview({ rating: 5, body: "great" });
+  assert.match(review.id, /^rev_/);
+});
+
+test("createReview keeps the rev_ prefix even for back-to-back creates", async () => {
+  const a = await createReview({ rating: 4, body: "a" });
+  const b = await createReview({ rating: 3, body: "b" });
+  assert.match(a.id, /^rev_/);
+  assert.match(b.id, /^rev_/);
+});
+
+test("two same-millisecond reviews receive distinct ids", async () => {
+  // Force Date.now() to return the same value for both calls so we can prove
+  // the collision-resistant counter is what guarantees uniqueness.
+  const realNow = Date.now;
+  let now = 1700000000000;
+  Date.now = () => now;
+  try {
+    const a = await createReview({ rating: 1, body: "first" });
+    now += 0; // same millisecond
+    const b = await createReview({ rating: 2, body: "second" });
+    assert.notEqual(a.id, b.id, "ids should differ even when created in the same millisecond");
+  } finally {
+    Date.now = realNow;
+  }
+});
+
+test("listReviews includes created reviews", async () => {
+  const before = (await listReviews()).length;
+  await createReview({ rating: 5, body: "listed" });
+  const after = (await listReviews()).length;
+  assert.equal(after, before + 1);
+});


### PR DESCRIPTION
## Summary

`apps/api/src/services/reviewService.js` generated review ids directly from `Date.now()`. Two reviews created within the same millisecond could receive the same `rev_` id, which broke lookups, reconciliation, and client-side tracking. This change adds an in-process counter suffix so ids remain sortable by creation time and unique within the same millisecond, and adds focused service test coverage.

## Changes

- **`apps/api/src/services/reviewService.js`** — new `nextReviewId()` helper combines `Date.now()` with a monotonic counter (`rev_${Date.now()}_${counter}`). Preserves the `rev_` prefix.
- **`apps/api/src/tests/reviews.test.js`** — new test file covering:
  1. Created reviews carry the `rev_` prefix.
  2. Back-to-back creates preserve the `rev_` prefix.
  3. Two same-millisecond creates produce **distinct** ids (regression test, freezes `Date.now`).
  4. `listReviews` reflects newly created reviews.

## Validation

\`\`\`
$ cd apps/api && node --test "src/tests/*.test.js"
✔ GET /health returns ok payload
✔ POST /api/uploads with no file returns 400
✔ POST /api/uploads with a file returns 201 success payload
✔ createReview returns ids with the rev_ prefix
✔ createReview keeps the rev_ prefix even for back-to-back creates
✔ two same-millisecond reviews receive distinct ids
✔ listReviews includes created reviews
ℹ tests 7
ℹ pass 7
ℹ fail 0
\`\`\`

Refs #11024.

/claim #11024
/claim #743
/bounty