### PR TITLE
fix: add authMiddleware to message and notification routes

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
+messageRoutes.use(authMiddleware);
 messageRoutes.get("/", getMessages);
 messageRoutes.post("/", postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);


### PR DESCRIPTION
## Bug

GET/POST /api/messages and GET/POST /api/notifications were registered without authMiddleware, allowing anonymous access to all messages and notifications.

## Fix

Added authMiddleware via router.use() in both route files:
- apps/api/src/routes/messageRoutes.js
- apps/api/src/routes/notificationRoutes.js

## Verification

- node --check passes on both files
- App imports successfully (createApp() returns function)
- Existing test infra has pre-existing Windows path issue (unrelated)

Fixes #11471
Parent bounty: #11398