### PR TITLE
fix(validation): enforce message validation schema on POST /api/messages (#11812)

### DIFF
--- a/apps/api/src/controllers/messageController.js
+++ b/apps/api/src/controllers/messageController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createMessageSchema } from "../validators/message.js";
 import { listMessages, sendMessage } from "../services/messageService.js";
 
 export async function getMessages(req, res) {
@@ -6,5 +7,9 @@ export async function getMessages(req, res) {
 }
 
 export async function postMessage(req, res) {
-  return ok(res, await sendMessage(req.body), 201);
+  const parsed = createMessageSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await sendMessage(parsed.data), 201);
 }

--- a/apps/api/src/tests/messages.test.js
+++ b/apps/api/src/tests/messages.test.js
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/messages creates message with valid payload", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      recipientId: "usr_freelancer_99",
+      content: "Hello! We would like to interview you for our project."
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.recipientId, "usr_freelancer_99");
+  assert.equal(payload.data.content, "Hello! We would like to interview you for our project.");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/messages rejects empty content or missing recipientId with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      recipientId: "",
+      content: ""
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/message.js
+++ b/apps/api/src/validators/message.js
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createMessageSchema = z.object({
+  recipientId: z.string().min(1),
+  content: z.string().min(1).max(5000),
+  conversationId: z.string().min(1).optional()
+});


### PR DESCRIPTION
## Summary

This PR resolves #11812 by implementing request schema validation on POST /api/messages.

- Created createMessageSchema in pps/api/src/validators/message.js enforcing non-empty ecipientId, content length between 1 and 5000 characters, and optional conversationId.
- Updated messageController.js to parse and validate incoming payloads, returning HTTP 400 Bad Request with validation details on invalid requests.
- Added regression tests in pps/api/src/tests/messages.test.js asserting successful message creation (201) and rejection of empty content or missing recipientId (400).

Closes #11812