### PR TITLE
fix: Add authentication to upload route

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
-import { Router } from "express";
-import multer from "multer";
-import { uploadFile } from "../controllers/uploadController.js";
+import { Router } from 'express';
+import multer from 'multer';
+import { uploadFile } from '../controllers/uploadController.js';
+import { authMiddleware } from '../middleware/auth.js';
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post('/', authMiddleware, upload.single('file'), uploadFile);

--- a/apps/api/tests/upload.test.js
+++ b/apps/api/tests/upload.test.js
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import app from '../../src/app.js';
+import { authRoutes } from '../../src/routes/authRoutes.js';
+import { uploadRoutes } from '../../src/routes/uploadRoutes.js';
+import { authMiddleware } from '../../src/middleware/auth.js';
+import { registerUser, loginUser } from '../../src/controllers/authController.js';
+import { uploadFile } from '../../src/controllers/uploadController.js';
+
+describe('Upload Routes', () => {
+  beforeEach(() => {
+    app.use('/api/auth', authRoutes);
+    app.use('/api/uploads', uploadRoutes);
+  });
+
+  it('should require authentication for upload', async () => {
+    const res = await request(app).post('/api/uploads').field('file', 'test.txt');
+    expect(res.status).toBe(401);
+  });
+
+  it('should allow authenticated upload', async () => {
+    // 先注册用户
+    const registerRes = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'password' });
+
+    // 获取登录凭证
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password' });
+
+    // 使用有效token进行上传
+    const res = await request(app)
+      .post('/api/uploads')
+      .set('Authorization', `Bearer ${loginRes.body.token}`)
+      .field('file', 'test.txt');
+    
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe('uploaded');
+  });
+});


### PR DESCRIPTION
Add authMiddleware to /api/uploads route to require authentication for file uploads. Also added test cases to verify the authentication requirement.

Closes #1771