### PR TITLE
fix(api): restrict CORS origin to prevent cross-origin data exposure

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -19,7 +19,9 @@ export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors({
+    origin: process.env.FRONTEND_URL ?? "http://localhost:3000"
+  }));
   app.use(express.json());
   app.use(apiLimiter);
 


### PR DESCRIPTION
Closes #11048

## Summary
Restricts CORS to the configured frontend origin instead of allowing all origins.

## Changes
- Added `origin` configuration to cors() in app.js, defaulting to localhost:3000