### PR TITLE
fix(security): limit search query length to prevent DoS (#11788)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -1,6 +1,15 @@
+import { fail } from "../utils/response.js";
 import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
+const MAX_QUERY_LENGTH = 200;
+
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+  const query = req.query.q ?? "";
+
+  if (query.length > MAX_QUERY_LENGTH) {
+    return fail(res, `Search query must be ${MAX_QUERY_LENGTH} characters or less`, 400);
+  }
+
+  return ok(res, await globalSearch(query));
 }

--- a/apps/api/src/tests/search.query-limit.test.js
+++ b/apps/api/src/tests/search.query-limit.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { search } from "../controllers/searchController.js";
+
+function makeReq(query) {
+  return { query: { q: query } };
+}
+
+function makeRes() {
+  const res = { statusCode: 200, body: null };
+  res.status = vi.fn((code) => { res.statusCode = code; return res; });
+  res.json = vi.fn((body) => { res.body = body; return res; });
+  return res;
+}
+
+describe("Search Query Length Limit", () => {
+  it("should accept a normal query", async () => {
+    const req = makeReq("javascript");
+    const res = makeRes();
+    await search(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("should accept a 200-character query", async () => {
+    const req = makeReq("a".repeat(200));
+    const res = makeRes();
+    await search(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("should reject a 201-character query", async () => {
+    const req = makeReq("a".repeat(201));
+    const res = makeRes();
+    await search(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("should reject a 500-character query", async () => {
+    const req = makeReq("x".repeat(500));
+    const res = makeRes();
+    await search(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("should accept empty query (defaults to empty string)", async () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+    await search(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

- Added 200-character limit on `q` query parameter in `searchController.js`
- Returns 400 with error message for queries exceeding the limit
- Added vitest suite covering normal/200-char/201-char/500-char/empty queries

## Testing
```bash
cd apps/api && npx vitest run src/tests/search.query-limit.test.js
```

Fixes #11788