### PR TITLE
fix: API test script should run test files explicitly

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #8346
+
+API test script should run test files explicitly


### PR DESCRIPTION
Closes #8346

API test script should run test files explicitly

/claim #8346