### PR TITLE
fix: forward native props from Card

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export function Card({ title, children, style, ...sectionProps }: React.HTMLAttributes<HTMLElement> & { title: string }) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...sectionProps}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Closes #11620
Parent bounty: #743

## Summary

- Extend Card props with native section attributes through React.HTMLAttributes<HTMLElement>.
- Forward caller attributes such as id, className, aria-*, and data-* to the rendered section.
- Merge caller-provided style after the defaults so individual defaults can be overridden while the remaining defaults stay intact.
- Keep the change limited to packages/ui/src/Card.tsx.

## Validation

- npx tsc --noEmit --jsx react-jsx --moduleResolution bundler --module esnext --target ES2022 --lib DOM,ES2022 --skipLibCheck --esModuleInterop packages/ui/src/Card.tsx
- node --test apps/api/src/tests/*.test.js (1 passed)
- npm run build -w apps/web
- git diff --check

The repository-level npm test script currently points Node at the src/tests directory instead of the test files; the direct test-file command passes.

/claim #743