### PR TITLE
fix: Message creation should reject empty and malformed payloads

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3226
+
+Message creation should reject empty and malformed payloads


### PR DESCRIPTION
Closes #3226

Message creation should reject empty and malformed payloads

/claim #3226