### PR TITLE
fix: rate limit before JSON body parser (closes #11592)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,8 +20,9 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  // rate limit BEFORE body parsing so malformed JSON still consumes quota
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/tests/rate-limit-order.test.js
+++ b/apps/api/src/tests/rate-limit-order.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("rate limiter runs before JSON body parser - malformed JSON still rate limited", async () => {
+  const app = createApp();
+  const mockReq = { method: "POST", url: "/api/test", headers: { "content-type": "application/json" }, body: {} };
+  const mockRes = { statusCode: 200, setHeader: () => {}, json: () => {}, end: () => {} };
+  const next = () => {};
+
+  // First request with malformed JSON should be counted by rate limiter
+  // (can't fully test rate limit without hitting the limit, but we verify order)
+  const middlewareStack = app._router.stack.map(l => l.handle.name || l.handle.toString().slice(0,50));
+  const limiterIdx = middlewareStack.findIndex(m => m.includes("apiLimiter") || m.includes("rateLimit"));
+  const parserIdx = middlewareStack.findIndex(m => m.includes("json") || m.includes("bodyParser"));
+  
+  assert.ok(limiterIdx >= 0, "rate limiter middleware present");
+  assert.ok(parserIdx >= 0, "JSON parser middleware present");
+  assert.ok(limiterIdx < parserIdx, "rate limiter must be before JSON parser");
+});


### PR DESCRIPTION
Closes #11592

Move `apiLimiter` above `express.json()` so malformed JSON bodies still consume rate-limit quota. Added middleware-order test.

/bounty