### PR TITLE
Validate search query input

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,23 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_SEARCH_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const rawQuery = req.query.q ?? "";
+
+  if (typeof rawQuery !== "string") {
+    return fail(res, "Search query must be a string", 400);
+  }
+
+  const query = rawQuery.trim();
+  if (query.length > MAX_SEARCH_QUERY_LENGTH) {
+    return fail(
+      res,
+      `Search query must be ${MAX_SEARCH_QUERY_LENGTH} characters or fewer`,
+      400
+    );
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/searchController.test.js
+++ b/apps/api/src/tests/searchController.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search trims string query before searching", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=%20freelancer%20`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.data.query, "freelancer");
+  });
+});
+
+test("GET /api/search rejects repeated non-string query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=one&q=two`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /must be a string/);
+  });
+});
+
+test("GET /api/search rejects overlong query values", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/search?q=${"a".repeat(201)}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /200 characters or fewer/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #11493.

- Validates that `q` is a string before calling the search service.
- Trims string queries before search execution.
- Rejects overlong queries above 200 characters with a 400 response.
- Adds focused API coverage for trimmed, repeated, and overlong query values.

## Validation

- `node --test apps/api/src/tests/*.js`

This PR was prepared with AI assistance under the account owner's direction.