### PR TITLE
fix: return 400 on Zod validation errors in postJob

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -6,7 +6,14 @@ export async function getJobs(req, res) {
   return ok(res, await listJobs());
 }
 
-export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+export async function postJob(req, res, next) {
+  try {
+    const payload = createJobSchema.parse(req.body);
+    return ok(res, await createJob(payload), 201);
+  } catch (err) {
+    if (err.name === "ZodError") {
+      return fail(res, err.errors, 400);
+    }
+    return next(err);
+  }
 }

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -19,6 +19,7 @@ test("GET /health returns ok payload", async () => {
   assert.deepEqual(payload, { ok: true, service: "api" });
 
   await new Promise((resolve, reject) => {
+    if (server.closeAllConnections) server.closeAllConnections();
     server.close((error) => (error ? reject(error) : resolve()));
   });
 });

--- a/apps/api/src/tests/job.test.js
+++ b/apps/api/src/tests/job.test.js
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+// Helper function to setup server
+async function setupServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  
+  const teardown = async () => {
+    if (server.closeAllConnections) server.closeAllConnections();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  };
+
+  return { baseUrl, teardown };
+}
+
+test("POST /jobs - valid payload", async () => {
+  const { baseUrl, teardown } = await setupServer();
+  
+  const payload = {
+    title: "Fullstack Developer",
+    description: "Looking for an experienced developer to build a web app.",
+    budgetMin: 50,
+    budgetMax: 150,
+    categoryId: "tech",
+    skills: ["React", "Node.js"]
+  };
+
+  const response = await fetch(`${baseUrl}/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  
+  const data = await response.json();
+  
+  assert.equal(response.status, 201);
+  assert.equal(data.success, true);
+  
+  await teardown();
+});
+
+test("POST /jobs - short title", async () => {
+  const { baseUrl, teardown } = await setupServer();
+  
+  const payload = {
+    title: "Dev", // length 3, min 4
+    description: "Looking for an experienced developer to build a web app.",
+    budgetMin: 50,
+    budgetMax: 150,
+    categoryId: "tech"
+  };
+
+  const response = await fetch(`${baseUrl}/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  
+  const data = await response.json();
+  
+  assert.equal(response.status, 400);
+  assert.equal(data.success, false);
+  assert.ok(Array.isArray(data.message));
+  
+  await teardown();
+});
+
+test("POST /jobs - short description", async () => {
+  const { baseUrl, teardown } = await setupServer();
+  
+  const payload = {
+    title: "Fullstack Developer",
+    description: "Too short", // length 9, min 10
+    budgetMin: 50,
+    budgetMax: 150,
+    categoryId: "tech"
+  };
+
+  const response = await fetch(`${baseUrl}/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  
+  const data = await response.json();
+  
+  assert.equal(response.status, 400);
+  assert.equal(data.success, false);
+  assert.ok(Array.isArray(data.message));
+  
+  await teardown();
+});
+
+test("POST /jobs - negative budget", async () => {
+  const { baseUrl, teardown } = await setupServer();
+  
+  const payload = {
+    title: "Fullstack Developer",
+    description: "Looking for an experienced developer to build a web app.",
+    budgetMin: -10, // negative
+    budgetMax: 150,
+    categoryId: "tech"
+  };
+
+  const response = await fetch(`${baseUrl}/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  
+  const data = await response.json();
+  
+  assert.equal(response.status, 400);
+  assert.equal(data.success, false);
+  assert.ok(Array.isArray(data.message));
+  
+  await teardown();
+});
+
+test("POST /jobs - missing fields", async () => {
+  const { baseUrl, teardown } = await setupServer();
+  
+  const payload = {
+    title: "Fullstack Developer"
+    // missing description, budgetMin, budgetMax, categoryId
+  };
+
+  const response = await fetch(`${baseUrl}/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  
+  const data = await response.json();
+  
+  assert.equal(response.status, 400);
+  assert.equal(data.success, false);
+  assert.ok(Array.isArray(data.message));
+  
+  await teardown();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Closes #11029

## Summary
- Wraps `createJobSchema.parse()` in a try/catch.
- Returns `fail(res, err.errors, 400)` for ZodError.
- Passes all other errors to the generic error handler via `next(err)`.
- Included regression tests in `apps/api/src/tests/job.test.js` for missing fields, short title, short description, and negative budget.