### PR TITLE
fix: implement global search for created users and jobs

### DIFF
--- a/apps/api/src/services/searchService.js
+++ b/apps/api/src/services/searchService.js
@@ -1,9 +1,18 @@
+import { listUsers } from "./userService.js";
+import { listJobs } from "./jobService.js";
+
 export async function globalSearch(query) {
-  // TODO: use PostgreSQL full-text search + ranking.
+  const q = query.toLowerCase();
+  const allUsers = await listUsers();
+  const allJobs = await listJobs();
+  
+  const users = allUsers.filter(u => u.fullName?.toLowerCase().includes(q) || u.email?.toLowerCase().includes(q));
+  const jobs = allJobs.filter(j => j.title?.toLowerCase().includes(q) || j.description?.toLowerCase().includes(q));
+
   return {
     query,
-    users: [],
-    jobs: [],
+    users,
+    jobs,
     freelancers: []
   };
 }


### PR DESCRIPTION
Fixes #11282.

This implements the global search by importing the current lists of users and jobs and filtering them based on the provided query (matching fullName/email for users and title/description for jobs).

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517