### PR TITLE
Fix auth validation error responses

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,32 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
+
+function parseBody(schema, body) {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    return { error: "Invalid request body" };
+  }
+  return { data: result.data };
+}
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const payload = parseBody(registerSchema, req.body);
+  if (payload.error) {
+    return fail(res, payload.error, 400);
+  }
+
+  const result = await registerUser(payload.data);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
+  const payload = parseBody(loginSchema, req.body);
+  if (payload.error) {
+    return fail(res, payload.error, 400);
+  }
+
+  const result = await loginUser(payload.data);
   return ok(res, result);
 }
 

--- a/apps/api/src/tests/auth-validation.test.js
+++ b/apps/api/src/tests/auth-validation.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function postJson(baseUrl, path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  });
+}
+
+test("POST /api/auth/register returns 400 for invalid request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/register", {
+      email: "not-an-email",
+      password: "short",
+      role: "invalid"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+  });
+});
+
+test("POST /api/auth/login returns 400 for invalid request bodies", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await postJson(baseUrl, "/api/auth/login", {
+      email: "not-an-email",
+      password: "short"
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request body");
+  });
+});


### PR DESCRIPTION
## Summary
- return 400 responses for invalid `/api/auth/register` request bodies
- return 400 responses for invalid `/api/auth/login` request bodies
- add regression coverage for both auth validation paths
- fix the API test script so Node's test runner receives the test files explicitly

## Tests
- `npm test --workspace apps/api`

Closes #11449
