### PR TITLE
fix: add Zod validation to notification, proposal, review endpoints

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,15 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/content.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid notification: " + parsed.error.issues.map(i => i.message).join(", "), 400);
+  }
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/content.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid proposal: " + parsed.error.issues.map(i => i.message).join(", "), 400);
+  }
+  const authorId = req.user?.sub ?? "unknown";
+  return ok(res, await createProposal(authorId, parsed.data), 201);
 }

--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,10 +1,16 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/content.js";
 
 export async function getReviews(req, res) {
   return ok(res, await listReviews());
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid review: " + parsed.error.issues.map(i => i.message).join(", "), 400);
+  }
+  const reviewerId = req.user?.sub ?? "unknown";
+  return ok(res, await createReview(reviewerId, parsed.data), 201);
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -4,8 +4,15 @@ export async function listNotifications() {
   return notifications;
 }
 
-export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+export async function createNotification(validatedData) {
+  const notification = {
+    id: `ntf_${Date.now()}`,
+    read: false,
+    type: validatedData.type,
+    message: validatedData.message,
+    recipientId: validatedData.recipientId,
+    createdAt: new Date().toISOString()
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -4,8 +4,17 @@ export async function listProposals() {
   return proposals;
 }
 
-export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+export async function createProposal(authorId, validatedData) {
+  const proposal = {
+    id: `prp_${Date.now()}`,
+    status: "pending",
+    authorId,
+    jobId: validatedData.jobId,
+    coverLetter: validatedData.coverLetter,
+    bidAmount: validatedData.bidAmount,
+    deliveryDays: validatedData.deliveryDays,
+    createdAt: new Date().toISOString()
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -4,8 +4,16 @@ export async function listReviews() {
   return reviews;
 }
 
-export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+export async function createReview(reviewerId, validatedData) {
+  const review = {
+    id: `rev_${Date.now()}`,
+    reviewerId,
+    targetUserId: validatedData.targetUserId,
+    jobId: validatedData.jobId,
+    rating: validatedData.rating,
+    comment: validatedData.comment,
+    createdAt: new Date().toISOString()
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/validators/content.js
+++ b/apps/api/src/validators/content.js
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  type: z.enum(["info", "warning", "success"]).default("info"),
+  message: z.string().min(1).max(500),
+  recipientId: z.string().min(1)
+});
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(10).max(5000),
+  bidAmount: z.number().positive().max(999999),
+  deliveryDays: z.number().int().positive().max(365).default(7)
+});
+
+export const createReviewSchema = z.object({
+  targetUserId: z.string().min(1),
+  jobId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(2000).default("")
+});


### PR DESCRIPTION
## Bug

All three services spread raw req.body allowing mass assignment:
- Notification: caller could set read:true, inject fields
- Proposal: caller could set status:accepted, inject fields
- Review: no rating bounds, caller could inject any field

## Fix

Created validators/content.js with Zod schemas:
- Notification: type enum, message 1-500 chars, recipientId required
- Proposal: jobId, coverLetter 10-5000, bidAmount positive max 999999, deliveryDays 1-365
- Review: rating 1-5 int, targetUserId, jobId, comment max 2000

Services now use explicit fields only. Author/reviewer bound from req.user.sub.

## Files changed (7)
- apps/api/src/validators/content.js (new)
- apps/api/src/services/notificationService.js
- apps/api/src/services/proposalService.js
- apps/api/src/services/reviewService.js
- apps/api/src/controllers/notificationController.js
- apps/api/src/controllers/proposalController.js
- apps/api/src/controllers/reviewController.js

## Verification
- node --check passes on all files
- App imports successfully

Fixes #11485
Parent bounty: #11398