### PR TITLE
Add CI workflow to run tests on pull requests - closes #11401

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,31 @@
+name: CI - Run Tests
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/**"
+      - "package.json"
+      - "package-lock.json"
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/**"
+      - "package.json"
+      - "package-lock.json"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci
+
+      - run: npm test


### PR DESCRIPTION
﻿> **Note:** Created by an automated agent. Please review carefully.

## Summary

Adds a GitHub Actions CI workflow that runs the existing test suite on every pull request and push to main for the ^Gpps/api package. This is a low-hanging-fruit automation that catches regressions before merge.

**What it does:**
- Triggers on PRs and pushes that touch ^Gpps/api/**
- Checks out code, installs dependencies with 
pm ci
- Runs 
pm test (Node.js native test runner)

**References:**
- Closes #11401
- Original meta-bounty: #743

**Test:** The workflow will run on this PR itself - check the Checks tab for results.
