### PR TITLE
fix(api): map Multer parser errors to 400 Bad Request (#12031)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,8 +1,18 @@
+﻿import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
+
+  if (err instanceof multer.MulterError || err?.name === "MulterError") {
+    return res.status(400).json({
+      success: false,
+      message: err.message || "Invalid multipart upload payload"
+    });
+  }
+
+  console.error("Unhandled API error:", err);
 
   return res.status(500).json({
     success: false,

--- a/apps/api/src/tests/upload_multer_error.test.js
+++ b/apps/api/src/tests/upload_multer_error.test.js
@@ -1,0 +1,44 @@
+﻿import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads with unexpected field returns 400 Bad Request", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+
+  const boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW";
+  const body = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="avatar"; filename="avatar.png"',
+    "Content-Type: image/png",
+    "",
+    "fake-image-binary-data",
+    `--${boundary}--`,
+    ""
+  ].join("\r\n");
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+    method: "POST",
+    headers: {
+      "Content-Type": `multipart/form-data; boundary=${boundary}`
+    },
+    body: body
+  });
+
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(payload.success, false);
+  assert.match(payload.message, /Unexpected field/i);
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});


### PR DESCRIPTION
Closes #12031
Parent bounty: #11398

## Description
When multipart uploads contain malformed inputs (such as unexpected field names like `avatar` instead of `file`), Multer raises a `MulterError` (e.g. `LIMIT_UNEXPECTED_FILE`). The global error handler was previously treating these as internal server failures and returning 500.

## Changes Made
- Updated `apps/api/src/middleware/errorHandler.js` to inspect `err instanceof multer.MulterError` and `err.name === 'MulterError'`.
- Returns HTTP `400 Bad Request` with the standard `{ success: false, message: err.message }` payload format for client-side parser errors.
- Preserves HTTP `500` for unexpected server errors.
- Added regression test suite in `apps/api/src/tests/upload_multer_error.test.js` verifying HTTP 400 response on unexpected field names.
