### PR TITLE
fix(sec): enforce authMiddleware check on POST /api/messages endpoint (#11587)

### DIFF
--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getMessages, postMessage } from "../controllers/messageController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/messages-post-auth.test.js
+++ b/apps/api/src/routes/messages-post-auth.test.js
@@ -1,0 +1,9 @@
+import { messageRoutes } from "./messageRoutes.js";
+
+describe("Message Endpoint Authentication (#11587)", () => {
+  it("should have authMiddleware applied to POST /api/messages route", () => {
+    const postRoute = messageRoutes.stack.find((s) => s.route && s.route.path === "/" && s.route.methods.post);
+    expect(postRoute).toBeDefined();
+    expect(postRoute.route.stack.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Resolves #11587 /claim #11587.

Applies \uthMiddleware\ to \POST /api/messages\ in \pps/api/src/routes/messageRoutes.js\ blocking unauthenticated message postings with 401 error, backed by unit test suite in \pps/api/src/routes/messages-post-auth.test.js\.