### PR TITLE
fix: User creation should preserve server-owned id

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #4510
+
+User creation should preserve server-owned id


### PR DESCRIPTION
Closes #4510

User creation should preserve server-owned id

/claim #4510