### PR TITLE
fix(api): require authentication on payment routes (Closes #11177)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
+
+paymentRoutes.use(authMiddleware);
 
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/paymentAuth.test.js
+++ b/apps/api/src/tests/paymentAuth.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function call(path, opts) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((res, rej) => {
+    server.once("listening", res);
+    server.once("error", rej);
+  });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, opts);
+  await new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  return response;
+}
+
+test("POST /api/payments requires authentication", async () => {
+  const r = await call("/api/payments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount: 100, currency: "usd" }),
+  });
+  assert.equal(r.status, 401);
+});


### PR DESCRIPTION
Closes #11359

Applies `authMiddleware` to `paymentRoutes`; adds a 401 test. Single-issue scope.