### PR TITLE
fix(sec): enforce adminMiddleware check on admin metrics endpoint (#11590)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function adminMiddleware(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/admin-rbac.test.js
+++ b/apps/api/src/routes/admin-rbac.test.js
@@ -1,0 +1,9 @@
+import request from "supertest";
+import { app } from "../app.js";
+
+describe("Admin Metrics RBAC Authorization (#11590)", () => {
+  it("GET /api/admin/metrics should return 401 unauthenticated", async () => {
+    const res = await request(app).get("/api/admin/metrics");
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, adminMiddleware } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);


### PR DESCRIPTION
Resolves #11590 /claim #11590.

Adds \dminMiddleware\ RBAC check to \pps/api/src/middleware/auth.js\ and applies it to \pps/api/src/routes/adminRoutes.js\, backed by unit test suite in \pps/api/src/routes/admin-rbac.test.js\.