### PR TITLE
Fix: Unsanitized filename output in uploadController (#11096)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test 'src/tests/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,14 @@
 import { ok } from "../utils/response.js";
+import path from "path";
 
 export async function uploadFile(req, res) {
+  let filename = req.file?.originalname ?? null;
+  if (filename) {
+    filename = path.basename(filename).replace(/[^a-zA-Z0-9.\-_]/g, "_");
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
+    filename,
     status: req.file ? "uploaded" : "no-file"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads sanitizes filename", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  
+  // Construct a multipart/form-data payload manually
+  const boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW";
+  let body = "";
+  body += `--${boundary}\r\n`;
+  body += `Content-Disposition: form-data; name="file"; filename="../../../etc/passwd"\r\n`;
+  body += `Content-Type: text/plain\r\n\r\n`;
+  body += `file content\r\n`;
+  body += `--${boundary}--\r\n`;
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: {
+      "Content-Type": `multipart/form-data; boundary=${boundary}`
+    },
+    body: body
+  });
+  
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.data.filename, "passwd");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
This PR fixes the unsanitized filename output in uploadController by adding path.basename and removing non-alphanumeric characters. It also includes a test case and fixes the test runner script.