### PR TITLE
Persist auth registrations and validate logins

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,29 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+function handleAuthError(res, error) {
+  return fail(res, error.message ?? "Authentication failed", error.status ?? 500);
+}
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    return handleAuthError(res, error);
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    return handleAuthError(res, error);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,21 +1,70 @@
+import crypto from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
-export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
+const usersByEmail = new Map();
+
+function createAuthError(message, status) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function normalizeRole(role) {
+  return role ?? "client";
+}
+
+function hashPassword(password, salt = crypto.randomBytes(16).toString("hex")) {
+  const derivedKey = crypto.scryptSync(password, salt, 64);
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+function verifyPassword(password, passwordHash) {
+  const [salt, storedHash] = passwordHash.split(":");
+
+  if (!salt || !storedHash) {
+    return false;
+  }
+
+  const derivedKey = crypto.scryptSync(password, salt, 64);
+  const storedBuffer = Buffer.from(storedHash, "hex");
+
+  return storedBuffer.length === derivedKey.length && crypto.timingSafeEqual(storedBuffer, derivedKey);
+}
+
+function buildAuthResponse(user) {
   return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
-export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
-  return {
+export async function registerUser(payload) {
+  if (usersByEmail.has(payload.email)) {
+    throw createAuthError("Email is already registered", 409);
+  }
+
+  const user = {
+    id: `usr_${crypto.randomUUID().replaceAll("-", "")}`,
     email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    passwordHash: hashPassword(payload.password),
+    role: normalizeRole(payload.role)
   };
+
+  usersByEmail.set(user.email, user);
+
+  return buildAuthResponse(user);
+}
+
+export async function loginUser(payload) {
+  const user = usersByEmail.get(payload.email);
+
+  if (!user || !verifyPassword(payload.password, user.passwordHash)) {
+    throw createAuthError("Invalid email or password", 401);
+  }
+
+  return buildAuthResponse(user);
 }
 
 export async function refreshToken() {

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(handler) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await handler(port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register persists users and login validates credentials", async () => {
+  const email = `auth-${Date.now()}@example.com`;
+  const password = "supersecret1";
+
+  await withServer(async (port) => {
+    const registerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, role: "freelancer" })
+    });
+
+    const registerPayload = await registerResponse.json();
+
+    assert.equal(registerResponse.status, 201);
+    assert.equal(registerPayload.success, true);
+    assert.equal(registerPayload.data.email, email);
+    assert.equal(registerPayload.data.role, "freelancer");
+    assert.match(registerPayload.data.id, /^usr_/);
+    assert.match(registerPayload.data.token, /^eyJ/);
+
+    const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password })
+    });
+
+    const loginPayload = await loginResponse.json();
+
+    assert.equal(loginResponse.status, 200);
+    assert.equal(loginPayload.success, true);
+    assert.equal(loginPayload.data.email, email);
+    assert.match(loginPayload.data.token, /^eyJ/);
+
+    const invalidLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: "wrongpass" })
+    });
+
+    const invalidLoginPayload = await invalidLoginResponse.json();
+
+    assert.equal(invalidLoginResponse.status, 401);
+    assert.equal(invalidLoginPayload.success, false);
+    assert.equal(invalidLoginPayload.message, "Invalid email or password");
+
+    const duplicateResponse = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, role: "freelancer" })
+    });
+
+    const duplicatePayload = await duplicateResponse.json();
+
+    assert.equal(duplicateResponse.status, 409);
+    assert.equal(duplicatePayload.success, false);
+    assert.equal(duplicatePayload.message, "Email is already registered");
+  });
+});


### PR DESCRIPTION
Closes #11272

Summary:
- replace placeholder auth responses with an in-memory user store
- hash and verify passwords for register/login
- reject duplicate registrations and invalid credentials cleanly
- add HTTP coverage for register/login/duplicate-login flows