### PR TITLE
fix: preserve server-owned id and read state in notification creation

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }


### PR DESCRIPTION
Fixes #2762.

This ensures that the server-owned `id` and `read` state cannot be overwritten by properties provided in the payload during notification creation.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517