### PR TITLE
feat(utils): implement guaranteed single-execution wrapper once (#11897)

### DIFF
--- a/apps/api/src/tests/once.test.js
+++ b/apps/api/src/tests/once.test.js
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from '../utils/once.js';
+
+describe('Single Execution Function Wrapper (once)', () => {
+  it('executes the underlying function exactly once and caches result', () => {
+    let callCount = 0;
+    const initialize = once((x) => {
+      callCount++;
+      return x * 10;
+    });
+
+    const v1 = initialize(5);
+    const v2 = initialize(10);
+    const v3 = initialize(20);
+
+    assert.equal(v1, 50);
+    assert.equal(v2, 50);
+    assert.equal(v3, 50);
+    assert.equal(callCount, 1);
+  });
+
+  it('preserves `this` context across execution', () => {
+    const context = {
+      base: 100,
+      compute: once(function (n) {
+        return this.base + n;
+      }),
+    };
+
+    assert.equal(context.compute(5), 105);
+    assert.equal(context.compute(50), 105);
+  });
+
+  it('throws TypeError if argument is not a function', () => {
+    assert.throws(() => once(null), { name: 'TypeError' });
+    assert.throws(() => once('invalid'), { name: 'TypeError' });
+  });
+});

--- a/apps/api/src/utils/once.js
+++ b/apps/api/src/utils/once.js
@@ -1,0 +1,23 @@
+/**
+ * Creates a function that is restricted to invoking fn once.
+ * Repeat calls to the function return the value of the first invocation.
+ * @template T
+ * @param {(...args: any[]) => T} fn - Function to restrict
+ * @returns {(...args: any[]) => T}
+ */
+export function once(fn) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('Expected a function');
+  }
+
+  let called = false;
+  let result;
+
+  return function (...args) {
+    if (!called) {
+      called = true;
+      result = fn.apply(this, args);
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
## Summary

Resolves #11897 by implementing \once(fn)\ in \pps/api/src/utils/once.js\ to guarantee that idempotent initialization routines, connection setups, and single-fire event handlers execute strictly once.

### Key Highlights
- **Single-Fire Guarantee**: Executes the underlying target function on first invocation and caches the return value for all subsequent invocations.
- **Context Preservation**: Seamlessly forwards \	his\ and caller arguments.
- **Unit Test Suite**: 100% test coverage in \pps/api/src/tests/once.test.js\.

Closes #11897