### PR TITLE
fix(api): require authentication on notification routes (Closes #11179)

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
+
+notificationRoutes.use(authMiddleware);
 
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/tests/notificationAuth.test.js
+++ b/apps/api/src/tests/notificationAuth.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function call(path, opts) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((res, rej) => {
+    server.once("listening", res);
+    server.once("error", rej);
+  });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, opts);
+  await new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  return response;
+}
+
+test("GET /api/notifications requires authentication", async () => {
+  assert.equal((await call("/api/notifications")).status, 401);
+});
+
+test("POST /api/notifications requires authentication", async () => {
+  const r = await call("/api/notifications", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(r.status, 401);
+});


### PR DESCRIPTION
Closes #11358

Applies `authMiddleware` to `notificationRoutes`; adds a 401 test. Single-issue scope.