### PR TITLE
fix: apply auth middleware to user creation endpoint

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
-import { Router } from "express";
-import { getUsers, postUser } from "../controllers/userController.js";
+import { Router } from 'express';
+import { getUsers, postUser } from '../controllers/userController.js';
+import { authMiddleware } from '../middleware/auth.js';
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
-userRoutes.post("/", postUser);
+userRoutes.get('/', getUsers);
+userRoutes.post('/', authMiddleware, postUser);

--- a/apps/api/tests/userRoutes.test.js
+++ b/apps/api/tests/userRoutes.test.js
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+import { authMiddleware } from '../../src/middleware/auth.js';
+
+describe('User routes authentication', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('should require authentication for POST /api/users', async () => {
+    const res = await request(app)
+      .post('/api/users')
+      .send({ username: 'test', password: 'pass' });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Unauthorized');
+  });
+
+  it('should allow authenticated users to create account', async () => {
+    // 假设已实现 JWT 认证模拟
+    const res = await request(app)
+      .post('/api/users')
+      .set('Authorization', 'Bearer valid_token')
+      .send({ username: 'test', password: 'pass' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('user');
+  });
+});


### PR DESCRIPTION
This PR addresses the security vulnerability by requiring authentication for user creation endpoint. Added authMiddleware to POST /api/users route and corresponding unit tests to validate the authentication mechanism.

Closes #2779