### PR TITLE
feat(utils): add bounded integer pagination helper parsePagination (#11836)

### DIFF
--- a/apps/api/src/utils/pagination.js
+++ b/apps/api/src/utils/pagination.js
@@ -1,0 +1,25 @@
+/**
+ * Bounded integer pagination parsing helper
+ * @param {object} query - Express request query object
+ * @param {number} [defaultTake=20] - Default page size
+ * @param {number} [maxTake=50] - Maximum allowed page size
+ * @returns {{ take: number, skip: number }}
+ */
+export function parsePagination(query = {}, defaultTake = 20, maxTake = 50) {
+  const rawTake = query.take !== undefined ? query.take : query.limit;
+  const rawSkip = query.skip !== undefined ? query.skip : query.offset;
+
+  let take = parseInt(rawTake, 10);
+  if (isNaN(take) || take <= 0) {
+    take = defaultTake;
+  } else if (take > maxTake) {
+    take = maxTake;
+  }
+
+  let skip = parseInt(rawSkip, 10);
+  if (isNaN(skip) || skip < 0) {
+    skip = 0;
+  }
+
+  return { take, skip };
+}

--- a/apps/api/src/utils/pagination.test.js
+++ b/apps/api/src/utils/pagination.test.js
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parsePagination } from './pagination.js';
+
+describe('parsePagination helper', () => {
+  it('returns default take and skip when query is empty', () => {
+    const result = parsePagination({});
+    assert.deepEqual(result, { take: 20, skip: 0 });
+  });
+
+  it('parses valid take and skip parameters', () => {
+    const result = parsePagination({ take: '15', skip: '30' });
+    assert.deepEqual(result, { take: 15, skip: 30 });
+  });
+
+  it('supports limit and offset aliases', () => {
+    const result = parsePagination({ limit: '10', offset: '20' });
+    assert.deepEqual(result, { take: 10, skip: 20 });
+  });
+
+  it('clamps take exceeding maxTake to maxTake', () => {
+    const result = parsePagination({ take: '100' }, 20, 50);
+    assert.deepEqual(result, { take: 50, skip: 0 });
+  });
+
+  it('handles negative or NaN inputs safely', () => {
+    const result = parsePagination({ take: '-5', skip: 'invalid' });
+    assert.deepEqual(result, { take: 20, skip: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #11836 by implementing a bounded integer pagination parsing utility \parsePagination\ to guarantee safe, clamped pagination limits across all listing API endpoints.

### Key Highlights
- **Safe Integer Conversion**: Safely parses \	ake\ (or \limit\) and \skip\ (or \offset\) query parameters.
- **Bounds Clamping**: Defaults to \	ake: 20\, \skip: 0\ and clamps \	ake\ to \maxTake: 50\ to avoid unbounded queries and memory exhaustion.
- **Robust Error Handling**: Automatically handles \NaN\ and negative integers safely.
- **Unit Test Suite**: Added 100% passing tests in \pps/api/src/utils/pagination.test.js\.

Closes #11836