### PR TITLE
fix: reject inverted budget ranges in job validation

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(422).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -6,7 +6,18 @@ export const createJobSchema = z.object({
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  skills: z.array(z.string().min(1)).default([]),
+}).refine(data => data.budgetMax >= data.budgetMin, {
+  message: "budgetMax must be >= budgetMin",
+  path: ["budgetMax"],
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = createJobSchema.partial().refine(data => {
+  if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+    return data.budgetMax >= data.budgetMin;
+  }
+  return true;
+}, {
+  message: "budgetMax must be >= budgetMin",
+  path: ["budgetMax"],
+});


### PR DESCRIPTION
Fixes #2853\n- Adds refine to createJobSchema ensuring budgetMax >= budgetMin\n- Updates updateJobSchema with same conditional check\n/bounty 0