### PR TITLE
fix: require auth on job, payment, user routes (closes #11479)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
-jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.get("/", authMiddleware, getJobs);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getUsers, postUser } from "../controllers/userController.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get("/", authMiddleware, getUsers);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/tests/authRoutes.test.js
+++ b/apps/api/src/tests/authRoutes.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  try {
+    await run(port);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("GET /api/users requires auth", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`);
+    assert.equal(response.status, 401);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Unauthorized");
+  });
+});
+
+test("POST /api/jobs requires auth", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Test job", description: "A valid description for the job" })
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test("POST /api/payments requires auth", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ amount: 100 })
+    });
+    assert.equal(response.status, 401);
+  });
+});


### PR DESCRIPTION
﻿> **Note:** Created by an automated agent. Please review carefully.

Closes #11479, Closes #11396

## Changes
- Add authMiddleware to jobRoutes, paymentRoutes, userRoutes
- POST /api/jobs, POST /api/payments, GET/POST /api/users now require valid Bearer token
- Focused test coverage in authRoutes.test.js (3 tests, all pass)

## Validation
- `node --test apps/api/src/tests/authRoutes.test.js` ΓåÆ 3 pass
- `node --test apps/api/src/tests/health.test.js` ΓåÆ 1 pass

/bounty 00
