### PR TITLE
fix: add input validation on createPayment

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,13 @@
+import { z } from "zod";
 import { ok } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
+const paymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).optional()
+});
+
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = paymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }


### PR DESCRIPTION
Fixes #11128.

Adds zod input validation to `createPayment` to ensure that required fields (like `amount`) are validated before passing them to the payment service.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517