### PR TITLE
fix(api): use shared ok() success envelope for GET /health (#4533)

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,4 +1,5 @@
 import cors from "cors";
+const { ok } = require('./utils/response');
 import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
@@ -13,9 +14,7 @@ import { messageRoutes } from "./routes/messageRoutes.js";
 import { notificationRoutes } from "./routes/notificationRoutes.js";
 import { uploadRoutes } from "./routes/uploadRoutes.js";
 import { searchRoutes } from "./routes/searchRoutes.js";
-import { adminRoutes } from "./routes/adminRoutes.js";
-
-export function createApp() {
+app.get('/health', (req, res) => ok(res, { service: 'api' }));
   const app = express();
 
   app.use(helmet());

--- a/apps/api/src/tests/health.test.js
+++ b/apps/api/src/tests/health.test.js
@@ -2,10 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createApp } from "../app.js";
 
-test("GET /health returns ok payload", async () => {
+  it('returns 200 with the shared success envelope and service name', async () => {
   const app = createApp();
   const server = app.listen(0);
-
+    expect(res.body).toEqual({ success: true, data: { service: 'api' } });
   await new Promise((resolve, reject) => {
     server.once("listening", resolve);
     server.once("error", reject);


### PR DESCRIPTION
## Summary Fixes #4533 (parent bounty #743, reference #4520).  `GET /health` was the only successful route in `apps/api/src/app.js` that bypassed the shared `ok()` helper, returning `{ ok: true, service: 'api' }`. It now uses `ok()` and returns `{ success: true, data: { service: 'api' } }` with HTTP