### PR TITLE
Add original poem: "The Freelance Flow"

### DIFF
--- a/POEM.md
+++ b/POEM.md
@@ -1,0 +1,77 @@
+# The Freelance Flow
+
+---
+
+## I. The Posting
+
+Someone somewhere has a problem —
+a gap between what exists
+and what they need to exist.
+They type it into a form,
+press a button,
+and a job is born:
+`job_1718200000000`, status: open,
+floating in memory
+like a seed waiting for rain.
+
+---
+
+## II. The Proposal
+
+The freelancer reads the listing at midnight,
+coffee cooling beside the keyboard.
+They weigh their hours against the ask,
+sharpen their words like tools,
+and send a proposal into the silence.
+`prp_1718200000001` —
+a small vessel launched
+across the wire,
+carrying competence
+and quiet hope.
+
+---
+
+## III. The Token
+
+Before any of this can happen,
+someone must prove they are who they say they are.
+A secret is signed.
+A JWT is minted, tucked into a header,
+carried through every request
+like a passport through a border.
+The server checks the signature,
+nods,
+and lets the work begin.
+
+---
+
+## IV. The Message
+
+Between the posting and the payment
+lives the conversation —
+`msg_1718200000002`, sentAt: now.
+Questions asked, answers given,
+scope clarified, deadlines agreed,
+the slow trust-building
+that no database schema
+can fully capture
+but every project depends on.
+
+---
+
+## V. The Merge
+
+One day the TODO comments are replaced.
+The placeholder drivers give way to real queries.
+Prisma speaks to Postgres,
+Stripe processes something real,
+and the `development-secret`
+is retired to an env file
+no one checks into git.
+The system breathes.
+The flow is live.
+Somewhere, a freelancer gets paid.
+
+---
+
+*Written for FreelanceFlow — the plumbing beneath the work.*


### PR DESCRIPTION
Adds POEM.md to the project root as required. The poem follows a free-verse form with a professional-yet-personal tone, themed around the lifecycle of freelance work — proposals, jobs, messages, and the invisible plumbing (auth, tokens, databases) that holds it all together — mirroring the actual domain of this codebase. Creative decision: chose free verse over rhyme to reflect the unpredictable, iterative nature of freelance development. Closes #76