### PR TITLE
Fix errorHandler to return Zod validation error details

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,14 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
+  if (err instanceof ZodError) {
+    return res.status(422).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);


### PR DESCRIPTION
Fixes #11398 (part) — global errorHandler now catches ZodError and returns 422 with field-level validation details instead of generic 500.

Changes:
- Import ZodError from zod
- Add instanceof check in errorHandler
- Return 422 with structured validation errors

/bounty 80