### PR TITLE
fix(api): return defensive snapshots from list service responses

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -9,3 +9,6 @@ export async function createJob(payload) {
   jobs.push(job);
   return job;
 }
+function getJobs() {
+  return [...jobs];
+}

--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -9,3 +9,6 @@ export async function sendMessage(payload) {
   messages.push(message);
   return message;
 }
+function getMessages() {
+  return [...messages];
+}

--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -9,3 +9,6 @@ export async function createNotification(payload) {
   notifications.push(notification);
   return notification;
 }
+function getNotifications() {
+  return [...notifications];
+}

--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -9,3 +9,5 @@ export async function createProposal(payload) {
   proposals.push(proposal);
   return proposal;
 }
+  return [...proposals];
+}

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -8,4 +8,5 @@ export async function createReview(payload) {
   const review = { id: `rev_${Date.now()}`, ...payload };
   reviews.push(review);
   return review;
+  return [...reviews];
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -8,4 +8,5 @@ export async function createUser(payload) {
   const user = { id: `usr_${Date.now()}`, ...payload };
   users.push(user);
   return user;
+  return [...users];
 }

--- a/apps/api/src/tests/listSnapshots.test.js
+++ b/apps/api/src/tests/listSnapshots.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const userService = require('../services/userService');
+const jobService = require('../services/jobService');
+const proposalService = require('../services/proposalService');
+const reviewService = require('../services/reviewService');
+const messageService = require('../services/messageService');
+const notificationService = require('../services/notificationService');
+
+// Regression coverage for #6346: list endpoints must hand callers a shallow
+// snapshot of the backing store. In-place array mutations on a response
+// (push/pop/splice/truncate) must never reach the module-level array the
+// service keeps.
+const listFunctions = [
+  { name: 'userService.getUsers', list: () => userService.getUsers() },
+  { name: 'jobService.getJobs', list: () => jobService.getJobs() },
+  { name: 'proposalService.getProposals', list: () => proposalService.getProposals() },
+  { name: 'reviewService.getReviews', list: () => reviewService.getReviews() },
+  { name: 'messageService.getMessages', list: () => messageService.getMessages() },
+  { name: 'notificationService.getNotifications', list: () => notificationService.getNotifications() },
+];
+
+for (const { name, list } of listFunctions) {
+  test(`${name} returns a snapshot that cannot corrupt the backing store`, () => {
+    const baseline = list();
+    const expectedLength = baseline.length;
+    const expectedIds = baseline.map((record) => record.id);
+
+    // Every in-place array mutation a hostile in-process caller could make.
+    const snapshot = list();
+    snapshot.push({ id: '__sentinel__' });
+    snapshot.unshift({ id: '__sentinel__' });
+    snapshot.pop();
+    snapshot.shift();
+    snapshot.splice(0, snapshot.length, { id: '__sentinel__' });
+    snapshot.length = 0;
+
+    const after = list();
+    assert.equal(
+      after.length,
+      expectedLength,
+      `${name}: backing store length changed after mutating a list response`
+    );
+    assert.deepEqual(
+      after.map((record) => record.id),
+      expectedIds,
+      `${name}: backing store contents changed after mutating a list response`
+    );
+  });
+
+  test(`${name} preserves response shape and record objects (shallow copy)`, () => {
+    const first = list();
+    const second = list();
+
+    assert.ok(Array.isArray(first), `${name}: response must be an array`);
+    assert.notEqual(first, second, `${name}: must not hand out the backing array`);
+    assert.equal(second.length, first.length, `${name}: snapshot length mismatch`);
+
+    if (first.length > 0) {
+      assert.equal(
+        second[0],
+        first[0],
+        `${name}: record objects must be preserved by the shallow copy`
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary  Fixes #6346 (mirrors #4530; parent Algora bounty #743).  Several API list services returned their module-level in-memory arrays directly, so any in-process caller could corrupt the backing store with `push`, `pop`, `splice`, or `length = 0`.  ## Changes  | File | List function | Change |