### PR TITLE
fix: resolve mock profiles by username and render fallback

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,23 @@
+import { freelancers } from "../../../lib/mock";
+
 export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+  const profile = freelancers.find(f => f.username === params.username);
+
+  if (!profile) {
+    return (
+      <section className="card">
+        <h2>Freelancer Profile</h2>
+        <p>Profile: <strong>{params.username}</strong> not found.</p>
+      </section>
+    );
+  }
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{profile.username}</strong></p>
+      <p>Rate: {profile.rate}</p>
+      <p>Skills: {profile.skills.join(", ")}</p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );


### PR DESCRIPTION
Fixes #2849, #2763.

The Freelancer Profile page now resolves mock profiles by username and renders their details. It properly displays an unknown fallback when a matching profile is not found.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517