### PR TITLE
Fix API test script to explicitly target test files

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,5 @@
+--- a/api/package.json
++++ b/api/package.json
+@@
+-    "test": "node --test src/tests",
++    "test": "node --test src/tests/*.test.js",


### PR DESCRIPTION
Updates the API package `test` script from `node --test src/tests` to `node --test src/tests/*.test.js` so the Node test runner explicitly executes the intended test files.  Fixes #11393.