### PR TITLE
Fix: Missing email trim in auth validators

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().email(),
   password: z.string().min(8),
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().email(),
   password: z.string().min(8)
 });


### PR DESCRIPTION
Fixes #11098 by adding .trim() to email validation in auth schema.