### PR TITLE
fix(env): validate PORT before use, fall back to 4000 if invalid

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,6 +1,16 @@
+function safePort(raw) {
+  if (raw === undefined || raw === null) return 4000;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) {
+    console.warn(`[env] Invalid PORT value "${raw}" (parsed as ${n}), falling back to 4000`);
+    return 4000;
+  }
+  return n;
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
+  port: safePort(process.env.PORT),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""


### PR DESCRIPTION
## Bug
 returns  when PORT is set to a non-numeric value, crashing the server.

## Fix
Added  that validates PORT is a finite number in range 1-65535. Invalid values log a warning and fall back to 4000.

## Testing


Closes #11391