### PR TITLE
fix(security): restrict public registration roles and enforce admin route authorization (#11800)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,16 +1,22 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
+  const parsed = loginSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  const result = await loginUser(parsed.data);
   return ok(res, result);
 }
 

--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,10 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireAdmin(req, res, next) {
+  if (!req.user || req.user.role !== "admin") {
+    return fail(res, "Forbidden: Admin access required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireAdmin } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/auth-security.test.js
+++ b/apps/api/src/tests/auth-security.test.js
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth/register rejects admin role with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "attacker@example.com",
+      password: "correct-horse-battery-staple",
+      role: "admin"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/auth/register accepts client role with 201 Created", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "user@example.com",
+      password: "correct-horse-battery-staple",
+      role: "client"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.role, "client");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/admin/metrics returns 403 Forbidden for non-admin client token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const clientToken = signAccessToken({ sub: "usr_client_1", role: "client" });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: {
+      Authorization: `Bearer ${clientToken}`
+    }
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 403);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("GET /api/admin/metrics returns 200 OK for admin token", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const adminToken = signAccessToken({ sub: "usr_admin_1", role: "admin" });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/admin/metrics`, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`
+    }
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.ok(payload.data.openJobs !== undefined);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,10 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, errors = undefined) {
+  const payload = { success: false, message };
+  if (errors !== undefined) {
+    payload.errors = errors;
+  }
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

This PR resolves #11800 by preventing privilege escalation via public registration and adding role authorization checks on administrative routes.

- Restricted egisterSchema in pps/api/src/validators/auth.js to ["client", "freelancer"].
- Added equireAdmin role guard in pps/api/src/middleware/auth.js returning HTTP 403 when a non-admin attempts access.
- Applied equireAdmin to pps/api/src/routes/adminRoutes.js.
- Added regression tests in pps/api/src/tests/auth-security.test.js validating that admin registration is rejected (400), non-admin client access to /api/admin/metrics returns 403 Forbidden, and authorized admin tokens succeed (200).

Closes #11800