### PR TITLE
fix: reject missing or blank search queries (#9686)

### DIFF
--- a/apps/api/src/controllers/searchController.js
+++ b/apps/api/src/controllers/searchController.js
@@ -2,5 +2,14 @@ import { ok } from "../utils/response.js";
 import { globalSearch } from "../services/searchService.js";
 
 export async function search(req, res) {
-  return ok(res, await globalSearch(req.query.q ?? ""));
+    const q = req.query.q;
+
+    // Reject missing or blank search queries (issue #9686).
+    if (typeof q !== 'string' || q.trim().length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: 'Query parameter "q" is required and must not be blank.',
+      });
+    }
+
 }

--- a/apps/api/src/tests/search.test.js
+++ b/apps/api/src/tests/search.test.js
@@ -1,0 +1,45 @@
+const request = require('supertest');
+
+jest.mock('../services/searchService', () => ({
+  globalSearch: jest.fn(),
+}));
+
+const app = require('../app');
+const searchService = require('../services/searchService');
+
+describe('GET /api/search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 when the q parameter is missing', async () => {
+    const res = await request(app).get('/api/search');
+
+    expect(res.statusCode).toBe(400);
+    expect(searchService.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the q parameter is an empty string', async () => {
+    const res = await request(app).get('/api/search?q=');
+
+    expect(res.statusCode).toBe(400);
+    expect(searchService.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the q parameter is only whitespace', async () => {
+    const res = await request(app).get('/api/search?q=%20%20%20');
+
+    expect(res.statusCode).toBe(400);
+    expect(searchService.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it('continues the existing search flow for a non-blank query', async () => {
+    searchService.globalSearch.mockResolvedValue({ results: [] });
+
+    const res = await request(app).get('/api/search?q=developer');
+
+    expect(res.statusCode).toBe(200);
+    expect(searchService.globalSearch).toHaveBeenCalledTimes(1);
+    expect(searchService.globalSearch).toHaveBeenCalledWith('developer');
+  });
+});


### PR DESCRIPTION
Fixes #9686 (parent Algora bounty: #743)  ## Bug `GET /api/search` returned a successful response when `q` was missing or blank because `searchController.globalSearch` fell back to an empty string (`req.query.q || ''`) before calling `searchService.globalSearch`.  ## Fix **`apps/api/src/controllers/