### PR TITLE
fix(api): run test files from npm test

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test \"src/tests/*.test.js\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

Fixes #11564.

The API workspace script used `node --test src/tests`, which Node interpreted as a file path and rejected with MODULE_NOT_FOUND in a fresh checkout. The repository stores tests as `src/tests/*.test.js`.

This change uses an explicit test-file glob so `npm test` discovers the current health test and future API test files.

## Validation

- `npm test` from `apps/api`
- 1 test passed, 0 failed

This PR addresses the creator-only issue opened under the SecureBanana bounty workflow (refs #11398).