### PR TITLE
fix(auth): prevent admin role self-assignment during registration (#11591)

### DIFF
--- a/apps/api/src/validators/admin-role-prevent.test.js
+++ b/apps/api/src/validators/admin-role-prevent.test.js
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "./auth.js";
+
+test("registerSchema permits client and freelancer roles", () => {
+  const clientRes = registerSchema.safeParse({
+    email: "user@example.com",
+    password: "password123",
+    role: "client",
+  });
+  assert.equal(clientRes.success, true, "client role must be allowed");
+
+  const freelancerRes = registerSchema.safeParse({
+    email: "dev@example.com",
+    password: "password123",
+    role: "freelancer",
+  });
+  assert.equal(freelancerRes.success, true, "freelancer role must be allowed");
+});
+
+test("registerSchema rejects admin role self-assignment", () => {
+  const adminRes = registerSchema.safeParse({
+    email: "attacker@example.com",
+    password: "password123",
+    role: "admin",
+  });
+  assert.equal(adminRes.success, false, "admin role self-assignment during registration must be rejected");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Resolves #11591 (refs #743).

Restricts registerSchema role enum in apps/api/src/validators/auth.js to ['client', 'freelancer'], rejecting admin role self-assignment during registration with HTTP 400 Bad Request, backed by unit test suite in apps/api/src/validators/admin-role-prevent.test.js.