### PR TITLE
fix: require JWT_SECRET in production, reject default (closes #11542)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,18 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: (() => {
+    const secret = process.env.JWT_SECRET;
+    const isProd = process.env.NODE_ENV === "production";
+    if (!secret) {
+      if (isProd) throw new Error("FATAL: JWT_SECRET is required in production");
+      return "development-secret";
+    }
+    if (isProd && secret === "development-secret") {
+      throw new Error("FATAL: JWT_SECRET must not be default in production");
+    }
+    return secret;
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Fixes hardcoded JWT secret fallback in production.

- Production requires JWT_SECRET env var (throws fatal error if missing)
- Production rejects default 'development-secret' value
- Development still works with fallback

/bounty $50