### PR TITLE
feat(ui): add Card component with native section props forwarding (#11715)

### DIFF
--- a/packages/ui/src/Card.test.tsx
+++ b/packages/ui/src/Card.test.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Card } from "./Card";
+
+describe("Card Component HTML Props Forwarding (#11620)", () => {
+  it("should export Card component function", () => {
+    expect(typeof Card).toBe("function");
+  });
+});

--- a/packages/ui/src/Card.test.tsx
+++ b/packages/ui/src/Card.test.tsx
@@ -1,8 +1,22 @@
 import React from "react";
 import { Card } from "./Card";
 
-describe("Card Component HTML Props Forwarding (#11620)", () => {
+describe("Card Component HTML Props Forwarding (#11715)", () => {
   it("should export Card component function", () => {
     expect(typeof Card).toBe("function");
+  });
+
+  it("should forward section props including className and aria attributes", () => {
+    const element = Card({
+      title: "Test Card",
+      children: "Card Content",
+      className: "custom-card",
+      "aria-label": "Card Section",
+    });
+
+    expect(element.type).toBe("section");
+    expect(element.props.title).toBeUndefined();
+    expect(element.props.className).toBe("custom-card");
+    expect(element.props["aria-label"]).toBe("Card Section");
   });
 });

--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+export interface CardProps extends React.HTMLAttributes<HTMLElement> {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+      {...props}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Resolves #11715 /claim #11715.

Ensures \Card\ UI component in \packages/ui/src/Card.tsx\ forwards all native HTML section element props (\className\, \ria-label\, event handlers), backed by unit test suite in \packages/ui/src/Card.test.tsx\.