### PR TITLE
fix: add express-async-errors to handle async route exceptions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^7.4.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,5 +1,6 @@
 import cors from "cors";
 import express from "express";
+import "express-async-errors";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";


### PR DESCRIPTION
Fixes #11185, #11126.

This adds `express-async-errors` to ensure that unhandled promise rejections in Express 4 async route handlers are caught and passed to the error handling middleware, instead of silently dropping the requests.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517