### PR TITLE
fix(validation): enforce notification title/body length limits (#11786)

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,10 +1,16 @@
+import { fail } from "../utils/response.js";
 import { ok } from "../utils/response.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
+import { createNotificationSchema } from "../validators/notification.js";
 
 export async function getNotifications(req, res) {
   return ok(res, await listNotifications());
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const result = createNotificationSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors.map(e => e.message).join(", "), 400);
+  }
+  return ok(res, await createNotification(result.data), 201);
 }

--- a/apps/api/src/tests/notification.validation.test.js
+++ b/apps/api/src/tests/notification.validation.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { createNotificationSchema } from "../validators/notification.js";
+
+describe("Notification Validation Schema", () => {
+  it("should accept a valid notification with title only", () => {
+    const valid = { title: "New message" };
+    const result = createNotificationSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a valid notification with body", () => {
+    const valid = { title: "New proposal", body: "You have a new proposal to review." };
+    const result = createNotificationSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject empty title", () => {
+    const invalid = { title: "" };
+    const result = createNotificationSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing title", () => {
+    const invalid = {};
+    const result = createNotificationSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject title over 200 characters", () => {
+    const invalid = { title: "a".repeat(201) };
+    const result = createNotificationSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject body over 5000 characters", () => {
+    const invalid = { title: "Test", body: "b".repeat(5001) };
+    const result = createNotificationSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  title: z.string().min(1, "Notification title is required").max(200, "Title must be 200 characters or less"),
+  body: z.string().max(5000, "Body must be 5000 characters or less").optional()
+});


### PR DESCRIPTION
## Summary

- Added `apps/api/src/validators/notification.js` with Zod schema
- Validates `title` (1-200 chars, required) and `body` (0-5000 chars, optional)
- Updated `notificationController.js` to validate before creating notifications
- Returns 400 with error details for invalid payloads
- Added vitest suite covering valid/empty title/missing title/oversized fields

## Testing
```bash
cd apps/api && npx vitest run src/tests/notification.validation.test.js
```

Fixes #11786