### PR TITLE
fix: add Zod validation to payment controller (Closes #11430, #11433)

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,8 @@
 import { ok } from "../utils/response.js";
+import { paymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const payload = paymentSchema.parse(req.body);
+  return ok(res, await createPaymentIntent(payload), 201);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const paymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.string().length(3).default("usd")
+});


### PR DESCRIPTION
## Summary
Adds Zod input validation to the payment controller and creates a payment validation schema with positive amount validation.

## Changes
- **`apps/api/src/validators/payment.js`**: New Zod schema validating positive amount and 3-char currency code
- **`apps/api/src/controllers/paymentController.js`**: Now validates input with `paymentSchema.parse()` before processing

## Impact
- Negative and zero payment amounts are now rejected
- Invalid currency codes are rejected
- Consistent with validation pattern used in auth and job controllers

Closes #11430, #11433