### PR TITLE
fix(paymentService): use randomUUID to avoid same-millisecond paymentId collisions

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: `pay_${randomUUID()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/payment.test.js
+++ b/apps/api/src/tests/payment.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Each test file gets a fresh module graph under node --test.
+const { createPaymentIntent } = await import("../services/paymentService.js");
+
+test("createPaymentIntent assigns a unique paymentId on every call", async () => {
+  const a = await createPaymentIntent({ amount: 1000 });
+  const b = await createPaymentIntent({ amount: 2000 });
+  assert.notEqual(a.paymentId, b.paymentId, "consecutive intents must not share an id");
+  assert.match(a.paymentId, /^pay_[0-9a-f-]{36}$/);
+  assert.match(b.paymentId, /^pay_[0-9a-f-]{36}$/);
+});
+
+test("createPaymentIntent preserves the pay_ prefix", async () => {
+  const p = await createPaymentIntent({ amount: 100 });
+  assert.ok(p.paymentId.startsWith("pay_"));
+});
+
+test("createPaymentIntent returns amount, currency (default usd), and provider stripe", async () => {
+  const p = await createPaymentIntent({ amount: 4999 });
+  assert.equal(p.amount, 4999);
+  assert.equal(p.currency, "usd");
+  assert.equal(p.provider, "stripe");
+});
+
+test("createPaymentIntent preserves an explicit currency value", async () => {
+  const p = await createPaymentIntent({ amount: 4999, currency: "EUR" });
+  assert.equal(p.currency, "EUR");
+});
+
+test("createPaymentIntent stays unique even when Date.now() is frozen at one millisecond", async () => {
+  const realNow = Date.now;
+  let frozen = 1_700_000_000_000;
+  Date.now = () => frozen;
+
+  try {
+    const a = await createPaymentIntent({ amount: 1 });
+    const b = await createPaymentIntent({ amount: 2 });
+    const c = await createPaymentIntent({ amount: 3 });
+    assert.notEqual(a.paymentId, b.paymentId);
+    assert.notEqual(b.paymentId, c.paymentId);
+    assert.notEqual(a.paymentId, c.paymentId);
+  } finally {
+    Date.now = realNow;
+  }
+});


### PR DESCRIPTION
Closes #11447.

## Summary

`apps/api/src/services/paymentService.js` was generating payment ids directly from `Date.now()`:

```js
return {
  paymentId: `pay_${Date.now()}`,
  ...
};
```

Two `createPaymentIntent` calls in the same millisecond shared the same `pay_` id. This is a financial transaction id — collisions make downstream reconciliation (Stripe, accounting, refunds, customer support lookups) silently ambiguous, which is materially worse than the same pattern in `reviewService` / `messageService` where the cost is only UX confusion. The same pattern was already accepted as a real bug for `reviewService` (#10931) and I just submitted a parallel fix for `messageService` (#11445 / #11446).

This PR switches the id source to `node:crypto`'s `randomUUID()` while preserving the existing `pay_` prefix, so existing id consumers keep working.

## Changes

- `apps/api/src/services/paymentService.js` — id source moved from `Date.now()` to `randomUUID()`; prefix `pay_` retained.
- `apps/api/src/tests/payment.test.js` (new) — focused regression coverage:
  - two consecutive `createPaymentIntent` calls produce distinct ids
  - every id keeps the `pay_` prefix
  - amount, default currency (`usd`), and provider (`stripe`) are preserved
  - an explicit non-default currency is preserved
  - even when `Date.now()` is frozen to a single value, all calls produce distinct ids

## Test results

```
$ npm run test -w apps/api
...
# tests 6
# pass 6
# fail 0
```

## Payout

Bounty payout destination — Base USDC, same EVM address works on every EVM chain:

- Address: `0x2a5a559afca0ea453b7c32b6a755254b0a5e6541`
- Preferred chain: Base
- USDC contract (Base): `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- Wallet: OKX Web3 Wallet (self-custody)

Refer to parent bounty #743.