### PR TITLE
Expose @freelanceflow/db package entrypoint

### DIFF
--- a/packages/db/db-entrypoint.test.mjs
+++ b/packages/db/db-entrypoint.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("db package is directly importable by workspace consumers", async () => {
+  const db = await import("@freelanceflow/db");
+
+  assert.equal(typeof db.PrismaClient, "function");
+  assert.ok(db.Prisma);
+});

--- a/packages/db/index.cjs
+++ b/packages/db/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require("@prisma/client");

--- a/packages/db/index.d.ts
+++ b/packages/db/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/index.mjs
+++ b/packages/db/index.mjs
@@ -1,0 +1,1 @@
+export * from "@prisma/client";

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,16 @@
 {
   "name": "@freelanceflow/db",
   "private": true,
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.cjs",
+      "default": "./index.mjs"
+    }
+  },
   "scripts": {
     "generate": "prisma generate",
     "migrate": "prisma migrate dev"


### PR DESCRIPTION
## Summary
- Add package exports for @freelanceflow/db so workspace consumers can import it directly.
- Provide ESM, CommonJS, and TypeScript declaration entrypoints that re-export @prisma/client.
- Add a regression test for dynamic package import.

## Validation
- `node --test packages/db/db-entrypoint.test.mjs`
- `node -e "const db=require('@freelanceflow/db'); if (typeof db.PrismaClient !== 'function') throw new Error('missing PrismaClient'); console.log('require ok')"`
- `node --test apps/api/src/tests/health.test.js`

Note: `npm.cmd test -w apps/api` still fails in this checkout because the existing script passes `src/tests` as a directory to Node 24; the actual health test file passes when run directly.

/claim #2775
Closes #2775.