### PR TITLE
fix(api): require auth for uploads

### DIFF
--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads rejects unauthenticated requests before processing the file", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const form = new FormData();
+  form.append("file", new Blob(["test content"], { type: "text/plain" }), "test.txt");
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: form
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(payload, { success: false, message: "Unauthorized" });
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

- Require authMiddleware before multipart parsing on POST /api/uploads.
- Add regression coverage proving unauthenticated uploads return 401 Unauthorized.

## Validation

- node --test src/tests/health.test.js src/tests/upload.test.js — 2 passed
- git diff --check — passed

## Related issue

Closes #11634

/claim #743

The change is intentionally limited to the upload route and its regression test. The test exercises a real multipart request against the Express app and verifies that authentication rejects it before file processing.