### PR TITLE
fix: fix: reject inverted budget ranges in job validation (fixes 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #11039
+
+fix: reject inverted budget ranges in job validation (fixes #2853)


### PR DESCRIPTION
Closes #11039

fix: reject inverted budget ranges in job validation (fixes #2853)

/claim #11039