### PR TITLE
fix(sec): enforce authMiddleware check on POST /api/jobs endpoint (#11589)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getJobs, postJob } from "../controllers/jobController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/jobs-post-auth.test.js
+++ b/apps/api/src/routes/jobs-post-auth.test.js
@@ -1,0 +1,9 @@
+import { jobRoutes } from "./jobRoutes.js";
+
+describe("Job Creation Endpoint Authentication (#11589)", () => {
+  it("should have authMiddleware applied to POST /api/jobs route", () => {
+    const postRoute = jobRoutes.stack.find((s) => s.route && s.route.path === "/" && s.route.methods.post);
+    expect(postRoute).toBeDefined();
+    expect(postRoute.route.stack.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Resolves #11589 /claim #11589.

Applies \uthMiddleware\ to \POST /api/jobs\ in \pps/api/src/routes/jobRoutes.js\ blocking unauthenticated job postings with 401 error, backed by unit test suite in \pps/api/src/routes/jobs-post-auth.test.js\.