### PR TITLE
fix(api): require admin role on admin metrics endpoint

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,12 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function roleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin.test.js
+++ b/apps/api/src/tests/admin.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("GET /api/admin/metrics rejects a request with no token", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`);
+  assert.equal(response.status, 401);
+  await closeServer(server);
+});
+
+test("GET /api/admin/metrics forbids a non-admin (client) user", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const token = signAccessToken({ sub: "usr_client", role: "client" });
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { authorization: `Bearer ${token}` }
+  });
+  assert.equal(response.status, 403);
+  await closeServer(server);
+});
+
+test("GET /api/admin/metrics allows an admin user", async () => {
+  const server = await startServer();
+  const { port } = server.address();
+  const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: { authorization: `Bearer ${token}` }
+  });
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.openJobs, 42);
+  await closeServer(server);
+});


### PR DESCRIPTION
### Summary
`/api/admin/metrics` was protected only by `authMiddleware`, which verifies the JWT but performs no role check, so any authenticated client or freelancer could read admin metrics.

### Fix
- Add a reusable `requireRole(role)` middleware in `middleware/auth.js` that returns `403 Forbidden` when `req.user.role` does not match. Matches the file's existing style (`fail` helper, named export).
- Apply `requireRole("admin")` on the admin router after `authMiddleware`.

### Tests
Adds `tests/admin.test.js` (same `node:test` + `createApp()` style as the existing health test):
- no token -> 401
- authenticated non-admin (client) -> 403
- admin -> 200 with the metrics payload

Verified locally: all three pass with the fix; the non-admin test fails without it (confirming it catches the vulnerability).

Fixes #11061

/claim #11061