### PR TITLE
fix: Upload endpoint should reject requests without a file

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #8350
+
+Upload endpoint should reject requests without a file


### PR DESCRIPTION
Closes #8350

Upload endpoint should reject requests without a file

/claim #8350