### PR TITLE
fix: Zod error details, refresh token verification, register token subject (Closes #11435, #11436, #11437)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -22,6 +22,14 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
-  return ok(res, result);
+  const { refreshToken: token } = req.body;
+  if (!token) {
+    return fail(res, "Refresh token is required", 400);
+  }
+  try {
+    const result = await refreshToken(token);
+    return ok(res, result);
+  } catch {
+    return fail(res, "Invalid refresh token", 401);
+  }
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,20 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation error",
+      errors: err.errors.map(e => ({
+        path: e.path.join("."),
+        message: e.message
+      }))
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,13 @@
-import { signAccessToken } from "../utils/jwt.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
@@ -18,6 +19,7 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(refreshTokenValue) {
+  const decoded = verifyAccessToken(refreshTokenValue);
+  return { token: signAccessToken({ sub: decoded.sub, role: decoded.role }) };
 }


### PR DESCRIPTION
## Summary
Fixes three auth-related bugs: Zod error handling, refresh token verification, and register token subject mismatch.

## Changes
- **`apps/api/src/middleware/errorHandler.js`**: Detects `ZodError` and returns 400 with field-level validation error details instead of generic 500
- **`apps/api/src/services/authService.js`**: 
  - `registerUser`: Generates user ID once and reuses it for token subject (fixes Date.now() race)
  - `refreshToken`: Now verifies the refresh token before issuing a new access token, preserving subject/role
- **`apps/api/src/controllers/authController.js`**: 
  - `refresh` handler now accepts refresh token from request body
  - Returns 400 if token missing, 401 if invalid

## Impact
- Zod validation errors return actionable 400 responses
- Token subject always matches returned user ID
- Refresh token endpoint requires valid refresh token (no more blind token issuance)

Closes #11435, #11436, #11437