### PR TITLE
fix(proposal): enforce required estimatedDuration validation on proposal creation (#11593)

### DIFF
--- a/apps/api/src/services/proposal-duration.test.js
+++ b/apps/api/src/services/proposal-duration.test.js
@@ -1,0 +1,13 @@
+import { createProposal } from "./proposalService.js";
+
+describe("Proposal Creation Estimated Duration Requirement (#11593)", () => {
+  it("should reject proposals missing estimatedDuration", async () => {
+    await expect(createProposal({ title: "Test Proposal", budget: 500 })).rejects.toThrow();
+  });
+
+  it("should accept proposals with valid estimatedDuration", async () => {
+    const res = await createProposal({ title: "Test Proposal", budget: 500, estimatedDuration: 10 });
+    expect(res.id).toBeDefined();
+    expect(res.estimatedDuration).toBe(10);
+  });
+});

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -5,7 +5,14 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const duration = payload?.estimatedDuration ?? payload?.duration;
+  if (duration === undefined || duration === null || typeof duration !== "number" || duration <= 0) {
+    const error = new Error("estimatedDuration is required and must be a positive number");
+    error.status = 400;
+    throw error;
+  }
+
+  const proposal = { id: `prp_${Date.now()}`, ...payload, estimatedDuration: duration };
   proposals.push(proposal);
   return proposal;
 }


### PR DESCRIPTION
Resolves #11593 /claim #11593.

Enforces required \estimatedDuration\ positive number validation in \pps/api/src/services/proposalService.js\ rejecting records missing duration with 400 error, backed by unit test suite in \pps/api/src/services/proposal-duration.test.js\.