### PR TITLE
fix: enforce admin role on /api/admin routes

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
## Summary
- Add `adminMiddleware` that checks `req.user.role === "admin"`
- Apply it to all `/api/admin` routes after `authMiddleware`
- Non-admin authenticated users now receive 403 Forbidden

Closes #11362
Parent bounty: #743

## Test plan
- [x] Code review: admin routes use `authMiddleware, adminMiddleware`
- [x] Non-admin role returns 403 via `fail(res, "Forbidden", 403)`