### PR TITLE
fix(api): validate user creation payloads and block admin role self-assignment (#11000)

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,10 +1,28 @@
 import { ok } from "../utils/response.js";
+const { createUserSchema } = require('../validators/user');
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
   return ok(res, await listUsers());
 }
 
+  const parsed = createUserSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      error: 'Validation failed',
+      details: parsed.error.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      })),
+    });
+  }
+
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+    const user = await userService.createUser(parsed.data);
 }
+  } catch (error) {
+    next(error);
+  }
+};

--- a/apps/api/src/tests/userValidation.test.js
+++ b/apps/api/src/tests/userValidation.test.js
@@ -1,0 +1,53 @@
+const { createUserSchema } = require('../validators/user');
+
+describe('POST /api/users payload validation', () => {
+  const validPayload = {
+    email: 'jane.doe@example.com',
+    fullName: 'Jane Doe',
+  };
+
+  it('accepts a valid payload and defaults role to client', () => {
+    const result = createUserSchema.safeParse(validPayload);
+
+    expect(result.success).toBe(true);
+    expect(result.data.email).toBe('jane.doe@example.com');
+    expect(result.data.fullName).toBe('Jane Doe');
+    expect(result.data.role).toBe('client');
+  });
+
+  it('rejects attempts to self-assign the admin role', () => {
+    const result = createUserSchema.safeParse({ ...validPayload, role: 'admin' });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.error.issues.some((issue) => issue.path.includes('role'))
+    ).toBe(true);
+  });
+
+  it('rejects an invalid email', () => {
+    const result = createUserSchema.safeParse({ ...validPayload, email: 'not-an-email' });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.error.issues.some((issue) => issue.path.includes('email'))
+    ).toBe(true);
+  });
+
+  it('rejects an empty or whitespace-only full name', () => {
+    const result = createUserSchema.safeParse({ ...validPayload, fullName: '   ' });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.error.issues.some((issue) => issue.path.includes('fullName'))
+    ).toBe(true);
+  });
+
+  it('allows client and freelancer roles explicitly', () => {
+    for (const role of ['client', 'freelancer']) {
+      const result = createUserSchema.safeParse({ ...validPayload, role });
+
+      expect(result.success).toBe(true);
+      expect(result.data.role).toBe(role);
+    }
+  });
+});

--- a/apps/api/src/validators/user.js
+++ b/apps/api/src/validators/user.js
@@ -1,0 +1,29 @@
+const { z } = require('zod');
+
+/**
+ * Validation schema for POST /api/users.
+ *
+ * - Requires a valid email and a non-empty full name.
+ * - role defaults to 'client' and only allows 'client' or 'freelancer',
+ *   so callers cannot self-assign privileged roles (e.g. 'admin').
+ * - Unknown fields are stripped before the payload reaches the service layer.
+ */
+const createUserSchema = z.object({
+  email: z
+    .string({ required_error: 'email is required' })
+    .trim()
+    .toLowerCase()
+    .email('email must be a valid email address'),
+  fullName: z
+    .string({ required_error: 'fullName is required' })
+    .trim()
+    .min(1, 'fullName must not be empty'),
+  password: z.string().min(1, 'password must not be empty').optional(),
+  role: z
+    .enum(['client', 'freelancer'], {
+      errorMap: () => ({ message: 'role must be either client or freelancer' }),
+    })
+    .default('client'),
+});
+
+module.exports = { createUserSchema };


### PR DESCRIPTION
Closes #11000 (parent Algora bounty: #743).  ## Problem POST /api/users passed req.body directly to userService.createUser() with no validation schema. Callers could create malformed user records and self-assign role: 'admin'. Validation failures fell through to generic error handling instead of a c