### PR TITLE
fix: remove admin role from public registration schema (Closes #11427)

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
Removes the `"admin"` role from the public registration Zod schema to prevent privilege escalation.

## Changes
- **`apps/api/src/validators/auth.js`**: Removed `"admin"` from the `registerSchema` role enum. Only `"client"` and `"freelancer"` are now valid.

## Impact
- Unauthenticated users can no longer self-assign admin privileges via registration
- Admin role assignment requires a separate, authenticated admin-only endpoint

Closes #11427