### PR TITLE
fix(jobs): validate budgetMax >= budgetMin in create/update schemas

### DIFF
--- a/apps/api/src/tests/job-validator.test.js
+++ b/apps/api/src/tests/job-validator.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects budgetMax < budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a full-stack developer for a landing page.",
+    budgetMin: 5000,
+    budgetMax: 100,
+    categoryId: "cat-1",
+    skills: ["React"]
+  });
+
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some((iss) => iss.path.includes("budgetMax")));
+});
+
+test("createJobSchema accepts budgetMax === budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a full-stack developer for a landing page.",
+    budgetMin: 2000,
+    budgetMax: 2000,
+    categoryId: "cat-1",
+    skills: ["React"]
+  });
+
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts budgetMax > budgetMin", () => {
+  const result = createJobSchema.safeParse({
+    title: "Build a website",
+    description: "Need a full-stack developer for a landing page.",
+    budgetMin: 1000,
+    budgetMax: 5000,
+    categoryId: "cat-1",
+    skills: ["React"]
+  });
+
+  assert.equal(result.success, true);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobBaseSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,23 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobBaseSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = jobBaseSchema.partial().refine(
+  (data) => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
## Summary

Adds a Zod `.refine()` to both `createJobSchema` and `updateJobSchema` that ensures `budgetMax` is greater than or equal to `budgetMin`. Previously the schema only validated each budget field independently as nonnegative, allowing nonsensical submissions like `budgetMin=5000, budgetMax=100`.

## Changes

- **`apps/api/src/validators/job.js`**: Extracted base schema, added `.refine()` to `createJobSchema` and `updateJobSchema` with a clear error message pointing to `budgetMax`.
- **`apps/api/src/tests/job-validator.test.js`**: Added 3 test cases covering invalid (budgetMax < budgetMin), equal, and valid ranges.

## Verification

All 4 tests pass (1 existing health test + 3 new):
```
✔ GET /health returns ok payload
✔ createJobSchema rejects budgetMax < budgetMin
✔ createJobSchema accepts budgetMax === budgetMin
✔ createJobSchema accepts budgetMax > budgetMin
```

Closes #11183
/claim #743