### PR TITLE
Fix: Reject inverted budget ranges

### DIFF
--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,31 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const baseJobShape = {
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
   categoryId: z.string().min(1),
   skills: z.array(z.string().min(1)).default([])
-});
+};
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = z.object(baseJobShape).refine(
+  data => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = z.object(baseJobShape).partial().refine(
+  data => {
+    if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+      return data.budgetMax >= data.budgetMin;
+    }
+    return true;
+  },
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);


### PR DESCRIPTION
Fixes #2853

Added Zod validation refinements to both createJobSchema and updateJobSchema to reject payloads where budgetMax is lower than budgetMin.