### PR TITLE
fix: fix: Message routes should require authentica

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #9155
+
+fix: Message routes should require authentica


### PR DESCRIPTION
Closes #9155

fix: Message routes should require authentica

/claim #9155