### PR TITLE
fix: require auth for GET /api/search

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);

--- a/apps/api/src/tests/search-auth.test.js
+++ b/apps/api/src/tests/search-auth.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try { await run(server.address().port); }
+  finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("GET /api/search without auth returns 401", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=dev`);
+    assert.equal(response.status, 401);
+  });
+});
+
+test("GET /api/search with auth succeeds", async () => {
+  await withServer(async (port) => {
+    const token = signAccessToken({ sub: "usr_test", role: "client" });
+    const response = await fetch(`http://127.0.0.1:${port}/api/search?q=dev`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    assert.notEqual(response.status, 401);
+  });
+});


### PR DESCRIPTION
## Summary
Protects search endpoint with authMiddleware.

## Test plan
- [x] Focused regression tests added
- [x] npm test ×3 green in apps/api

Closes #11594

Made with [Cursor](https://cursor.com)