### PR TITLE
fix(validation): reject inverted budget range in createJobSchema and updateJobSchema (#11798)

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,9 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
-  return ok(res, await createJob(payload), 201);
+  const parsed = createJobSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await createJob(parsed.data), 201);
 }

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,19 @@
+import { ZodError } from "zod";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof ZodError || err.name === "ZodError" || err.issues) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.issues || err.errors
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/jobs.test.js
+++ b/apps/api/src/tests/jobs.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/jobs accepts valid budget ranges", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: "Build landing page",
+      description: "Looking for an expert Next.js developer to create a responsive landing page",
+      budgetMin: 500,
+      budgetMax: 1500,
+      categoryId: "cat_frontend",
+      skills: ["React", "Next.js", "TailwindCSS"]
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.title, "Build landing page");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/jobs rejects inverted budget range with 400 response", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: "Invalid Job Budget",
+      description: "This job has budgetMin higher than budgetMax and should be rejected",
+      budgetMin: 5000,
+      budgetMax: 1000,
+      categoryId: "cat_frontend",
+      skills: ["React"]
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,10 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, errors = undefined) {
+  const payload = { success: false, message };
+  if (errors !== undefined) {
+    payload.errors = errors;
+  }
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,37 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMax >= data.budgetMin, {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z
+  .object({
+    title: z.string().min(4).optional(),
+    description: z.string().min(10).optional(),
+    budgetMin: z.number().nonnegative().optional(),
+    budgetMax: z.number().nonnegative().optional(),
+    categoryId: z.string().min(1).optional(),
+    skills: z.array(z.string().min(1)).optional()
+  })
+  .refine(
+    (data) => {
+      if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+        return data.budgetMax >= data.budgetMin;
+      }
+      return true;
+    },
+    {
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    }
+  );


### PR DESCRIPTION
## Summary

This PR resolves #11798 by enforcing cross-field budget range validation in createJobSchema and updateJobSchema.

- Added .refine((data) => data.budgetMax >= data.budgetMin) to createJobSchema and updateJobSchema.
- Updated jobController.js and errorHandler.js to return HTTP 400 with descriptive validation errors on invalid inputs.
- Added route-level regression test coverage in pps/api/src/tests/jobs.test.js verifying that valid budget ranges are accepted (201) and inverted budget ranges are rejected with 400.

Closes #11798