### PR TITLE
Require fullName during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -5,6 +5,7 @@ export async function registerUser(payload) {
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
+    fullName: payload.fullName,
     role: payload.role,
     token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
   };

--- a/apps/api/src/tests/authRegistration.test.js
+++ b/apps/api/src/tests/authRegistration.test.js
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerUser } from "../services/authService.js";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema requires a non-empty fullName", () => {
+  assert.equal(
+    registerSchema.safeParse({
+      email: "client@example.com",
+      password: "password123",
+      role: "client"
+    }).success,
+    false
+  );
+
+  assert.equal(
+    registerSchema.safeParse({
+      email: "client@example.com",
+      password: "password123",
+      fullName: "   ",
+      role: "client"
+    }).success,
+    false
+  );
+});
+
+test("registerUser returns the validated fullName", async () => {
+  const payload = registerSchema.parse({
+    email: "client@example.com",
+    password: "password123",
+    fullName: "Ada Client",
+    role: "client"
+  });
+
+  const result = await registerUser(payload);
+
+  assert.equal(result.fullName, "Ada Client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  fullName: z.string().trim().min(1),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
## Summary
- Require a non-empty fullName in the registration schema.
- Return the validated fullName from registerUser so the auth response matches the user model requirement.
- Add focused regression coverage for missing/blank fullName and returned fullName.

## Validation
- `node --test apps/api/src/tests/authRegistration.test.js apps/api/src/tests/health.test.js`

/claim #2770
Closes #2770.