### PR TITLE
Reject upload requests without files

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST" });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "File is required" });
+  });
+});
+
+test("POST /api/uploads accepts a multipart file upload", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.append("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: { filename: "hello.txt", status: "uploaded" }
+    });
+  });
+});


### PR DESCRIPTION
/claim #743

Closes #11147.

## Summary

- Return `400` when `POST /api/uploads` is called without an attached `file` field.
- Preserve the existing `201` success response for valid multipart file uploads.
- Add focused API regression tests for missing-file and valid-file upload requests.

## Problem

The upload endpoint previously returned `201` with `{ filename: null, status: "no-file" }` when no file was submitted. That makes a failed upload look successful to clients.

## Validation

```bash
node --test apps/api/src/tests/*.test.js
```

Result:

```text
# tests 3
# pass 3
# fail 0
```

Manual behavior check before the fix showed:

```text
POST /api/uploads without a file -> 201 {"success":true,"data":{"filename":null,"status":"no-file"}}
```

The new regression test verifies that the same request now returns:

```json
{ "success": false, "message": "File is required" }
```
