### PR TITLE
feat(utils): implement guaranteed single-execution wrapper once (#743…

### DIFF
--- a/apps/api/src/tests/once.test.js
+++ b/apps/api/src/tests/once.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import once from '../utils/once.js';
+
+describe('once utility', () => {
+  it('should execute the wrapped function only once', () => {
+    let count = 0;
+    const fn = once(() => ++count);
+
+    expect(fn()).toBe(1);
+    expect(fn()).toBe(1);
+    expect(fn()).toBe(1);
+    expect(count).toBe(1);
+  });
+
+  it('should return initial result for subsequent calls with different arguments', () => {
+    const add = once((a, b) => a + b);
+
+    expect(add(5, 5)).toBe(10);
+    expect(add(20, 30)).toBe(10);
+  });
+
+  it('should preserve this context during execution', () => {
+    const context = {
+      multiplier: 3,
+      calc: once(function (val) {
+        return val * this.multiplier;
+      }),
+    };
+
+    expect(context.calc(4)).toBe(12);
+    expect(context.calc(10)).toBe(12);
+  });
+
+  it('should throw TypeError when argument is not a function', () => {
+    expect(() => once(null)).toThrow(TypeError);
+    expect(() => once(123)).toThrow(TypeError);
+  });
+});

--- a/apps/api/src/utils/once.js
+++ b/apps/api/src/utils/once.js
@@ -1,0 +1,25 @@
+/**
+ * Guarantees a function is executed at most once.
+ * On subsequent invocations, returns the cached result of the initial call.
+ * Preserves `this` context and initial arguments.
+ *
+ * @param {Function} fn - Function to wrap.
+ * @returns {Function} Single-execution wrapped function.
+ */
+export function once(fn) {
+  if (typeof fn !== 'function') {
+    throw new TypeError('Expected a function');
+  }
+  let called = false;
+  let result;
+
+  return function (...args) {
+    if (!called) {
+      called = true;
+      result = fn.apply(this, args);
+    }
+    return result;
+  };
+}
+
+export default once;


### PR DESCRIPTION
…, fixes #11897)

### Summary of Changes (Fixes #11897)
Implemented guaranteed single-execution function wrapper `once(fn)`.

- **`apps/api/src/utils/once.js`**: Added `once(fn)` wrapper that caches initial return values, preserves `this` context, and validates function parameter.
- **`apps/api/src/tests/once.test.js`**: Created comprehensive test suite verifying single execution, cached return values, context preservation, and error handling.

### Verification
- Verified single execution count, argument handling, `this` binding, and type error handling. All 4 unit tests passed 100% cleanly.

---
### 💳 Payment & Bounty Details
- **PayPal Link:** https://paypal.me/mgarg1102