### PR TITLE
fix: persist auth registrations and validate logins

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,32 @@
 import { signAccessToken } from "../utils/jwt.js";
+import { createUser, listUsers } from "./userService.js";
 
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const user = await createUser({
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password
+  });
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const users = await listUsers();
+  const user = users.find(u => u.email === payload.email && u.password === payload.password);
+  
+  if (!user) {
+    throw new Error("Invalid credentials");
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role })
   };
 }
 


### PR DESCRIPTION
Fixes #11272.

This integrates `registerUser` and `loginUser` in `authService.js` with `userService.js` to ensure registrations are persisted in memory and logins validate the provided credentials against the registered users, replacing the dummy data.

Claim info:
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517