### PR TITLE
fix: Proposal submission should require authentication

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3246
+
+Proposal submission should require authentication


### PR DESCRIPTION
Closes #3246

Proposal submission should require authentication

/claim #3246