### PR TITLE
feat(utils): add safe numeric clamp helper (#11868)

### DIFF
--- a/apps/api/src/tests/clamp.test.js
+++ b/apps/api/src/tests/clamp.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { clamp } from "../utils/clamp.js";
+import defaultClamp from "../utils/clamp.js";
+
+test("clamp: basic clamping within inclusive bounds", () => {
+  assert.equal(clamp(5, 0, 10), 5);
+  assert.equal(clamp(0, 0, 10), 0);
+  assert.equal(clamp(10, 0, 10), 10);
+  assert.equal(defaultClamp(7.5, 0, 10), 7.5);
+});
+
+test("clamp: values below minimum return minimum", () => {
+  assert.equal(clamp(-5, 0, 10), 0);
+  assert.equal(clamp(-100, -50, 50), -50);
+  assert.equal(clamp(0, 10, 20), 10);
+});
+
+test("clamp: values above maximum return maximum", () => {
+  assert.equal(clamp(15, 0, 10), 10);
+  assert.equal(clamp(100, -50, 50), 50);
+  assert.equal(clamp(25, 10, 20), 20);
+});
+
+test("clamp: inverted bounds (min > max) are normalized safely", () => {
+  assert.equal(clamp(15, 20, 10), 15);
+  assert.equal(clamp(5, 20, 10), 10);
+  assert.equal(clamp(25, 20, 10), 20);
+  assert.equal(clamp(-15, -5, -20), -15);
+  assert.equal(clamp(-30, -5, -20), -20);
+  assert.equal(clamp(0, -5, -20), -5);
+});
+
+test("clamp: handles NaN inputs with defaultValue fallback", () => {
+  assert.equal(clamp(NaN, 0, 10, 5), 5);
+  assert.equal(clamp(NaN, 0, 10, 15), 10); // defaultValue clamped to max
+  assert.equal(clamp(NaN, 0, 10, -5), 0);  // defaultValue clamped to min
+  assert.equal(clamp(NaN, 0, 10), 0);     // default 0 clamped between 0 and 10
+  assert.equal(clamp(NaN, 5, 10), 5);     // default 0 clamped to min 5
+});
+
+test("clamp: handles infinite inputs safely", () => {
+  assert.equal(clamp(Infinity, 0, 100), 100);
+  assert.equal(clamp(-Infinity, 0, 100), 0);
+  assert.equal(clamp(Infinity, -50, 50), 50);
+  assert.equal(clamp(-Infinity, -50, 50), -50);
+});
+
+test("clamp: handles non-numeric and string inputs safely", () => {
+  assert.equal(clamp("50", 0, 100), 50);
+  assert.equal(clamp("150", 0, 100), 100);
+  assert.equal(clamp("-20", 0, 100), 0);
+  assert.equal(clamp("invalid", 0, 100, 25), 25);
+  assert.equal(clamp(null, 10, 20, 15), 15);
+  assert.equal(clamp(undefined, 0, 100, 42), 42);
+  assert.equal(clamp({}, 0, 100, 50), 50);
+});
+
+test("clamp: handles negative and fractional bounds", () => {
+  assert.equal(clamp(-7.25, -10.5, -5.5), -7.25);
+  assert.equal(clamp(-12, -10.5, -5.5), -10.5);
+  assert.equal(clamp(-2, -10.5, -5.5), -5.5);
+  assert.equal(clamp(0.555, 0.1, 0.9), 0.555);
+});

--- a/apps/api/src/utils/clamp.js
+++ b/apps/api/src/utils/clamp.js
@@ -1,0 +1,51 @@
+/**
+ * Safely clamps a numeric value within inclusive minimum and maximum bounds.
+ *
+ * Guarantees bounded outputs for NaN, infinite, non-numeric,
+ * or inverted min/max inputs.
+ *
+ * @param {number|string|any} val - The input value to clamp.
+ * @param {number} [min=-Infinity] - The inclusive lower bound.
+ * @param {number} [max=Infinity] - The inclusive upper bound.
+ * @param {number} [defaultValue=0] - Fallback value if val cannot be resolved to a valid number.
+ * @returns {number} The clamped numeric value.
+ */
+export function clamp(val, min = -Infinity, max = Infinity, defaultValue = 0) {
+  let lower = typeof min === "number" && !Number.isNaN(min) ? min : -Infinity;
+  let upper = typeof max === "number" && !Number.isNaN(max) ? max : Infinity;
+
+  // Handle inverted min/max
+  if (lower > upper) {
+    const temp = lower;
+    lower = upper;
+    upper = temp;
+  }
+
+  let num;
+  if (typeof val === "number") {
+    num = val;
+  } else if (typeof val === "string" && val.trim() !== "") {
+    num = Number(val);
+  } else {
+    num = NaN;
+  }
+
+  if (Number.isNaN(num)) {
+    let fallback = typeof defaultValue === "number" ? defaultValue : Number(defaultValue);
+    if (Number.isNaN(fallback)) {
+      fallback = Number.isFinite(lower) ? lower : (Number.isFinite(upper) ? upper : 0);
+    }
+    num = fallback;
+  }
+
+  if (num < lower) {
+    return lower;
+  }
+  if (num > upper) {
+    return upper;
+  }
+
+  return num;
+}
+
+export default clamp;


### PR DESCRIPTION
### Summary of Changes

Resolves #11868
Refs #743

This PR implements the safe numeric `clamp` utility in `apps/api/src/utils/clamp.js` and provides full test coverage in `apps/api/src/tests/clamp.test.js`.

### Features & Guarantees
- **Safe Numeric Clamping**: Clamps values strictly between inclusive `[min, max]` bounds.
- **Inverted Bounds Support**: Safely detects and swaps `min` and `max` when `min > max`.
- **NaN / Non-numeric Resilience**: Fallback to `defaultValue` when input `val` cannot be resolved to a finite number.
- **Infinite Value Handling**: Properly clamps `Infinity` to upper bound and `-Infinity` to lower bound.
- **Dual Export**: Supports both named `export { clamp }` and `export default clamp`.

### Test Plan
- Added `apps/api/src/tests/clamp.test.js` covering:
  - Basic clamping within inclusive bounds
  - Values below minimum returning minimum
  - Values above maximum returning maximum
  - Inverted bounds normalization
  - NaN inputs with and without fallback `defaultValue`
  - Infinite inputs (`Infinity`, `-Infinity`)
  - String inputs and non-numeric fallbacks
  - Negative and fractional bounds
- Ran unit tests locally:
  ```bash
  node --test src/tests/health.test.js src/tests/clamp.test.js
  ```
  Result: **9/9 tests passing (100% pass rate)**.
