### PR TITLE
Prevent self-assigned admin role during registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Fixes #11405

## Summary

Prevent users from assigning themselves the admin role during registration.

## Vulnerability

The registration endpoint accepted `admin` as a user-provided role.

An attacker could send:

```json
{
  "email": "attacker@example.com",
  "password": "password123",
  "role": "admin"
}
The API accepted this value and included it in the generated JWT token, allowing unauthorized users to obtain admin privileges.

Changes Made
Removed admin from the allowed registration roles.

Registration now only accepts:

client

freelancer

Admin privileges can no longer be assigned through the public registration endpoint.

Testing
Verified the following cases:

✅ Registration with role: "admin" is rejected
✅ Registration with role: "client" works
✅ Registration with role: "freelancer" works
✅ Registration without a role defaults to client

Security Impact
This prevents unauthorized privilege escalation by ensuring users cannot self-assign administrative permissions during account creation.
