### PR TITLE
fix: add admin role verification to admin routes

### DIFF
--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,18 @@
-import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { Router } from 'express';
+import { metrics } from '../controllers/adminController.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { fail } from '../utils/response.js';
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
-adminRoutes.get("/metrics", metrics);
+
+// 管理员角色验证中间件
+adminRoutes.use((req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    return next();
+  }
+  return fail(res, 'Unauthorized', 403);
+});
+
+adminRoutes.get('/metrics', metrics);


### PR DESCRIPTION
Add role-based authorization check to ensure only admin users can access /api/admin/metrics endpoint

Closes #1764