### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin must be less than or equal to budgetMax",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Fixes #2853, #2835, #2827.

Job validation now correctly rejects inverted budget ranges (where budgetMin > budgetMax).

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517