### PR TITLE
Fix API workspace test discovery

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
/claim #743

Closes #11278

## Summary

- Updates the API workspace test script to target the existing `*.test.js` files instead of the `src/tests` directory path.
- Keeps the change scoped to test discovery only; no application runtime code changes.

## Validation

- `npm test -w apps/api`
- `git diff --check`

## Demo video

https://litter.catbox.moe/o991a9.mp4

Disclosure: this focused patch was prepared with AI assistance and validated locally before submission.
