### PR TITLE
fix: API workspace test script should target test files explicitl

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #8355
+
+API workspace test script should target test files explicitly


### PR DESCRIPTION
Closes #8355

API workspace test script should target test files explicitly

/claim #8355