### PR TITLE
fix(validators): reject inverted job budget range (budgetMax < budgetMin) (#4605)

### DIFF
--- a/apps/api/src/tests/job.validator.test.js
+++ b/apps/api/src/tests/job.validator.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+const baseJob = {
+  title: "Build a landing page",
+  description: "A simple static landing page with a signup form.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "design",
+  skills: ["html", "css"]
+};
+
+test("createJobSchema accepts a valid job with budgetMax >= budgetMin", () => {
+  const result = createJobSchema.safeParse(baseJob);
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema accepts budgetMax === budgetMin", () => {
+  const result = createJobSchema.safeParse({ ...baseJob, budgetMin: 300, budgetMax: 300 });
+  assert.equal(result.success, true);
+});
+
+test("createJobSchema rejects an inverted budget range (budgetMax < budgetMin)", () => {
+  const result = createJobSchema.safeParse({ ...baseJob, budgetMin: 500, budgetMax: 100 });
+  assert.equal(result.success, false);
+
+  const issue = result.error.issues[0];
+  assert.equal(issue.path[0], "budgetMax");
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
+const jobObject = z.object({
   title: z.string().min(4),
   description: z.string().min(10),
   budgetMin: z.number().nonnegative(),
@@ -9,4 +9,12 @@ export const createJobSchema = z.object({
   skills: z.array(z.string().min(1)).default([])
 });
 
-export const updateJobSchema = createJobSchema.partial();
+export const createJobSchema = jobObject.refine(
+  (data) => data.budgetMax >= data.budgetMin,
+  {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  }
+);
+
+export const updateJobSchema = jobObject.partial();


### PR DESCRIPTION
`createJobSchema` validated `budgetMin`/`budgetMax` independently but didn't enforce `budgetMax >= budgetMin`, so an inverted range like `{budgetMin: 500, budgetMax: 100}` was accepted and stored. Added a cross-field `.refine()` that rejects it with the error on the `budgetMax` path. Scoped to the validator only, per the issue. Added regression tests in `src/tests/job.validator.test.js`.

Closes #4605.

---
**Parent Algora bounty:** #743. Related issue: #4605 (https://github.com/SecureBananaLabs/bug-bounty/issues/4605).