### PR TITLE
fix(sec): require authMiddleware for proposal creation without restricting reads (#11618)

### DIFF
--- a/apps/api/src/routes/proposal-auth.test.js
+++ b/apps/api/src/routes/proposal-auth.test.js
@@ -1,0 +1,16 @@
+import request from "supertest";
+import { app } from "../app.js";
+
+describe("Proposal Creation Auth Requirement (#11618)", () => {
+  it("GET /api/proposals should allow public reads without auth", async () => {
+    const res = await request(app).get("/api/proposals");
+    expect(res.status).not.toBe(401);
+  });
+
+  it("POST /api/proposals should return 401 unauthenticated", async () => {
+    const res = await request(app)
+      .post("/api/proposals")
+      .send({ title: "Test Proposal", description: "Desc", budget: 100 });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);


### PR DESCRIPTION
Resolves #11618 /claim #11618.

Requires \uthMiddleware\ on POST \/api/proposals\ endpoint in \pps/api/src/routes/proposalRoutes.js\ while preserving public GET read access, backed by unit test suite in \pps/api/src/routes/proposal-auth.test.js\.