### PR TITLE
Implement Stripe PaymentIntent in createPaymentIntent

### DIFF
--- a/src/payments/createPaymentIntent.js
+++ b/src/payments/createPaymentIntent.js
@@ -1,0 +1,53 @@
+import Stripe from "stripe";
+
+function getStripeClient() {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY environment variable is required");
+  }
+  return new Stripe(key);
+}
+
+/**
+ * Create a Stripe PaymentIntent and return client-facing fields.
+ * @param {{ amount: number, currency?: string, metadata?: Record<string, string> }} payload
+ */
+export async function createPaymentIntent(payload) {
+  if (payload == null || payload.amount === undefined || payload.amount === null) {
+    throw new Error("amount is required and must be a positive integer");
+  }
+  if (!Number.isInteger(payload.amount) || payload.amount <= 0) {
+    throw new Error(
+      "amount must be a positive integer (smallest currency unit, e.g. cents)"
+    );
+  }
+
+  const currency = payload.currency ?? "usd";
+  const params = { amount: payload.amount, currency };
+  if (payload.metadata && typeof payload.metadata === "object") {
+    params.metadata = payload.metadata;
+  }
+
+  try {
+    const stripe = getStripeClient();
+    const paymentIntent = await stripe.paymentIntents.create(params);
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+      provider: "stripe",
+    };
+  } catch (error) {
+    // Preserve original Stripe error messages (StripeCardError, etc.)
+    if (
+      error &&
+      (String(error.type || "").startsWith("Stripe") ||
+        error.raw !== undefined ||
+        String(error.constructor?.name || "").includes("Stripe"))
+    ) {
+      throw new Error(error.message);
+    }
+    throw error;
+  }
+}

--- a/src/payments/createPaymentIntent.test.js
+++ b/src/payments/createPaymentIntent.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+
+const mockCreate = jest.fn();
+
+jest.unstable_mockModule("stripe", () => ({
+  default: jest.fn().mockImplementation(() => ({
+    paymentIntents: { create: mockCreate },
+  })),
+}));
+
+const { createPaymentIntent } = await import("./createPaymentIntent.js");
+
+describe("createPaymentIntent", () => {
+  const prevKey = process.env.STRIPE_SECRET_KEY;
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    process.env.STRIPE_SECRET_KEY = "sk_test_mock";
+  });
+
+  afterEach(() => {
+    process.env.STRIPE_SECRET_KEY = prevKey;
+  });
+
+  it("requires a positive integer amount", async () => {
+    await expect(createPaymentIntent({})).rejects.toThrow(/amount is required/i);
+    await expect(createPaymentIntent({ amount: 0 })).rejects.toThrow(/positive integer/i);
+    await expect(createPaymentIntent({ amount: -5 })).rejects.toThrow(/positive integer/i);
+    await expect(createPaymentIntent({ amount: 1.5 })).rejects.toThrow(/positive integer/i);
+  });
+
+  it("calls stripe.paymentIntents.create with amount and default currency", async () => {
+    mockCreate.mockResolvedValue({
+      id: "pi_test_123",
+      client_secret: "pi_test_123_secret_abc",
+      amount: 2500,
+      currency: "usd",
+    });
+
+    const result = await createPaymentIntent({ amount: 2500 });
+
+    expect(mockCreate).toHaveBeenCalledWith({ amount: 2500, currency: "usd" });
+    expect(result).toEqual({
+      paymentId: "pi_test_123",
+      clientSecret: "pi_test_123_secret_abc",
+      amount: 2500,
+      currency: "usd",
+      provider: "stripe",
+    });
+  });
+
+  it("passes custom currency and metadata", async () => {
+    mockCreate.mockResolvedValue({
+      id: "pi_eur",
+      client_secret: "sec",
+      amount: 100,
+      currency: "eur",
+    });
+
+    await createPaymentIntent({
+      amount: 100,
+      currency: "eur",
+      metadata: { orderId: "ord_1" },
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      amount: 100,
+      currency: "eur",
+      metadata: { orderId: "ord_1" },
+    });
+  });
+
+  it("re-throws Stripe errors with original message", async () => {
+    const err = new Error("Invalid currency");
+    err.type = "StripeInvalidRequestError";
+    mockCreate.mockRejectedValue(err);
+    await expect(createPaymentIntent({ amount: 100 })).rejects.toThrow("Invalid currency");
+  });
+
+  it("smoke: creates a test-mode PaymentIntent when RUN_STRIPE_SMOKE=1", async () => {
+    if (process.env.RUN_STRIPE_SMOKE !== "1" || !process.env.STRIPE_SECRET_KEY?.startsWith("sk_test")) {
+      return;
+    }
+    jest.resetModules();
+    const { createPaymentIntent: live } = await import("./createPaymentIntent.js");
+    const result = await live({ amount: 50, currency: "usd" });
+    expect(result.paymentId).toMatch(/^pi_/);
+    expect(result.clientSecret).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Replaces the payment stub with a real Stripe PaymentIntent integration.

- Initializes Stripe from STRIPE_SECRET_KEY (no hardcoded keys)
- Validates amount as a required positive integer (cents)
- Defaults currency to usd
- Returns paymentId and clientSecret from the PaymentIntent
- Surfaces Stripe API errors with original messages
- Adds unit tests (mocked SDK) and an env-guarded smoke test

## Bounty
https://github.com/SecureBananaLabs/bug-bounty/issues/1

Fixes #1
$ #1

---
_Submitted by Grok Bounty Hunter (automated draft — review before merge)._