### PR TITLE
fix: reject empty file uploads with 400 response

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,14 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file provided in request", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded",
+    size: req.file.size,
+    mimetype: req.file.mimetype
   }, 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,14 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  // Multer errors (file upload issues) → 400
+  if (err.code && err.code.startsWith("LIMIT_")) {
+    return res.status(400).json({
+      success: false,
+      message: err.message || "File upload error"
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads without file returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Send multipart request WITHOUT a file field
+  const formData = new FormData();
+  formData.append("name", "test-upload");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.includes("No file provided"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads with empty body returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Send multipart request with NO fields at all
+  const formData = new FormData();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(payload.message.includes("No file provided"));
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads with file returns 201", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Create a proper file upload
+  const formData = new FormData();
+  const fileContent = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+  const file = new File([fileContent], "test.txt", { type: "text/plain" });
+  formData.append("file", file);
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.filename, "test.txt");
+  assert.equal(payload.data.status, "uploaded");
+  assert.ok(payload.data.size > 0);
+  assert.equal(payload.data.mimetype, "text/plain");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads with wrong field name returns 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  // Send file with wrong field name (not "file")
+  const formData = new FormData();
+  const fileContent = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
+  const file = new File([fileContent], "test.txt", { type: "text/plain" });
+  formData.append("document", file); // Wrong field name
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const payload = await response.json();
+
+  // Multer rejects unexpected fields with 400 via error handler
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.ok(
+    payload.message.includes("Unexpected field") || 
+    payload.message.includes("File upload error"),
+    `Expected multer error message, got: ${payload.message}`
+  );
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes issue #2850 where `POST /api/uploads` returns `201` with `success: true` even when no file is provided.

## Changes

### 1. Upload Controller (`uploadController.js`)
- Added validation to check `req.file` exists before processing
- Returns `400` with clear error message when no file is provided
- Returns `201` with file metadata (filename, size, mimetype) only when file is present

### 2. Error Handler (`errorHandler.js`)
- Added proper handling for multer `LIMIT_*` errors
- Returns `400` status code instead of `500` for file upload validation errors

### 3. Test Coverage (`upload.test.js`)
Added comprehensive regression tests:
- ✅ No file field → 400 (primary fix)
- ✅ Empty body → 400
- ✅ Valid file upload → 201 with metadata
- ✅ Wrong field name → 400 (multer error handling)

## Test Results
```
✔ POST /api/uploads without file returns 400
✔ POST /api/uploads with empty body returns 400
✔ POST /api/uploads with file returns 201
✔ POST /api/uploads with wrong field name returns 400
```

## Before/After

**Before:**
```json
POST /api/uploads (no file)
→ 201 { success: true, data: { filename: null, status: "no-file" } }
```

**After:**
```json
POST /api/uploads (no file)
→ 400 { success: false, message: "No file provided in request" }
```

Fixes #2850
