### PR TITLE
Reject admin role during registration

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const result = registerSchema.safeParse({
+    email: "attacker@example.com",
+    password: "correct-horse-battery-staple",
+    role: "admin"
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("registerSchema still accepts public registration roles", () => {
+  for (const role of ["client", "freelancer"]) {
+    const result = registerSchema.safeParse({
+      email: `${role}@example.com`,
+      password: "correct-horse-battery-staple",
+      role
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.data.role, role);
+  }
+});
+
+test("registerSchema defaults omitted role to client", () => {
+  const result = registerSchema.safeParse({
+    email: "new-client@example.com",
+    password: "correct-horse-battery-staple"
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Closes #11489.

- Removes `admin` from the public registration role enum so unauthenticated users cannot self-assign administrative access.
- Adds focused validator coverage proving `admin` is rejected while `client`, `freelancer`, and the default client role still work.

## Validation

- `node --test apps/api/src/tests/*.js`

This PR was prepared with AI assistance under the account owner's direction.