### PR TITLE
fix: prevent admin role self-assignment during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #2832.

This prevents the admin role from being passed during registration and self-assigned by a regular user.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517