### PR TITLE
fix(api): require authentication for POST /api/proposals (issue #2773)

### DIFF
--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+// Security fix (issue #2773): proposal creation must be authenticated.
+proposalRoutes.post("/", authMiddleware, postProposal);

--- a/apps/api/src/tests/proposalAuth.test.js
+++ b/apps/api/src/tests/proposalAuth.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { createApp } from "../app.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    const { port } = server.address();
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/proposals rejects unauthenticated requests", async () => {
+  await withServer(async (base) => {
+    const response = await fetch(`${base}/api/proposals`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ job_id: 1, cover_letter: "spam" }),
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test("POST /api/proposals rejects invalid tokens", async () => {
+  await withServer(async (base) => {
+    const response = await fetch(`${base}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer not-a-real-token",
+      },
+      body: JSON.stringify({ job_id: 1, cover_letter: "spam" }),
+    });
+    assert.equal(response.status, 401);
+  });
+});
+
+test("POST /api/proposals accepts a valid access token", async () => {
+  await withServer(async (base) => {
+    const token = jwt.sign({ sub: 1, email: "user@example.com" }, process.env.JWT_SECRET ?? "development-secret", {
+      expiresIn: "10m",
+    });
+    const response = await fetch(`${base}/api/proposals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ job_id: 1, cover_letter: "hello" }),
+    });
+    assert.equal(response.status, 201);
+  });
+});


### PR DESCRIPTION
Fixes #2773

POST /api/proposals didn't check auth at all — anyone could create proposals by hitting the endpoint directly.

The route now runs authMiddleware before postProposal, same as adminRoutes already does.

Testing:

Ran the new regression tests against the unpatched route first to make sure they actually catch the bug: 1/3 pass without the fix, 3/3 with it (node --test apps/api/src/tests/proposalAuth.test.js).

Also verified against a running server:
- POST with no token -> 401
- POST with a garbage token -> 401
- POST with a real JWT from /api/auth/register -> 201

One note for whoever runs the tests: `node --test src/tests` (directory form) fails on this repo even on a clean checkout, so run the test files individually.