### PR TITLE
fix(billing): reject negative or zero pricing values in payment intent creation (#11604)

### DIFF
--- a/apps/api/src/services/payment-positive-amount.test.js
+++ b/apps/api/src/services/payment-positive-amount.test.js
@@ -1,0 +1,14 @@
+import { createPaymentIntent } from "./paymentService.js";
+
+describe("Proposal Billing Positive Pricing Requirement (#11604)", () => {
+  it("should reject negative or zero payment amounts", async () => {
+    await expect(createPaymentIntent({ amount: -50 })).rejects.toThrow();
+    await expect(createPaymentIntent({ amount: 0 })).rejects.toThrow();
+  });
+
+  it("should accept valid positive payment amount", async () => {
+    const res = await createPaymentIntent({ amount: 100, currency: "usd" });
+    expect(res.paymentId).toBeDefined();
+    expect(res.amount).toBe(100);
+  });
+});

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,4 +1,10 @@
 export async function createPaymentIntent(payload) {
+  if (payload?.amount === undefined || payload?.amount === null || typeof payload.amount !== "number" || payload.amount <= 0) {
+    const error = new Error("Payment amount must be a positive number greater than zero");
+    error.status = 400;
+    throw error;
+  }
+
   // TODO: integrate Stripe SDK and return client secret.
   return {
     paymentId: `pay_${Date.now()}`,


### PR DESCRIPTION
Resolves #11604 /claim #11604.

Enforces positive pricing amount validation in \pps/api/src/services/paymentService.js\ rejecting zero or negative amounts with 400 error, backed by unit test suite in \pps/api/src/services/payment-positive-amount.test.js\.