### PR TITLE
fix: add graceful shutdown and ZodError handling

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,21 @@
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  // Handle Zod validation errors (thrown by .parse())
+  if (err.name === "ZodError") {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues.map(issue => ({
+        path: issue.path.join("."),
+        message: issue.message
+      }))
+    });
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -5,9 +5,28 @@ import { createApp } from "./app.js";
 async function bootstrap() {
   await connectDb();
   const app = createApp();
-  app.listen(env.port, () => {
+  const server = app.listen(env.port, () => {
     console.log(`API listening on http://localhost:${env.port}`);
   });
+
+  function shutdown(signal) {
+    console.log(`Received ${signal}, shutting down gracefully...`);
+    server.close(() => {
+      console.log("HTTP server closed");
+      process.exit(0);
+    });
+    // Force exit after 10s if connections don't drain
+    setTimeout(() => {
+      console.error("Forced shutdown after timeout");
+      process.exit(1);
+    }, 10000).unref();
+  }
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
 }
 
-bootstrap();
+bootstrap().catch((err) => {
+  console.error("Failed to start server:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bugs fixed (2)

### 1. No graceful shutdown
server.js now handles SIGTERM/SIGINT: closes HTTP server, drains connections, force-exits after 10s timeout. bootstrap().catch() logs errors and exits(1).

### 2. ZodError returns 500 instead of 400
errorHandler now detects err.name === 'ZodError' and returns 400 with structured issues array (path + message per field).

## Files changed
- apps/api/src/server.js
- apps/api/src/middleware/errorHandler.js

## Verification
- node --check passes
- App imports successfully

Fixes #11487
Parent bounty: #11398