### PR TITLE
fix: sanitize uploaded filenames

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,9 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  const sanitizedFilename = req.file?.originalname?.replace(/[^a-zA-Z0-9.\-_]/g, "_") ?? null;
   return ok(res, {
-    filename: req.file?.originalname ?? null,
+    filename: sanitizedFilename,
     status: req.file ? "uploaded" : "no-file"
   }, 201);
 }


### PR DESCRIPTION
Fixes #11123.

This sanitizes the uploaded filename by replacing any non-alphanumeric (and non-standard) characters with underscores to prevent directory traversal or invalid filename issues.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517