### PR TITLE
fix: reject inverted job budget ranges

### DIFF
--- a/apps/api/src/tests/job.validation.test.js
+++ b/apps/api/src/tests/job.validation.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+const validJob = {
+  title: "Backend API work",
+  description: "Implement ordered budget validation coverage.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "backend",
+  skills: ["node", "zod"]
+};
+
+test("createJobSchema accepts ordered budget ranges", () => {
+  const parsed = createJobSchema.parse(validJob);
+
+  assert.equal(parsed.budgetMin, 100);
+  assert.equal(parsed.budgetMax, 500);
+});
+
+test("createJobSchema rejects inverted budget ranges", () => {
+  assert.throws(
+    () =>
+      createJobSchema.parse({
+        ...validJob,
+        budgetMin: 500,
+        budgetMax: 100
+      }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema rejects inverted ranges when both budget fields are present", () => {
+  assert.throws(
+    () =>
+      updateJobSchema.parse({
+        budgetMin: 750,
+        budgetMax: 250
+      }),
+    /budgetMax must be greater than or equal to budgetMin/
+  );
+});
+
+test("updateJobSchema allows partial updates without both budget fields", () => {
+  const parsed = updateJobSchema.parse({ budgetMin: 250 });
+
+  assert.equal(parsed.budgetMin, 250);
+  assert.equal(parsed.budgetMax, undefined);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,20 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+function validateBudgetOrder(payload, ctx) {
+  if (
+    typeof payload.budgetMin === "number" &&
+    typeof payload.budgetMax === "number" &&
+    payload.budgetMax < payload.budgetMin
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["budgetMax"],
+      message: "budgetMax must be greater than or equal to budgetMin"
+    });
+  }
+}
+
+const baseJobSchema = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +23,6 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = baseJobSchema.superRefine(validateBudgetOrder);
+
+export const updateJobSchema = baseJobSchema.partial().superRefine(validateBudgetOrder);


### PR DESCRIPTION
## Summary
- reject job payloads where `budgetMax` is lower than `budgetMin`
- apply the same ordered-range check to partial update payloads when both fields are present
- add regression tests for valid create payloads, inverted create/update ranges, and partial updates

Closes #11639

## Test plan
- [x] `npm test -w apps/api`