### PR TITLE
Require authentication for job creation

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/tests/jobs-auth.test.js
+++ b/apps/api/src/tests/jobs-auth.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJob = {
+  title: "Build a landing page",
+  description: "Create a responsive landing page for a cooperative finance app.",
+  budgetMin: 100,
+  budgetMax: 250,
+  categoryId: "web",
+  skills: ["react"]
+};
+
+test("GET /api/jobs remains public", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(Array.isArray(payload.data), true);
+  });
+});
+
+test("POST /api/jobs rejects unauthenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Unauthorized"
+    });
+  });
+});
+
+test("POST /api/jobs allows authenticated callers", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_job_owner", role: "client" });
+    const response = await fetch(`${baseUrl}/api/jobs`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify(validJob)
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.match(payload.data.id, /^job_/);
+    assert.equal(payload.data.status, "open");
+    assert.equal(payload.data.title, validJob.title);
+  });
+});


### PR DESCRIPTION
## Summary
- require bearer authentication on POST /api/jobs
- keep GET /api/jobs public
- add route coverage for public listing, unauthenticated rejection, and authenticated job creation

## Testing
- node --test src/tests/*.test.js

Closes #11035