### PR TITLE
fix: Return defensive snapshots from list service functions (#6346)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,5 +1,5 @@
 const jobs = [];
-
+  return [...jobs];
 export async function listJobs() {
   return jobs;
 }

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,5 +1,5 @@
 const messages = [];
-
+  return [...messages];
 export async function listMessages() {
   return messages;
 }

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,5 +1,5 @@
 const notifications = [];
-
+  return [...notifications];
 export async function listNotifications() {
   return notifications;
 }

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,5 +1,5 @@
 const proposals = [];
-
+  return [...proposals];
 export async function listProposals() {
   return proposals;
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,5 +1,5 @@
 const reviews = [];
-
+  return [...reviews];
 export async function listReviews() {
   return reviews;
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,5 +1,5 @@
 const users = [];
-
+  return [...users];
 export async function listUsers() {
   return users;
 }

--- a/apps/api/src/tests/listSnapshot.test.js
+++ b/apps/api/src/tests/listSnapshot.test.js
@@ -1,0 +1,63 @@
+const userService = require('../services/userService');
+const jobService = require('../services/jobService');
+const proposalService = require('../services/proposalService');
+const reviewService = require('../services/reviewService');
+const messageService = require('../services/messageService');
+const notificationService = require('../services/notificationService');
+
+describe('List service responses are defensive snapshots', () => {
+  it('userService.listUsers returns a snapshot', () => {
+    const list1 = userService.listUsers();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = userService.listUsers();
+    expect(list2.length).toBe(originalLength);
+    expect(list2.find(u => u.id === 'injected')).toBeUndefined();
+  });
+
+  it('jobService.listJobs returns a snapshot', () => {
+    const list1 = jobService.listJobs();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = jobService.listJobs();
+    expect(list2.length).toBe(originalLength);
+  });
+
+  it('proposalService.listProposals returns a snapshot', () => {
+    const list1 = proposalService.listProposals();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = proposalService.listProposals();
+    expect(list2.length).toBe(originalLength);
+  });
+
+  it('reviewService.listReviews returns a snapshot', () => {
+    const list1 = reviewService.listReviews();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = reviewService.listReviews();
+    expect(list2.length).toBe(originalLength);
+  });
+
+  it('messageService.listMessages returns a snapshot', () => {
+    const list1 = messageService.listMessages();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = messageService.listMessages();
+    expect(list2.length).toBe(originalLength);
+  });
+
+  it('notificationService.listNotifications returns a snapshot', () => {
+    const list1 = notificationService.listNotifications();
+    const originalLength = list1.length;
+    list1.push({ id: 'injected' });
+    list1.length = 0;
+    const list2 = notificationService.listNotifications();
+    expect(list2.length).toBe(originalLength);
+  });
+});


### PR DESCRIPTION
## Summary  Fixes #6346 (mirrors #4530, parent bounty #743).  List service functions were returning direct references to their module-level in-memory arrays. Any in-process caller could mutate the backing store via `push`, `pop`, `splice`, or `length = 0`, corrupting data for subsequent reads.  ## C