### PR TITLE
fix(auth): return 400 for invalid payloads instead of 500

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,34 @@
+import { ZodError } from "zod";
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const messages = err.errors.map(e => `${e.path.join(".")}: ${e.message}`).join("; ");
+      return fail(res, `Validation error: ${messages}`, 400);
+    }
+    throw err;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      const messages = err.errors.map(e => `${e.path.join(".")}: ${e.message}`).join("; ");
+      return fail(res, `Validation error: ${messages}`, 400);
+    }
+    throw err;
+  }
 }
 
 export async function oauthCallback(req, res) {


### PR DESCRIPTION
## Bug
Auth register/login endpoints let Zod schema validation errors bubble out as 500s instead of returning a client error.

## Fix
Wrap registerSchema.parse() and loginSchema.parse() in try-catch. Catch ZodError and return 400 Bad Request with the validation error messages.

Closes #11394