### PR TITLE
Limit upload file size

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,27 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { fail } from "../utils/response.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 }
+});
+
+function singleFileUpload(req, res, next) {
+  upload.single("file")(req, res, (error) => {
+    if (error instanceof multer.MulterError && error.code === "LIMIT_FILE_SIZE") {
+      return fail(res, "Uploaded file is too large", 413);
+    }
+
+    if (error) {
+      return next(error);
+    }
+
+    return next();
+  });
+}
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", singleFileUpload, uploadFile);

--- a/apps/api/src/tests/uploadLimit.test.js
+++ b/apps/api/src/tests/uploadLimit.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/uploads accepts files within the size limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob(["hello"]), "hello.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.filename, "hello.txt");
+  });
+});
+
+test("POST /api/uploads rejects files over the size limit", async () => {
+  await withServer(async (baseUrl) => {
+    const form = new FormData();
+    form.set("file", new Blob([new Uint8Array(5 * 1024 * 1024 + 1)]), "large.bin");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Uploaded file is too large");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #11517.

- Adds a 5 MB file-size limit to the in-memory upload middleware.
- Returns a controlled 413 API response when uploads exceed the limit.
- Adds route coverage for accepted and rejected uploads.

## Validation

- `node --test apps/api/src/tests/*.js`

This PR was prepared with AI assistance under the account owner's direction.