### PR TITLE
fix: Navigation should link to all existing top-level pages

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3182
+
+Navigation should link to all existing top-level pages


### PR DESCRIPTION
Closes #3182

Navigation should link to all existing top-level pages

/claim #3182