### PR TITLE
fix(validation): enforce proposal bidAmount range and required fields (#11787)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,10 +1,16 @@
+import { fail } from "../utils/response.js";
 import { ok } from "../utils/response.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
+import { createProposalSchema } from "../validators/proposal.js";
 
 export async function getProposals(req, res) {
   return ok(res, await listProposals());
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const result = createProposalSchema.safeParse(req.body);
+  if (!result.success) {
+    return fail(res, result.error.errors.map(e => e.message).join(", "), 400);
+  }
+  return ok(res, await createProposal(result.data), 201);
 }

--- a/apps/api/src/tests/proposal.validation.test.js
+++ b/apps/api/src/tests/proposal.validation.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { createProposalSchema } from "../validators/proposal.js";
+
+describe("Proposal Validation Schema", () => {
+  const valid = {
+    jobId: "job_123",
+    title: "I can build this",
+    coverLetter: "I have 5 years of experience with this tech stack and can deliver in 2 weeks.",
+    bidAmount: 1500
+  };
+
+  it("should accept a valid proposal", () => {
+    const result = createProposalSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject missing jobId", () => {
+    const { jobId, ...rest } = valid;
+    const result = createProposalSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject title under 3 characters", () => {
+    const result = createProposalSchema.safeParse({ ...valid, title: "AB" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject cover letter under 10 characters", () => {
+    const result = createProposalSchema.safeParse({ ...valid, coverLetter: "Short" });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject zero bid amount", () => {
+    const result = createProposalSchema.safeParse({ ...valid, bidAmount: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject negative bid amount", () => {
+    const result = createProposalSchema.safeParse({ ...valid, bidAmount: -100 });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject title over 200 characters", () => {
+    const result = createProposalSchema.safeParse({ ...valid, title: "a".repeat(201) });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1, "Job ID is required"),
+  title: z.string().min(3, "Title must be at least 3 characters").max(200, "Title must be 200 characters or less"),
+  coverLetter: z.string().min(10, "Cover letter must be at least 10 characters").max(5000, "Cover letter must be 5000 characters or less"),
+  bidAmount: z.number().positive("Bid amount must be a positive number")
+});


### PR DESCRIPTION
## Summary

- Added `apps/api/src/validators/proposal.js` with Zod schema
- Validates `jobId` (required), `title` (3-200 chars), `coverLetter` (10-5000 chars), `bidAmount` (positive number)
- Updated `proposalController.js` to validate before creating proposals
- Returns 400 with error details for invalid payloads
- Added vitest suite covering valid/missing fields/bounds/range checks

## Testing
```bash
cd apps/api && npx vitest run src/tests/proposal.validation.test.js
```

Fixes #11787