### PR TITLE
Fix search query validation

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const { q } = req.query;
+
+  if (typeof q !== "string" || q.trim().length === 0) {
+    return fail(res, "Search query is required");
+  }
+
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search rejects missing search query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is required"
+    });
+  });
+});
+
+test("GET /api/search rejects blank search query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20%20%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Search query is required"
+    });
+  });
+});
+
+test("GET /api/search returns results for a valid search query", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=design`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        query: "design",
+        users: [],
+        jobs: [],
+        freelancers: []
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Reject missing or whitespace-only `q` parameters in `GET /api/search` with the existing structured API error response.

## Root cause

The search controller previously coerced a missing query parameter to an empty string and passed it to `globalSearch`, so invalid search requests returned `200` with empty results.

## Impact

Clients now receive a clear `400` response when the search query is absent or blank, while valid search requests continue to return the existing result shape.

## Validation

- `node --test src/tests/*.test.js`

/claim #743

Fixes #9548
Part of #743