### PR TITLE
fix(payments): normalize currency before intent creation (#4516)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -5,5 +5,20 @@ export async function createPaymentIntent(payload) {
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"
+  const normalizeCurrency = (value) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+      return 'usd';
+    }
+    return value.trim().toLowerCase();
+  };
+
   };
 }
+    amount,
+    currency: normalizeCurrency(currency),
+    status: 'requires_payment_method',
+    ...rest,
+  };
+};
+
+module.exports = { createPaymentIntent };

--- a/apps/api/src/tests/paymentRoutes.test.js
+++ b/apps/api/src/tests/paymentRoutes.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /api/payments/intents – currency normalization', () => {
+  const basePayload = { amount: 5000 };
+
+  it('defaults currency to "usd" when currency is missing', async () => {
+    const res = await request(app)
+      .post('/api/payments/intents')
+      .send(basePayload)
+      .expect(200);
+
+    expect(res.body.currency).toBe('usd');
+  });
+
+  it('trims and lowercases a mixed-case / whitespace-padded currency string', async () => {
+    const res = await request(app)
+      .post('/api/payments/intents')
+      .send({ ...basePayload, currency: '  USD  ' })
+      .expect(200);
+
+    expect(res.body.currency).toBe('usd');
+  });
+
+  it('falls back to "usd" when currency is a blank string', async () => {
+    const res = await request(app)
+      .post('/api/payments/intents')
+      .send({ ...basePayload, currency: '   ' })
+      .expect(200);
+
+    expect(res.body.currency).toBe('usd');
+  });
+
+  it('falls back to "usd" when currency is a non-string value', async () => {
+    const res = await request(app)
+      .post('/api/payments/intents')
+      .send({ ...basePayload, currency: 840 })
+      .expect(200);
+
+    expect(res.body.currency).toBe('usd');
+  });
+
+  it('preserves an already-valid lowercase currency', async () => {
+    const res = await request(app)
+      .post('/api/payments/intents')
+      .send({ ...basePayload, currency: 'eur' })
+      .expect(200);
+
+    expect(res.body.currency).toBe('eur');
+  });
+});


### PR DESCRIPTION
## Summary  Fixes #4516 (reissue via #743, ref #4471, related #4512).  `createPaymentIntent()` was returning `payload.currency` verbatim, so mixed-case or whitespace-padded values like `" USD "` reached payment providers in non-canonical form. Providers expect lowercase ISO-4217 codes.  ## Changes  