### PR TITLE
fix(api): require authentication on user routes (Closes #11171)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
+
+userRoutes.use(authMiddleware);
 
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/tests/userAuth.test.js
+++ b/apps/api/src/tests/userAuth.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function call(path, opts) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((res, rej) => {
+    server.once("listening", res);
+    server.once("error", rej);
+  });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, opts);
+  await new Promise((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  return response;
+}
+
+test("GET /api/users requires authentication", async () => {
+  assert.equal((await call("/api/users")).status, 401);
+});
+
+test("POST /api/users requires authentication", async () => {
+  const r = await call("/api/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "x@y.test" }),
+  });
+  assert.equal(r.status, 401);
+});


### PR DESCRIPTION
Closes #11360

Applies `authMiddleware` to `userRoutes`; adds a 401 test. Single-issue scope.