### PR TITLE
fix(api): fall back to default port 4000 when PORT env is invalid

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,22 @@
-export const env = {
-  nodeEnv: process.env.NODE_ENV ?? "development",
-  port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
-  stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
-  databaseUrl: process.env.DATABASE_URL ?? ""
-};
+--- a/apps/api/src/config/env.js
++++ b/apps/api/src/config/env.js
+@@ -1 +1,17 @@
+-const PORT = Number(process.env.PORT ?? 4000);
++const DEFAULT_PORT = 4000;
++
++function parsePort(raw) {
++  if (raw === undefined || raw === null || raw === '') {
++    return DEFAULT_PORT;
++  }
++
++  const parsed = Number(raw);
++
++  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
++    console.warn(`[env] Invalid PORT "${raw}", falling back to ${DEFAULT_PORT}`);
++    return DEFAULT_PORT;
++  }
++
++  return parsed;
++}
++
++const PORT = parsePort(process.env.PORT);


### PR DESCRIPTION
Closes #9152 (parent Algora bounty: #743)  ## Bug `Number(process.env.PORT ?? 4000)` yields `NaN` when `PORT` is set to a non-numeric value (e.g. `PORT=abc`), which crashes API startup.  ## Fix Replaces the raw `Number()` coercion in `apps/api/src/config/env.js` with a `parsePort()` guard: - `PORT` 