### PR TITLE
fix: secure upload routes and enforce rate limiting on malformed JSON

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -17,11 +17,10 @@ import { adminRoutes } from "./routes/adminRoutes.js";
 
 export function createApp() {
   const app = express();
-
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
   app.use(apiLimiter);
+  app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,11 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "File is required", 400);
+  }
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import multer from "multer";
+import { authMiddleware } from "../middleware/auth.js";
 import { uploadFile } from "../controllers/uploadController.js";
 
 const upload = multer({ storage: multer.memoryStorage() });
 
 export const uploadRoutes = Router();
 
-uploadRoutes.post("/", upload.single("file"), uploadFile);
+uploadRoutes.post("/", authMiddleware, upload.single("file"), uploadFile);


### PR DESCRIPTION
This PR addresses multiple low-hanging fruit bugs referenced in #743:  1. **Rate limiter bypass via malformed JSON**: Moved `apiLimiter` before `express.json()` in `app.js` so that requests with malformed bodies still consume rate limit quota. 2. **Upload endpoint lacks authentication**: Added `auth