### PR TITLE
fix: remove hardcoded JWT fallback secret and validate PORT env (Closes #11426)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,7 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  port: Number.isNaN(Number(process.env.PORT)) ? 4000 : Number(process.env.PORT ?? 4000),
+  jwtSecret: process.env.JWT_SECRET ?? (() => { throw new Error("JWT_SECRET environment variable is required"); })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
## Summary
Fixes the hardcoded JWT fallback secret that enables token forgery.

## Changes
- **`apps/api/src/config/env.js`**: Removed `"development-secret"` fallback for `jwtSecret`. Now throws a clear error when `JWT_SECRET` is not configured.
- Also validates `PORT` environment variable to handle non-numeric strings gracefully.

## Verification
- No JWT tokens can be forged using a known default secret
- Invalid PORT values now fall back to 4000 instead of crashing

Closes #11426