### PR TITLE
fix(payment): normalize currency before return (refs #743)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,11 @@
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
+  const rawCurrency = payload.currency ?? "usd";
+  const currency = String(rawCurrency).trim().toLowerCase() || "usd";
   return {
     paymentId: `pay_${Date.now()}`,
     amount: payload.amount,
-    currency: payload.currency ?? "usd",
+    currency,
     provider: "stripe"
   };
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("normalizes uppercase currency to lowercase", async () => {
+  const intent = await createPaymentIntent({ amount: 125, currency: "USD" });
+  assert.equal(intent.currency, "usd");
+});
+
+test("trims whitespace around currency", async () => {
+  const intent = await createPaymentIntent({ amount: 125, currency: " USD " });
+  assert.equal(intent.currency, "usd");
+});
+
+test("defaults to usd when currency is only whitespace", async () => {
+  const intent = await createPaymentIntent({ amount: 125, currency: "   " });
+  assert.equal(intent.currency, "usd");
+});
+
+test("defaults to usd when currency is missing", async () => {
+  const intent = await createPaymentIntent({ amount: 125 });
+  assert.equal(intent.currency, "usd");
+});
+
+test("preserves a valid lowercase currency", async () => {
+  const intent = await createPaymentIntent({ amount: 125, currency: "eur" });
+  assert.equal(intent.currency, "eur");
+});


### PR DESCRIPTION
## Summary
Fixes the currency-normalization bug from parent Algora bounty #743 (scoped issue #11114).

`apps/api/src/services/paymentService.js` returned `payload.currency` exactly as submitted, so mixed-case / whitespace-padded values like `" USD "` were stored as non-canonical currency codes. This normalizes the currency to a canonical lowercase value (trim + lowercase) and preserves the existing `usd` default for blank/missing values.

## Changes
- `apps/api/src/services/paymentService.js`: normalize currency before return.
- `apps/api/src/tests/paymentService.test.js`: new service-level regression coverage (uppercase, whitespace, whitespace-only, missing, valid lowercase).

## Validation (per issue plan)
- `node --test apps/api/src/tests/paymentService.test.js` -> 5/5 pass (verified locally).
- `npm test --workspace apps/api`
- `git diff --check`

## Safety
No payout, contact, credential, wallet, or off-platform payment details posted here.

Closes #11114.
Refs #743.