### PR TITLE
fix: Upload endpoint should reject missing file submissions

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3175
+
+Upload endpoint should reject missing file submissions


### PR DESCRIPTION
Closes #3175

Upload endpoint should reject missing file submissions

/claim #3175