### PR TITLE
Fix: Require authentication for user creation (fixes #11171)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);


### PR DESCRIPTION
Fixes #11171 by adding the `authMiddleware` to the `postUser` route to prevent unauthorized users from creating user records.