### PR TITLE
Preserve notification server-owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client_supplied",
+    read: true,
+    recipient: "usr_client",
+    message: "Proposal received"
+  });
+
+  assert.match(notification.id, /^ntf_/);
+  assert.notEqual(notification.id, "client_supplied");
+  assert.equal(notification.read, false);
+  assert.equal(notification.recipient, "usr_client");
+  assert.equal(notification.message, "Proposal received");
+});


### PR DESCRIPTION
## Summary
- Ensure notification creation always uses a server-generated id.
- Force new notifications to start unread even if the request body includes read: true.
- Add focused regression coverage for caller-supplied id/read fields.

## Validation
- `node --test apps/api/src/tests/notificationService.test.js`
- `node --test apps/api/src/tests/health.test.js`
- `node --test apps/api/src/tests/notificationService.test.js apps/api/src/tests/health.test.js`

Note: an earlier parallel test run timed out, but both files pass reliably when run directly/sequentially.

/claim #2762
Closes #2762.