### PR TITLE
fix(api): run concrete test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- Update the API package test script to target concrete `*.test.js` files instead of the `src/tests` directory.
- This lets `node --test` execute the existing API tests cross-platform instead of trying to load the tests directory as a module.

## Validation
- Before fix: `npm run test -w apps/api` failed with `Cannot find module '...\\apps\\api\\src\\tests'`.
- `npm run test -w apps/api`
- `npm test`
- `npm run build -w apps/web`
- `npm run lint`
- `git diff --check`

Closes #11027
/claim #743