### PR TITLE
fix(api): require auth for notification routes

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationRoutes.test.js
+++ b/apps/api/src/tests/notificationRoutes.test.js
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(assertions) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await assertions(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/notifications requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/notifications requires authentication", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "private notification" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("authenticated clients can access notification routes", async () => {
+  await withServer(async (baseUrl) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const headers = { authorization: `Bearer ${token}` };
+
+    const getResponse = await fetch(`${baseUrl}/api/notifications`, { headers });
+    const getPayload = await getResponse.json();
+
+    assert.equal(getResponse.status, 200);
+    assert.deepEqual(getPayload, { success: true, data: [] });
+
+    const postResponse = await fetch(`${baseUrl}/api/notifications`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({ message: "private notification" })
+    });
+    const postPayload = await postResponse.json();
+
+    assert.equal(postResponse.status, 201);
+    assert.equal(postPayload.success, true);
+    assert.equal(postPayload.data.message, "private notification");
+    assert.equal(postPayload.data.read, false);
+  });
+});


### PR DESCRIPTION
Closes #11203

## Summary
- applies authMiddleware to notification routes
- adds regression tests for unauthenticated GET/POST access
- verifies authenticated clients can still read and create notifications

## Tests
- npm.cmd install
- node --test src/tests/health.test.js src/tests/notificationRoutes.test.js