### PR TITLE
fix(api): generate unique job IDs for same-millisecond creates

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,17 @@
+const crypto = require("crypto");
+
+/**
+ * Generate a collision-resistant job ID.
+ *
+ * The millisecond timestamp keeps IDs roughly ordered by creation time and
+ * stays parseable by any consumer that relied on the old `job_<timestamp>`
+ * shape; the 48-bit random suffix guarantees uniqueness for jobs created
+ * within the same millisecond (issue #10846).
+ */
+function generateJobId() {
+  return `job_${Date.now()}_${crypto.randomBytes(6).toString("hex")}`;
+}
+
 const jobs = [];
 
 export async function listJobs() {
@@ -9,3 +23,9 @@ export async function createJob(payload) {
   jobs.push(job);
   return job;
 }
+function createJob(payload) {
+  const job = { id: generateJobId(), status: "open", ...payload };
+module.exports = {
+  generateJobId,
+  createJob,
+};

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const jobService = require("../services/jobService");
+
+// Regression coverage for issue #10846: job IDs were built from Date.now()
+// alone, so two jobs created within the same millisecond collided.
+describe("jobService job ID generation", () => {
+  const FIXED_TIMESTAMP = 1724332800000; // 2024-08-22T12:00:00.000Z
+  let originalDateNow;
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    // Freeze the clock so every ID below is generated in the exact same
+    // millisecond — deterministically reproduces the collision scenario.
+    Date.now = () => FIXED_TIMESTAMP;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
+  it("generates distinct IDs for same-millisecond generation", () => {
+    const COUNT = 200;
+    const ids = new Set();
+
+    for (let i = 0; i < COUNT; i += 1) {
+      ids.add(jobService.generateJobId());
+    }
+
+    // The old `job_${Date.now()}` implementation would produce size 1 here.
+    expect(ids.size).toBe(COUNT);
+  });
+
+  it("keeps the job_ prefix and embeds the creation timestamp", () => {
+    const id = jobService.generateJobId();
+
+    expect(id.startsWith("job_")).toBe(true);
+    expect(id).toMatch(/^job_\d+_[0-9a-f]{12}$/);
+    expect(id).toContain(String(FIXED_TIMESTAMP));
+  });
+
+  it("assigns unique IDs to jobs created in the same millisecond", async () => {
+    const COUNT = 50;
+    const ids = new Set();
+
+    for (let i = 0; i < COUNT; i += 1) {
+      const result = jobService.createJob({
+        title: `Same millisecond job ${i}`,
+        description: "regression test payload",
+      });
+      const job =
+        result && typeof result.then === "function" ? await result : result;
+
+      expect(job.id.startsWith("job_")).toBe(true);
+      ids.add(job.id);
+    }
+
+    expect(ids.size).toBe(COUNT);
+  });
+});


### PR DESCRIPTION
## Summary  Fixes #10846 (parent bounty #743).  Job creation built IDs from `Date.now()` alone, so two jobs created within the same millisecond received identical IDs, making later lookups, updates, and client-side reconciliation ambiguous.  ## Root cause  `apps/api/src/services/jobService.js` (line