### PR TITLE
fix: add authMiddleware to payment/job routes + drop self-assignable admin role

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,9 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  // `admin` is reserved for internally-provisioned accounts and must not be
+  // self-assignable by unauthenticated registrations (bounty #11456).
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
Fixes three auth-related security bugs:

- **#11458** `POST /api/payments` was registered without `authMiddleware` — anyone could create payments. Now guarded.
- **#11457** `POST /api/jobs` was registered without `authMiddleware` — anonymous job creation. Now guarded.
- **#11456** `registerSchema` allowed `admin` self-assignment — unauthenticated callers could grant themselves admin. Removed from enum.

## Changes
- `apps/api/src/routes/paymentRoutes.js`: `paymentRoutes.post("/", authMiddleware, createPayment)`
- `apps/api/src/routes/jobRoutes.js`: `jobRoutes.post("/", authMiddleware, postJob)`
- `apps/api/src/validators/auth.js`: `role: z.enum(["client","freelancer"]).default("client")`

Closes #11458, Closes #11457, Closes #11456