### PR TITLE
fix: JWT secret production guard, payment validation, user password leak

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,5 +1,11 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+
+if (nodeEnv === "production" && !process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET must be set in production environment");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",

--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,18 @@
-import { ok } from "../utils/response.js";
+import { z } from "zod";
+import { ok, fail } from "../utils/response.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
+const ALLOWED_CURRENCIES = ["usd", "eur", "gbp"];
+
+const paymentSchema = z.object({
+  amount: z.number().int().positive().max(999999),
+  currency: z.enum(ALLOWED_CURRENCIES).default("usd")
+});
+
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = paymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid payment payload: " + parsed.error.issues.map(i => i.message).join(", "), 400);
+  }
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { password, ...safePayload } = payload;
+  const user = { id: `usr_${Date.now()}`, ...safePayload };
   users.push(user);
   return user;
 }


### PR DESCRIPTION
## Bugs fixed (3)

### 1. JWT secret known default in production
env.js now throws at startup if NODE_ENV=production and JWT_SECRET is not set. Prevents tokens signed with publicly known key.

### 2. Payment accepts unvalidated amount
Added Zod schema: amount must be positive integer (max 999999), currency restricted to usd/eur/gbp whitelist. Returns 400 on invalid input.

### 3. User list leaks passwords
userService.createUser now destructures password out of payload before storing. GET /api/users no longer exposes credentials.

## Files changed
- apps/api/src/config/env.js
- apps/api/src/controllers/paymentController.js
- apps/api/src/services/userService.js

## Verification
- node --check passes on all files
- App imports successfully

Fixes #11481
Parent bounty: #11398