### PR TITLE
fix: Fix: Enforce admin role authorization on metrics endpoint

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #3191
+
+Fix: Enforce admin role authorization on metrics endpoint


### PR DESCRIPTION
Closes #3191

Fix: Enforce admin role authorization on metrics endpoint

/claim #3191