### PR TITLE
fix: require auth for proposal creation

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposal-auth.test.js
+++ b/apps/api/src/tests/proposal-auth.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("proposal reads stay public while creation requires a valid token", async () => {
+  await withServer(async (baseUrl) => {
+    const publicResponse = await fetch(`${baseUrl}/api/proposals`);
+    const publicPayload = await publicResponse.json();
+
+    assert.equal(publicResponse.status, 200);
+    assert.equal(publicPayload.success, true);
+    assert.ok(Array.isArray(publicPayload.data));
+
+    const unauthenticatedResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Unauthenticated proposal" }),
+    });
+
+    assert.equal(unauthenticatedResponse.status, 401);
+    assert.deepEqual(await unauthenticatedResponse.json(), {
+      success: false,
+      message: "Unauthorized",
+    });
+
+    const invalidTokenResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer invalid-token",
+      },
+      body: JSON.stringify({ title: "Invalid-token proposal" }),
+    });
+
+    assert.equal(invalidTokenResponse.status, 401);
+    assert.deepEqual(await invalidTokenResponse.json(), {
+      success: false,
+      message: "Invalid token",
+    });
+
+    const title = `Authenticated proposal ${Date.now()}`;
+    const authenticatedResponse = await fetch(`${baseUrl}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${signAccessToken({ sub: "usr_test" })}`,
+      },
+      body: JSON.stringify({ title }),
+    });
+    const authenticatedPayload = await authenticatedResponse.json();
+
+    assert.equal(authenticatedResponse.status, 201);
+    assert.equal(authenticatedPayload.success, true);
+    assert.equal(authenticatedPayload.data.title, title);
+    assert.match(authenticatedPayload.data.id, /^prp_/);
+  });
+});


### PR DESCRIPTION
## Summary

- require the existing bearer-token middleware for `POST /api/proposals`
- keep `GET /api/proposals` publicly readable
- cover missing credentials, invalid tokens, authenticated creation, and public reads through the HTTP boundary

## Validation

- `node --test src/tests/*.test.js` (2 tests passed)
- `git diff --check`

The repository's existing `npm test` script passes the tests directory as a file target, which Node 25 rejects before discovering any test files. The explicit test-file glob above exercises the same complete test set without changing that out-of-scope script.

Closes #11618

Run-Id: `run-20260806T032443Z-misa3-securebanana-proposal-auth`
Trace-Id: `9e7beb80-8bca-41b1-bdc2-d3b067125a30`
Requester: Jun Discord sender_id `473730953735438336`
Implementer: MISA 3 bot ID `1516725819517567077`
