### PR TITLE
fix(api): remove hardcoded JWT fallback secret, fail closed when JWT_SECRET is unset (Closes #11169)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "JWT_SECRET=test-suite-only-secret-do-not-use-in-prod node --test 'src/tests/**/*.test.js'"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,19 @@
+const INSECURE_JWT_SECRETS = new Set(["development-secret"]);
+
+function requireJwtSecret() {
+  const secret = process.env.JWT_SECRET?.trim();
+  if (!secret || INSECURE_JWT_SECRETS.has(secret.toLowerCase())) {
+    throw new Error(
+      "JWT_SECRET environment variable must be set to a non-default value; refusing to start."
+    );
+  }
+  return secret;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: requireJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/env.test.js
+++ b/apps/api/src/tests/env.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const envModulePath = path.join(__dirname, "..", "config", "env.js");
+
+function runWithJwtSecret(jwtSecret) {
+  const childEnv = { ...process.env };
+  if (jwtSecret === undefined) {
+    delete childEnv.JWT_SECRET;
+  } else {
+    childEnv.JWT_SECRET = jwtSecret;
+  }
+
+  return spawnSync(process.execPath, [envModulePath], {
+    env: childEnv,
+    encoding: "utf8"
+  });
+}
+
+test("refuses to start when JWT_SECRET is unset", () => {
+  const result = runWithJwtSecret(undefined);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET/);
+});
+
+test("refuses to start when JWT_SECRET is the known-insecure default", () => {
+  const result = runWithJwtSecret("development-secret");
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET/);
+});
+
+test("refuses to start when JWT_SECRET is the known-insecure default in a different case", () => {
+  const result = runWithJwtSecret("Development-Secret");
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET/);
+});
+
+test("refuses to start when JWT_SECRET is whitespace only", () => {
+  const result = runWithJwtSecret("   ");
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /JWT_SECRET/);
+});
+
+test("starts successfully when a real JWT_SECRET is provided", () => {
+  const result = runWithJwtSecret("a-sufficiently-random-production-secret");
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, "");
+});


### PR DESCRIPTION
Closes #11357

Fixes the hardcoded JWT fallback secret in `apps/api/src/config/env.js`. `requireJwtSecret()` fails closed if `JWT_SECRET` is missing/blank or a known-insecure default; adds `env.test.js` (passes). Single-issue scope.