### PR TITLE
fix: throw error if JWT_SECRET is missing in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,7 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: process.env.JWT_SECRET ?? (process.env.NODE_ENV === "production" ? (() => { throw new Error("JWT_SECRET is required in production"); })() : "development-secret"),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Fixes #11169.

Removes the hardcoded fallback JWT secret in production. It now correctly throws an error if `JWT_SECRET` is missing and the environment is `production`.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517