### PR TITLE
fix: add authMiddleware to job, payment, and user routes

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
+jobRoutes.use(authMiddleware);
 jobRoutes.get("/", getJobs);
 jobRoutes.post("/", postJob);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getUsers, postUser } from "../controllers/userController.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
## Bug

POST /api/jobs, POST /api/payments, and GET/POST /api/users were registered without authMiddleware. Critical: payments could be created and user data enumerated anonymously.

## Fix

Added authMiddleware via router.use() in:
- apps/api/src/routes/jobRoutes.js
- apps/api/src/routes/paymentRoutes.js
- apps/api/src/routes/userRoutes.js

## Verification

- node --check passes on all 3 files
- App imports successfully

Fixes #11479
Parent bounty: #11398