### PR TITLE
Reject upload requests without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "File is required" });
+  });
+});
+
+test("POST /api/uploads preserves successful file uploads", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Return the existing API failure envelope when an upload request omits the `file` field
- Preserve the successful 201 response, original filename, and `uploaded` status for valid file uploads
- Add focused API coverage for missing-file and successful-upload paths

Fixes #11046

## Tests
- `node.exe --test apps/api/src/tests/health.test.js apps/api/src/tests/upload.test.js`

/claim #743