### PR TITLE
fix: reject admin role self-assignment during registration (closes #11591)

### DIFF
--- a/apps/api/src/tests/admin-role-reject.test.js
+++ b/apps/api/src/tests/admin-role-reject.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("registerSchema rejects admin role", () => {
+  const result = registerSchema.safeParse({
+    email: "admin@example.com",
+    password: "password123",
+    role: "admin"
+  });
+  assert.equal(result.success, false);
+});
+
+test("registerSchema accepts client role", () => {
+  const result = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "password123",
+    role: "client"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerSchema accepts freelancer role", () => {
+  const result = registerSchema.safeParse({
+    email: "freelancer@example.com",
+    password: "password123",
+    role: "freelancer"
+  });
+  assert.equal(result.success, true);
+});
+
+test("registerSchema defaults to client when role omitted", () => {
+  const result = registerSchema.safeParse({
+    email: "new@example.com",
+    password: "password123"
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.role, "client");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #11591

Remove 'admin' from registerSchema enum. Registration only allows client/freelancer. 4 tests added.

/bounty