### PR TITLE
fix: fall back to default PORT when env value is invalid

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,20 @@
+function resolvePort(raw, fallback = 4000) {
+  if (raw === undefined || raw === null || raw === "") {
+    return fallback;
+  }
+
+  const port = Number(raw);
+  if (!Number.isFinite(port) || !Number.isInteger(port) || port < 0 || port > 65535) {
+    console.warn(`Invalid PORT "${raw}", falling back to ${fallback}`);
+    return fallback;
+  }
+
+  return port;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: resolvePort(process.env.PORT, 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Summary
- Validate `PORT` env before calling `Number(...)`
- Fall back to `4000` and log a warning when the value is non-numeric / out of range
- Prevents API startup crash from `NaN` listen port

Closes #11361
Parent bounty: #743

## Test plan
- [x] `PORT=abc` falls back to 4000 with warning
- [x] `PORT=3000` keeps 3000
- [x] empty / unset PORT uses 4000