### PR TITLE
fix: reject inverted job budget ranges (Closes #11431)

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be greater than or equal to budgetMin",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
## Summary
Adds validation to reject inverted job budget ranges where `budgetMax < budgetMin`.

## Changes
- **`apps/api/src/validators/job.js`**: Added `.refine()` check to ensure `budgetMax >= budgetMin` with a clear error message

## Impact
- Prevents creation of jobs with inverted budget ranges (e.g., budgetMax: 1000, budgetMin: 5000)
- Returns clear validation error to API consumers
- Maintains data integrity

Closes #11431