### PR TITLE
fix: prevent admin role self-assignment on register

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,32 @@
+import { ZodError } from "zod";
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Validation failed", 400);
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Validation failed", 400);
+    }
+    throw error;
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/tests/register-no-admin.test.js
+++ b/apps/api/src/tests/register-no-admin.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try { await run(server.address().port); }
+  finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/register rejects admin role self-assignment", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "admin@example.com",
+        password: "password123",
+        role: "admin"
+      })
+    });
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/auth/register allows client role", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "client@example.com",
+        password: "password123",
+        role: "client"
+      })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.role, "client");
+  });
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary
Registration schema only allows client/freelancer roles.

## Test plan
- [x] Focused regression tests added
- [x] npm test ×3 green in apps/api

Closes #11591

Made with [Cursor](https://cursor.com)