### PR TITLE
feat(utils): add human-readable file size formatter formatBytes (#11876)

### DIFF
--- a/apps/api/src/tests/formatBytes.test.js
+++ b/apps/api/src/tests/formatBytes.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../utils/formatBytes.js';
+
+describe('formatBytes', () => {
+  it('should return "0 B" for zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('should return "0 B" for negative values', () => {
+    expect(formatBytes(-100)).toBe('0 B');
+  });
+
+  it('should return "0 B" for NaN/Infinity', () => {
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
+  });
+
+  it('should format bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1024)).toBe('1.00 KB');
+    expect(formatBytes(1536)).toBe('1.50 KB');
+    expect(formatBytes(1048576)).toBe('1.00 MB');
+    expect(formatBytes(1073741824)).toBe('1.00 GB');
+    expect(formatBytes(1099511627776)).toBe('1.00 TB');
+  });
+
+  it('should respect custom decimal places', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB');
+    expect(formatBytes(1536, 4)).toBe('1.5000 KB');
+  });
+
+  it('should handle edge case of exactly 1024', () => {
+    expect(formatBytes(1023)).toBe('1023 B');
+    expect(formatBytes(1024)).toBe('1.00 KB');
+  });
+
+  it('should not exceed TB unit for very large numbers', () => {
+    const result = formatBytes(1099511627776 * 1024);
+    expect(result).toContain('TB');
+  });
+});

--- a/apps/api/src/utils/formatBytes.js
+++ b/apps/api/src/utils/formatBytes.js
@@ -1,0 +1,22 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+const BASE = 1024;
+
+/**
+ * Format bytes into a human-readable string.
+ * @param {number} bytes - The number of bytes
+ * @param {number} decimals - Number of decimal places (default: 2)
+ * @returns {string} Formatted string (e.g. "1.5 MB")
+ */
+export function formatBytes(bytes, decimals = 2) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+
+  if (bytes === 0) return '0 B';
+
+  const i = Math.floor(Math.log(bytes) / Math.log(BASE));
+  const index = Math.min(i, UNITS.length - 1);
+
+  const value = bytes / Math.pow(BASE, index);
+  // Don't show decimals for bytes
+  if (index === 0) return `${Math.round(value)} ${UNITS[index]}`;
+  return `${value.toFixed(decimals)} ${UNITS[index]}`;
+}


### PR DESCRIPTION
## Summary
- Implements `formatBytes(bytes, decimals)` in `apps/api/src/utils/formatBytes.js`
- Formats bytes across B, KB, MB, GB, TB using 1024 base
- Handles edge cases: negative, NaN, Infinity, zero
- No decimal places for byte-level values, configurable for larger units

## Test Coverage
- 7 tests covering: zero, negative, NaN/Infinity, standard conversions, custom decimals, boundary (1023/1024), overflow

Closes #11876