### PR TITLE
Use consistent registered user id in token

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const userId = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id: userId,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: userId, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser signs access token for the returned user id", async () => {
+  const originalNow = Date.now;
+  let now = 1700000000000;
+  Date.now = () => now++;
+
+  try {
+    const user = await registerUser({
+      email: "new-user@example.com",
+      password: "correct-horse-battery-staple",
+      role: "client"
+    });
+    const tokenPayload = verifyAccessToken(user.token);
+
+    assert.equal(user.id, "usr_1700000000000");
+    assert.equal(tokenPayload.sub, user.id);
+    assert.equal(tokenPayload.role, user.role);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Closes #11491.

- Generates the registered user id once in `registerUser()`.
- Reuses that same id for the returned `id` field and JWT `sub` claim.
- Adds a focused service test that forces `Date.now()` to advance between calls and verifies the token subject matches the returned user id.

## Validation

- `node --test apps/api/src/tests/*.js`

This PR was prepared with AI assistance under the account owner's direction.