### PR TITLE
fix: Payment creation passes raw body to service without input validation

### DIFF
--- a/apps/api/src/controllers/paymentController.js
+++ b/apps/api/src/controllers/paymentController.js
@@ -1,6 +1,23 @@
 import { ok } from "../utils/response.js";
+const { createPaymentSchema } = require('../validators/payment');
 import { createPaymentIntent } from "../services/paymentService.js";
 
 export async function createPayment(req, res) {
-  return ok(res, await createPaymentIntent(req.body), 201);
+    const parsed = createPaymentSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Invalid payment payload',
+        details: parsed.error.issues.map((issue) => ({
+          field: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
+    }
+
+    const paymentIntent = await paymentService.createPaymentIntent(parsed.data);
 }
+  } catch (err) {
+    return next(err);
+  }
+};

--- a/apps/api/src/validators/payment.js
+++ b/apps/api/src/validators/payment.js
@@ -1,0 +1,24 @@
+const { z } = require('zod');
+
+/**
+ * Validation schema for POST /api/payments (payment intent creation).
+ * Requires a positive numeric amount and a non-empty currency code.
+ */
+const createPaymentSchema = z.object({
+  amount: z
+    .number({
+      required_error: 'amount is required',
+      invalid_type_error: 'amount must be a number',
+    })
+    .positive('amount must be a positive number'),
+  currency: z
+    .string({
+      required_error: 'currency is required',
+      invalid_type_error: 'currency must be a string',
+    })
+    .min(1, 'currency must not be empty'),
+});
+
+module.exports = {
+  createPaymentSchema,
+};


### PR DESCRIPTION
## Summary Fixes #4623 (parent bounty #743).  `paymentController.createPayment` previously passed `req.body` straight into `paymentService.createPaymentIntent`, so `POST /api/payments` with `{}` returned `201` with `amount: undefined` and a silent `currency: 'usd'` fallback.  ## Changes - **Create `