### PR TITLE
fix(validation): enforce notification validation schema on POST /api/notifications (#11814)

### DIFF
--- a/apps/api/src/controllers/notificationController.js
+++ b/apps/api/src/controllers/notificationController.js
@@ -1,4 +1,5 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
+import { createNotificationSchema } from "../validators/notification.js";
 import { createNotification, listNotifications } from "../services/notificationService.js";
 
 export async function getNotifications(req, res) {
@@ -6,5 +7,9 @@ export async function getNotifications(req, res) {
 }
 
 export async function postNotification(req, res) {
-  return ok(res, await createNotification(req.body), 201);
+  const parsed = createNotificationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Validation failed", 400, parsed.error.issues);
+  }
+  return ok(res, await createNotification(parsed.data), 201);
 }

--- a/apps/api/src/tests/notifications.test.js
+++ b/apps/api/src/tests/notifications.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/notifications creates notification with valid payload", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      userId: "usr_client_42",
+      title: "Proposal Accepted",
+      message: "Your proposal for Project #123 has been accepted by the client.",
+      type: "success"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 201);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.userId, "usr_client_42");
+  assert.equal(payload.data.type, "success");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("POST /api/notifications rejects missing userId or invalid type with 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      userId: "",
+      title: "Invalid Notification",
+      message: "Testing invalid type",
+      type: "unsupported_type"
+    })
+  });
+
+  const payload = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.equal(payload.message, "Validation failed");
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});

--- a/apps/api/src/validators/notification.js
+++ b/apps/api/src/validators/notification.js
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const createNotificationSchema = z.object({
+  userId: z.string().min(1),
+  title: z.string().min(1).max(200),
+  message: z.string().min(1).max(2000),
+  type: z.enum(["info", "warning", "success", "alert"]).default("info")
+});


### PR DESCRIPTION
## Summary

This PR resolves #11814 by implementing request schema validation on POST /api/notifications.

- Created createNotificationSchema in pps/api/src/validators/notification.js enforcing non-empty userId, 	itle (1 to 200 chars), message (1 to 2000 chars), and supported 	ype enum (info, warning, success, lert).
- Updated 
otificationController.js to parse and validate incoming payloads, returning HTTP 400 Bad Request with validation details on invalid requests.
- Added regression tests in pps/api/src/tests/notifications.test.js asserting successful notification creation (201) and rejection of invalid types or empty userId (400).

Closes #11814