### PR TITLE
fix(messageService): use randomUUID to avoid same-millisecond id collisions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,11 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    id: `msg_${randomUUID()}`,
+    ...payload,
+    sentAt: new Date().toISOString()
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/message.test.js
+++ b/apps/api/src/tests/message.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Each test file gets a fresh module graph under node --test, so the
+// in-memory `messages` array inside messageService is isolated per test.
+const { sendMessage, listMessages } = await import("../services/messageService.js");
+
+test("sendMessage assigns a unique id on every call", async () => {
+  const a = await sendMessage({ body: "hello" });
+  const b = await sendMessage({ body: "world" });
+  assert.notEqual(a.id, b.id, "consecutive messages must not share an id");
+  assert.match(a.id, /^msg_[0-9a-f-]{36}$/);
+  assert.match(b.id, /^msg_[0-9a-f-]{36}$/);
+});
+
+test("sendMessage preserves the msg_ prefix", async () => {
+  const m = await sendMessage({ body: "x" });
+  assert.ok(m.id.startsWith("msg_"));
+});
+
+test("sendMessage stores payload fields and sentAt timestamp", async () => {
+  const before = Date.now();
+  const m = await sendMessage({ body: "hi", senderId: "u1", receiverId: "u2" });
+  const after = Date.now();
+
+  assert.equal(m.body, "hi");
+  assert.equal(m.senderId, "u1");
+  assert.equal(m.receiverId, "u2");
+  assert.ok(typeof m.sentAt === "string");
+  const sentAtMs = Date.parse(m.sentAt);
+  assert.ok(sentAtMs >= before && sentAtMs <= after, "sentAt should fall within the call window");
+});
+
+test("sendMessage stays unique even when Date.now() is frozen at one millisecond", async () => {
+  const realNow = Date.now;
+  let frozen = 1_700_000_000_000;
+  Date.now = () => frozen;
+
+  try {
+    const a = await sendMessage({ body: "first" });
+    const b = await sendMessage({ body: "second" });
+    const c = await sendMessage({ body: "third" });
+    assert.notEqual(a.id, b.id);
+    assert.notEqual(b.id, c.id);
+    assert.notEqual(a.id, c.id);
+  } finally {
+    Date.now = realNow;
+  }
+});
+


### PR DESCRIPTION
Closes #11445.

## Summary

`apps/api/src/services/messageService.js` was generating message ids directly from `Date.now()`:

```js
const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
```

Two messages created in the same millisecond would share the same `msg_` id, breaking lookup, reconciliation, and client-side tracking. The same pattern was already accepted as a real bug for `reviewService` (PR landed for #10931); `messageService` had the same flaw and was never fixed.

This PR switches the id source to `node:crypto`'s `randomUUID()` while preserving the existing `msg_` prefix, so existing id consumers keep working.

## Changes

- `apps/api/src/services/messageService.js` — id source moved from `Date.now()` to `randomUUID()`; prefix `msg_` retained.
- `apps/api/src/tests/message.test.js` (new) — focused regression coverage:
  - two consecutive `sendMessage` calls produce distinct ids
  - every id keeps the `msg_` prefix
  - payload fields and `sentAt` timestamp are preserved
  - even when `Date.now()` is frozen to a single value, all calls produce distinct ids
- `apps/api/package.json` — `test` script switched from `node --test src/tests` to `node --test src/tests/*.test.js` so the new test file is picked up by `npm run test -w apps/api` (the previous form was treating `src/tests` as a module path on Node 22 and failing with `MODULE_NOT_FOUND`).

## Test results

```
$ npm run test -w apps/api
...
# tests 5
# pass 5
# fail 0
```

## Payout

Bounty payout destination — Base USDC, same EVM address works on every EVM chain:

- Address: `0x2a5a559afca0ea453b7c32b6a755254b0a5e6541`
- Preferred chain: Base
- USDC contract (Base): `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- Wallet: OKX Web3 Wallet (self-custody)

Refer to parent bounty #743.