### PR TITLE
fix: reject uploads without a file

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  return {
+    port,
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  };
+}
+
+test("POST /api/uploads rejects requests without a file", async () => {
+  const server = await startServer();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/uploads`, {
+      method: "POST",
+      body: new FormData()
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "File is required"
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /api/uploads accepts multipart file uploads", async () => {
+  const server = await startServer();
+
+  try {
+    const form = new FormData();
+    form.append("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(payload, {
+      success: true,
+      data: {
+        filename: "hello.txt",
+        status: "uploaded"
+      }
+    });
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- return a 400 error when the upload route is called without a multipart file
- keep the existing 201 upload response for valid file submissions
- add route regression coverage for missing-file and successful upload requests

Closes #11641

## Test plan
- [x] `npm test -w apps/api`