### PR TITLE
fix: registration token sub matches returned user id (fixes #2768)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { env } from "../config/env.js";
+import { registerUser, loginUser, refreshToken } from "../services/authService.js";
+
+test("registerUser returns id matching jwt sub", async () => {
+  const payload = { email: "test@test.com", role: "client" };
+  const result = await registerUser(payload);
+  const decoded = jwt.verify(result.token, env.jwtSecret);
+  assert.equal(decoded.sub, result.id);
+});
+
+test("registerUser token sub matches id even when Date.now advances between calls", async () => {
+  const originalNow = Date.now;
+  let callCount = 0;
+  Date.now = () => {
+    callCount++;
+    return 1700000000000 + (callCount > 1 ? 2 : 0);
+  };
+
+  const payload = { email: "advance@test.com", role: "freelancer" };
+  const result = await registerUser(payload);
+  const decoded = jwt.verify(result.token, env.jwtSecret);
+
+  assert.equal(decoded.sub, result.id);
+  assert.notEqual(callCount, 0);
+
+  Date.now = originalNow;
+});


### PR DESCRIPTION
Fixes #2768

- Use a single `Date.now()` call for both the user id and JWT sub claim
- Add regression test proving the decoded token subject matches `result.id` even when `Date.now()` advances between calls

Parent bounty: #743

/bounty