### PR TITLE
fix: add authentication to payment route

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
-import { Router } from "express";
-import { createPayment } from "../controllers/paymentController.js";
+import { Router } from 'express';
+import { createPayment } from '../controllers/paymentController.js';
+import authMiddleware from '../middleware/auth.js';
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post('/', authMiddleware, createPayment);

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const app = require('../../apps/api/src/app.js');
+const { createApp } = require('../../apps/api/src/app');
+const { verifyAccessToken } = require('../../apps/api/src/utils/jwt');
+
+describe('Payment Routes', () => {
+  let server;
+
+  beforeEach(() => {
+    server = createApp();
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('should require authentication for payment creation', async () => {
+    const response = await request(server).post('/api/payments').send({ amount: 100 });
+    expect(response.status).toBe(401);
+    expect(response.body).toHaveProperty('error', 'Unauthorized');
+  });
+
+  it('should allow authenticated users to create payments', async () => {
+    const mockUser = { id: '123' };
+    const mockToken = 'mock.jwt.token';
+    
+    // 模拟认证中间件通过
+    const response = await request(server)
+      .post('/api/payments')
+      .set('Authorization', `Bearer ${mockToken}`)
+      .send({ amount: 100 });
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('paymentIntent');
+  });
+});


### PR DESCRIPTION
Add authMiddleware to /api/payments route to prevent unauthorized access to payment creation functionality. This addresses the high-impact security vulnerability where financial operations could be initiated by any user.

Closes #1772