### PR TITLE
fix(sec): apply authMiddleware to userRoutes router (#11396)

### DIFF
--- a/apps/api/src/routes/user-auth.test.js
+++ b/apps/api/src/routes/user-auth.test.js
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { userRoutes } from "./userRoutes.js";
+
+test("userRoutes has authMiddleware mounted", () => {
+  assert.ok(userRoutes.stack.length > 0, "userRoutes stack must contain middleware");
+  const hasAuthMiddleware = userRoutes.stack.some((layer) => layer.handle?.name === "authMiddleware");
+  assert.equal(hasAuthMiddleware, true, "userRoutes router must include authMiddleware layer");
+});

--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
+userRoutes.use(authMiddleware);
 userRoutes.get("/", getUsers);
 userRoutes.post("/", postUser);


### PR DESCRIPTION
Resolves #11396 (refs #743).

Applies authMiddleware in apps/api/src/routes/userRoutes.js to require JWT authentication for /api/users endpoints, preventing unauthenticated user enumeration and creation, backed by unit test suite in apps/api/src/routes/user-auth.test.js.