### PR TITLE
feat(utils): implement collection predicate partition helper partition (#11907)

### DIFF
--- a/apps/api/src/tests/partition.test.js
+++ b/apps/api/src/tests/partition.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { partition } from '../utils/partition.js';
+
+describe('Collection Predicate Partition Utility (partition)', () => {
+  it('partitions numbers based on even/odd predicate', () => {
+    const numbers = [1, 2, 3, 4, 5, 6];
+    const [evens, odds] = partition(numbers, (n) => n % 2 === 0);
+
+    assert.deepEqual(evens, [2, 4, 6]);
+    assert.deepEqual(odds, [1, 3, 5]);
+  });
+
+  it('partitions complex objects based on property value', () => {
+    const users = [
+      { id: 1, active: true },
+      { id: 2, active: false },
+      { id: 3, active: true },
+    ];
+
+    const [active, inactive] = partition(users, (u) => u.active);
+    assert.deepEqual(active, [{ id: 1, active: true }, { id: 3, active: true }]);
+    assert.deepEqual(inactive, [{ id: 2, active: false }]);
+  });
+
+  it('defaults to truthiness check if predicate is omitted', () => {
+    const items = [0, 1, false, 2, '', 3, null, undefined];
+    const [truthy, falsy] = partition(items);
+
+    assert.deepEqual(truthy, [1, 2, 3]);
+    assert.deepEqual(falsy, [0, false, '', null, undefined]);
+  });
+
+  it('handles non-array inputs gracefully', () => {
+    assert.deepEqual(partition(null), [[], []]);
+    assert.deepEqual(partition('abc'), [[], []]);
+  });
+});

--- a/apps/api/src/utils/partition.js
+++ b/apps/api/src/utils/partition.js
@@ -1,0 +1,27 @@
+/**
+ * Splits an array into two groups: those that satisfy predicate and those that do not.
+ * @template T
+ * @param {T[]} array - Input array
+ * @param {(item: T, index: number, array: T[]) => boolean} predicate - Evaluator function
+ * @returns {[T[], T[]]} Tuple of [matches, nonMatches]
+ */
+export function partition(array, predicate) {
+  if (!Array.isArray(array)) {
+    return [[], []];
+  }
+
+  const fn = typeof predicate === 'function' ? predicate : Boolean;
+  const matches = [];
+  const nonMatches = [];
+
+  for (let i = 0; i < array.length; i++) {
+    const item = array[i];
+    if (fn(item, i, array)) {
+      matches.push(item);
+    } else {
+      nonMatches.push(item);
+    }
+  }
+
+  return [matches, nonMatches];
+}


### PR DESCRIPTION
## Summary

Resolves #11907 by implementing \partition(array, predicate)\ in \pps/api/src/utils/partition.js\ to divide collections into matched and unmatched buckets according to an evaluation function.

### Key Highlights
- **Tuple Division**: Returns cleanly separated \[matches, nonMatches]\ arrays.
- **Fail-Safe Argument Normalization**: Defaults to truthiness evaluation on omitted predicates and safely handles invalid array inputs.
- **Unit Test Suite**: 100% test coverage in \pps/api/src/tests/partition.test.js\.

Closes #11907