### PR TITLE
fix: User listing should not expose submitted passwords

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #4514
+
+User listing should not expose submitted passwords


### PR DESCRIPTION
Closes #4514

User listing should not expose submitted passwords

/claim #4514