### PR TITLE
fix(val): add createUserSchema Zod validation for user creation endpoint (#11575)

### DIFF
--- a/apps/api/src/validators/user-creation-validation.test.js
+++ b/apps/api/src/validators/user-creation-validation.test.js
@@ -1,0 +1,23 @@
+import { createUserSchema } from "./user.js";
+
+describe("User Creation Input Validation (#11575)", () => {
+  it("should reject invalid email and short name", () => {
+    const res = createUserSchema.safeParse({
+      name: "A",
+      email: "invalid-email-format",
+      role: "freelancer"
+    });
+
+    expect(res.success).toBe(false);
+  });
+
+  it("should accept valid user creation payload", () => {
+    const res = createUserSchema.safeParse({
+      name: "John Doe",
+      email: "john@example.com",
+      role: "client"
+    });
+
+    expect(res.success).toBe(true);
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createUserSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+  email: z.string().email("Must be a valid email address"),
+  role: z.enum(["client", "freelancer", "admin"]).default("client")
+});
+
+export const updateUserSchema = createUserSchema.partial();


### PR DESCRIPTION
Resolves #11575 /claim #11575.

Adds \createUserSchema\ in \pps/api/src/validators/user.js\ enforcing name, email, and role enum validation, backed by unit test suite in \pps/api/src/validators/user-creation-validation.test.js\.