### PR TITLE
fix(api): authenticate refresh tokens and preserve identity

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,6 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(callback) {
+  const server = createApp().listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    return await callback(`http://127.0.0.1:${server.address().port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh rejects unauthenticated requests", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, { method: "POST" });
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), { success: false, message: "Unauthorized" });
+  });
+});
+
+test("POST /api/auth/refresh preserves the authenticated subject and role", async () => {
+  await withServer(async (baseUrl) => {
+    const accessToken = signAccessToken({ sub: "usr_refresh_test", role: "admin" });
+    const response = await fetch(`${baseUrl}/api/auth/refresh`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${accessToken}` }
+    });
+
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    const refreshed = verifyAccessToken(payload.data.token);
+    assert.equal(refreshed.sub, "usr_refresh_test");
+    assert.equal(refreshed.role, "admin");
+  });
+});


### PR DESCRIPTION
Fixes #11530

/claim #743

Summary:
- require Bearer authentication on POST /api/auth/refresh
- preserve the verified subject and role in the refreshed JWT
- add regression tests for rejection and identity preservation
- fix the npm test script to discover src/tests/*.test.js

Validation:
- npm test (3 passed)
- git diff --check (passed)

Files changed:
- apps/api/package.json
- apps/api/src/controllers/authController.js
- apps/api/src/routes/authRoutes.js
- apps/api/src/services/authService.js
- apps/api/src/tests/auth-refresh.test.js

https://github.com/user-attachments/assets/27ef4b6c-40dc-4def-baaf-6317e3436bef

