### PR TITLE
fix: Registration should require fullName before creating users

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3177
+
+Registration should require fullName before creating users


### PR DESCRIPTION
Closes #3177

Registration should require fullName before creating users

/claim #3177