### PR TITLE
fix(val): reject inverted job budget ranges (budgetMin > budgetMax) (#11637)

### DIFF
--- a/apps/api/src/validators/job-budget-range-reissue.test.js
+++ b/apps/api/src/validators/job-budget-range-reissue.test.js
@@ -1,0 +1,16 @@
+import { createJobSchema } from "./job.js";
+
+describe("Job Budget Range Validation Reissue (#11637)", () => {
+  it("should reject inverted budget ranges where budgetMin > budgetMax", () => {
+    const res = createJobSchema.safeParse({
+      title: "Senior Backend Developer",
+      description: "Build robust Node.js microservices and REST API routes.",
+      budgetMin: 2000,
+      budgetMax: 1000,
+      categoryId: "cat_backend",
+      skills: ["nodejs"]
+    });
+
+    expect(res.success).toBe(false);
+  });
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -7,6 +7,9 @@ export const createJobSchema = z.object({
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
+}).refine((data) => data.budgetMin <= data.budgetMax, {
+  message: "budgetMin cannot exceed budgetMax",
+  path: ["budgetMax"]
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Resolves #11637 /claim #11637.

Adds \udgetMin <= budgetMax\ refinement to \createJobSchema\ in \pps/api/src/validators/job.js\ rejecting inverted budget ranges with validation error, backed by unit test suite in \pps/api/src/validators/job-budget-range-reissue.test.js\.