### PR TITLE
Expose @freelanceflow/ui package entrypoint

### DIFF
--- a/packages/ui/index.cjs
+++ b/packages/ui/index.cjs
@@ -1,0 +1,29 @@
+const React = require("react");
+
+function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}
+
+module.exports = { Button, Card };

--- a/packages/ui/index.d.ts
+++ b/packages/ui/index.d.ts
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export interface ButtonProps {
+  children: ReactNode;
+}
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export declare function Button(props: ButtonProps): JSX.Element;
+export declare function Card(props: CardProps): JSX.Element;

--- a/packages/ui/index.mjs
+++ b/packages/ui/index.mjs
@@ -1,0 +1,27 @@
+import React from "react";
+
+export function Button({ children }) {
+  return React.createElement(
+    "button",
+    {
+      style: {
+        background: "#5468ff",
+        color: "white",
+        border: "none",
+        borderRadius: 8,
+        padding: "0.6rem 0.9rem",
+        cursor: "pointer"
+      }
+    },
+    children
+  );
+}
+
+export function Card({ title, children }) {
+  return React.createElement(
+    "section",
+    { style: { border: "1px solid #ddd", borderRadius: 8, padding: "1rem" } },
+    React.createElement("h3", null, title),
+    React.createElement("div", null, children)
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@freelanceflow/ui",
   "private": true,
-  "main": "src/index.ts"
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.cjs",
+      "default": "./index.mjs"
+    }
+  }
 }

--- a/packages/ui/ui-entrypoint.test.mjs
+++ b/packages/ui/ui-entrypoint.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+test("ui package is directly importable by workspace consumers", async () => {
+  const ui = await import("@freelanceflow/ui");
+
+  assert.equal(typeof ui.Button, "function");
+  assert.equal(typeof ui.Card, "function");
+
+  const buttonHtml = renderToStaticMarkup(
+    React.createElement(ui.Button, null, "Hire now")
+  );
+  const cardHtml = renderToStaticMarkup(
+    React.createElement(ui.Card, { title: "Profile" }, "Available")
+  );
+
+  assert.match(buttonHtml, /Hire now/);
+  assert.match(cardHtml, /Profile/);
+  assert.match(cardHtml, /Available/);
+});


### PR DESCRIPTION
## Summary
- Add package exports for @freelanceflow/ui so workspace consumers can import it directly.
- Provide ESM, CommonJS, and TypeScript declaration entrypoints for Button and Card.
- Add a regression test that imports the package and renders both components.

## Validation
- `node --test packages/ui/ui-entrypoint.test.mjs`
- `node -e "const ui=require('@freelanceflow/ui'); if (typeof ui.Button !== 'function' || typeof ui.Card !== 'function') throw new Error('missing ui exports'); console.log('require ok')"`
- `npm.cmd run build -w apps/web`

/claim #2781
Closes #2781.