### PR TITLE
fix(upload): reject upload requests missing file payload with 400 error (#11641)

### DIFF
--- a/apps/api/src/controllers/upload-file-required.test.js
+++ b/apps/api/src/controllers/upload-file-required.test.js
@@ -1,0 +1,14 @@
+import { uploadFile } from "./uploadController.js";
+
+describe("Upload File Requirement (#11641)", () => {
+  it("should return 400 when req.file is missing", async () => {
+    const req = {};
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await uploadFile(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,16 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({
+      success: false,
+      error: "No file uploaded. A valid file payload is required."
+    });
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    size: req.file.size,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Resolves #11641 /claim #11641.

Rejects upload requests missing \eq.file\ payload in \pps/api/src/controllers/uploadController.js\ with 400 error, backed by unit test suite in \pps/api/src/controllers/upload-file-required.test.js\.