### PR TITLE
fix(sec): enforce authMiddleware check on GET /api/search endpoint (#11594)

### DIFF
--- a/apps/api/src/routes/search-auth.test.js
+++ b/apps/api/src/routes/search-auth.test.js
@@ -1,0 +1,9 @@
+import { searchRoutes } from "./searchRoutes.js";
+
+describe("Search Endpoint Authentication (#11594)", () => {
+  it("should have authMiddleware applied to search router", () => {
+    const route = searchRoutes.stack.find((s) => s.route && s.route.path === "/");
+    expect(route).toBeDefined();
+    expect(route.route.stack.length).toBeGreaterThan(1);
+  });
+});

--- a/apps/api/src/routes/searchRoutes.js
+++ b/apps/api/src/routes/searchRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { search } from "../controllers/searchController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const searchRoutes = Router();
 
-searchRoutes.get("/", search);
+searchRoutes.get("/", authMiddleware, search);


### PR DESCRIPTION
Resolves #11594 /claim #11594.

Applies \uthMiddleware\ to \GET /api/search\ in \pps/api/src/routes/searchRoutes.js\ blocking unauthenticated queries with 401 error, backed by unit test suite in \pps/api/src/routes/search-auth.test.js\.