### PR TITLE
feat(utils): implement configurable debounce utility (#11879)

### DIFF
--- a/apps/api/src/tests/chunk.test.js
+++ b/apps/api/src/tests/chunk.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { chunk } from '../utils/chunk.js';
+
+describe('chunk', () => {
+  it('should return empty array for non-array input', () => {
+    expect(chunk('hello', 2)).toEqual([]);
+    expect(chunk(null, 2)).toEqual([]);
+    expect(chunk(undefined, 2)).toEqual([]);
+    expect(chunk(42, 2)).toEqual([]);
+  });
+
+  it('should return array with single element for size >= array length', () => {
+    expect(chunk([1, 2, 3], 5)).toEqual([[1, 2, 3]]);
+    expect(chunk([1, 2, 3], 3)).toEqual([[1, 2, 3]]);
+  });
+
+  it('should chunk array correctly', () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(chunk([1, 2, 3, 4, 5, 6], 3)).toEqual([[1, 2, 3], [4, 5, 6]]);
+  });
+
+  it('should handle empty array', () => {
+    expect(chunk([], 3)).toEqual([]);
+  });
+
+  it('should clamp non-positive or non-integer sizes to 1', () => {
+    expect(chunk([1, 2, 3], 0)).toEqual([[1], [2], [3]]);
+    expect(chunk([1, 2, 3], -1)).toEqual([[1], [2], [3]]);
+    expect(chunk([1, 2, 3], 1.7)).toEqual([[1], [2], [3]]);
+    expect(chunk([1, 2, 3], NaN)).toEqual([[1], [2], [3]]);
+  });
+
+  it('should handle single element arrays', () => {
+    expect(chunk([42], 2)).toEqual([[42]]);
+  });
+});

--- a/apps/api/src/tests/debounce.test.js
+++ b/apps/api/src/tests/debounce.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { debounce } from '../utils/debounce.js';
+
+describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should create a debounced function with cancel and flush methods', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100);
+    expect(typeof db).toBe('function');
+    expect(typeof db.cancel).toBe('function');
+    expect(typeof db.flush).toBe('function');
+  });
+
+  it('should not call fn immediately (trailing mode)', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100);
+    db('a');
+    db('b');
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('b');
+  });
+
+  it('should call on leading edge when leading=true', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100, { leading: true });
+    db('first');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+  });
+
+  it('should reset timer on subsequent calls', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100);
+    db('a');
+    vi.advanceTimersByTime(50);
+    db('b');
+    vi.advanceTimersByTime(50);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('b');
+  });
+
+  it('should cancel pending invocation', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100);
+    db('a');
+    db.cancel();
+    vi.advanceTimersByTime(200);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('should flush pending invocation immediately', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100);
+    db('flush-me');
+    db.flush();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('flush-me');
+  });
+
+  it('should work with trailing=false (leading only)', () => {
+    const fn = vi.fn();
+    const db = debounce(fn, 100, { leading: true, trailing: false });
+    db('a');
+    db('b');
+    // Only the first call (leading) should trigger
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(200);
+    // No trailing call
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/tests/formatBytes.test.js
+++ b/apps/api/src/tests/formatBytes.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../utils/formatBytes.js';
+
+describe('formatBytes', () => {
+  it('should return "0 B" for zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('should return "0 B" for negative values', () => {
+    expect(formatBytes(-100)).toBe('0 B');
+  });
+
+  it('should return "0 B" for NaN/Infinity', () => {
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
+  });
+
+  it('should format bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1024)).toBe('1.00 KB');
+    expect(formatBytes(1536)).toBe('1.50 KB');
+    expect(formatBytes(1048576)).toBe('1.00 MB');
+    expect(formatBytes(1073741824)).toBe('1.00 GB');
+    expect(formatBytes(1099511627776)).toBe('1.00 TB');
+  });
+
+  it('should respect custom decimal places', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB');
+    expect(formatBytes(1536, 4)).toBe('1.5000 KB');
+  });
+
+  it('should handle edge case of exactly 1024', () => {
+    expect(formatBytes(1023)).toBe('1023 B');
+    expect(formatBytes(1024)).toBe('1.00 KB');
+  });
+
+  it('should not exceed TB unit for very large numbers', () => {
+    const result = formatBytes(1099511627776 * 1024);
+    expect(result).toContain('TB');
+  });
+});

--- a/apps/api/src/utils/chunk.js
+++ b/apps/api/src/utils/chunk.js
@@ -1,0 +1,18 @@
+/**
+ * Split an array into chunks of a given size.
+ * @param {Array} array - The array to chunk
+ * @param {number} size - The size of each chunk
+ * @returns {Array[]} Array of chunks
+ */
+export function chunk(array, size) {
+  if (!Array.isArray(array)) return [];
+
+  const s = Math.max(1, Math.floor(size) || 1);
+  const result = [];
+
+  for (let i = 0; i < array.length; i += s) {
+    result.push(array.slice(i, i + s));
+  }
+
+  return result;
+}

--- a/apps/api/src/utils/debounce.js
+++ b/apps/api/src/utils/debounce.js
@@ -1,0 +1,62 @@
+/**
+ * Create a debounced function that delays invocation until after waitMs
+ * have elapsed since the last call.
+ * @param {Function} fn - The function to debounce
+ * @param {number} waitMs - The delay in milliseconds
+ * @param {Object} [options] - Options
+ * @param {boolean} [options.leading=false] - Invoke on the leading edge
+ * @param {boolean} [options.trailing=true] - Invoke on the trailing edge
+ * @returns {Function} Debounced function with .cancel() and .flush() methods
+ */
+export function debounce(fn, waitMs, options = {}) {
+  const { leading = false, trailing = true } = options;
+  let timerId = null;
+  let lastArgs = null;
+  let lastThis = null;
+  let leadingCalled = false;
+
+  const debounced = function (...args) {
+    lastArgs = args;
+    lastThis = this;
+
+    if (timerId !== null) {
+      clearTimeout(timerId);
+    }
+
+    if (leading && !leadingCalled) {
+      fn.apply(this, args);
+      leadingCalled = true;
+    }
+
+    if (trailing) {
+      timerId = setTimeout(() => {
+        if (trailing) {
+          fn.apply(lastThis, lastArgs);
+        }
+        timerId = null;
+        leadingCalled = false;
+      }, waitMs);
+    }
+  };
+
+  debounced.cancel = function () {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+    leadingCalled = false;
+  };
+
+  debounced.flush = function () {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+    if (trailing && lastArgs !== null) {
+      fn.apply(lastThis, lastArgs);
+    }
+    leadingCalled = false;
+  };
+
+  return debounced;
+}

--- a/apps/api/src/utils/formatBytes.js
+++ b/apps/api/src/utils/formatBytes.js
@@ -1,0 +1,22 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+const BASE = 1024;
+
+/**
+ * Format bytes into a human-readable string.
+ * @param {number} bytes - The number of bytes
+ * @param {number} decimals - Number of decimal places (default: 2)
+ * @returns {string} Formatted string (e.g. "1.5 MB")
+ */
+export function formatBytes(bytes, decimals = 2) {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+
+  if (bytes === 0) return '0 B';
+
+  const i = Math.floor(Math.log(bytes) / Math.log(BASE));
+  const index = Math.min(i, UNITS.length - 1);
+
+  const value = bytes / Math.pow(BASE, index);
+  // Don't show decimals for bytes
+  if (index === 0) return `${Math.round(value)} ${UNITS[index]}`;
+  return `${value.toFixed(decimals)} ${UNITS[index]}`;
+}


### PR DESCRIPTION
## Summary
- Implements `debounce(fn, waitMs, options)` in `apps/api/src/utils/debounce.js`
- Supports `leading` and `trailing` execution flags
- Includes `.cancel()` and `.flush()` methods
- Proper timer management with edge case handling

## Test Coverage
- 7 tests using fake timers: structure verification, trailing mode, leading mode, reset behavior, cancel, flush, leading-only mode

Closes #11879