### PR TITLE
fix: generate unique payment IDs for same-millisecond intents (#10848)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,3 +1,26 @@
+const crypto = require('crypto');
+
+let lastIdTimestamp = 0;
+let idSequence = 0;
+
+/**
+ * Generate a collision-resistant payment intent ID.
+ *
+ * Same-millisecond calls receive a strictly increasing sequence component,
+ * and a short crypto-random suffix keeps IDs unique across processes and
+ * server restarts. The existing `pay_` prefix is preserved.
+ */
+function generatePaymentId() {
+  const now = Date.now();
+  if (now <= lastIdTimestamp) {
+    idSequence += 1;
+  } else {
+    lastIdTimestamp = now;
+    idSequence = 0;
+  }
+  return `pay_${now}${idSequence.toString(36)}${crypto.randomBytes(4).toString('hex')}`;
+}
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
@@ -7,3 +30,11 @@ export async function createPaymentIntent(payload) {
     provider: "stripe"
   };
 }
+  const intent = {
+    paymentId: generatePaymentId(),
+    amount,
+    currency,
+    status: 'requires_confirmation',
+    createdAt: new Date().toISOString(),
+  };
+module.exports.generatePaymentId = generatePaymentId;

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const paymentService = require('../services/paymentService');
+
+describe('paymentService payment ID generation', () => {
+  const FIXED_NOW = 1700000000000;
+  let originalDateNow;
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    // Freeze the clock so every call lands in the "same millisecond".
+    Date.now = () => FIXED_NOW;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
+  it('keeps the pay_ prefix', () => {
+    expect(paymentService.generatePaymentId().startsWith('pay_')).toBe(true);
+  });
+
+  it('generates unique IDs even when Date.now is frozen (same-millisecond regression)', () => {
+    const total = 1000;
+    const ids = new Set();
+    for (let i = 0; i < total; i += 1) {
+      ids.add(paymentService.generatePaymentId());
+    }
+    expect(ids.size).toBe(total);
+  });
+
+  it('creates payment intents with unique IDs in the same millisecond', async () => {
+    const first = await paymentService.createPaymentIntent({ amount: 1000, currency: 'usd' });
+    const second = await paymentService.createPaymentIntent({ amount: 2500, currency: 'usd' });
+
+    expect(first.paymentId).toMatch(/^pay_/);
+    expect(second.paymentId).toMatch(/^pay_/);
+    expect(first.paymentId).not.toBe(second.paymentId);
+  });
+});


### PR DESCRIPTION
Fixes #10848  ## Root cause `apps/api/src/services/paymentService.js` built payment intent IDs directly from the wall clock inside `createPaymentIntent`:  ```js paymentId: `pay_${Date.now()}` ```  `Date.now()` has millisecond resolution, so two intent requests handled within the same millisecond pro