### PR TITLE
fix(sec): apply authMiddleware to GET /api/users endpoint (#11595)

### DIFF
--- a/apps/api/src/routes/userRoutes.js
+++ b/apps/api/src/routes/userRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getUsers, postUser } from "../controllers/userController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const userRoutes = Router();
 
-userRoutes.get("/", getUsers);
+userRoutes.get("/", authMiddleware, getUsers);
 userRoutes.post("/", postUser);

--- a/apps/api/src/routes/users-get-auth.test.js
+++ b/apps/api/src/routes/users-get-auth.test.js
@@ -1,0 +1,9 @@
+import request from "supertest";
+import { app } from "../app.js";
+
+describe("GET /api/users Auth Protection (#11595)", () => {
+  it("GET /api/users should return 401 unauthenticated", async () => {
+    const res = await request(app).get("/api/users");
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Resolves #11595 /claim #11595.

Applies \uthMiddleware\ to GET \/api/users\ in \pps/api/src/routes/userRoutes.js\ preventing unauthenticated user list exposure, backed by unit test suite in \pps/api/src/routes/users-get-auth.test.js\.