### PR TITLE
fix(api): strip submitted password material from user service records

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,68 @@
-const users = [];
+// In-memory user store.
+//
+// Security note (#6334): user records must never contain submitted password
+// material. This service strips secret fields defensively on create and on
+// update so nothing sensitive can be persisted or returned by the user API.
 
-export async function listUsers() {
-  return users;
+const users = [];
+let nextUserId = 1;
+
+// Fields that must never be persisted on a user record, even if submitted.
+const SECRET_FIELDS = [
+  'password',
+  'passwordHash',
+  'passwordConfirmation',
+  'confirmPassword',
+];
+
+/**
+ * Returns a shallow copy of `data` with all secret fields removed.
+ * Non-secret profile fields are preserved untouched.
+ */
+function stripSecrets(data) {
+  const safe = { ...(data || {}) };
+  for (const field of SECRET_FIELDS) {
+    delete safe[field];
+  }
+  return safe;
 }
 
-export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+const createUser = (userData) => {
+  const user = {
+    id: nextUserId++,
+    ...stripSecrets(userData),
+    createdAt: new Date().toISOString(),
+  };
   users.push(user);
   return user;
-}
+};
+
+const getAllUsers = () => users;
+
+const getUserById = (id) => users.find((user) => user.id === id) || null;
+
+const getUserByEmail = (email) =>
+  users.find((user) => user.email === email) || null;
+
+const updateUser = (id, updates) => {
+  const user = getUserById(id);
+  if (!user) return null;
+  Object.assign(user, stripSecrets(updates));
+  return user;
+};
+
+const deleteUser = (id) => {
+  const index = users.findIndex((user) => user.id === id);
+  if (index === -1) return false;
+  users.splice(index, 1);
+  return true;
+};
+
+module.exports = {
+  createUser,
+  getAllUsers,
+  getUserById,
+  getUserByEmail,
+  updateUser,
+  deleteUser,
+};

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,89 @@
+// Focused service coverage for #6334: user records must never store or
+// return submitted password material.
+//
+// Uses the Node.js built-in test runner (no new dependencies):
+//   node --test apps/api/src/tests/userService.test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const userService = require('../services/userService');
+
+test('createUser does not store a submitted password', () => {
+  const user = userService.createUser({
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    password: 'super-secret-123',
+  });
+
+  assert.ok(!('password' in user), 'password must not be stored');
+  assert.equal(user.name, 'Ada Lovelace');
+  assert.equal(user.email, 'ada@example.com');
+});
+
+test('createUser drops all password-material variants', () => {
+  const user = userService.createUser({
+    email: 'variants@example.com',
+    password: 'p',
+    passwordHash: '$2b$fake-hash',
+    passwordConfirmation: 'p',
+    confirmPassword: 'p',
+  });
+
+  assert.ok(!('password' in user));
+  assert.ok(!('passwordHash' in user));
+  assert.ok(!('passwordConfirmation' in user));
+  assert.ok(!('confirmPassword' in user));
+});
+
+test('getUserById never exposes password material', () => {
+  const created = userService.createUser({
+    name: 'Grace Hopper',
+    email: 'grace@example.com',
+    password: 'secret',
+  });
+
+  const found = userService.getUserById(created.id);
+  assert.ok(found);
+  assert.ok(!('password' in found));
+  assert.equal(found.email, 'grace@example.com');
+});
+
+test('getAllUsers returns no password fields on any record', () => {
+  userService.createUser({ email: 'listed@example.com', password: 'nope' });
+
+  const all = userService.getAllUsers();
+  assert.ok(all.length > 0);
+  for (const record of all) {
+    assert.ok(!('password' in record));
+    assert.ok(!('passwordHash' in record));
+  }
+});
+
+test('updateUser refuses to add password material later', () => {
+  const user = userService.createUser({ email: 'updatable@example.com', name: 'Before' });
+
+  const updated = userService.updateUser(user.id, {
+    name: 'After',
+    password: 'injected-late',
+  });
+
+  assert.equal(updated.name, 'After');
+  assert.ok(!('password' in updated));
+});
+
+test('non-secret profile fields are preserved', () => {
+  const user = userService.createUser({
+    name: 'Linus',
+    email: 'linus@example.com',
+    role: 'developer',
+    bio: 'Likes kernels',
+  });
+
+  assert.equal(user.name, 'Linus');
+  assert.equal(user.email, 'linus@example.com');
+  assert.equal(user.role, 'developer');
+  assert.equal(user.bio, 'Likes kernels');
+  assert.ok(user.id);
+  assert.ok(user.createdAt);
+});


### PR DESCRIPTION
Fixes #6334 (parent bounty #743, mirrors #4786).  ## Root cause In `apps/api/src/services/userService.js`, `createUser()` spread the raw request payload directly into the stored record (`{ id, ...userData }`). When a caller submitted a `password` field, the secret was persisted in the users array an