### PR TITLE
fix: resolve mock jobs by id on job detail page

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,22 @@
+import { jobs } from "../../../lib/mock";
+
 export default function JobDetailPage({ params }: { params: { id: string } }) {
+  const job = jobs.find(j => j.id === params.id);
+  
+  if (!job) {
+    return (
+      <section className="card">
+        <h2>Job Detail</h2>
+        <p>Job <strong>{params.id}</strong> not found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{job.title}</strong>.</p>
+      <p>Budget: {job.budget}</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Fixes #2790.

The Job Detail page now dynamically resolves mock jobs by id and renders their details (such as the title and budget). It also handles the case where the job is not found.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517