### PR TITLE
fix: discover API test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## 变更说明

修复 API workspace 的测试脚本。原命令 `node --test src/tests` 在当前 Node.js 中会把测试目录当作模块路径执行，导致根目录 `npm test` 报 `MODULE_NOT_FOUND`。

本 PR 将脚本改为显式发现现有的 `src/tests/*.test.js` 文件，不修改应用运行逻辑。

Closes #11189

/claim #743

## 验证

```bash
npm test
```

结果：

```text
# tests 1
# pass 1
# fail 0
```

```bash
npm run build -w apps/web
```

结果：Next.js production build 成功。

## 演示视频

[下载/播放 7 秒前后对比视频](https://raw.githubusercontent.com/chxcode/bug-bounty/demo-assets/demo/api-test-discovery-demo.mp4)

视频展示了修复前 `npm test` 的 `MODULE_NOT_FOUND`，以及修复后 1 个测试通过、0 个测试失败。