### PR TITLE
fix: UI package should explicitly declare React dependency

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #4523
+
+UI package should explicitly declare React dependency


### PR DESCRIPTION
Closes #4523

UI package should explicitly declare React dependency

/claim #4523