### PR TITLE
fix: require auth for POST /api/users

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);

--- a/apps/api/src/tests/users-auth.test.js
+++ b/apps/api/src/tests/users-auth.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await run(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/users without auth returns 401", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@example.com" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 401);
+    assert.equal(payload.success, false);
+  });
+});
+
+test("POST /api/users with auth is not unauthorized", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({ email: "a@example.com", name: "user" })
+    });
+    assert.notEqual(response.status, 401);
+  });
+});


### PR DESCRIPTION
## Summary
Adds authMiddleware to user creation so unauthenticated clients cannot create users.

## Test plan
- [x] Added focused regression tests
- [x] Ran npm test in apps/api three times with zero failures

Closes #11570

Made with [Cursor](https://cursor.com)