### PR TITLE
fix: add RBAC to admin routes and fix refresh token identity

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,12 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return fail(res, "Forbidden: insufficient role", 403);
+    }
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,13 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const now = Date.now();
+  const userId = `usr_${now}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 
@@ -18,6 +20,9 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  // Issue a fresh token for the authenticated caller
+  const sub = user?.sub ?? "usr_unknown";
+  const role = user?.role ?? "client";
+  return { token: signAccessToken({ sub, role }) };
 }


### PR DESCRIPTION
## Bugs fixed (2)

### 1. Admin routes lack role-based access control
Any authenticated user could access /api/admin/metrics. Added requireRole(admin) middleware guard.

### 2. Refresh endpoint issues hard-coded tokens
refreshToken() always returned a token for usr_existing. Now:
- /api/auth/refresh requires authMiddleware (identifies caller)
- refreshToken(user) issues a token for the actual authenticated user

## Files changed
- apps/api/src/middleware/auth.js (added requireRole)
- apps/api/src/routes/adminRoutes.js (added role guard)
- apps/api/src/routes/authRoutes.js (refresh requires auth)
- apps/api/src/controllers/authController.js (passes req.user)
- apps/api/src/services/authService.js (uses caller identity)

## Verification
- node --check passes on all 5 files
- App imports successfully

Fixes #11477
Parent bounty: #11398