### PR TITLE
fix: restrict CORS to an explicit origin allowlist

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -14,12 +14,40 @@ import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
 import { adminRoutes } from "./routes/adminRoutes.js";
+import { env } from "./config/env.js";
+
+function buildCorsOptions() {
+  const configured = (process.env.CORS_ORIGINS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const allowlist =
+    configured.length > 0
+      ? configured
+      : env.nodeEnv === "production"
+        ? []
+        : ["http://localhost:3000", "http://127.0.0.1:3000"];
+
+  return {
+    origin(origin, callback) {
+      // Allow non-browser / same-origin requests with no Origin header.
+      if (!origin) {
+        return callback(null, true);
+      }
+      if (allowlist.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error(`Origin ${origin} is not allowed by CORS`));
+    }
+  };
+}
 
 export function createApp() {
   const app = express();
 
   app.use(helmet());
-  app.use(cors());
+  app.use(cors(buildCorsOptions()));
   app.use(express.json());
   app.use(apiLimiter);
 

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -38,7 +38,7 @@ function buildCorsOptions() {
       if (allowlist.includes(origin)) {
         return callback(null, true);
       }
-      return callback(new Error(`Origin ${origin} is not allowed by CORS`));
+      return callback(null, false);
     }
   };
 }

--- a/apps/api/src/tests/cors-allowlist.test.js
+++ b/apps/api/src/tests/cors-allowlist.test.js
@@ -28,12 +28,11 @@ test("allows configured localhost origin", async () => {
   });
 });
 
-test("rejects unknown origin", async () => {
+test("rejects unknown origin without ACAO header", async () => {
   await withServer(async (port) => {
     const response = await fetch(`http://127.0.0.1:${port}/health`, {
       headers: { Origin: "https://evil.example" }
     });
-    // cors package surfaces error via error handler / failed request
-    assert.notEqual(response.headers.get("access-control-allow-origin"), "https://evil.example");
+    assert.equal(response.headers.get("access-control-allow-origin"), null);
   });
 });

--- a/apps/api/src/tests/cors-allowlist.test.js
+++ b/apps/api/src/tests/cors-allowlist.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("allows configured localhost origin", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "http://localhost:3000" }
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("access-control-allow-origin"), "http://localhost:3000");
+  });
+});
+
+test("rejects unknown origin", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      headers: { Origin: "https://evil.example" }
+    });
+    // cors package surfaces error via error handler / failed request
+    assert.notEqual(response.headers.get("access-control-allow-origin"), "https://evil.example");
+  });
+});


### PR DESCRIPTION
## Summary
Replaces open cors() with an env-driven allowlist (safe localhost defaults outside production).

## Test plan
- [x] Added focused regression tests
- [x] Ran npm test in apps/api three times with zero failures

Closes #11569

Made with [Cursor](https://cursor.com)