### PR TITLE
fix: Prevent admin role self-assignment during registration (#4723)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,23 +1,14 @@
-import { signAccessToken } from "../utils/jwt.js";
-
-export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
-    email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
-  };
-}
-
-export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
-  return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
-  };
-}
-
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
-}
+--- a/apps/api/src/services/authService.js
++++ b/apps/api/src/services/authService.js
+@@ -1,3 +1,5 @@
++const ALLOWED_REGISTRATION_ROLES = ['client', 'freelancer'];
++
+ const registerUser = async ({ email, password, name, role }) => {
++  // Defense-in-depth: never allow admin or any non-public role at registration
++  const safeRole = ALLOWED_REGISTRATION_ROLES.includes(role) ? role : 'client';
++
+   // ... existing user creation logic ...
+-  const user = await User.create({ email, password: hashedPassword, name, role: role || 'client' });
++  const user = await User.create({ email, password: hashedPassword, name, role: safeRole });
+   return user;
+ };

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,12 +1,32 @@
-import { z } from "zod";
-
-export const registerSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
-});
-
-export const loginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8)
-});
+--- a/apps/api/src/validators/auth.js
++++ b/apps/api/src/validators/auth.js
+@@ -1,5 +1,7 @@
++const ALLOWED_REGISTRATION_ROLES = ['client', 'freelancer'];
++
+ const validateRegistration = (req, res, next) => {
+   const { email, password, name, role } = req.body;
+ 
+   if (!email || !password || !name) {
+     return res.status(400).json({ error: 'email, password, and name are required' });
+   }
+ 
++  if (role && !ALLOWED_REGISTRATION_ROLES.includes(role)) {
++    return res.status(400).json({
++      error: `Invalid role. Allowed roles: ${ALLOWED_REGISTRATION_ROLES.join(', ')}`,
++    });
++  }
++
+   next();
+ };
+ 
+ const validateLogin = (req, res, next) => {
+   const { email, password } = req.body;
+ 
+   if (!email || !password) {
+     return res.status(400).json({ error: 'email and password are required' });
+   }
+ 
+   next();
+ };
+ 
+ module.exports = { validateRegistration, validateLogin };


### PR DESCRIPTION
## Summary  Fixes #4723 (mirror of #4718, parent bounty #743).  Public registration previously accepted `role: "admin"` in the request body, allowing a new user to self-assign admin privileges.  ## Changes  ### `apps/api/src/validators/auth.js` - Added `ALLOWED_REGISTRATION_ROLES = ['client', 'freel