### PR TITLE
Resolve mock job detail page by id

### DIFF
--- a/apps/web/__tests__/job-detail.test.cjs
+++ b/apps/web/__tests__/job-detail.test.cjs
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+const ts = require("typescript");
+
+for (const extension of [".ts", ".tsx"]) {
+  require.extensions[extension] = (module, filename) => {
+    const source = fs.readFileSync(filename, "utf8");
+    const output = ts.transpileModule(source, {
+      compilerOptions: {
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022
+      },
+      fileName: filename
+    }).outputText;
+
+    module._compile(output, filename);
+  };
+}
+
+const JobDetailPage = require(path.join(
+  __dirname,
+  "../app/jobs/[id]/page.tsx"
+)).default;
+
+function renderJobDetail(id) {
+  return renderToStaticMarkup(
+    React.createElement(JobDetailPage, { params: { id } })
+  );
+}
+
+test("renders the matching mock job for a known id", () => {
+  const html = renderJobDetail("job-101");
+
+  assert.match(html, /Build an AI customer support widget/);
+  assert.match(html, /\$1,500/);
+  assert.doesNotMatch(html, /Viewing details for/);
+});
+
+test("renders a clear fallback for an unknown job id", () => {
+  const html = renderJobDetail("job-missing");
+
+  assert.match(html, /Job not found/);
+  assert.match(html, /job-missing/);
+  assert.doesNotMatch(html, /Responsibilities, milestones/);
+});

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,9 +1,23 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find((item) => item.id === params.id);
+
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job not found</h2>
+        <p>No job matches <strong>{params.id}</strong>.</p>
+        <p>Return to the job list to choose an available project.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
-      <p>Responsibilities, milestones, and proposals would be shown here.</p>
+      <h2>{job.title}</h2>
+      <p><strong>Budget:</strong> {job.budget}</p>
+      <p>Responsibilities, milestones, and proposals for this project would be shown here.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Look up job detail data from the shared mock jobs by route id.
- Render the matching job title and budget for known job ids.
- Show a clear fallback for unknown job ids instead of placeholder success copy.

## Validation
- `node --test apps/web/__tests__/job-detail.test.cjs`
- `npm.cmd run build -w apps/web`

/claim #2755
Closes #2755.