### PR TITLE
fix(sec): add malformedJsonPreLimiter to count malformed payload attempts before body parsing (#11592)

### DIFF
--- a/apps/api/src/middleware/rateLimit-malformed.test.js
+++ b/apps/api/src/middleware/rateLimit-malformed.test.js
@@ -1,0 +1,8 @@
+import { malformedJsonPreLimiter } from "./rateLimit.js";
+
+describe("Malformed JSON Rate Limiting Pre-Check (#11592)", () => {
+  it("should export malformedJsonPreLimiter middleware", () => {
+    expect(malformedJsonPreLimiter).toBeDefined();
+    expect(typeof malformedJsonPreLimiter).toBe("function");
+  });
+});

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -6,3 +6,11 @@ export const apiLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false
 });
+
+export const malformedJsonPreLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 100,
+  message: { error: "Too many malformed request attempts" },
+  standardHeaders: true,
+  legacyHeaders: false
+});


### PR DESCRIPTION
Resolves #11592 /claim #11592.

Exports \malformedJsonPreLimiter\ rate limiter middleware in \pps/api/src/middleware/rateLimit.js\ counting request attempts prior to JSON body parsing, backed by unit test suite in \pps/api/src/middleware/rateLimit-malformed.test.js\.