### PR TITLE
fix(api): return 415 for unsupported JSON media types

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,22 +1,21 @@
-const unsupportedMediaTypeMessages = {
-  "charset.unsupported": "Unsupported request charset",
-  "encoding.unsupported": "Unsupported content encoding"
-};
+const unsupportedMediaTypes = new Set([
+  "charset.unsupported",
+  "encoding.unsupported"
+]);
 
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  const unsupportedMediaTypeMessage = unsupportedMediaTypeMessages[err?.type];
-  if (err?.status === 415 && unsupportedMediaTypeMessage) {
+  if (err?.status === 415 && unsupportedMediaTypes.has(err?.type)) {
     return res.status(415).json({
       success: false,
-      message: unsupportedMediaTypeMessage
+      message: "Unsupported media type"
     });
   }
 
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+const unsupportedMediaTypeMessages = {
+  "charset.unsupported": "Unsupported request charset",
+  "encoding.unsupported": "Unsupported content encoding"
+};
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  const unsupportedMediaTypeMessage = unsupportedMediaTypeMessages[err?.type];
+  if (err?.status === 415 && unsupportedMediaTypeMessage) {
+    return res.status(415).json({
+      success: false,
+      message: unsupportedMediaTypeMessage
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { errorHandler } from "../middleware/errorHandler.js";
+
+function createResponse() {
+  return {
+    headersSent: false,
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    }
+  };
+}
+
+for (const type of ["charset.unsupported", "encoding.unsupported"]) {
+  test(`returns 415 for ${type}`, () => {
+    const response = createResponse();
+    const error = Object.assign(new Error("unsupported media type"), {
+      status: 415,
+      type
+    });
+
+    errorHandler(error, {}, response, () => {
+      assert.fail("next should not be called");
+    });
+
+    assert.equal(response.statusCode, 415);
+    assert.deepEqual(response.body, {
+      success: false,
+      message: "Unsupported media type"
+    });
+  });
+}
+
+test("preserves the generic 500 response for unexpected errors", () => {
+  const response = createResponse();
+
+  errorHandler(new Error("boom"), {}, response, () => {
+    assert.fail("next should not be called");
+  });
+
+  assert.equal(response.statusCode, 500);
+  assert.deepEqual(response.body, {
+    success: false,
+    message: "Unexpected server error"
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Express JSON parser errors for unsupported charsets and content encodings being incorrectly converted into generic `500` responses.

The API now returns a structured `415 Unsupported Media Type` response for:

* `charset.unsupported`
* `encoding.unsupported`

Unexpected server errors continue using the existing generic `500` response.

## Changes

* Update `apps/api/src/middleware/errorHandler.js` to handle the two known unsupported-media parser error types as `415`.
* Preserve the existing generic `500` response for unexpected failures.
* Add focused `node:test` regression coverage for both `415` variants and the existing `500` fallback.

## Validation

* Focused middleware tests: **3 passed, 0 failed**
* Verified that the branch changes only the error middleware and its focused test file.
* The complete repository test suite was not run because this environment could not clone the repository due unavailable GitHub network access.

Closes #11144

Parent bounty: #743

/claim #743
