### PR TITLE
Fix: Missing email trim in auth validators

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().email(),
   password: z.string().min(8)
 });


### PR DESCRIPTION
## Fix

Closes #11098

**Files:** apps/api/src/validators/auth.js
**Severity:** Low

**Description:**
The email field in registerSchema and loginSchema doesn't use .trim(). Users with leading/trailing spaces in email could ...