### PR TITLE
fix: add auth middleware to POST /api/proposals, /api/reviews, /api/users (closes #2773, #2776, #2779)

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
 userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.post("/", authMiddleware, postUser);


### PR DESCRIPTION
## Changes
- Added `authMiddleware` to `POST /api/proposals` — was accepting unauthenticated proposal creation
- Added `authMiddleware` to `POST /api/reviews` — was accepting unauthenticated review creation  
- Added `authMiddleware` to `POST /api/users` — was accepting unauthenticated user creation

All three routes now require a valid Bearer token, matching the auth pattern used elsewhere in the codebase.

Closes #2773, closes #2776, closes #2779