### PR TITLE
fix(api): add multer file size limit to prevent memory exhaustion attacks

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,10 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
Closes #11047

## Summary
Adds a 10MB file size limit to the multer upload middleware to prevent memory exhaustion attacks via arbitrarily large file uploads.

## Changes
- Added `limits: { fileSize: 10 * 1024 * 1024 }` to multer configuration

## Testing
- Verified that the limit is enforced by multer (returns 413 for files >10MB)