### PR TITLE
Require JWT_SECRET in production (reissue #743)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,10 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: (() => {
+    if (process.env.NODE_ENV === "production" && !process.env.JWT_SECRET) throw new Error("JWT_SECRET is required in production");
+    return process.env.JWT_SECRET ?? "development-secret";
+  })(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
Fixes reissue #11726 for SecureBananaLabs/bug-bounty#743 — require JWT_SECRET in production, otherwise throw. Closes #11726. Parent bounty #743 80, original #8693. Diff: env.js jwtSecret guard.