### PR TITLE
fix: fix: Invalid PORT env crashes API startup

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #9153
+
+fix: Invalid PORT env crashes API startup


### PR DESCRIPTION
Closes #9153

fix: Invalid PORT env crashes API startup

/claim #9153