### PR TITLE
Fix dropped leaderboard updates during PR bursts

### DIFF
--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -1,0 +1,52 @@
+import { pathToFileURL } from "node:url";
+
+export const MAX_ATTEMPTS = 5;
+
+export function commitSubject(prNumber) {
+  return `chore: update leaderboard for PR #${prNumber}`;
+}
+
+function required(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function parseInputs(env) {
+  const token = required(env, "GH_TOKEN");
+  const defaultBranch = required(env, "DEFAULT_BRANCH");
+  const repository = required(env, "GITHUB_REPOSITORY");
+  const prUser = required(env, "PR_USER");
+  const prNumber = required(env, "PR_NUMBER");
+
+  if (!/^\d+$/.test(prNumber)) {
+    throw new Error("PR_NUMBER must contain digits only");
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("GITHUB_REPOSITORY must be owner/name");
+  }
+  if (defaultBranch.startsWith("-") || defaultBranch.includes("\0")) {
+    throw new Error("DEFAULT_BRANCH is invalid");
+  }
+
+  return { token, defaultBranch, repository, prUser, prNumber };
+}
+
+export function incrementLeaderboardText(source, user) {
+  const leaderboard = source.trim() ? JSON.parse(source) : {};
+  if (leaderboard === null || Array.isArray(leaderboard) || typeof leaderboard !== "object") {
+    throw new Error("leaderboard.json must contain a JSON object");
+  }
+
+  const current = leaderboard[user] ?? 0;
+  if (typeof current !== "number" || !Number.isFinite(current)) {
+    throw new Error(`leaderboard entry for ${user} must be a finite number`);
+  }
+
+  leaderboard[user] = current + 1;
+  return `${JSON.stringify(leaderboard, null, 2)}\n`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  parseInputs(process.env);
+}

--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -44,14 +44,17 @@ export function incrementLeaderboardText(source, user) {
     throw new Error("leaderboard.json must contain a JSON object");
   }
 
-  const current = leaderboard[user] ?? 0;
-  if (typeof current !== "number" || !Number.isFinite(current)) {
-    throw new Error(`leaderboard entry for ${user} must be a finite number`);
+  for (const value of Object.values(leaderboard)) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error("leaderboard top-level values must be finite numbers");
+    }
   }
 
+  const hasUser = Object.prototype.hasOwnProperty.call(leaderboard, user);
+  const current = hasUser ? leaderboard[user] : 0;
   const next = current + 1;
   const key = JSON.stringify(user);
-  if (Object.prototype.hasOwnProperty.call(leaderboard, user)) {
+  if (hasUser) {
     const valuePattern = new RegExp(`(^[ \\t]*${escapeRegExp(key)}[ \\t]*:[ \\t]*)(-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)(?=[ \\t]*\\r?(?:,|$))`, "m");
     const match = valuePattern.exec(source);
     if (!match) throw new Error(`leaderboard entry for ${user} must be a top-level number`);
@@ -109,11 +112,11 @@ export async function runUpdate({
     requireGit(git(["reset", "--hard", `origin/${defaultBranch}`]), "reset to default branch", token);
 
     const existing = requireGit(
-      git(["log", "--format=%s", `--grep=^${subject}$`, "-n", "1"]),
+      git(["log", "--format=%s", `--grep=^${subject}$`]),
       "check idempotency commit",
       token,
     );
-    if (existing.stdout.trim()) return "already-counted";
+    if (existing.stdout.split(/\r?\n/).some((line) => line === subject)) return "already-counted";
 
     const source = file.exists("leaderboard.json") ? file.read("leaderboard.json") : "{}\n";
     file.write("leaderboard.json", incrementLeaderboardText(source, prUser));

--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -39,7 +39,7 @@ function escapeRegExp(value) {
 }
 
 export function incrementLeaderboardText(source, user) {
-  const leaderboard = source.trim() ? JSON.parse(source) : {};
+  const leaderboard = JSON.parse(source);
   if (leaderboard === null || Array.isArray(leaderboard) || typeof leaderboard !== "object") {
     throw new Error("leaderboard.json must contain a JSON object");
   }

--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -52,7 +52,7 @@ export function incrementLeaderboardText(source, user) {
   const next = current + 1;
   const key = JSON.stringify(user);
   if (Object.prototype.hasOwnProperty.call(leaderboard, user)) {
-    const valuePattern = new RegExp(`(^[ \\t]*${escapeRegExp(key)}[ \\t]*:[ \\t]*)(-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)(?=[ \\t]*(?:,|$))`, "m");
+    const valuePattern = new RegExp(`(^[ \\t]*${escapeRegExp(key)}[ \\t]*:[ \\t]*)(-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)(?=[ \\t]*\\r?(?:,|$))`, "m");
     const match = valuePattern.exec(source);
     if (!match) throw new Error(`leaderboard entry for ${user} must be a top-level number`);
     return `${source.slice(0, match.index)}${match[1]}${next}${source.slice(match.index + match[0].length)}`;

--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -34,6 +34,10 @@ export function parseInputs(env) {
   return { token, defaultBranch, repository, prUser, prNumber };
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function incrementLeaderboardText(source, user) {
   const leaderboard = source.trim() ? JSON.parse(source) : {};
   if (leaderboard === null || Array.isArray(leaderboard) || typeof leaderboard !== "object") {
@@ -45,8 +49,23 @@ export function incrementLeaderboardText(source, user) {
     throw new Error(`leaderboard entry for ${user} must be a finite number`);
   }
 
-  leaderboard[user] = current + 1;
-  return `${JSON.stringify(leaderboard, null, 2)}\n`;
+  const next = current + 1;
+  const key = JSON.stringify(user);
+  if (Object.prototype.hasOwnProperty.call(leaderboard, user)) {
+    const valuePattern = new RegExp(`(^[ \\t]*${escapeRegExp(key)}[ \\t]*:[ \\t]*)(-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)(?=[ \\t]*(?:,|$))`, "m");
+    const match = valuePattern.exec(source);
+    if (!match) throw new Error(`leaderboard entry for ${user} must be a top-level number`);
+    return `${source.slice(0, match.index)}${match[1]}${next}${source.slice(match.index + match[0].length)}`;
+  }
+
+  const closeIndex = source.lastIndexOf("}");
+  const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
+  const indentation = source.match(new RegExp(`${lineEnding}([ \\t]+)${escapeRegExp(JSON.stringify(Object.keys(leaderboard)[0] ?? ""))}`))?.[1] ?? "  ";
+  const beforeClose = source.slice(0, closeIndex);
+  const trailingWhitespace = beforeClose.match(/\s*$/)?.[0] ?? "";
+  const content = beforeClose.slice(0, beforeClose.length - trailingWhitespace.length);
+  const prefix = Object.keys(leaderboard).length ? `,${lineEnding}` : lineEnding;
+  return `${content}${prefix}${indentation}${key}: ${next}${lineEnding}}${source.slice(closeIndex + 1)}`;
 }
 
 function defaultGit(args) {

--- a/.github/scripts/update-pr-leaderboard.mjs
+++ b/.github/scripts/update-pr-leaderboard.mjs
@@ -1,4 +1,6 @@
 import { pathToFileURL } from "node:url";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 export const MAX_ATTEMPTS = 5;
 
@@ -47,6 +49,84 @@ export function incrementLeaderboardText(source, user) {
   return `${JSON.stringify(leaderboard, null, 2)}\n`;
 }
 
+function defaultGit(args) {
+  const completed = spawnSync("git", args, { encoding: "utf8" });
+  return {
+    status: completed.status ?? 1,
+    stdout: completed.stdout ?? "",
+    stderr: completed.stderr ?? completed.error?.message ?? "",
+  };
+}
+
+const defaultFile = {
+  exists: existsSync,
+  read: (path) => readFileSync(path, "utf8"),
+  write: (path, contents) => writeFileSync(path, contents, "utf8"),
+};
+
+function requireGit(result, operation, token) {
+  if (result.status === 0) return result;
+  const detail = result.stderr.replaceAll(token, "[redacted]").trim();
+  throw new Error(`${operation} failed${detail ? `: ${detail}` : ""}`);
+}
+
+export async function runUpdate({
+  inputs,
+  git = defaultGit,
+  file = defaultFile,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  log = (message) => console.log(message),
+} = {}) {
+  const { token, defaultBranch, repository, prUser, prNumber } = inputs;
+  const subject = commitSubject(prNumber);
+  const remoteUrl = `https://x-access-token:${token}@github.com/${repository}.git`;
+
+  requireGit(git(["config", "user.name", "github-actions[bot]"]), "configure Git user", token);
+  requireGit(git(["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]), "configure Git email", token);
+  requireGit(git(["remote", "set-url", "origin", remoteUrl]), "configure authenticated origin", token);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    requireGit(git(["fetch", "origin", defaultBranch]), "fetch default branch", token);
+    requireGit(git(["reset", "--hard", `origin/${defaultBranch}`]), "reset to default branch", token);
+
+    const existing = requireGit(
+      git(["log", "--format=%s", `--grep=^${subject}$`, "-n", "1"]),
+      "check idempotency commit",
+      token,
+    );
+    if (existing.stdout.trim()) return "already-counted";
+
+    const source = file.exists("leaderboard.json") ? file.read("leaderboard.json") : "{}\n";
+    file.write("leaderboard.json", incrementLeaderboardText(source, prUser));
+    requireGit(git(["add", "leaderboard.json"]), "stage leaderboard", token);
+
+    const diff = git(["diff", "--cached", "--quiet", "--", "leaderboard.json"]);
+    if (diff.status === 0) return "no-change";
+    if (diff.status !== 1) requireGit(diff, "inspect staged leaderboard", token);
+
+    requireGit(git(["commit", "-m", subject]), "commit leaderboard", token);
+    const push = git(["push", "origin", `HEAD:${defaultBranch}`]);
+    if (push.status === 0) return "updated";
+
+    if (attempt === MAX_ATTEMPTS) {
+      const detail = push.stderr.replaceAll(token, "[redacted]").trim();
+      throw new Error(`leaderboard push failed after ${MAX_ATTEMPTS} attempts${detail ? `: ${detail}` : ""}`);
+    }
+
+    log(`Push attempt ${attempt} lost a race; recomputing from origin/${defaultBranch}.`);
+    await sleep(attempt * 250);
+  }
+
+  throw new Error("unreachable retry state");
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  parseInputs(process.env);
+  const inputs = parseInputs(process.env);
+  runUpdate({ inputs }).then(
+    (status) => console.log(`Leaderboard update: ${status}`),
+    (error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    },
+  );
 }

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -27,9 +27,13 @@ test("different PRs do not share a replaceable pending concurrency slot", () => 
 test("workflow invokes the tested Node updater from the trusted checkout", () => {
   const workflow = readFileSync(workflowPath, "utf8");
 
+  assert.match(workflow, /^\s*pull_request_target:\s*$/m);
+  assert.match(workflow, /^\s*contents:\s*write\s*$/m);
+  assert.match(workflow, /^\s*pull-requests:\s*read\s*$/m);
+  assert.match(workflow, /^\s*ref:\s*\$\{\{ github\.event\.repository\.default_branch \}\}\s*$/m);
   assert.match(workflow, /^\s*run:\s*node \.github\/scripts\/update-pr-leaderboard\.mjs\s*$/m);
   assert.doesNotMatch(workflow, /jq --arg user/);
-  assert.match(workflow, /ref:\s*\$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.doesNotMatch(workflow, /^\s*GITHUB_REPOSITORY:\s*/m);
 });
 
 test("leaderboard mutation increments one user and preserves unrelated values", async () => {
@@ -40,6 +44,26 @@ test("leaderboard mutation increments one user and preserves unrelated values", 
     incrementLeaderboardText(source, "alice"),
     `${JSON.stringify({ alice: 3, bob: 7 }, null, 2)}\n`,
   );
+});
+
+test("leaderboard mutation preserves numeric-key order and formatting", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const source = '{\n  "alice": 2,\n  "2569658930": 7,\n  "bob": 9\n}\n';
+  const expected = '{\n  "alice": 2,\n  "2569658930": 8,\n  "bob": 9\n}\n';
+
+  const result = incrementLeaderboardText(source, "2569658930");
+  assert.equal(result, expected);
+  assert.deepEqual(JSON.parse(result), { alice: 2, "2569658930": 8, bob: 9 });
+});
+
+test("leaderboard mutation appends a new key after numeric keys", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const source = '{\n  "alice": 2,\n  "2569658930": 7,\n  "bob": 9\n}\n';
+  const expected = '{\n  "alice": 2,\n  "2569658930": 7,\n  "bob": 9,\n  "charlie": 1\n}\n';
+
+  const result = incrementLeaderboardText(source, "charlie");
+  assert.equal(result, expected);
+  assert.deepEqual(JSON.parse(result), { alice: 2, "2569658930": 7, bob: 9, charlie: 1 });
 });
 
 test("leaderboard mutation appends a new user and keeps shell text as data", async () => {

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -56,3 +56,97 @@ test("workflow inputs reject malformed PR numbers", async () => {
     /PR_NUMBER must contain digits only/,
   );
 });
+
+function result(status = 0, stdout = "", stderr = "") {
+  return { status, stdout, stderr };
+}
+
+function makeFile(initial = "{}\n") {
+  let contents = initial;
+  let writes = 0;
+  return {
+    exists: () => true,
+    read: () => contents,
+    write: (_path, next) => {
+      contents = next;
+      writes += 1;
+    },
+    snapshot: () => ({ contents, writes }),
+  };
+}
+
+const inputs = {
+  token: "secret-token",
+  defaultBranch: "main",
+  repository: "owner/repo",
+  prUser: "alice",
+  prNumber: "123",
+};
+
+test("already-counted PR exits before writing or pushing", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile();
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "log") return result(0, "chore: update leaderboard for PR #123\n");
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "already-counted");
+  assert.equal(file.snapshot().writes, 0);
+  assert.equal(calls.some((args) => args[0] === "push"), false);
+});
+
+test("rejected push resets, recomputes, and succeeds without losing a concurrent increment", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile(`${JSON.stringify({ alice: 4, bob: 2 }, null, 2)}\n`);
+  let pushes = 0;
+  let resets = 0;
+  const git = (args) => {
+    if (args[0] === "log") return result();
+    if (args[0] === "diff") return result(1);
+    if (args[0] === "reset") {
+      resets += 1;
+      if (resets === 2) {
+        file.write("leaderboard.json", `${JSON.stringify({ alice: 4, bob: 3 }, null, 2)}\n`);
+      }
+      return result();
+    }
+    if (args[0] === "push") {
+      pushes += 1;
+      return pushes === 1 ? result(1, "", "non-fast-forward") : result();
+    }
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "updated");
+  assert.equal(pushes, 2);
+  assert.equal(resets, 2);
+  assert.deepEqual(JSON.parse(file.snapshot().contents), { alice: 5, bob: 3 });
+});
+
+test("retry exhaustion fails visibly without leaking the token", async () => {
+  const { runUpdate, MAX_ATTEMPTS } = await loadUpdater();
+  const file = makeFile();
+  let pushes = 0;
+  const git = (args) => {
+    if (args[0] === "log") return result();
+    if (args[0] === "diff") return result(1);
+    if (args[0] === "push") {
+      pushes += 1;
+      return result(1, "", `rejected secret-token attempt ${pushes}`);
+    }
+    return result();
+  };
+
+  await assert.rejects(
+    runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }),
+    (error) => {
+      assert.match(error.message, /failed after 5 attempts/);
+      assert.doesNotMatch(error.message, /secret-token/);
+      return true;
+    },
+  );
+  assert.equal(pushes, MAX_ATTEMPTS);
+});

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -24,6 +24,14 @@ test("different PRs do not share a replaceable pending concurrency slot", () => 
   );
 });
 
+test("workflow invokes the tested Node updater from the trusted checkout", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /^\s*run:\s*node \.github\/scripts\/update-pr-leaderboard\.mjs\s*$/m);
+  assert.doesNotMatch(workflow, /jq --arg user/);
+  assert.match(workflow, /ref:\s*\$\{\{ github\.event\.repository\.default_branch \}\}/);
+});
+
 test("leaderboard mutation increments one user and preserves unrelated values", async () => {
   const { incrementLeaderboardText } = await loadUpdater();
   const source = `${JSON.stringify({ alice: 2, bob: 7 }, null, 2)}\n`;

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const workflowPath = new URL("../workflows/update-pr-leaderboard.yml", import.meta.url);
+
+test("different PRs do not share a replaceable pending concurrency slot", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.doesNotMatch(
+    workflow,
+    /^\s*group:\s*leaderboard-json-update\s*$/m,
+  );
+  assert.match(
+    workflow,
+    /^\s*group:\s*leaderboard-json-update-\$\{\{\s*github\.event\.pull_request\.number\s*\}\}\s*$/m,
+  );
+});

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -26,12 +26,15 @@ test("different PRs do not share a replaceable pending concurrency slot", () => 
 
 test("workflow invokes the tested Node updater from the trusted checkout", () => {
   const workflow = readFileSync(workflowPath, "utf8");
+  const job = workflow.slice(workflow.indexOf("  update-leaderboard:"));
+  const checkoutIndex = job.indexOf("uses: actions/checkout@v4");
+  const refIndex = job.indexOf("ref: ${{ github.event.repository.default_branch }}");
+  const runIndex = job.indexOf("run: node .github/scripts/update-pr-leaderboard.mjs");
 
   assert.match(workflow, /^\s*pull_request_target:\s*$/m);
   assert.match(workflow, /^\s*contents:\s*write\s*$/m);
   assert.match(workflow, /^\s*pull-requests:\s*read\s*$/m);
-  assert.match(workflow, /^\s*ref:\s*\$\{\{ github\.event\.repository\.default_branch \}\}\s*$/m);
-  assert.match(workflow, /^\s*run:\s*node \.github\/scripts\/update-pr-leaderboard\.mjs\s*$/m);
+  assert.ok(checkoutIndex >= 0 && checkoutIndex < refIndex && refIndex < runIndex);
   assert.doesNotMatch(workflow, /jq --arg user/);
   assert.doesNotMatch(workflow, /^\s*GITHUB_REPOSITORY:\s*/m);
 });
@@ -50,6 +53,16 @@ test("leaderboard mutation preserves numeric-key order and formatting", async ()
   const { incrementLeaderboardText } = await loadUpdater();
   const source = '{\n  "alice": 2,\n  "2569658930": 7,\n  "bob": 9\n}\n';
   const expected = '{\n  "alice": 2,\n  "2569658930": 8,\n  "bob": 9\n}\n';
+
+  const result = incrementLeaderboardText(source, "2569658930");
+  assert.equal(result, expected);
+  assert.deepEqual(JSON.parse(result), { alice: 2, "2569658930": 8, bob: 9 });
+});
+
+test("leaderboard mutation preserves numeric-key order and formatting with CRLF", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const source = '{\r\n  "alice": 2,\r\n  "bob": 9,\r\n  "2569658930": 7\r\n}\r\n';
+  const expected = '{\r\n  "alice": 2,\r\n  "bob": 9,\r\n  "2569658930": 8\r\n}\r\n';
 
   const result = incrementLeaderboardText(source, "2569658930");
   assert.equal(result, expected);

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -108,6 +108,14 @@ test("leaderboard mutation rejects nested and non-numeric top-level values", asy
   }
 });
 
+test("leaderboard mutation rejects empty and whitespace-only source text", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+
+  for (const source of ["", " \t\r\n"]) {
+    assert.throws(() => incrementLeaderboardText(source, "alice"), SyntaxError);
+  }
+});
+
 test("workflow inputs reject malformed PR numbers", async () => {
   const { parseInputs } = await loadUpdater();
 
@@ -167,6 +175,25 @@ test("already-counted PR exits before writing or pushing", async () => {
     "--format=%s",
     "--grep=^chore: update leaderboard for PR #123$",
   ]);
+});
+
+test("an existing whitespace-only leaderboard fails before writing, committing, or pushing", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile(" \t\r\n");
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "log") return result();
+    return result();
+  };
+
+  await assert.rejects(
+    runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }),
+    SyntaxError,
+  );
+  assert.equal(file.snapshot().writes, 0);
+  assert.equal(calls.filter((args) => args[0] === "commit").length, 0);
+  assert.equal(calls.filter((args) => args[0] === "push").length, 0);
 });
 
 test("a body-only grep match with a different subject is not already-counted", async () => {

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -87,6 +87,27 @@ test("leaderboard mutation appends a new user and keeps shell text as data", asy
   assert.deepEqual(result, { [user]: 1 });
 });
 
+test("leaderboard mutation treats Object.prototype names as new users", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+
+  assert.deepEqual(JSON.parse(incrementLeaderboardText("{}\n", "constructor")), { constructor: 1 });
+  assert.deepEqual(JSON.parse(incrementLeaderboardText("{}\n", "__proto__")), JSON.parse('{"__proto__": 1}'));
+});
+
+test("leaderboard mutation rejects nested and non-numeric top-level values", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+
+  for (const source of [
+    '{\n  "alice": 2,\n  "metadata": {"alice": 99}\n}\n',
+    '{\n  "alice": 2,\n  "bob": "two"\n}\n',
+  ]) {
+    assert.throws(
+      () => incrementLeaderboardText(source, "alice"),
+      /top-level values must be finite numbers/,
+    );
+  }
+});
+
 test("workflow inputs reject malformed PR numbers", async () => {
   const { parseInputs } = await loadUpdater();
 
@@ -141,14 +162,41 @@ test("already-counted PR exits before writing or pushing", async () => {
   assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "already-counted");
   assert.equal(file.snapshot().writes, 0);
   assert.equal(calls.some((args) => args[0] === "push"), false);
+  assert.deepEqual(calls[5], [
+    "log",
+    "--format=%s",
+    "--grep=^chore: update leaderboard for PR #123$",
+  ]);
+});
+
+test("a body-only grep match with a different subject is not already-counted", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile();
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "log") return result(0, "chore: unrelated maintenance\n");
+    if (args[0] === "diff") return result(1);
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "updated");
+  assert.equal(file.snapshot().writes, 1);
+  assert.deepEqual(calls[5], [
+    "log",
+    "--format=%s",
+    "--grep=^chore: update leaderboard for PR #123$",
+  ]);
 });
 
 test("rejected push resets, recomputes, and succeeds without losing a concurrent increment", async () => {
   const { runUpdate } = await loadUpdater();
   const file = makeFile(`${JSON.stringify({ alice: 4, bob: 2 }, null, 2)}\n`);
+  const calls = [];
   let pushes = 0;
   let resets = 0;
   const git = (args) => {
+    calls.push(args);
     if (args[0] === "log") return result();
     if (args[0] === "diff") return result(1);
     if (args[0] === "reset") {
@@ -169,6 +217,56 @@ test("rejected push resets, recomputes, and succeeds without losing a concurrent
   assert.equal(pushes, 2);
   assert.equal(resets, 2);
   assert.deepEqual(JSON.parse(file.snapshot().contents), { alice: 5, bob: 3 });
+  assert.deepEqual(calls, [
+    ["config", "user.name", "github-actions[bot]"],
+    ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"],
+    ["remote", "set-url", "origin", "https://x-access-token:secret-token@github.com/owner/repo.git"],
+    ["fetch", "origin", "main"],
+    ["reset", "--hard", "origin/main"],
+    ["log", "--format=%s", "--grep=^chore: update leaderboard for PR #123$"],
+    ["add", "leaderboard.json"],
+    ["diff", "--cached", "--quiet", "--", "leaderboard.json"],
+    ["commit", "-m", "chore: update leaderboard for PR #123"],
+    ["push", "origin", "HEAD:main"],
+    ["fetch", "origin", "main"],
+    ["reset", "--hard", "origin/main"],
+    ["log", "--format=%s", "--grep=^chore: update leaderboard for PR #123$"],
+    ["add", "leaderboard.json"],
+    ["diff", "--cached", "--quiet", "--", "leaderboard.json"],
+    ["commit", "-m", "chore: update leaderboard for PR #123"],
+    ["push", "origin", "HEAD:main"],
+  ]);
+});
+
+test("ambiguous push failure finds the accepted commit before a second write", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile();
+  const calls = [];
+  let logChecks = 0;
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "log") {
+      logChecks += 1;
+      return logChecks === 1
+        ? result()
+        : result(0, "chore: update leaderboard for PR #123\n");
+    }
+    if (args[0] === "diff") return result(1);
+    if (args[0] === "push") return result(1, "", "network connection reset");
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "already-counted");
+  assert.equal(file.snapshot().writes, 1);
+  assert.equal(calls.filter((args) => args[0] === "commit").length, 1);
+  assert.equal(calls.filter((args) => args[0] === "push").length, 1);
+  assert.deepEqual(
+    calls.filter((args) => args[0] === "log"),
+    [
+      ["log", "--format=%s", "--grep=^chore: update leaderboard for PR #123$"],
+      ["log", "--format=%s", "--grep=^chore: update leaderboard for PR #123$"],
+    ],
+  );
 });
 
 test("retry exhaustion fails visibly without leaking the token", async () => {

--- a/.github/scripts/update-pr-leaderboard.test.mjs
+++ b/.github/scripts/update-pr-leaderboard.test.mjs
@@ -1,8 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 
 const workflowPath = new URL("../workflows/update-pr-leaderboard.yml", import.meta.url);
+const updaterUrl = new URL("./update-pr-leaderboard.mjs", import.meta.url);
+
+async function loadUpdater() {
+  assert.equal(existsSync(updaterUrl), true, "updater script must exist");
+  return import(updaterUrl.href);
+}
 
 test("different PRs do not share a replaceable pending concurrency slot", () => {
   const workflow = readFileSync(workflowPath, "utf8");
@@ -14,5 +21,38 @@ test("different PRs do not share a replaceable pending concurrency slot", () => 
   assert.match(
     workflow,
     /^\s*group:\s*leaderboard-json-update-\$\{\{\s*github\.event\.pull_request\.number\s*\}\}\s*$/m,
+  );
+});
+
+test("leaderboard mutation increments one user and preserves unrelated values", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const source = `${JSON.stringify({ alice: 2, bob: 7 }, null, 2)}\n`;
+
+  assert.equal(
+    incrementLeaderboardText(source, "alice"),
+    `${JSON.stringify({ alice: 3, bob: 7 }, null, 2)}\n`,
+  );
+});
+
+test("leaderboard mutation appends a new user and keeps shell text as data", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const user = "$(touch-not-executed)";
+  const result = JSON.parse(incrementLeaderboardText("{}\n", user));
+
+  assert.deepEqual(result, { [user]: 1 });
+});
+
+test("workflow inputs reject malformed PR numbers", async () => {
+  const { parseInputs } = await loadUpdater();
+
+  assert.throws(
+    () => parseInputs({
+      GH_TOKEN: "token",
+      DEFAULT_BRANCH: "main",
+      GITHUB_REPOSITORY: "owner/repo",
+      PR_USER: "alice",
+      PR_NUMBER: "12; echo injected",
+    }),
+    /PR_NUMBER must contain digits only/,
   );
 });

--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: leaderboard-json-update
+  group: leaderboard-json-update-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/update-pr-leaderboard.yml
+++ b/.github/workflows/update-pr-leaderboard.yml
@@ -31,36 +31,4 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PR_USER: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          git checkout "${DEFAULT_BRANCH}"
-          git pull --ff-only origin "${DEFAULT_BRANCH}"
-
-          if git --no-pager log --format=%s --grep="^chore: update leaderboard for PR #${PR_NUMBER}$" -n 1 | grep -q .; then
-            echo "PR #${PR_NUMBER} already counted."
-            exit 0
-          fi
-
-          if [ ! -f leaderboard.json ]; then
-            printf '{}\n' > leaderboard.json
-          fi
-
-          tmp_file="$(mktemp)"
-          jq --arg user "${PR_USER}" '.[$user] = ((.[$user] // 0) + 1)' leaderboard.json > "${tmp_file}"
-          mv "${tmp_file}" leaderboard.json
-
-          git add leaderboard.json
-
-          if git diff --cached --quiet -- leaderboard.json; then
-            echo "No leaderboard changes to commit."
-            exit 0
-          fi
-
-          git commit -m "chore: update leaderboard for PR #${PR_NUMBER}"
-          git pull --rebase origin "${DEFAULT_BRANCH}"
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+        run: node .github/scripts/update-pr-leaderboard.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 .env.*
 coverage
 *.log
+
+.worktrees/

--- a/docs/superpowers/plans/2026-07-16-reliable-leaderboard-updates.md
+++ b/docs/superpowers/plans/2026-07-16-reliable-leaderboard-updates.md
@@ -632,4 +632,3 @@ Closes #11198
 - [ ] **Step 6: Verify remote checks and PR state**
 
 Confirm the PR is open, non-draft, mergeable, the changed-file list matches the local diff, and every available GitHub check passes. Address review comments or CI failures before reporting completion.
-

--- a/docs/superpowers/plans/2026-07-16-reliable-leaderboard-updates.md
+++ b/docs/superpowers/plans/2026-07-16-reliable-leaderboard-updates.md
@@ -1,0 +1,635 @@
+# Reliable Leaderboard Updates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent burst PR-open events from being dropped and retry leaderboard pushes without double-counting a PR.
+
+**Architecture:** Give each PR its own GitHub Actions concurrency key, then move the leaderboard mutation into a testable Node ESM script. The script recomputes from the latest remote default branch after a rejected push and uses the existing exact commit subject as its idempotency key.
+
+**Tech Stack:** GitHub Actions YAML, Node.js ESM, `node:test`, Git CLI, JSON.
+
+## Global Constraints
+
+- Preserve the trusted `pull_request_target` default-branch checkout; never execute contributor-branch code.
+- Keep `permissions` at `contents: write` and `pull-requests: read`.
+- Preserve `leaderboard.json` key order, two-space indentation, and trailing newline.
+- Use argument-array Git execution; do not interpolate PR-derived values into a shell command.
+- Retry at most five pushes and fail visibly after exhaustion.
+- Use the exact idempotency subject `chore: update leaderboard for PR #<number>`.
+- Do not add runtime dependencies.
+
+---
+
+## File structure
+
+- Modify `.github/workflows/update-pr-leaderboard.yml`: PR-specific concurrency and invocation of the tested updater.
+- Create `.github/scripts/update-pr-leaderboard.mjs`: validation, pure JSON mutation, Git command adapter, idempotent retry loop, and CLI entrypoint.
+- Create `.github/scripts/update-pr-leaderboard.test.mjs`: workflow configuration, JSON mutation, idempotency, retry, exhaustion, and command-injection regression tests.
+
+### Task 1: Make workflow concurrency lossless across different PRs
+
+**Files:**
+- Modify: `.github/workflows/update-pr-leaderboard.yml:12-14`
+- Create: `.github/scripts/update-pr-leaderboard.test.mjs`
+
+**Interfaces:**
+- Consumes: GitHub event value `${{ github.event.pull_request.number }}`.
+- Produces: concurrency group `leaderboard-json-update-${{ github.event.pull_request.number }}`.
+
+- [ ] **Step 1: Write the failing workflow configuration test**
+
+Create `.github/scripts/update-pr-leaderboard.test.mjs` with:
+
+```js
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const workflowPath = new URL("../workflows/update-pr-leaderboard.yml", import.meta.url);
+
+test("different PRs do not share a replaceable pending concurrency slot", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.doesNotMatch(
+    workflow,
+    /^\s*group:\s*leaderboard-json-update\s*$/m,
+  );
+  assert.match(
+    workflow,
+    /^\s*group:\s*leaderboard-json-update-\$\{\{\s*github\.event\.pull_request\.number\s*\}\}\s*$/m,
+  );
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: one failed test because the workflow still contains `group: leaderboard-json-update` and lacks the PR-number suffix.
+
+- [ ] **Step 3: Make the minimal workflow change**
+
+Replace the concurrency block with:
+
+```yaml
+concurrency:
+  group: leaderboard-json-update-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: one passed test, zero failures.
+
+- [ ] **Step 5: Commit the concurrency fix**
+
+```powershell
+git add .github/workflows/update-pr-leaderboard.yml .github/scripts/update-pr-leaderboard.test.mjs
+git commit -m "fix: isolate leaderboard workflow concurrency by PR"
+```
+
+### Task 2: Add validated, format-preserving leaderboard mutation
+
+**Files:**
+- Create: `.github/scripts/update-pr-leaderboard.mjs`
+- Modify: `.github/scripts/update-pr-leaderboard.test.mjs`
+
+**Interfaces:**
+- Produces: `commitSubject(prNumber: string): string`.
+- Produces: `parseInputs(env: Record<string, string | undefined>): Inputs`.
+- Produces: `incrementLeaderboardText(source: string, user: string): string`.
+- `Inputs` fields: `token`, `defaultBranch`, `repository`, `prUser`, `prNumber`.
+
+- [ ] **Step 1: Add failing behavior tests**
+
+Append:
+
+```js
+import { existsSync } from "node:fs";
+
+const updaterUrl = new URL("./update-pr-leaderboard.mjs", import.meta.url);
+
+async function loadUpdater() {
+  assert.equal(existsSync(updaterUrl), true, "updater script must exist");
+  return import(updaterUrl.href);
+}
+
+test("leaderboard mutation increments one user and preserves unrelated values", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const source = `${JSON.stringify({ alice: 2, bob: 7 }, null, 2)}\n`;
+
+  assert.equal(
+    incrementLeaderboardText(source, "alice"),
+    `${JSON.stringify({ alice: 3, bob: 7 }, null, 2)}\n`,
+  );
+});
+
+test("leaderboard mutation appends a new user and keeps shell text as data", async () => {
+  const { incrementLeaderboardText } = await loadUpdater();
+  const user = "$(touch-not-executed)";
+  const result = JSON.parse(incrementLeaderboardText("{}\n", user));
+
+  assert.deepEqual(result, { [user]: 1 });
+});
+
+test("workflow inputs reject malformed PR numbers", async () => {
+  const { parseInputs } = await loadUpdater();
+
+  assert.throws(
+    () => parseInputs({
+      GH_TOKEN: "token",
+      DEFAULT_BRANCH: "main",
+      GITHUB_REPOSITORY: "owner/repo",
+      PR_USER: "alice",
+      PR_NUMBER: "12; echo injected",
+    }),
+    /PR_NUMBER must contain digits only/,
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: the workflow test passes and the first updater test fails with `updater script must exist`.
+
+- [ ] **Step 3: Implement the pure functions and input validation**
+
+Create `.github/scripts/update-pr-leaderboard.mjs` with these exports before adding Git operations:
+
+```js
+import { pathToFileURL } from "node:url";
+
+export const MAX_ATTEMPTS = 5;
+
+export function commitSubject(prNumber) {
+  return `chore: update leaderboard for PR #${prNumber}`;
+}
+
+function required(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function parseInputs(env) {
+  const token = required(env, "GH_TOKEN");
+  const defaultBranch = required(env, "DEFAULT_BRANCH");
+  const repository = required(env, "GITHUB_REPOSITORY");
+  const prUser = required(env, "PR_USER");
+  const prNumber = required(env, "PR_NUMBER");
+
+  if (!/^\d+$/.test(prNumber)) {
+    throw new Error("PR_NUMBER must contain digits only");
+  }
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("GITHUB_REPOSITORY must be owner/name");
+  }
+  if (defaultBranch.startsWith("-") || defaultBranch.includes("\0")) {
+    throw new Error("DEFAULT_BRANCH is invalid");
+  }
+
+  return { token, defaultBranch, repository, prUser, prNumber };
+}
+
+export function incrementLeaderboardText(source, user) {
+  const leaderboard = source.trim() ? JSON.parse(source) : {};
+  if (leaderboard === null || Array.isArray(leaderboard) || typeof leaderboard !== "object") {
+    throw new Error("leaderboard.json must contain a JSON object");
+  }
+
+  const current = leaderboard[user] ?? 0;
+  if (typeof current !== "number" || !Number.isFinite(current)) {
+    throw new Error(`leaderboard entry for ${user} must be a finite number`);
+  }
+
+  leaderboard[user] = current + 1;
+  return `${JSON.stringify(leaderboard, null, 2)}\n`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  parseInputs(process.env);
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: four passed tests, zero failures.
+
+- [ ] **Step 5: Commit the tested mutation layer**
+
+```powershell
+git add .github/scripts/update-pr-leaderboard.mjs .github/scripts/update-pr-leaderboard.test.mjs
+git commit -m "test: cover leaderboard update inputs and formatting"
+```
+
+### Task 3: Add idempotent optimistic push retries
+
+**Files:**
+- Modify: `.github/scripts/update-pr-leaderboard.mjs`
+- Modify: `.github/scripts/update-pr-leaderboard.test.mjs`
+
+**Interfaces:**
+- Produces: `runUpdate(options): Promise<"already-counted" | "no-change" | "updated">`.
+- `options.git(args)` returns `{ status: number, stdout: string, stderr: string }`.
+- `options.file` supplies `exists(path)`, `read(path)`, and `write(path, text)`.
+- `options.sleep(milliseconds)` returns a promise.
+- `options.log(message)` records retry information without credentials.
+
+- [ ] **Step 1: Add failing idempotency and retry tests**
+
+Append tests that use an in-memory file and scripted Git adapter:
+
+```js
+function result(status = 0, stdout = "", stderr = "") {
+  return { status, stdout, stderr };
+}
+
+function makeFile(initial = "{}\n") {
+  let contents = initial;
+  let writes = 0;
+  return {
+    exists: () => true,
+    read: () => contents,
+    write: (_path, next) => {
+      contents = next;
+      writes += 1;
+    },
+    snapshot: () => ({ contents, writes }),
+  };
+}
+
+const inputs = {
+  token: "secret-token",
+  defaultBranch: "main",
+  repository: "owner/repo",
+  prUser: "alice",
+  prNumber: "123",
+};
+
+test("already-counted PR exits before writing or pushing", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile();
+  const calls = [];
+  const git = (args) => {
+    calls.push(args);
+    if (args[0] === "log") return result(0, "chore: update leaderboard for PR #123\n");
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "already-counted");
+  assert.equal(file.snapshot().writes, 0);
+  assert.equal(calls.some((args) => args[0] === "push"), false);
+});
+
+test("rejected push resets, recomputes, and succeeds without losing a concurrent increment", async () => {
+  const { runUpdate } = await loadUpdater();
+  const file = makeFile(`${JSON.stringify({ alice: 4, bob: 2 }, null, 2)}\n`);
+  let pushes = 0;
+  let resets = 0;
+  const git = (args) => {
+    if (args[0] === "log") return result();
+    if (args[0] === "diff") return result(1);
+    if (args[0] === "reset") {
+      resets += 1;
+      if (resets === 2) {
+        file.write("leaderboard.json", `${JSON.stringify({ alice: 4, bob: 3 }, null, 2)}\n`);
+      }
+      return result();
+    }
+    if (args[0] === "push") {
+      pushes += 1;
+      return pushes === 1 ? result(1, "", "non-fast-forward") : result();
+    }
+    return result();
+  };
+
+  assert.equal(await runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }), "updated");
+  assert.equal(pushes, 2);
+  assert.equal(resets, 2);
+  assert.deepEqual(JSON.parse(file.snapshot().contents), { alice: 5, bob: 3 });
+});
+
+test("retry exhaustion fails visibly without leaking the token", async () => {
+  const { runUpdate, MAX_ATTEMPTS } = await loadUpdater();
+  const file = makeFile();
+  let pushes = 0;
+  const git = (args) => {
+    if (args[0] === "log") return result();
+    if (args[0] === "diff") return result(1);
+    if (args[0] === "push") {
+      pushes += 1;
+      return result(1, "", `rejected secret-token attempt ${pushes}`);
+    }
+    return result();
+  };
+
+  await assert.rejects(
+    runUpdate({ inputs, git, file, sleep: async () => {}, log: () => {} }),
+    (error) => {
+      assert.match(error.message, /failed after 5 attempts/);
+      assert.doesNotMatch(error.message, /secret-token/);
+      return true;
+    },
+  );
+  assert.equal(pushes, MAX_ATTEMPTS);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: the new tests fail because `runUpdate` is not exported.
+
+- [ ] **Step 3: Implement Git execution, idempotency, and bounded retry**
+
+Extend `.github/scripts/update-pr-leaderboard.mjs` with:
+
+```js
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+function defaultGit(args) {
+  const completed = spawnSync("git", args, { encoding: "utf8" });
+  return {
+    status: completed.status ?? 1,
+    stdout: completed.stdout ?? "",
+    stderr: completed.stderr ?? completed.error?.message ?? "",
+  };
+}
+
+const defaultFile = {
+  exists: existsSync,
+  read: (path) => readFileSync(path, "utf8"),
+  write: (path, contents) => writeFileSync(path, contents, "utf8"),
+};
+
+function requireGit(result, operation, token) {
+  if (result.status === 0) return result;
+  const detail = result.stderr.replaceAll(token, "[redacted]").trim();
+  throw new Error(`${operation} failed${detail ? `: ${detail}` : ""}`);
+}
+
+export async function runUpdate({
+  inputs,
+  git = defaultGit,
+  file = defaultFile,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  log = (message) => console.log(message),
+} = {}) {
+  const { token, defaultBranch, repository, prUser, prNumber } = inputs;
+  const subject = commitSubject(prNumber);
+  const remoteUrl = `https://x-access-token:${token}@github.com/${repository}.git`;
+
+  requireGit(git(["config", "user.name", "github-actions[bot]"]), "configure Git user", token);
+  requireGit(git(["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]), "configure Git email", token);
+  requireGit(git(["remote", "set-url", "origin", remoteUrl]), "configure authenticated origin", token);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    requireGit(git(["fetch", "origin", defaultBranch]), "fetch default branch", token);
+    requireGit(git(["reset", "--hard", `origin/${defaultBranch}`]), "reset to default branch", token);
+
+    const existing = requireGit(
+      git(["log", "--format=%s", `--grep=^${subject}$`, "-n", "1"]),
+      "check idempotency commit",
+      token,
+    );
+    if (existing.stdout.trim()) return "already-counted";
+
+    const source = file.exists("leaderboard.json") ? file.read("leaderboard.json") : "{}\n";
+    file.write("leaderboard.json", incrementLeaderboardText(source, prUser));
+    requireGit(git(["add", "leaderboard.json"]), "stage leaderboard", token);
+
+    const diff = git(["diff", "--cached", "--quiet", "--", "leaderboard.json"]);
+    if (diff.status === 0) return "no-change";
+    if (diff.status !== 1) requireGit(diff, "inspect staged leaderboard", token);
+
+    requireGit(git(["commit", "-m", subject]), "commit leaderboard", token);
+    const push = git(["push", "origin", `HEAD:${defaultBranch}`]);
+    if (push.status === 0) return "updated";
+
+    if (attempt === MAX_ATTEMPTS) {
+      const detail = push.stderr.replaceAll(token, "[redacted]").trim();
+      throw new Error(`leaderboard push failed after ${MAX_ATTEMPTS} attempts${detail ? `: ${detail}` : ""}`);
+    }
+
+    log(`Push attempt ${attempt} lost a race; recomputing from origin/${defaultBranch}.`);
+    await sleep(attempt * 250);
+  }
+
+  throw new Error("unreachable retry state");
+}
+```
+
+Replace the direct-execution block with:
+
+```js
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const inputs = parseInputs(process.env);
+  runUpdate({ inputs }).then(
+    (status) => console.log(`Leaderboard update: ${status}`),
+    (error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    },
+  );
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: seven passed tests, zero failures.
+
+- [ ] **Step 5: Commit the retry implementation**
+
+```powershell
+git add .github/scripts/update-pr-leaderboard.mjs .github/scripts/update-pr-leaderboard.test.mjs
+git commit -m "fix: retry concurrent leaderboard pushes"
+```
+
+### Task 4: Wire the tested updater into GitHub Actions
+
+**Files:**
+- Modify: `.github/workflows/update-pr-leaderboard.yml:28-66`
+- Modify: `.github/scripts/update-pr-leaderboard.test.mjs`
+
+**Interfaces:**
+- Consumes environment variables `GH_TOKEN`, `DEFAULT_BRANCH`, `GITHUB_REPOSITORY`, `PR_USER`, and `PR_NUMBER`.
+- Invokes `node .github/scripts/update-pr-leaderboard.mjs` from the trusted default-branch checkout.
+
+- [ ] **Step 1: Add a failing workflow invocation test**
+
+Append:
+
+```js
+test("workflow invokes the tested Node updater from the trusted checkout", () => {
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  assert.match(workflow, /^\s*run:\s*node \.github\/scripts\/update-pr-leaderboard\.mjs\s*$/m);
+  assert.doesNotMatch(workflow, /jq --arg user/);
+  assert.match(workflow, /ref:\s*\$\{\{ github\.event\.repository\.default_branch \}\}/);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+```
+
+Expected: the new invocation test fails because the workflow still contains the inline `jq` block.
+
+- [ ] **Step 3: Replace the inline shell block**
+
+Keep the existing checkout step and replace the update step with:
+
+```yaml
+      - name: Increment PR count in leaderboard.json
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node .github/scripts/update-pr-leaderboard.mjs
+```
+
+`GITHUB_REPOSITORY` remains available as a default GitHub Actions environment variable and must not be replaced with PR-controlled input.
+
+- [ ] **Step 4: Run focused tests and YAML parsing**
+
+Run:
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+@'
+import pathlib, yaml
+path = pathlib.Path('.github/workflows/update-pr-leaderboard.yml')
+with path.open(encoding='utf-8') as stream:
+    parsed = yaml.safe_load(stream)
+assert isinstance(parsed, dict)
+print('workflow yaml parsed')
+'@ | python -
+```
+
+Expected: eight passed Node tests and `workflow yaml parsed`.
+
+- [ ] **Step 5: Commit workflow wiring**
+
+```powershell
+git add .github/workflows/update-pr-leaderboard.yml .github/scripts/update-pr-leaderboard.test.mjs
+git commit -m "ci: run tested leaderboard updater"
+```
+
+### Task 5: Full verification and publication
+
+**Files:**
+- Verify: all changed files
+- Update only if verification finds a defect: `.github/scripts/update-pr-leaderboard.mjs`, `.github/scripts/update-pr-leaderboard.test.mjs`, `.github/workflows/update-pr-leaderboard.yml`
+
+**Interfaces:**
+- Produces: a pushed branch and PR that closes Issue #11198 and claims parent bounty #743.
+
+- [ ] **Step 1: Run all automated checks**
+
+```powershell
+node --test ".github/scripts/update-pr-leaderboard.test.mjs"
+node --test "apps/api/src/tests/health.test.js"
+npm run build -w apps/web
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected:
+
+- leaderboard tests: eight passed, zero failed;
+- API health test: one passed, zero failed;
+- Next.js production build: completed successfully;
+- `git diff --check`: no output;
+- `git status --short`: no output.
+
+- [ ] **Step 2: Inspect the security boundary**
+
+```powershell
+git diff origin/main...HEAD -- .github/workflows/update-pr-leaderboard.yml .github/scripts/update-pr-leaderboard.mjs
+```
+
+Confirm the checkout still pins the default branch, no PR branch is checked out or executed, Git uses argument arrays, and errors redact `GH_TOKEN`.
+
+- [ ] **Step 3: Review the complete branch diff**
+
+```powershell
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+Expected: only the ignore entry, design/plan documentation, workflow, updater, and updater tests are changed.
+
+- [ ] **Step 4: Push the branch**
+
+```powershell
+git push -u fork codex/fix-leaderboard-11198
+```
+
+Expected: branch created or updated at `qq2401672073-hub/bug-bounty`.
+
+- [ ] **Step 5: Open the pull request**
+
+Create a PR from `qq2401672073-hub:codex/fix-leaderboard-11198` to `SecureBananaLabs:main` with:
+
+```markdown
+## Summary
+- prevent different PR-open events from sharing GitHub Actions' single replaceable pending concurrency slot
+- retry leaderboard updates from the latest default branch after concurrent push races
+- preserve idempotency and add regression coverage for retries and command-injection inputs
+
+## Validation
+- `node --test .github/scripts/update-pr-leaderboard.test.mjs`
+- `node --test apps/api/src/tests/health.test.js`
+- `npm run build -w apps/web`
+- workflow YAML parse check
+- `git diff --check origin/main...HEAD`
+
+Closes #11198
+
+/claim #743
+```
+
+- [ ] **Step 6: Verify remote checks and PR state**
+
+Confirm the PR is open, non-draft, mergeable, the changed-file list matches the local diff, and every available GitHub check passes. Address review comments or CI failures before reporting completion.
+

--- a/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
@@ -1,0 +1,92 @@
+# Leaderboard Burst Concurrency Design
+
+## Context
+
+The `Update PR leaderboard` workflow runs for every opened pull request and commits an increment to `leaderboard.json`. It currently places all runs in the fixed `leaderboard-json-update` concurrency group. GitHub Actions retains only one running and one pending run per group, so a burst of three or more PR-open events can replace an older pending run. Because the workflow listens only to the `opened` event, a replaced run is never replayed.
+
+This failure occurred for PR #11181: neighboring PRs #11180 and #11182 produced leaderboard commits, while the #11181 run was cancelled before starting and no matching commit exists on the default branch.
+
+## Goal
+
+Process every PR-open event exactly once from the workflow's perspective, without losing events to concurrency replacement or double-counting a PR after a retry.
+
+## Non-goals
+
+- Rebuilding historical leaderboard counts.
+- Changing which PR events qualify for the leaderboard.
+- Changing leaderboard ordering or JSON formatting.
+- Changing repository permissions or the trusted `pull_request_target` checkout model.
+
+## Considered approaches
+
+### 1. PR-specific concurrency plus optimistic retry — selected
+
+Use the PR number in the concurrency key so different PRs cannot replace one another. Let different PR updates run concurrently, and make each updater retry from the newest default-branch state after a non-fast-forward push.
+
+This preserves prompt event handling, avoids a lossy global queue, and remains correct under push races. It requires a small testable update script rather than the current one-shot inline shell block.
+
+### 2. Remove concurrency without adding retry
+
+Every event would start, but simultaneous runs could race on `leaderboard.json`; one or more pushes would fail. This changes the loss mechanism rather than fixing it.
+
+### 3. Scheduled full reconciliation
+
+A scheduled job could periodically rebuild the leaderboard from GitHub history. This could repair missed events, but it is broader, slower, API-intensive, and changes the current event-driven model.
+
+## Architecture
+
+The workflow retains its trusted default-branch checkout and write permissions. Its concurrency key becomes `leaderboard-json-update-${{ github.event.pull_request.number }}`, preventing pending runs for different PRs from sharing a replaceable slot.
+
+The inline update block moves to `.github/scripts/update-pr-leaderboard.mjs`. The module exposes pure or dependency-injected functions for tests and executes its CLI only when launched directly. It performs these steps:
+
+1. Validate the branch, repository, PR number, and PR user inputs supplied by GitHub Actions.
+2. Configure the bot identity and authenticated origin URL.
+3. Fetch and hard-reset the ephemeral runner checkout to the latest default branch.
+4. Check the exact commit subject `chore: update leaderboard for PR #<number>`; exit successfully if already counted.
+5. Parse `leaderboard.json`, increment only the PR author's key, and write two-space-indented JSON with a trailing newline.
+6. Commit the update and attempt a direct push to the default branch.
+7. If the push loses a race, discard the local attempt, return to step 3, recompute from the new remote state, and retry up to five times with a short bounded delay.
+8. Fail the workflow after the fifth rejected push so GitHub surfaces a visible error instead of silently losing the event.
+
+Hard-resetting is safe here because the checkout is an ephemeral GitHub-hosted runner containing only the deterministic leaderboard update. Recomputing avoids merge conflicts and guarantees the increment is based on the latest committed count.
+
+## Data and idempotency
+
+The commit subject is the idempotency key. A retried or manually rerun event checks the remote branch after every fetch and exits without changing the file when that subject already exists.
+
+JSON object insertion order is preserved by parsing and serializing the existing object. Existing users remain in their current order; a new user is appended. No unrelated leaderboard entries are modified.
+
+## Error handling
+
+- Missing or malformed workflow inputs fail before any repository write.
+- Missing `leaderboard.json` is treated as an empty object, matching the current workflow.
+- Invalid JSON fails loudly without committing.
+- A no-diff update exits successfully.
+- Push conflicts are retried from a clean copy of the latest remote branch.
+- Non-retryable Git failures and retry exhaustion return a non-zero exit code.
+- Authentication tokens are never printed in logs or included in command error messages.
+
+## Security
+
+The workflow continues to check out only the repository's default branch under `pull_request_target`; it never executes code from the contributor's PR branch. Git commands are launched with argument arrays rather than a shell command string, so PR-derived values cannot inject shell syntax. The script validates `PR_NUMBER` as digits and treats `PR_USER` only as a JSON key.
+
+## Testing
+
+Add Node `node:test` coverage that:
+
+- rejects the fixed global concurrency key and requires a PR-specific key;
+- verifies existing and new users are incremented without changing unrelated values;
+- verifies an already-counted PR performs no write or push;
+- simulates a rejected first push and proves the script fetches, resets, recomputes, and succeeds on a later attempt;
+- verifies retry exhaustion fails visibly;
+- verifies shell-like PR user text is stored as data and never executed.
+
+Run the new focused tests, the existing API tests with an explicit test-file path on Windows, the web production build, `git diff --check`, and a YAML parse/static inspection. Browser testing is not applicable because the change has no web UI. Network penetration testing is not applicable; the relevant security boundary is covered by trusted-checkout inspection and command-injection regression tests.
+
+## Success criteria
+
+- Different PR-open events never share one replaceable pending concurrency slot.
+- A simulated non-fast-forward push is retried from the newest default-branch state.
+- A PR cannot be counted twice after retry or rerun.
+- All new tests pass, existing executable tests pass, the web build succeeds, and the workflow remains valid YAML.
+

--- a/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
@@ -43,7 +43,7 @@ The inline update block moves to `.github/scripts/update-pr-leaderboard.mjs`. Th
 2. Configure the bot identity and authenticated origin URL.
 3. Fetch and hard-reset the ephemeral runner checkout to the latest default branch.
 4. Check the exact commit subject `chore: update leaderboard for PR #<number>`; exit successfully if already counted.
-5. Parse `leaderboard.json`, increment only the PR author's key, and write two-space-indented JSON with a trailing newline.
+5. Parse `leaderboard.json`, verify it is a flat mapping whose every top-level value is a finite number, then increment only the PR author's key by replacing the existing numeric token in the source text or appending a new key before the closing brace.
 6. Commit the update and attempt a direct push to the default branch.
 7. If the push loses a race, discard the local attempt, return to step 3, recompute from the new remote state, and retry up to five times with a short bounded delay.
 8. Fail the workflow after the fifth rejected push so GitHub surfaces a visible error instead of silently losing the event.
@@ -54,7 +54,7 @@ Hard-resetting is safe here because the checkout is an ephemeral GitHub-hosted r
 
 The commit subject is the idempotency key. A retried or manually rerun event checks the remote branch after every fetch and exits without changing the file when that subject already exists.
 
-JSON object insertion order is preserved by parsing and serializing the existing object. Existing users remain in their current order; a new user is appended. No unrelated leaderboard entries are modified.
+The updater first parses and validates a flat finite-number mapping, then makes a targeted source-text change: it replaces an existing user's numeric value or appends a new key at the end. This preserves numeric-looking key order, LF or CRLF line endings, indentation, and trailing newlines. Existing users remain in their current order, a new user is appended, and no unrelated leaderboard entries are modified.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-16-leaderboard-burst-concurrency-design.md
@@ -89,4 +89,3 @@ Run the new focused tests, the existing API tests with an explicit test-file pat
 - A simulated non-fast-forward push is retried from the newest default-branch state.
 - A PR cannot be counted twice after retry or rerun.
 - All new tests pass, existing executable tests pass, the web build succeeds, and the workflow remains valid YAML.
-


### PR DESCRIPTION
## Summary
- prevent different PR-open events from sharing GitHub Actions' single replaceable pending concurrency slot
- retry leaderboard updates from the latest default branch after concurrent push races
- preserve exact idempotency, original key order, LF/CRLF formatting, and token redaction
- add regression coverage for ambiguous pushes, body-only commit matches, prototype-like usernames, invalid data, and empty files

## Validation
- `node --test .github/scripts/update-pr-leaderboard.test.mjs` (17 passed)
- `node --test apps/api/src/tests/health.test.js` (1 passed)
- `npm run build -w apps/web`
- workflow YAML parse check
- `git diff --check origin/main...HEAD`

Closes #11198

/claim #743