### PR TITLE
fix: prevent client-controlled IDs via object spread in services (Closes #11429)

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -5,7 +5,8 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const { id: _id, ...safe } = payload;
+  const message = { id: `msg_${Date.now()}`, ...safe, sentAt: new Date().toISOString() };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,8 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const { id: _id, read: _read, ...safe } = payload;
+  const notification = { id: `ntf_${Date.now()}`, read: false, ...safe };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _id, ...safe } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safe };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Summary
Prevents clients from controlling server-generated IDs and read status via object spread in service layer.

## Changes
- **`apps/api/src/services/userService.js`**: Destructure `id` from payload before spread
- **`apps/api/src/services/notificationService.js`**: Destructure `id` and `read` from payload before spread
- **`apps/api/src/services/messageService.js`**: Destructure `id` from payload before spread

## Impact
- Server-generated IDs always take precedence
- Clients cannot override notification read status
- Prevents ID collision/injection attacks

Closes #11429