### PR TITLE
fix(validation): enforce message content length and required fields (#11785)

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,10 +1,16 @@
+import { fail } from "../utils/response.js";
 import { ok } from "../utils/response.js";
-import { listMessages, sendMessage } from "../services/messageService.js";
+import { createMessage, listMessages } from "../services/messageService.js";
+import { createMessageSchema } from "../validators/message.js";
 
 export async function getMessages(req, res) {
   return ok(res, await listMessages());
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const result = createMessageSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors.map(e => e.message).join(", "), 400);
+  }
+  return ok(res, await createMessage(result.data), 201);
 }

--- a/apps/api/src/tests/message.validation.test.js
+++ b/apps/api/src/tests/message.validation.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { createMessageSchema } from "../validators/message.js";
+
+describe("Message Validation Schema", () => {
+  it("should accept a valid message", () => {
+    const valid = { content: "Hello!", sender: "user_1", recipient: "user_2" };
+    const result = createMessageSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject empty content", () => {
+    const invalid = { content: "", sender: "user_1", recipient: "user_2" };
+    const result = createMessageSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing sender", () => {
+    const invalid = { content: "Hello!", recipient: "user_2" };
+    const result = createMessageSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing recipient", () => {
+    const invalid = { content: "Hello!", sender: "user_1" };
+    const result = createMessageSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject content over 5000 characters", () => {
+    const invalid = { content: "a".repeat(5001), sender: "user_1", recipient: "user_2" };
+    const result = createMessageSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  content: z.string().min(1, "Message content is required").max(5000, "Message content must be 5000 characters or less"),
+  sender: z.string().min(1, "Sender ID is required"),
+  recipient: z.string().min(1, "Recipient ID is required")
+});


### PR DESCRIPTION
## Summary

- Added `apps/api/src/validators/message.js` with Zod schema for message creation
- Validates `content` (1-5000 chars), `sender` (required), `recipient` (required)
- Updated `messageController.js` to validate before creating messages
- Returns 400 with error details for invalid payloads
- Added vitest suite covering valid/empty content/missing fields/oversized content

## Testing
```bash
cd apps/api && npx vitest run src/tests/message.validation.test.js
```

Fixes #11785