### PR TITLE
fix: Next.js frontend should set baseline security headers

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #7123
+
+Next.js frontend should set baseline security headers


### PR DESCRIPTION
Closes #7123

Next.js frontend should set baseline security headers

/claim #7123