### PR TITLE
fix: require estimatedDuration in proposal creation (closes #11593)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,6 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const payload = createProposalSchema.parse(req.body);
+  return ok(res, await createProposal(payload), 201);
 }

--- a/apps/api/src/tests/proposal-validation.test.js
+++ b/apps/api/src/tests/proposal-validation.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposalSchema } from "../validators/proposal.js";
+
+test("createProposalSchema rejects missing estimatedDuration", () => {
+  const result = createProposalSchema.safeParse({
+    jobId: "job-1",
+    amount: 500,
+    description: "Will deliver the feature within the agreed timeline."
+  });
+  assert.equal(result.success, false);
+  assert.ok(result.error.issues.some(i => i.path.includes("estimatedDuration")));
+});
+
+test("createProposalSchema accepts valid estimatedDuration", () => {
+  const result = createProposalSchema.safeParse({
+    jobId: "job-1",
+    amount: 500,
+    description: "Will deliver the feature within the agreed timeline.",
+    estimatedDuration: 30
+  });
+  assert.equal(result.success, true);
+});
+
+test("createProposalSchema rejects non-positive estimatedDuration", () => {
+  const result = createProposalSchema.safeParse({
+    jobId: "job-1",
+    amount: 500,
+    description: "Will deliver the feature within the agreed timeline.",
+    estimatedDuration: -5
+  });
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  amount: z.number().positive(),
+  description: z.string().min(10),
+  estimatedDuration: z.number().positive("estimatedDuration must be greater than 0")
+});


### PR DESCRIPTION
Closes #11593

Add Zod validation requiring `estimatedDuration > 0` on proposal creation. Added 3 test cases.

/bounty