### PR TITLE
fix: require estimatedDuration on proposal create

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,20 @@
-import { ok } from "../utils/response.js";
+import { ZodError } from "zod";
+import { fail, ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  try {
+    const payload = createProposalSchema.parse(req.body ?? {});
+    return ok(res, await createProposal(payload), 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Validation failed", 400);
+    }
+    throw error;
+  }
 }

--- a/apps/api/src/tests/proposal-duration.test.js
+++ b/apps/api/src/tests/proposal-duration.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try { await run(server.address().port); }
+  finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects missing estimatedDuration", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId: "job_1" })
+    });
+    assert.equal(response.status, 400);
+  });
+});
+
+test("POST /api/proposals accepts estimatedDuration", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId: "job_1", estimatedDuration: "3 days" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.estimatedDuration, "3 days");
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  coverLetter: z.string().min(1).optional(),
+  amount: z.number().nonnegative().optional(),
+  estimatedDuration: z.string().min(1)
+});


### PR DESCRIPTION
## Summary
Rejects proposal payloads missing estimatedDuration with HTTP 400.

## Test plan
- [x] Focused regression tests added
- [x] npm test ×3 green in apps/api

Closes #11593

Made with [Cursor](https://cursor.com)