### PR TITLE
fix: make API test script discover test files

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Fixes #11189, #11194, #11193, #11187.

This fixes the API test script by changing `node --test src/tests` to `node --test` so that the node test runner correctly discovers test files instead of treating the directory as a file.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517