### PR TITLE
fix(uploads): reject missing file upload with 400 Bad Request on POST /api/uploads (#11806)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,18 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
-  return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
-  }, 201);
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
+
+  return ok(
+    res,
+    {
+      filename: req.file.originalname,
+      size: req.file.size,
+      mimetype: req.file.mimetype,
+      status: "uploaded"
+    },
+    201
+  );
 }

--- a/apps/api/src/tests/uploads.test.js
+++ b/apps/api/src/tests/uploads.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads rejects requests without a file with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST"
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "File is required");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/uploads accepts valid file upload and returns metadata", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const formData = new FormData();
+  const blob = new Blob(["test file content"], { type: "text/plain" });
+  formData.append("file", blob, "sample.txt");
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    body: formData
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.filename, "sample.txt");
+  assert.equal(payload.data.status, "uploaded");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/utils/response.js
+++ b/apps/api/src/utils/response.js
@@ -2,6 +2,10 @@ export function ok(res, data, status = 200) {
   return res.status(status).json({ success: true, data });
 }
 
-export function fail(res, message, status = 400) {
-  return res.status(status).json({ success: false, message });
+export function fail(res, message, status = 400, errors = undefined) {
+  const payload = { success: false, message };
+  if (errors !== undefined) {
+    payload.errors = errors;
+  }
+  return res.status(status).json(payload);
 }


### PR DESCRIPTION
## Summary

This PR resolves #11806 by updating POST /api/uploads to properly validate multipart file uploads.

- Added check in uploadController.js to ensure eq.file exists, returning HTTP 400 with message "File is required" when missing.
- Returns HTTP 201 with file metadata (ilename, size, mimetype, status: "uploaded") when a valid file is provided.
- Added regression tests in pps/api/src/tests/uploads.test.js validating both failure (400) and success (201) paths.

Closes #11806