### PR TITLE
fix: integrate Stripe payment intents

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/**/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.3.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,69 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+function getStripeClient() {
+  if (!stripeClient) {
+    if (!env.stripeSecretKey) {
+      throw new Error("STRIPE_SECRET_KEY is required to create a Stripe PaymentIntent");
+    }
+
+    stripeClient = new Stripe(env.stripeSecretKey);
+  }
+
+  return stripeClient;
+}
+
+function validatePaymentIntentPayload(payload = {}) {
+  const { amount, currency = "usd", metadata } = payload;
+
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error("amount is required and must be a positive integer in the smallest currency unit");
+  }
+
+  if (typeof currency !== "string" || currency.trim() === "") {
+    throw new Error("currency must be a non-empty string");
+  }
+
+  const request = {
+    amount,
+    currency: currency.toLowerCase()
   };
+
+  if (metadata !== undefined) {
+    if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+      throw new Error("metadata must be an object when provided");
+    }
+
+    request.metadata = metadata;
+  }
+
+  return request;
+}
+
+function toPaymentIntentError(error) {
+  const stripeMessage = error?.message || "Stripe payment intent creation failed";
+  const wrapped = new Error(`Stripe payment intent creation failed: ${stripeMessage}`);
+  wrapped.cause = error;
+  wrapped.type = error?.type;
+  return wrapped;
+}
+
+export async function createPaymentIntent(payload, client = getStripeClient()) {
+  const request = validatePaymentIntentPayload(payload);
+
+  try {
+    const paymentIntent = await client.paymentIntents.create(request);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: request.amount,
+      currency: request.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    throw toPaymentIntentError(error);
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent validates payload and creates a Stripe PaymentIntent", async () => {
+  const calls = [];
+  const stripeClient = {
+    paymentIntents: {
+      create: async (args) => {
+        calls.push(args);
+        return {
+          id: "pi_test_123",
+          client_secret: "pi_test_secret_123"
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent(
+    { amount: 1999, currency: "eur", metadata: { orderId: "order_123" } },
+    stripeClient
+  );
+
+  assert.deepEqual(calls, [
+    { amount: 1999, currency: "eur", metadata: { orderId: "order_123" } }
+  ]);
+  assert.deepEqual(result, {
+    paymentId: "pi_test_123",
+    clientSecret: "pi_test_secret_123",
+    amount: 1999,
+    currency: "eur",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent defaults currency to usd", async () => {
+  const calls = [];
+  const stripeClient = {
+    paymentIntents: {
+      create: async (args) => {
+        calls.push(args);
+        return {
+          id: "pi_default_currency",
+          client_secret: "pi_default_currency_secret"
+        };
+      }
+    }
+  };
+
+  const result = await createPaymentIntent({ amount: 500 }, stripeClient);
+
+  assert.deepEqual(calls, [{ amount: 500, currency: "usd" }]);
+  assert.equal(result.currency, "usd");
+});
+
+test("createPaymentIntent rejects missing or invalid amounts before calling Stripe", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        throw new Error("Stripe should not be called for invalid input");
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({}, stripeClient),
+    /amount is required and must be a positive integer/i
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, stripeClient),
+    /amount is required and must be a positive integer/i
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 12.34 }, stripeClient),
+    /amount is required and must be a positive integer/i
+  );
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripeClient = {
+    paymentIntents: {
+      create: async () => {
+        const error = new Error("Your card was declined");
+        error.type = "StripeCardError";
+        throw error;
+      }
+    }
+  };
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 500 }, stripeClient),
+    /Your card was declined/
+  );
+});
+
+test("createPaymentIntent smoke test can create a real test-mode Stripe PaymentIntent", { skip: process.env.STRIPE_PAYMENT_SMOKE_TEST !== "1" }, async () => {
+  const result = await createPaymentIntent({ amount: 100, currency: "usd", metadata: { smoke: "true" } });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_.*_secret_/);
+  assert.equal(result.amount, 100);
+  assert.equal(result.currency, "usd");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.3.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2053,6 +2054,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.0.tgz",
+      "integrity": "sha512-ypO6xjVrMWs9SmIMeHr8naCx3dAQ0clxMdUTxn7Ejd7hmY9meBGfE+N4pVHkf9sUNebAHp6uJo6mV3GxDIc2cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2146,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
- Replace the stubbed `pay_${Date.now()}` payment intent response with a real Stripe `PaymentIntent` creation flow.
- Initialize Stripe through `STRIPE_SECRET_KEY` from the existing env config; no keys are hardcoded.
- Validate `amount` as a required positive integer in the smallest currency unit and default `currency` to `usd`.
- Return `paymentId` from `paymentIntent.id` and `clientSecret` from `paymentIntent.client_secret`.
- Preserve Stripe error messages when rethrowing failures.
- Add unit tests using a mocked Stripe client plus a guarded smoke test for real Stripe test-mode execution.
- Fix the API package test script so all `*.test.js` files run reliably on Windows/Node.

Closes #1

## Test Plan
- [x] `node --test apps/api/src/tests/paymentService.test.js`
- [x] `npm test -w apps/api`

## Notes
- Smoke test is intentionally skipped unless `STRIPE_PAYMENT_SMOKE_TEST=1` is set with a valid `STRIPE_SECRET_KEY`.
- No Stripe secrets are included in this PR.
