### PR TITLE
fix: verify login credentials against registered users

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/**/*.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,35 @@
+import { ZodError } from "zod";
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Validation failed", 400);
+    }
+    throw error;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return fail(res, "Validation failed", 400);
+    }
+    if (error?.statusCode === 401) {
+      return fail(res, error.message, 401);
+    }
+    throw error;
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,34 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+// Demo in-memory store for staging/bounty API (not production-grade hashing).
+const usersByEmail = new Map();
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  usersByEmail.set(payload.email.toLowerCase(), {
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    password: payload.password
+  });
+  return {
+    id,
+    email: payload.email,
+    role: payload.role,
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const existing = usersByEmail.get(payload.email.toLowerCase());
+  if (!existing || existing.password !== payload.password) {
+    const error = new Error("Invalid credentials");
+    error.statusCode = 401;
+    throw error;
+  }
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: existing.email,
+    token: signAccessToken({ sub: existing.id, role: existing.role })
   };
 }
 

--- a/apps/api/src/tests/login-verify.test.js
+++ b/apps/api/src/tests/login-verify.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try { await run(server.address().port); }
+  finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("login rejects unknown user", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "missing@example.com", password: "password123" })
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test("login accepts registered credentials", async () => {
+  await withServer(async (port) => {
+    await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "ok@example.com",
+        password: "password123",
+        role: "client"
+      })
+    });
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "ok@example.com", password: "password123" })
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.token);
+  });
+});
+
+test("login rejects wrong password", async () => {
+  await withServer(async (port) => {
+    await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "pw@example.com",
+        password: "password123",
+        role: "client"
+      })
+    });
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "pw@example.com", password: "wrong-password" })
+    });
+    assert.equal(response.status, 401);
+  });
+});


### PR DESCRIPTION
## Summary
Adds in-memory credential check so login returns 401 for unknown/wrong passwords.

## Test plan
- [x] Focused regression tests added
- [x] npm test ×3 green in apps/api

Closes #11596

Made with [Cursor](https://cursor.com)