### PR TITLE
fix(validation): enforce positive payment amount and currency validation on POST /api/payments (#11804)

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createPaymentSchema } from "../validators/payment.js";
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+  const parsed = createPaymentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await createPaymentIntent(parsed.data), 201);
 }

--- a/apps/api/src/tests/payments.test.js
+++ b/apps/api/src/tests/payments.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments creates payment intent for valid positive amount", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: 250,
+      currency: "usd",
+      jobId: "job_123"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.amount, 250);
+  assert.equal(payload.data.currency, "usd");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payments rejects non-positive amount (-100 or 0) with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: -100,
+      currency: "usd"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/payments rejects unsupported currency with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: 50,
+      currency: "invalid_currency"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,10 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, errors = undefined) {
+  const payload = { success: false, message };
+  if (errors !== undefined) {
+    payload.errors = errors;
+  }
+  return res.status(status).json(payload);
 }

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createPaymentSchema = z.object({
+  amount: z.number().positive(),
+  currency: z.enum(["usd", "eur", "gbp"]).default("usd"),
+  jobId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Summary

This PR resolves #11804 by implementing schema validation for payment creation requests in POST /api/payments.

- Created createPaymentSchema in pps/api/src/validators/payment.js enforcing mount: z.number().positive() and supported currency enum (usd, eur, gbp).
- Updated paymentController.js to parse and validate incoming payloads, returning HTTP 400 with descriptive error details when validation fails.
- Added regression tests in pps/api/src/tests/payments.test.js validating that valid positive payments are accepted (201) and negative amounts or unsupported currencies are rejected (400).

Closes #11804