### PR TITLE
fix: verify token in refreshToken and preserve subject

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,10 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const { token } = req.body;
+  if (!token) {
+    return fail(res, "Refresh token is required", 400);
+  }
+  const result = await refreshToken(token);
   return ok(res, result);
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
@@ -18,6 +19,8 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(token) {
+  // TODO: look up stored refresh token in database
+  const decoded = verifyAccessToken(token);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser, refreshToken } from "../services/authService.js";
+
+test("#2847 refreshToken: rejects missing token", async () => {
+  await assert.rejects(
+    () => refreshToken(null),
+    { message: /jwt must be provided|invalid/i }
+  );
+});
+
+test("#2847 refreshToken: rejects invalid token", async () => {
+  await assert.rejects(
+    () => refreshToken("not.a.real.jwt"),
+    { message: /invalid signature|jwt malformed/i }
+  );
+});
+
+test("#2847 refreshToken: issues new token preserving original subject", async () => {
+  // First register to get a valid token
+  const registered = await registerUser({
+    email: "refresh@test.com",
+    password: "secret1234",
+    role: "client"
+  });
+
+  // Now refresh with that token
+  const refreshed = await refreshToken(registered.token);
+
+  assert.ok(refreshed.token, "refreshed response must include a token");
+
+  // Decode both tokens
+  const decode = (t) => JSON.parse(Buffer.from(t.split(".")[1], "base64url").toString());
+  const originalPayload = decode(registered.token);
+  const refreshedPayload = decode(refreshed.token);
+
+  assert.equal(refreshedPayload.sub, originalPayload.sub, "refreshed token sub must match original");
+  assert.equal(refreshedPayload.role, originalPayload.role, "refreshed token role must match original");
+});


### PR DESCRIPTION
## Summary
Fixes #2847 — `refreshToken` was ignoring input and issuing a generic token for `usr_existing`.

## Fix
1. Updated `authController.js` to require a `token` in the request body.
2. Updated `authService.js` to verify the provided token and sign a new one preserving the original `sub` (subject) and `role`.

## Changes
- `apps/api/src/controllers/authController.js` — added token validation in `refresh` endpoint.
- `apps/api/src/services/authService.js` — implemented token verification and subject preservation in `refreshToken`.
- `apps/api/src/tests/auth-refresh.test.js` — added 3 test cases verifying token validation and subject preservation.

## Testing
```
✔ #2847 refreshToken: rejects missing token
✔ #2847 refreshToken: rejects invalid token
✔ #2847 refreshToken: issues new token preserving original subject
```
All tests pass.