### PR TITLE
fix: add input validation and length limit to search query

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
+import { searchQuerySchema } from "../validators/search.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const parsed = searchQuerySchema.safeParse(req.query.q ?? "");
+  if (!parsed.success) {
+    return fail(res, parsed.error.issues[0].message);
+  }
+  return ok(res, await globalSearch(parsed.data));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { searchQuerySchema } from "../validators/search.js";
+
+test("searchQuerySchema accepts a valid query", () => {
+  const result = searchQuerySchema.parse("react developer");
+  assert.equal(result, "react developer");
+});
+
+test("searchQuerySchema trims whitespace", () => {
+  const result = searchQuerySchema.parse("  hello world  ");
+  assert.equal(result, "hello world");
+});
+
+test("searchQuerySchema accepts empty string", () => {
+  const result = searchQuerySchema.parse("");
+  assert.equal(result, "");
+});
+
+test("searchQuerySchema accepts exactly 200 characters", () => {
+  const result = searchQuerySchema.parse("a".repeat(200));
+  assert.equal(result.length, 200);
+});
+
+test("searchQuerySchema rejects query over 200 characters", () => {
+  assert.throws(() => searchQuerySchema.parse("a".repeat(201)), /at most 200/);
+});
+
+test("searchQuerySchema rejects array input (repeated q params)", () => {
+  assert.throws(() => searchQuerySchema.parse(["a", "b"]), /Expected string/);
+});
+
+test("searchQuerySchema rejects number input", () => {
+  assert.throws(() => searchQuerySchema.parse(123), /Expected string/);
+});
+
+test("searchQuerySchema rejects null input", () => {
+  assert.throws(() => searchQuerySchema.parse(null), /Expected string/);
+});

--- a/apps/api/src/validators/search.js
+++ b/apps/api/src/validators/search.js
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const searchQuerySchema = z.string().trim().max(200, "Query must be at most 200 characters");


### PR DESCRIPTION
Add zod schema for search query: trimmed string, max 200 chars, rejects arrays/numbers/null. Update controller to use safeParse. Add 8 tests covering valid, trimmed, boundary, rejected cases.

Closes #2833