### PR TITLE
fix: add authentication to payment route

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
-import { Router } from "express";
-import { createPayment } from "../controllers/paymentController.js";
+import { Router } from 'express';
+import { createPayment } from '../controllers/paymentController.js';
+import authMiddleware from '../middleware/auth.js';
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post('/', authMiddleware, createPayment);

--- a/apps/api/tests/routes/payment.test.js
+++ b/apps/api/tests/routes/payment.test.js
@@ -1,0 +1,32 @@
+import request from 'supertest';
+import { createApp } from '../../src/app.js';
+import { createPayment } from '../../src/controllers/paymentController.js';
+import { authMiddleware } from '../../src/middleware/auth.js';
+
+describe('Payment Routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('should require authentication for /api/payments', async () => {
+    const res = await request(app)
+      .post('/api/payments')
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error', 'Unauthorized');
+  });
+
+  it('should allow authenticated users to create payment', async () => {
+    // 模拟认证信息
+    const res = await request(app)
+      .post('/api/payments')
+      .set('Authorization', 'Bearer valid_token')
+      .send({ amount: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('paymentIntent');
+  });
+});


### PR DESCRIPTION
Implement authentication middleware for /api/payments route to prevent unauthorized access to payment functionality. Added corresponding unit tests to verify the authentication requirement.

Closes #1772