### PR TITLE
fix(sec): enforce role validation on user role updates (#11597)

### DIFF
--- a/apps/api/src/services/user-role-verification.test.js
+++ b/apps/api/src/services/user-role-verification.test.js
@@ -1,0 +1,14 @@
+import { createUser, updateUserRole } from "./userService.js";
+
+describe("User Role Update Verification (#11597)", () => {
+  it("should reject invalid user roles", async () => {
+    const user = await createUser({ email: "test@example.com", role: "client" });
+    await expect(updateUserRole(user.id, "supergod")).rejects.toThrow();
+  });
+
+  it("should update valid user role", async () => {
+    const user = await createUser({ email: "test2@example.com", role: "client" });
+    const updated = await updateUserRole(user.id, "admin");
+    expect(updated.role).toBe("admin");
+  });
+});

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -9,3 +9,22 @@ export async function createUser(payload) {
   users.push(user);
   return user;
 }
+
+export async function updateUserRole(userId, newRole) {
+  const ALLOWED_ROLES = ["client", "freelancer", "admin"];
+  if (!newRole || typeof newRole !== "string" || !ALLOWED_ROLES.includes(newRole.toLowerCase())) {
+    const error = new Error(`Invalid role. Allowed roles are: ${ALLOWED_ROLES.join(", ")}`);
+    error.status = 400;
+    throw error;
+  }
+
+  const user = users.find((u) => u.id === userId);
+  if (!user) {
+    const error = new Error("User not found");
+    error.status = 404;
+    throw error;
+  }
+
+  user.role = newRole.toLowerCase();
+  return user;
+}


### PR DESCRIPTION
Resolves #11597 /claim #11597.

Adds \updateUserRole\ in \pps/api/src/services/userService.js\ enforcing strict role enum validation (\client\, \reelancer\, \dmin\) with 400 error, backed by unit test suite in \pps/api/src/services/user-role-verification.test.js\.