### PR TITLE
fix: Expose existing app pages in navigation

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3183
+
+Expose existing app pages in navigation


### PR DESCRIPTION
Closes #3183

Expose existing app pages in navigation

/claim #3183