### PR TITLE
fix(payment): apply authMiddleware to POST /api/payments endpoint (#11606)

### DIFF
--- a/apps/api/src/routes/payment-auth.test.js
+++ b/apps/api/src/routes/payment-auth.test.js
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { paymentRoutes } from "./paymentRoutes.js";
+
+test("paymentRoutes applies authMiddleware requiring JWT token", async () => {
+  let middlewareCalled = false;
+  let statusSet = 0;
+
+  const req = { headers: {} };
+  const res = {
+    status(code) {
+      statusSet = code;
+      return this;
+    },
+    json(data) {
+      return this;
+    },
+  };
+
+  const next = () => {
+    middlewareCalled = true;
+  };
+
+  // Find authMiddleware layer in stack
+  const authLayer = paymentRoutes.stack.find((layer) => layer.name === "authMiddleware" || layer.handle?.name === "authMiddleware");
+  assert.ok(authLayer, "paymentRoutes must include authMiddleware layer");
+
+  await authLayer.handle(req, res, next);
+
+  assert.equal(statusSet, 401, "Unauthenticated request to paymentRoutes must return HTTP 401 Unauthorized");
+  assert.equal(middlewareCalled, false, "next() must not be called without valid authorization header");
+});

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);


### PR DESCRIPTION
Resolves #11606 (refs #11398).

Applies authMiddleware to paymentRoutes router in apps/api/src/routes/paymentRoutes.js to require JWT authorization for POST /api/payments, backed by unit test suite in apps/api/src/routes/payment-auth.test.js.