### PR TITLE
Fix: Require admin role for metrics endpoint (fixes #11173)

### DIFF
--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -1,6 +1,9 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { getAdminMetrics } from "../services/adminService.js";
 
 export async function metrics(req, res) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden: Admin role required", 403);
+  }
   return ok(res, await getAdminMetrics());
 }


### PR DESCRIPTION
Fixes #11173 by enforcing an admin role check on the `/metrics` endpoint, preventing privilege escalation and data exposure to standard users.