### PR TITLE
fix(auth): prevent public admin privilege escalation

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,11 +1,19 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
-  return ok(res, result, 201);
+  try {
+    const payload = registerSchema.parse(req.body);
+    const result = await registerUser(payload);
+    return ok(res, result, 201);
+  } catch (error) {
+    if (error?.name === "ZodError") {
+      return fail(res, "Invalid registration payload", 400);
+    }
+
+    throw error;
+  }
 }
 
 export async function login(req, res) {

--- a/apps/api/src/middleware/admin.js
+++ b/apps/api/src/middleware/admin.js
@@ -1,0 +1,9 @@
+import { fail } from "../utils/response.js";
+
+export function adminMiddleware(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { adminMiddleware } from "../middleware/admin.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(adminMiddleware);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/security.test.js
+++ b/apps/api/src/tests/security.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${server.address().port}`
+  };
+}
+
+async function stopServer(server) {
+  server.close();
+}
+
+test("public registration rejects admin role", async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const response = await fetch(`${baseUrl}/api/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "attacker@example.com",
+        password: "correct-horse-battery-staple",
+        role: "admin"
+      })
+    });
+
+    assert.equal(response.status, 400);
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("non-admin tokens cannot access admin metrics", async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const token = signAccessToken({
+      sub: "usr_client_test",
+      role: "client"
+    });
+
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.status, 403);
+  } finally {
+    await stopServer(server);
+  }
+});
+
+test("admin tokens can access admin metrics", async () => {
+  const { server, baseUrl } = await startServer();
+
+  try {
+    const token = signAccessToken({
+      sub: "usr_admin_test",
+      role: "admin"
+    });
+
+    const response = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.status, 200);
+
+    const body = await response.json();
+    assert.equal(body.success, true);
+  } finally {
+    await stopServer(server);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes the privilege-escalation path described in #11779 and implements the required security boundary for the $700 bounty in #743.

## Root cause

Public registration accepted `role: "admin"`, and the registration service signed that caller-controlled role into the JWT. The admin routes only verified token validity, so an unauthenticated user could mint an admin token and access `/api/admin/metrics`.

## Changes

- Remove `admin` from the public registration role enum.
- Return `400 Bad Request` for invalid registration payloads.
- Add explicit admin authorization middleware for `/api/admin` routes.
- Add regression tests covering rejected admin registration, forbidden non-admin access, and allowed admin access.

## Verification

`npm test` passes:

- 4 tests
- 4 passed
- 0 failed

## Bounty claim

/claim #743

Reference: #11779