### PR TITLE
fix(api): add authentication requirement to job creation endpoint

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
Closes #11051

## Summary
Adds auth middleware to POST /api/jobs to prevent unauthenticated users from creating jobs.

## Changes
- Added authMiddleware to job creation route in jobRoutes.js