### PR TITLE
fix(sec): add adminMiddleware role check on admin routes (#11362)

### DIFF
--- a/apps/api/src/middleware/admin.test.js
+++ b/apps/api/src/middleware/admin.test.js
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { adminMiddleware } from "./auth.js";
+
+test("adminMiddleware returns 403 Forbidden for non-admin user role", () => {
+  let statusCode = 0;
+  let responseData = null;
+  let nextCalled = false;
+
+  const req = { user: { role: "client" } };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(data) {
+      responseData = data;
+      return this;
+    },
+  };
+  const next = () => { nextCalled = true; };
+
+  adminMiddleware(req, res, next);
+
+  assert.equal(statusCode, 403, "Status code must be 403 Forbidden");
+  assert.equal(nextCalled, false, "next() must not be called when role is not admin");
+});
+
+test("adminMiddleware calls next() for user with admin role", () => {
+  let nextCalled = false;
+  const req = { user: { role: "admin" } };
+  const res = {};
+  const next = () => { nextCalled = true; };
+
+  adminMiddleware(req, res, next);
+  assert.equal(nextCalled, true, "next() must be called for admin role");
+});

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Resolves #11362 (refs #743).

Adds adminMiddleware in apps/api/src/middleware/auth.js and applies it to adminRoutes to enforce req.user.role === 'admin' with HTTP 403 Forbidden on unauthorized attempts, backed by unit test suite in apps/api/src/middleware/admin.test.js.