### PR TITLE
fix: require auth and preserve subject on token refresh

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,11 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  const sub = user?.sub ?? user?.id;
+  const role = user?.role ?? "client";
+  if (!sub) {
+    throw new Error("Authenticated user subject is required");
+  }
+  return { token: signAccessToken({ sub, role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+import { env } from "../config/env.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/refresh without token returns 401", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, { method: "POST" });
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/auth/refresh preserves authenticated subject and role", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_abc", role: "freelancer" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    const decoded = jwt.verify(payload.data.token, env.jwtSecret);
+    assert.equal(decoded.sub, "usr_abc");
+    assert.equal(decoded.role, "freelancer");
+  });
+});


### PR DESCRIPTION
## Summary
Protects /api/auth/refresh with authMiddleware and signs refreshed tokens for the authenticated subject/role.

## Test plan
- [x] Added focused regression tests
- [x] Ran npm test in apps/api three times with zero failures

Closes #11567

Made with [Cursor](https://cursor.com)