### PR TITLE
fix: add auth middleware to job creation endpoint (closes #11457)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);


### PR DESCRIPTION
﻿> **Note:** Created by an automated agent. Please review carefully.

## Fix: Add auth middleware to job creation endpoint

### Problem
POST /api/jobs was registered without authMiddleware. Anyone could create job listings anonymously.

### Fix
Added authMiddleware to the POST route so only authenticated users can create jobs.

### Related
Closes #11457

/bounty $800
