### PR TITLE
fix(api/auth): trim and lowercase email in validators

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema, loginSchema } from "../validators/auth.js";
+
+test("registerSchema trims whitespace and lowercases email", () => {
+  const result = registerSchema.parse({
+    email: "  Alice@Example.COM  ",
+    password: "supersecret"
+  });
+  assert.equal(result.email, "alice@example.com");
+});
+
+test("loginSchema rejects empty email after trim", () => {
+  const result = loginSchema.safeParse({
+    email: "   ",
+    password: "supersecret"
+  });
+  assert.equal(result.success, false);
+});
+
+test("loginSchema normalises mixed-case email with surrounding spaces", () => {
+  const result = loginSchema.parse({
+    email: "\tBob@Example.com\n",
+    password: "supersecret"
+  });
+  assert.equal(result.email, "bob@example.com");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
+const emailField = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email("Invalid email address");
+
 export const registerSchema = z.object({
-  email: z.string().email(),
+  email: emailField,
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: emailField,
   password: z.string().min(8)
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

The `email` field in `registerSchema` and `loginSchema` did not normalize whitespace or case. Users with leading/trailing spaces (or accidentally using caps lock) could fail login even with a valid registered email because the persisted value was trimmed at the DB layer (or stored raw) while the login payload came in with whitespace.

This change:
- Adds `z.string().trim().toLowerCase()` to a shared `emailField` used by both schemas.
- Provides a clearer error message (`"Invalid email address"`) via `.email("Invalid email address")`.
- Adds focused unit tests in `apps/api/src/tests/authValidator.test.js`.

## Changes

- `apps/api/src/validators/auth.js` — extract shared `emailField` with trim+lowercase; reuse in both schemas.
- `apps/api/src/tests/authValidator.test.js` — new tests:
  1. Whitespace + mixed-case email is normalised.
  2. Whitespace-only email is rejected by the email validator.
  3. Tabs and newlines around the email are stripped and cased lowered.

## Validation

```
$ cd apps/api && node --test "src/tests/*.test.js"
✔ registerSchema trims whitespace and lowercases email
✔ loginSchema rejects empty email after trim
✔ loginSchema normalises mixed-case email with surrounding spaces
✔ GET /health returns ok payload
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

Closes #11098

/claim #11098
/claim #743
/bounty