### PR TITLE
fix(api): return defensive user snapshots

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,7 +1,7 @@
 const users = [];
 
 export async function listUsers() {
-  return users;
+  return users.map((user) => ({ ...user }));
 }
 
 export async function createUser(payload) {

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("listUsers returns a defensive snapshot", async () => {
+  await createUser({
+    email: "snapshot@example.com",
+    fullName: "Snapshot User"
+  });
+
+  const snapshot = await listUsers();
+  snapshot.push({
+    id: "usr_malicious",
+    email: "evil@example.com",
+    fullName: "Malicious User"
+  });
+
+  snapshot[0].fullName = "Tampered User";
+
+  const fresh = await listUsers();
+  assert.equal(fresh.length, 1);
+  assert.deepEqual(fresh[0], {
+    id: fresh[0].id,
+    email: "snapshot@example.com",
+    fullName: "Snapshot User"
+  });
+});


### PR DESCRIPTION
Closes #11196

/claim #743

This change makes `listUsers()` return defensive snapshots so callers cannot mutate the in-memory user store through the returned array.

Validation:
- `node --test src/tests/*.test.js`
- `git diff --check`