### PR TITLE
Return bad request for validation errors

### DIFF
--- a/apps/api/src/middleware/asyncHandler.js
+++ b/apps/api/src/middleware/asyncHandler.js
@@ -1,0 +1,5 @@
+export function asyncHandler(handler) {
+  return function wrappedHandler(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,18 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof ZodError) {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid request payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
-authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
+authRoutes.get("/oauth/:provider/callback", asyncHandler(oauthCallback));
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { asyncHandler } from "../middleware/asyncHandler.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", asyncHandler(getJobs));
+jobRoutes.post("/", asyncHandler(postJob));

--- a/apps/api/src/tests/validationErrors.test.js
+++ b/apps/api/src/tests/validationErrors.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register returns 400 for invalid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", password: "short" })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Invalid request payload");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #11511.

- Adds an async route wrapper so Express 4 forwards rejected controller promises to the global error handler.
- Handles Zod validation failures as HTTP 400 responses in the existing API error shape.
- Adds a regression test for invalid registration payloads.

## Validation

- `node --test apps/api/src/tests/*.js`

This PR was prepared with AI assistance under the account owner's direction.