### PR TITLE
security: prevent self-registration as admin

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,15 @@
 import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
+  // Security: prevent self-registration as admin even if schema is bypassed
+  const safeRole = payload.role === "admin" ? "client" : payload.role;
+
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: safeRole,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role: safeRole })
   };
 }
 

--- a/apps/api/src/tests/auth-security.test.js
+++ b/apps/api/src/tests/auth-security.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+import { registerUser } from "../services/authService.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "attacker@evil.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.success, false, "admin role should be rejected by schema");
+});
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.safeParse({
+    email: "user@test.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "freelancer@test.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerUser downgrades admin role to client", async () => {
+  const result = await registerUser({
+    email: "attacker@evil.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.role, "client", "admin role should be downgraded to client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes a critical security vulnerability where any unauthenticated user could self-register with admin privileges.

## Changes

1. ****: Removed  from  enum — only  and  are now accepted at the validation layer.
2. ****: Added server-side defense-in-depth in  — if a role of  somehow bypasses validation, it is downgraded to .
3. ****: Added tests verifying:
   - Schema rejects  role
   - Schema accepts  and  roles
   - Server-side downgrade of  to 

## Related Issue
Closes #11540
Refs #11398