### PR TITLE
Fix POST /api/uploads missing-file handling

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,12 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/tests/upload.test.js
+++ b/apps/api/src/tests/upload.test.js
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const server = createApp().listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
+test("POST /api/uploads rejects a multipart request with no file", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/uploads`, { method: "POST", body: new FormData() });
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { success: false, message: "File is required" });
+  });
+});


### PR DESCRIPTION
Fixes #11783.

Creator-only fix under #743.

- Reject multipart POST /api/uploads requests when req.file is missing with HTTP 400.
- Preserve HTTP 201 only for successful uploads.
- Add focused route-level regression coverage for the missing-file case.

Local regression coverage for this narrow change passed before submission.