### PR TITLE
fix: upload endpoint rejects empty file submissions

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file || req.file.size === 0) {
+    return res.status(400).json({ error: "Empty or missing file submission" });
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Fixes #2850.

The upload endpoint now checks if the file exists and is not empty.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517