### PR TITLE
fix(auth): verify requester on POST /api/auth/refresh and preserve subject/role (#11802)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,8 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  const sub = user?.sub || "usr_existing";
+  const role = user?.role || "client";
+  return { token: signAccessToken({ sub, role }) };
 }

--- a/apps/api/src/tests/auth-refresh.test.js
+++ b/apps/api/src/tests/auth-refresh.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken, verifyAccessToken } from "../utils/jwt.js";
+
+test("POST /api/auth/refresh rejects unauthenticated requests with 401 Unauthorized", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST"
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 401);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/auth/refresh returns new valid token preserving caller subject and role", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const originalToken = signAccessToken({ sub: "usr_freelancer_777", role: "freelancer" });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${originalToken}`
+    }
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.success, true);
+  assert.ok(payload.data.token);
+
+  const decoded = verifyAccessToken(payload.data.token);
+  assert.equal(decoded.sub, "usr_freelancer_777");
+  assert.equal(decoded.role, "freelancer");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves #11802 by securing the POST /api/auth/refresh endpoint and preserving authenticated caller identity and role.

- Added uthMiddleware to POST /api/auth/refresh in pps/api/src/routes/authRoutes.js.
- Passed eq.user from controller to efreshToken(user) in pps/api/src/services/authService.js to sign the refreshed token with the authenticated user's sub and ole.
- Added regression tests in pps/api/src/tests/auth-refresh.test.js validating that unauthenticated requests receive 401 Unauthorized and valid callers receive a new JWT retaining their subject and role.

Closes #11802