### PR TITLE
Fix apps/api test script to run the actual test file

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Closes #11194.

`npm test -w apps/api` was failing because the package script pointed Node at `src/tests` instead of an executable test file. This updates the script to `node --test src/tests/*.test.js`, which matches the existing health test and makes the suite pass.

This also supports the recursive issue flow requested in #743.
