### PR TITLE
fix(api): collision-resistant review ids for same-millisecond creates

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,62 @@
-const reviews = [];
+'use strict';
 
-export async function listReviews() {
-  return reviews;
+const crypto = require('crypto');
+
+// ---------------------------------------------------------------------------
+// Collision-resistant id generation
+//
+// Previously ids were `rev_${Date.now()}`, so two reviews created within the
+// same millisecond could receive identical ids. Ids are now composed of:
+//
+//   rev_<epochMs>_<sequence>_<entropy>
+//
+// - epochMs keeps ids time-sortable and preserves the legacy timestamp signal
+// - sequence is a monotonic counter that advances on every same-millisecond
+//   (or clock-rewind) request, guaranteeing uniqueness within this process
+// - entropy is 48 bits from crypto.randomBytes, making cross-process and
+//   cross-restart collisions impractical
+// ---------------------------------------------------------------------------
+
+let lastTimestamp = 0;
+let sequence = 0;
+
+function generateReviewId(now = Date.now()) {
+  if (now <= lastTimestamp) {
+    sequence += 1;
+  } else {
+    lastTimestamp = now;
+    sequence = 0;
+  }
+
+  const entropy = crypto.randomBytes(6).toString('hex');
+  return `rev_${now}_${sequence}_${entropy}`;
 }
 
-export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
-  reviews.push(review);
+// In-memory review store.
+const reviews = new Map();
+
+function createReview(payload = {}) {
+  const review = { id: generateReviewId(), ...payload };
+  reviews.set(review.id, review);
   return review;
 }
+
+function getReviewById(id) {
+  return reviews.get(id) || null;
+}
+
+function listReviews() {
+  return Array.from(reviews.values());
+}
+
+function deleteReview(id) {
+  return reviews.delete(id);
+}
+
+module.exports = {
+  generateReviewId,
+  createReview,
+  getReviewById,
+  listReviews,
+  deleteReview,
+};

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const reviewService = require('../services/reviewService');
+
+function withFrozenTime(fn) {
+  const realNow = Date.now;
+  const frozen = realNow();
+  Date.now = () => frozen;
+  try {
+    return fn();
+  } finally {
+    Date.now = realNow;
+  }
+}
+
+test('two same-millisecond creates receive distinct rev_ ids', () => {
+  withFrozenTime(() => {
+    const first = reviewService.createReview({ rating: 5, comment: 'great' });
+    const second = reviewService.createReview({ rating: 4, comment: 'good' });
+
+    assert.ok(first.id.startsWith('rev_'), `missing rev_ prefix: ${first.id}`);
+    assert.ok(second.id.startsWith('rev_'), `missing rev_ prefix: ${second.id}`);
+    assert.notStrictEqual(first.id, second.id);
+  });
+});
+
+test('same-millisecond creates stay unique at volume and retrievable by id', () => {
+  withFrozenTime(() => {
+    const ids = new Set();
+    for (let i = 0; i < 500; i += 1) {
+      const review = reviewService.createReview({ rating: 3, jobId: `job_${i}` });
+      assert.ok(review.id.startsWith('rev_'), `missing rev_ prefix: ${review.id}`);
+      ids.add(review.id);
+    }
+    assert.strictEqual(ids.size, 500, 'expected 500 unique ids');
+
+    for (const id of ids) {
+      const found = reviewService.getReviewById(id);
+      assert.ok(found, `review ${id} should be retrievable`);
+      assert.strictEqual(found.id, id);
+    }
+  });
+});
+
+test('generateReviewId keeps the rev_ prefix under a stalled clock', () => {
+  const realNow = Date.now;
+  Date.now = () => 1_700_000_000_000;
+  try {
+    const seen = new Set();
+    for (let i = 0; i < 100; i += 1) {
+      const id = reviewService.generateReviewId();
+      assert.ok(id.startsWith('rev_'), `missing rev_ prefix: ${id}`);
+      assert.ok(!seen.has(id), `duplicate id generated: ${id}`);
+      seen.add(id);
+    }
+  } finally {
+    Date.now = realNow;
+  }
+});


### PR DESCRIPTION
## Root cause  `apps/api/src/services/reviewService.js` built ids as `rev_${Date.now()}` inside the `createReview` object literal, so two reviews created within the same millisecond received identical ids, making lookups, reconciliation, and client-side tracking ambiguous.  ## Changes  **`apps/api/s