### PR TITLE
Hide admin link from public navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -1,16 +1,21 @@
 import Link from "next/link";
 
-const links = [
+type UserRole = "client" | "freelancer" | "admin";
+
+const publicLinks = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
-  ["/messaging", "Messaging"],
-  ["/admin", "Admin"]
-];
+  ["/messaging", "Messaging"]
+] as const;
 
-export function Navigation() {
+const adminLink = ["/admin", "Admin"] as const;
+
+export function Navigation({ currentUserRole }: { currentUserRole?: UserRole }) {
+  const links = currentUserRole === "admin" ? [...publicLinks, adminLink] : publicLinks;
+
   return (
     <nav style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
       {links.map(([href, label]) => (


### PR DESCRIPTION
/claim #743

Fixes #11106

## Summary
- Split the public navigation links from the admin-only link.
- Add an optional `currentUserRole` prop to `Navigation`.
- Keep the root layout's default visitor navigation free of the Admin link unless the caller explicitly passes `admin`.

## Validation
- `node node_modules/typescript/bin/tsc -p apps/web/tsconfig.json --noEmit --incremental false`
- `git diff --check`

Note: `npm run build -w apps/web` compiled successfully but this local Windows sandbox blocked Next's TypeScript worker spawn with `EPERM`, so the direct TypeScript check above was used for validation.