### PR TITLE
fix: fail fast on missing JWT_SECRET in production

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,17 @@
+const nodeEnv = process.env.NODE_ENV ?? "development";
+const jwtSecret = process.env.JWT_SECRET;
+
+if (!jwtSecret) {
+  if (nodeEnv === "production") {
+    throw new Error("FATAL: JWT_SECRET must be set in production environment. A default development secret MUST NOT be used in production.");
+  }
+  console.warn("WARNING: JWT_SECRET not set, using development-only default. Do NOT use in production.");
+}
+
 export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv,
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: jwtSecret ?? "dev-secret-do-not-use-in-production",
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
## Summary
Fixes #11542 — Hardcoded JWT secret fallback (`"development-secret"`) in production allows arbitrary token forgery.

## Changes
- `apps/api/src/config/env.js`: 
  - Fail fast with explicit error if `JWT_SECRET` is unset in production
  - In development, emit a warning but allow the default
  - Changed default value to `"dev-secret-do-not-use-in-production"` to be more explicit

## Impact
- **Before**: Missing env var → all JWTs signed with publicly known secret → anyone can forge tokens → full account takeover
- **After**: Missing env var → app crashes on startup in production with clear error message

## Testing
- `NODE_ENV=production` without `JWT_SECRET` → throws on import
- `NODE_ENV=development` without `JWT_SECRET` → warns but starts
- All existing functionality preserved when `JWT_SECRET` is set

Related: #11398