### PR TITLE
feat(admin): add manual payout endpoint for unsupported Algora regions

### DIFF
--- a/apps/api/src/controllers/adminController.js
+++ b/apps/api/src/controllers/adminController.js
@@ -4,3 +4,28 @@ import { getAdminMetrics } from "../services/adminService.js";
 export async function metrics(req, res) {
   return ok(res, await getAdminMetrics());
 }
+  }
+}
+
+async function processManualPayout(req, res) {
+  try {
+    const { proposalId, txHash, method } = req.body;
+    if (!proposalId || !txHash) {
+      return res.status(400).json({ error: 'proposalId and txHash are required' });
+    }
+    
+    const proposal = await paymentService.processManualPayout(proposalId, txHash, method);
+    
+    res.json({ success: true, message: 'Manual payout recorded', proposal });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+module.exports = {
+  getUsers,
+  banUser,
+  unbanUser,
+  approveBounty,
+  processManualPayout
+};

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -6,3 +6,9 @@ export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
 adminRoutes.get("/metrics", metrics);
+router.post('/users/:id/ban', adminController.banUser);
+router.post('/users/:id/unban', adminController.unbanUser);
+router.post('/bounties/:id/approve', adminController.approveBounty);
+router.post('/payouts/manual', adminController.processManualPayout);
+
+module.exports = router;

--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -7,3 +7,23 @@ export async function createPaymentIntent(payload) {
     provider: "stripe"
   };
 }
+  return payment;
+}
+
+async function processManualPayout(proposalId, txHash, method = 'crypto') {
+  const proposal = await Proposal.findById(proposalId);
+  if (!proposal) throw new Error('Proposal not found');
+  
+  proposal.status = 'paid';
+  proposal.paymentMethod = method;
+  proposal.transactionHash = txHash;
+  proposal.paidAt = new Date();
+  await proposal.save();
+
+  return proposal;
+}
+
+module.exports = {
+  createAlgoraPayout,
+  processManualPayout
+};


### PR DESCRIPTION
### Issue Fixes #7458  ### Problem When Algora does not support a contributor's region, the automated payout system fails, leaving bounties in a stuck state. The issue requested hardcoding a specific USDT wallet address into the codebase. Hardcoding user PII or financial addresses in source code is 