### PR TITLE
fix(auth): normalize invalid request bodies to HTTP 400 response (#11394)

### DIFF
--- a/apps/api/src/controllers/auth-payload-validation.test.js
+++ b/apps/api/src/controllers/auth-payload-validation.test.js
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { register, login } from "./authController.js";
+
+test("register returns 400 Bad Request for invalid payload", async () => {
+  let statusCode = 0;
+  let responseData = null;
+
+  const req = { body: { email: "not-an-email" } };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(data) {
+      responseData = data;
+      return this;
+    },
+  };
+
+  await register(req, res);
+
+  assert.equal(statusCode, 400, "Invalid register payload must return HTTP 400");
+  assert.equal(responseData?.error, "Invalid payload", "Error message must indicate invalid payload");
+});
+
+test("login returns 400 Bad Request for invalid payload", async () => {
+  let statusCode = 0;
+  let responseData = null;
+
+  const req = { body: {} };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(data) {
+      responseData = data;
+      return this;
+    },
+  };
+
+  await login(req, res);
+
+  assert.equal(statusCode, 400, "Invalid login payload must return HTTP 400");
+  assert.equal(responseData?.error, "Invalid payload", "Error message must indicate invalid payload");
+});

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,31 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (err) {
+    if (err?.name === "ZodError" || err?.errors) {
+      return fail(res, "Invalid payload", 400);
+    }
+    throw err;
+  }
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err?.name === "ZodError" || err?.errors) {
+      return fail(res, "Invalid payload", 400);
+    }
+    throw err;
+  }
 }
 
 export async function oauthCallback(req, res) {


### PR DESCRIPTION
Resolves #11394 (refs #743).

Catches ZodError payload validation failures in register and login handlers in apps/api/src/controllers/authController.js and returns HTTP 400 Bad Request instead of unhandled 500 errors, backed by unit test suite in apps/api/src/controllers/auth-payload-validation.test.js.