### PR TITLE
fix: reject inverted budget range in job schemas

### DIFF
--- a/apps/api/src/tests/job-budget.test.js
+++ b/apps/api/src/tests/job-budget.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("#2853 createJobSchema: rejects inverted budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test job posting",
+    description: "A detailed description of the job that is long enough",
+    budgetMin: 500,
+    budgetMax: 100,  // inverted!
+    categoryId: "cat_1",
+    skills: ["javascript"]
+  });
+
+  assert.equal(result.success, false, "should reject inverted budget");
+  assert.ok(
+    result.error.issues.some(i => i.message.includes("budgetMax")),
+    `error should mention budgetMax, got: ${JSON.stringify(result.error.issues)}`
+  );
+});
+
+test("#2853 createJobSchema: accepts valid budget range", () => {
+  const result = createJobSchema.safeParse({
+    title: "Test job posting",
+    description: "A detailed description of the job that is long enough",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_1",
+    skills: ["javascript"]
+  });
+
+  assert.equal(result.success, true, "should accept valid budget range");
+});
+
+test("#2853 createJobSchema: accepts equal min/max", () => {
+  const result = createJobSchema.safeParse({
+    title: "Fixed price job",
+    description: "A detailed description of the job that is long enough",
+    budgetMin: 300,
+    budgetMax: 300,
+    categoryId: "cat_1"
+  });
+
+  assert.equal(result.success, true, "should accept equal min/max");
+});
+
+test("#2853 updateJobSchema: partial updates also validate budget range", () => {
+  const result = updateJobSchema.safeParse({
+    budgetMin: 1000,
+    budgetMax: 500  // inverted
+  });
+
+  assert.equal(result.success, false, "should reject inverted budget in partial update");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,17 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  { message: "budgetMax must be greater than or equal to budgetMin", path: ["budgetMax"] }
+);
+
+export const updateJobSchema = baseJobSchema.partial().superRefine((data, ctx) => {
+  if (data.budgetMin != null && data.budgetMax != null && data.budgetMax < data.budgetMin) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #2853 — The job creation and update schemas allowed `budgetMax` to be less than `budgetMin`, which is logically impossible.

## Fix
1. Defined a `baseJobSchema` to maintain consistency.
2. Added a `.refine()` to `createJobSchema` to ensure `budgetMax >= budgetMin`.
3. Added a `.superRefine()` to `updateJobSchema` to perform the same check only when both budget fields are provided in a partial update.

## Changes
- `apps/api/src/validators/job.js` — updated schemas to enforce budget range logic.
- `apps/api/src/tests/job-budget.test.js` — added 4 test cases verifying range validation in both creation and updates.

## Testing
```
✔ #2853 createJobSchema: rejects inverted budget range
✔ #2853 createJobSchema: accepts valid budget range
✔ #2853 createJobSchema: accepts equal min/max
✔ #2853 updateJobSchema: partial updates also validate budget range
```
All tests pass.