### PR TITLE
fix(validation): enforce review validation schema on POST /api/reviews (#11810)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,9 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const parsed = createReviewSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await createReview(parsed.data), 201);
 }

--- a/apps/api/src/tests/reviews.test.js
+++ b/apps/api/src/tests/reviews.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/reviews creates review with valid payload", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      targetUserId: "usr_client_88",
+      rating: 5,
+      comment: "Exceptional delivery speed, clean code, and great communication!"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.rating, 5);
+  assert.equal(payload.data.targetUserId, "usr_client_88");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/reviews rejects invalid rating (e.g. 0, 6) or short comment with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/reviews`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      targetUserId: "usr_client_88",
+      rating: 10,
+      comment: "bad"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetUserId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(5).max(1000)
+});


### PR DESCRIPTION
## Summary

This PR resolves #11810 by implementing request schema validation on POST /api/reviews.

- Created createReviewSchema in pps/api/src/validators/review.js enforcing non-empty 	argetUserId, integer ating bounded between 1 and 5, and comment length between 5 and 1000 characters.
- Updated eviewController.js to parse and validate incoming payloads, returning HTTP 400 Bad Request with details when validation fails.
- Added regression tests in pps/api/src/tests/reviews.test.js validating successful creation (201) and rejection of invalid ratings or comments (400).

Closes #11810