### PR TITLE
fix: registerUser id/sub mismatch, admin self-assignment, search validation

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,12 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const q = (req.query.q ?? "").toString().trim().slice(0, MAX_QUERY_LENGTH);
+  if (!q) {
+    return fail(res, "Query parameter 'q' is required", 400);
+  }
+  return ok(res, await globalSearch(q));
 }

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const now = Date.now();
+  const userId = `usr_${now}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Bugs fixed (3)

### 1. registerUser id/sub mismatch
Date.now() was called twice producing different values for user id and JWT sub. Now captured once and reused.

### 2. Admin role self-assignment
registerSchema allowed role: admin. Removed from enum - admin should only be assigned server-side.

### 3. Unvalidated search query
Added trim(), 200-char max length, and empty query rejection (400).

## Files changed
- apps/api/src/services/authService.js
- apps/api/src/validators/auth.js
- apps/api/src/controllers/searchController.js

## Verification
- node --check passes on all files
- App imports successfully

Fixes #11475
Parent bounty: #11398