### PR TITLE
fix: use single user id for register response and JWT sub

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/register-id.test.js
+++ b/apps/api/src/tests/register-id.test.js
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { registerUser } from "../services/authService.js";
+import { env } from "../config/env.js";
+
+test("registerUser token subject matches returned id even if time advances", async () => {
+  const realNow = Date.now;
+  let calls = 0;
+  Date.now = () => {
+    calls += 1;
+    return 1_700_000_000_000 + calls * 25;
+  };
+  try {
+    const result = await registerUser({ email: "a@example.com", role: "client" });
+    const decoded = jwt.verify(result.token, env.jwtSecret);
+    assert.equal(result.id, decoded.sub);
+    assert.equal(result.id, "usr_1700000000025");
+  } finally {
+    Date.now = realNow;
+  }
+});


### PR DESCRIPTION
## Summary
Generates the user id once so registration response id and JWT subject cannot drift.

## Test plan
- [x] Added focused regression tests
- [x] Ran npm test in apps/api three times with zero failures

Closes #11568

Made with [Cursor](https://cursor.com)