### PR TITLE
fix(api): reject upload requests missing file payload with 400 error (#11654)

### DIFF
--- a/apps/api/src/controllers/upload-without-file-rejection.test.js
+++ b/apps/api/src/controllers/upload-without-file-rejection.test.js
@@ -1,0 +1,14 @@
+import { uploadFile } from "./uploadController.js";
+
+describe("Upload Without File Rejection (#11654)", () => {
+  it("should return 400 when req.file is missing", async () => {
+    const req = {};
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await uploadFile(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,15 @@
 import { ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return res.status(400).json({
+      success: false,
+      error: "No file uploaded. A valid file payload is required."
+    });
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }


### PR DESCRIPTION
Resolves #11654 /claim #11654.

Rejects upload requests missing \eq.file\ payload in \pps/api/src/controllers/uploadController.js\ with 400 error, backed by unit test suite in \pps/api/src/controllers/upload-without-file-rejection.test.js\.