### PR TITLE
Implement Stripe payment intent service

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+The payment service reads `STRIPE_SECRET_KEY` at runtime and never hardcodes a
+credential. The normal test suite uses a mocked Stripe client. To opt into the
+live Stripe test-mode smoke test, set both `STRIPE_SECRET_KEY` and
+`RUN_STRIPE_INTEGRATION_TESTS=1` before running `npm test`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +14,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.1.1",
+    "stripe": "^22.4.0",
     "zod": "^3.23.8"
   }
 }

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,9 +1,76 @@
-export async function createPaymentIntent(payload) {
-  // TODO: integrate Stripe SDK and return client secret.
-  return {
-    paymentId: `pay_${Date.now()}`,
-    amount: payload.amount,
-    currency: payload.currency ?? "usd",
-    provider: "stripe"
-  };
+import Stripe from "stripe";
+import { env } from "../config/env.js";
+
+let stripeClient;
+
+function getStripeClient() {
+  // Read the process environment at call time so long-running workers and
+  // tests that inject configuration after module load behave predictably.
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY ?? env.stripeSecretKey;
+  if (!stripeSecretKey) {
+    throw new Error("STRIPE_SECRET_KEY must be configured to create a payment intent");
+  }
+
+  stripeClient ??= new Stripe(stripeSecretKey);
+  return stripeClient;
+}
+
+function validatePaymentPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    throw new TypeError("Payment payload is required");
+  }
+
+  if (!Number.isSafeInteger(payload.amount) || payload.amount <= 0) {
+    throw new TypeError("payload.amount must be a positive integer in the smallest currency unit");
+  }
+
+  const currency = payload.currency ?? "usd";
+  if (typeof currency !== "string" || !/^[a-z]{3}$/i.test(currency)) {
+    throw new TypeError("payload.currency must be a three-letter currency code");
+  }
+
+  const request = { amount: payload.amount, currency: currency.toLowerCase() };
+  if (payload.metadata !== undefined) {
+    if (
+      payload.metadata === null ||
+      typeof payload.metadata !== "object" ||
+      Array.isArray(payload.metadata)
+    ) {
+      throw new TypeError("payload.metadata must be an object when provided");
+    }
+
+    request.metadata = payload.metadata;
+  }
+
+  return request;
+}
+
+/**
+ * Create a Stripe PaymentIntent and expose the stable fields used by callers.
+ *
+ * The optional client argument is intentionally injectable so unit tests can
+ * exercise the service without contacting Stripe or requiring a secret key.
+ */
+export async function createPaymentIntent(payload, client) {
+  const request = validatePaymentPayload(payload);
+  const stripe = client ?? getStripeClient();
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create(request);
+
+    return {
+      paymentId: paymentIntent.id,
+      clientSecret: paymentIntent.client_secret,
+      amount: request.amount,
+      currency: request.currency,
+      provider: "stripe"
+    };
+  } catch (error) {
+    // Preserve Stripe's original error text while keeping a stable service
+    // context for logs and API consumers.
+    if (error instanceof Error) {
+      throw new Error(`Stripe payment intent creation failed: ${error.message}`, { cause: error });
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+function mockStripe(create = async () => ({ id: "pi_test", client_secret: "pi_test_secret" })) {
+  return {
+    paymentIntents: { create }
+  };
+}
+
+test("createPaymentIntent creates a Stripe PaymentIntent and maps its response", async () => {
+  let receivedParams;
+  const stripe = mockStripe(async (params) => {
+    receivedParams = params;
+    return { id: "pi_123", client_secret: "pi_123_secret" };
+  });
+
+  const result = await createPaymentIntent({ amount: 2500 }, stripe);
+
+  assert.deepEqual(receivedParams, { amount: 2500, currency: "usd" });
+  assert.deepEqual(result, {
+    paymentId: "pi_123",
+    clientSecret: "pi_123_secret",
+    amount: 2500,
+    currency: "usd",
+    provider: "stripe"
+  });
+});
+
+test("createPaymentIntent normalizes a valid currency code", async () => {
+  let receivedParams;
+  const stripe = mockStripe(async (params) => {
+    receivedParams = params;
+    return { id: "pi_eur", client_secret: "secret_eur" };
+  });
+
+  await createPaymentIntent({ amount: 100, currency: "EUR" }, stripe);
+
+  assert.deepEqual(receivedParams, { amount: 100, currency: "eur" });
+});
+
+test("createPaymentIntent validates and forwards optional metadata", async () => {
+  let receivedParams;
+  const stripe = mockStripe(async (params) => {
+    receivedParams = params;
+    return { id: "pi_metadata", client_secret: "secret_metadata" };
+  });
+
+  await createPaymentIntent({ amount: 100, metadata: { orderId: "order_123" } }, stripe);
+
+  assert.deepEqual(receivedParams, {
+    amount: 100,
+    currency: "usd",
+    metadata: { orderId: "order_123" }
+  });
+});
+
+test("createPaymentIntent rejects invalid metadata before Stripe is called", async () => {
+  let calls = 0;
+  const stripe = mockStripe(async () => {
+    calls += 1;
+    return { id: "unused", client_secret: "unused" };
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, metadata: [] }, stripe),
+    /payload\.metadata must be an object/
+  );
+  assert.equal(calls, 0);
+});
+
+test("createPaymentIntent rejects missing or invalid amounts before Stripe is called", async () => {
+  let calls = 0;
+  const stripe = mockStripe(async () => {
+    calls += 1;
+    return { id: "unused", client_secret: "unused" };
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 0 }, stripe),
+    /payload\.amount must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 12.5 }, stripe),
+    /payload\.amount must be a positive integer/
+  );
+  await assert.rejects(
+    () => createPaymentIntent({}, stripe),
+    /payload\.amount must be a positive integer/
+  );
+
+  assert.equal(calls, 0);
+});
+
+test("createPaymentIntent rejects invalid currency before Stripe is called", async () => {
+  let calls = 0;
+  const stripe = mockStripe(async () => {
+    calls += 1;
+    return { id: "unused", client_secret: "unused" };
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100, currency: "dollars" }, stripe),
+    /payload\.currency must be a three-letter currency code/
+  );
+  assert.equal(calls, 0);
+});
+
+test("createPaymentIntent preserves Stripe error messages", async () => {
+  const stripe = mockStripe(async () => {
+    throw new Error("Your card was declined");
+  });
+
+  await assert.rejects(
+    () => createPaymentIntent({ amount: 100 }, stripe),
+    (error) => {
+      assert.match(error.message, /Stripe payment intent creation failed/);
+      assert.match(error.message, /Your card was declined/);
+      assert.equal(error.cause.message, "Your card was declined");
+      return true;
+    }
+  );
+});
+
+const integrationEnabled =
+  process.env.RUN_STRIPE_INTEGRATION_TESTS === "1" && Boolean(process.env.STRIPE_SECRET_KEY);
+
+test("Stripe integration creates a test-mode PaymentIntent", { skip: !integrationEnabled }, async () => {
+  const result = await createPaymentIntent({ amount: 50 });
+
+  assert.match(result.paymentId, /^pi_/);
+  assert.match(result.clientSecret, /^pi_/);
+  assert.equal(result.amount, 50);
+  assert.equal(result.currency, "usd");
+  assert.equal(result.provider, "stripe");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.1.1",
+        "stripe": "^22.4.0",
         "zod": "^3.23.8"
       }
     },
@@ -742,7 +743,7 @@
       "version": "22.15.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
       "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1203,7 +1204,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2053,6 +2053,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.4.0.tgz",
+      "integrity": "sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -2128,7 +2145,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
Implements the Stripe PaymentIntent service for #1.

Changes:
- use the official Stripe SDK initialized from STRIPE_SECRET_KEY
- validate positive safe-integer amount and a 3-letter currency
- map PaymentIntent id/client_secret to paymentId/clientSecret
- preserve provider error messages via cause
- add mocked unit tests and an opt-in RUN_STRIPE_INTEGRATION_TESTS smoke test

Validation: npm test (8 passing, 1 skipped integration without STRIPE_SECRET_KEY).

/claim #1
Closes #1