### PR TITLE
fix(validation): enforce proposal validation schema on POST /api/proposals (#11808)

### DIFF
--- a/apps/api/src/controllers/proposalController.js
+++ b/apps/api/src/controllers/proposalController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createProposalSchema } from "../validators/proposal.js";
 import { createProposal, listProposals } from "../services/proposalService.js";
 
 export async function getProposals(req, res) {
@@ -6,5 +7,9 @@ export async function getProposals(req, res) {
 }
 
 export async function postProposal(req, res) {
-  return ok(res, await createProposal(req.body), 201);
+  const parsed = createProposalSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await createProposal(parsed.data), 201);
 }

--- a/apps/api/src/tests/proposals.test.js
+++ b/apps/api/src/tests/proposals.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/proposals creates proposal with valid payload", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jobId: "job_456",
+      bidAmount: 750,
+      coverLetter: "I am an expert full-stack developer with 5 years experience in building high-scale apps.",
+      estimatedDays: 14
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.bidAmount, 750);
+  assert.equal(payload.data.jobId, "job_456");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/proposals rejects invalid bidAmount (<=0) or short coverLetter with 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/proposals`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jobId: "job_456",
+      bidAmount: -50,
+      coverLetter: "too short",
+      estimatedDays: 0
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/proposal.js
+++ b/apps/api/src/validators/proposal.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createProposalSchema = z.object({
+  jobId: z.string().min(1),
+  bidAmount: z.number().positive(),
+  coverLetter: z.string().min(10),
+  estimatedDays: z.number().int().positive()
+});


### PR DESCRIPTION
## Summary

This PR resolves #11808 by enforcing request validation on proposal creation requests in POST /api/proposals.

- Added createProposalSchema in pps/api/src/validators/proposal.js validating jobId, positive idAmount, descriptive coverLetter, and positive integer estimatedDays.
- Updated proposalController.js to parse and validate incoming payloads, returning HTTP 400 with details when validation fails.
- Added regression tests in pps/api/src/tests/proposals.test.js validating successful proposal creation (201) and rejection of invalid payloads (400).

Closes #11808