### PR TITLE
fix(proposals): require authentication on POST /api/proposals

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/proposals rejects unauthenticated requests with 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jobId: "job_1", freelancerId: "usr_1", coverLetter: "test" }),
+  });
+
+  assert.equal(response.status, 401);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/proposals remains publicly accessible", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`);
+  assert.equal(response.status, 200);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Problem

The `POST /api/proposals` endpoint at `apps/api/src/routes/proposalRoutes.js` was missing `authMiddleware`, allowing unauthenticated users to submit proposals to any job listing.

## Root cause

```js
// Before
proposalRoutes.post("/", postProposal);
```

No bearer-token validation was applied to the POST handler.

## Fix

```js
// After
proposalRoutes.post("/", authMiddleware, postProposal);
```

Added `authMiddleware` so only requests with a valid JWT can create proposals. The `GET /api/proposals` endpoint is intentionally left public.

## Tests

Added `apps/api/src/tests/proposals.test.js` with two cases:
- Unauthenticated `POST` returns `401`
- Unauthenticated `GET` returns `200`

Closes #2773