### PR TITLE
feat: implement bcrypt password hashing in authService (#11558)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "test": "node --test src/tests"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,51 @@
+import bcrypt from "bcryptjs";
 import { signAccessToken } from "../utils/jwt.js";
 
+const SALT_ROUNDS = 12;
+
+// In-memory user store (replace with Prisma/DB in production)
+const users = new Map();
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
+  // Hash the password before storing
+  const passwordHash = await bcrypt.hash(payload.password, SALT_ROUNDS);
+
+  const user = {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: payload.role || "client",
+    passwordHash,
+    createdAt: new Date().toISOString(),
+  };
+
+  users.set(user.email, user);
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    token: signAccessToken({ sub: user.id, role: user.role }),
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  // Look up user by email
+  const user = users.get(payload.email);
+
+  if (!user) {
+    throw new Error("Invalid email or password");
+  }
+
+  // Verify password hash against stored user record
+  const isValid = await bcrypt.compare(payload.password, user.passwordHash);
+
+  if (!isValid) {
+    throw new Error("Invalid email or password");
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: user.email,
+    token: signAccessToken({ sub: user.id, role: user.role }),
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { registerUser, loginUser } from "../services/authService.js";
+
+describe("authService", () => {
+  const testEmail = `test_${Date.now()}@example.com`;
+  const testPassword = "securePassword123";
+
+  it("should register a user and return a token", async () => {
+    const result = await registerUser({
+      email: testEmail,
+      password: testPassword,
+      role: "client",
+    });
+
+    assert.ok(result.token);
+    assert.strictEqual(result.email, testEmail);
+    assert.strictEqual(result.role, "client");
+  });
+
+  it("should login with correct password", async () => {
+    const result = await loginUser({
+      email: testEmail,
+      password: testPassword,
+    });
+
+    assert.ok(result.token);
+    assert.strictEqual(result.email, testEmail);
+  });
+
+  it("should reject login with wrong password", async () => {
+    await assert.rejects(
+      () =>
+        loginUser({
+          email: testEmail,
+          password: "wrongPassword",
+        }),
+      { message: "Invalid email or password" }
+    );
+  });
+
+  it("should reject login with non-existent email", async () => {
+    await assert.rejects(
+      () =>
+        loginUser({
+          email: "nonexistent@example.com",
+          password: testPassword,
+        }),
+      { message: "Invalid email or password" }
+    );
+  });
+
+  it("should not store passwords in plaintext", async () => {
+    const result = await registerUser({
+      email: `hash_test_${Date.now()}@example.com`,
+      password: "plaintextPassword",
+      role: "client",
+    });
+
+    // Token should not contain the password
+    assert.ok(!result.token?.includes?.("plaintextPassword"));
+    assert.ok(!result.passwordHash);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
     "apps/api": {
       "name": "@freelanceflow/api",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",
@@ -793,6 +794,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {


### PR DESCRIPTION
## Summary

Implements secure password hashing using bcryptjs in the auth service.

### Changes
- **`authService.js`**: 
  - `registerUser()` now hashes passwords with bcrypt (12 salt rounds) before storage
  - `loginUser()` now verifies passwords against stored bcrypt hashes
  - Added in-memory user store with migration path to Prisma/DB
  - Throws proper `Invalid email or password` error for auth failures
- **`package.json`**: Added `bcryptjs` dependency
- **`auth.test.js`**: Added comprehensive test suite (5 tests):
  - Register user and get token
  - Login with correct password
  - Reject wrong password
  - Reject non-existent email
  - Verify plaintext passwords are never exposed

### Test Results
```
? should register a user and return a token
? should login with correct password
? should reject login with wrong password
? should reject login with non-existent email
? should not store passwords in plaintext
5/5 passing
```

Closes #11558