### PR TITLE
Resolve freelancer profiles from mock data

### DIFF
--- a/apps/web/__tests__/freelancer-profile.test.cjs
+++ b/apps/web/__tests__/freelancer-profile.test.cjs
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+const ts = require("typescript");
+
+for (const extension of [".ts", ".tsx"]) {
+  require.extensions[extension] = (module, filename) => {
+    const source = fs.readFileSync(filename, "utf8");
+    const output = ts.transpileModule(source, {
+      compilerOptions: {
+        esModuleInterop: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022
+      },
+      fileName: filename
+    }).outputText;
+
+    module._compile(output, filename);
+  };
+}
+
+const FreelancerProfilePage = require(path.join(
+  __dirname,
+  "../app/freelancers/[username]/page.tsx"
+)).default;
+
+function renderFreelancerProfile(username) {
+  return renderToStaticMarkup(
+    React.createElement(FreelancerProfilePage, { params: { username } })
+  );
+}
+
+test("renders the matching mock freelancer for a known username", () => {
+  const html = renderFreelancerProfile("maya-dev");
+
+  assert.match(html, /maya-dev/);
+  assert.match(html, /Next\.js/);
+  assert.match(html, /TypeScript/);
+  assert.match(html, /\$65\/hr/);
+  assert.doesNotMatch(html, /Portfolio, reviews, and active proposals appear here/);
+});
+
+test("renders a clear fallback for an unknown username", () => {
+  const html = renderFreelancerProfile("missing-user");
+
+  assert.match(html, /Freelancer not found/);
+  assert.match(html, /missing-user/);
+  assert.doesNotMatch(html, /\$65\/hr/);
+});

--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,9 +1,24 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const freelancer = freelancers.find((item) => item.username === params.username);
+
+  if (!freelancer) {
+    return (
+      <section className="card">
+        <h2>Freelancer not found</h2>
+        <p>No freelancer matches <strong>{params.username}</strong>.</p>
+        <p>Return to search to choose an available freelancer profile.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
-      <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
-      <p>Portfolio, reviews, and active proposals appear here.</p>
+      <h2>{freelancer.username}</h2>
+      <p><strong>Skills:</strong> {freelancer.skills.join(", ")}</p>
+      <p><strong>Rate:</strong> {freelancer.rate}</p>
+      <p>Portfolio, reviews, and active proposals for this freelancer appear here.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Look up freelancer profiles from the shared mock freelancer data by route username.
- Render matching skills and hourly rate for known freelancer usernames.
- Show a clear not-found fallback for unknown usernames instead of placeholder success copy.

## Validation
- `node --test apps/web/__tests__/freelancer-profile.test.cjs`
- `npm.cmd run build -w apps/web`

/claim #2763
Closes #2763.