### PR TITLE
fix(val): reject inverted job budget ranges (budgetMin > budgetMax) (#11639)

### DIFF
--- a/apps/api/src/validators/job-budget-range.test.js
+++ b/apps/api/src/validators/job-budget-range.test.js
@@ -1,0 +1,29 @@
+import { createJobSchema } from "./job.js";
+
+describe("Job Budget Range Inversion Validation (#11639)", () => {
+  it("should reject inverted budget ranges where budgetMin > budgetMax", () => {
+    const res = createJobSchema.safeParse({
+      title: "Fullstack Developer Required",
+      description: "Build robust API integration and frontend components.",
+      budgetMin: 1000,
+      budgetMax: 500,
+      categoryId: "cat_dev",
+      skills: ["javascript"]
+    });
+
+    expect(res.success).toBe(false);
+  });
+
+  it("should accept valid non-inverted budget ranges", () => {
+    const res = createJobSchema.safeParse({
+      title: "Fullstack Developer Required",
+      description: "Build robust API integration and frontend components.",
+      budgetMin: 500,
+      budgetMax: 1000,
+      categoryId: "cat_dev",
+      skills: ["javascript"]
+    });
+
+    expect(res.success).toBe(true);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin cannot exceed budgetMax",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Resolves #11639 /claim #11639.

Adds \udgetMin <= budgetMax\ refinement to \createJobSchema\ in \pps/api/src/validators/job.js\ rejecting inverted budget ranges with validation error, backed by unit test suite in \pps/api/src/validators/job-budget-range.test.js\.