### PR TITLE
feat(utils): implement debounce utility for rate limiting (#11894)

### DIFF
--- a/apps/api/src/tests/debounce.test.js
+++ b/apps/api/src/tests/debounce.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { debounce } from "../utils/debounce.js";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("debounce Utility", () => {
+    it("debounces a function", async () => {
+        let callCount = 0;
+        const debounced = debounce(() => callCount++, 32);
+
+        debounced();
+        debounced();
+        debounced();
+        
+        assert.equal(callCount, 0);
+        
+        await sleep(64);
+        assert.equal(callCount, 1);
+    });
+
+    it("supports leading edge", async () => {
+        let callCount = 0;
+        const debounced = debounce(() => callCount++, 32, { leading: true, trailing: false });
+
+        debounced(); // calls immediately
+        assert.equal(callCount, 1);
+        
+        debounced(); // ignored
+        debounced(); // ignored
+        
+        await sleep(64);
+        assert.equal(callCount, 1);
+    });
+    
+    it("supports cancel", async () => {
+        let callCount = 0;
+        const debounced = debounce(() => callCount++, 32);
+
+        debounced();
+        debounced.cancel();
+        
+        await sleep(64);
+        assert.equal(callCount, 0);
+    });
+    
+    it("supports flush", () => {
+        let callCount = 0;
+        const debounced = debounce(() => callCount++, 32);
+
+        debounced();
+        debounced.flush();
+        
+        assert.equal(callCount, 1);
+    });
+});

--- a/apps/api/src/utils/debounce.js
+++ b/apps/api/src/utils/debounce.js
@@ -1,0 +1,107 @@
+/**
+ * Debounce utility for rate limiting.
+ * Delays invoking a function until after wait milliseconds have elapsed since the last time it was invoked.
+ */
+
+/**
+ * Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
+ * @param {Function} func The function to debounce
+ * @param {number} wait The number of milliseconds to delay
+ * @param {Object} [options] The options object
+ * @param {boolean} [options.leading=false] Specify invoking on the leading edge of the timeout
+ * @param {boolean} [options.trailing=true] Specify invoking on the trailing edge of the timeout
+ * @returns {Function} The new debounced function
+ */
+export function debounce(func, wait, options = {}) {
+    let timeoutId;
+    let lastArgs;
+    let lastThis;
+    let lastCallTime;
+    let lastInvokeTime = 0;
+
+    const leading = !!options.leading;
+    const trailing = "trailing" in options ? !!options.trailing : true;
+
+    function invokeFunc(time) {
+        const args = lastArgs;
+        const thisArg = lastThis;
+
+        lastArgs = lastThis = undefined;
+        lastInvokeTime = time;
+        return func.apply(thisArg, args);
+    }
+
+    function leadingEdge(time) {
+        lastInvokeTime = time;
+        timeoutId = setTimeout(timerExpired, wait);
+        return leading ? invokeFunc(time) : undefined;
+    }
+
+    function remainingWait(time) {
+        const timeSinceLastCall = time - lastCallTime;
+        const timeSinceLastInvoke = time - lastInvokeTime;
+        const timeWaiting = wait - timeSinceLastCall;
+
+        return timeWaiting;
+    }
+
+    function shouldInvoke(time) {
+        const timeSinceLastCall = time - lastCallTime;
+        return (
+            lastCallTime === undefined ||
+            timeSinceLastCall >= wait ||
+            timeSinceLastCall < 0
+        );
+    }
+
+    function timerExpired() {
+        const time = Date.now();
+        if (shouldInvoke(time)) {
+            return trailingEdge(time);
+        }
+        timeoutId = setTimeout(timerExpired, remainingWait(time));
+    }
+
+    function trailingEdge(time) {
+        timeoutId = undefined;
+
+        if (trailing && lastArgs) {
+            return invokeFunc(time);
+        }
+        lastArgs = lastThis = undefined;
+        return undefined;
+    }
+
+    function debounced(...args) {
+        const time = Date.now();
+        const isInvoking = shouldInvoke(time);
+
+        lastArgs = args;
+        lastThis = this;
+        lastCallTime = time;
+
+        if (isInvoking) {
+            if (timeoutId === undefined) {
+                return leadingEdge(lastCallTime);
+            }
+        }
+        if (timeoutId === undefined) {
+            timeoutId = setTimeout(timerExpired, wait);
+        }
+        return undefined;
+    }
+
+    debounced.cancel = function () {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+        }
+        lastInvokeTime = 0;
+        lastArgs = lastCallTime = lastThis = timeoutId = undefined;
+    };
+
+    debounced.flush = function () {
+        return timeoutId === undefined ? undefined : trailingEdge(Date.now());
+    };
+
+    return debounced;
+}


### PR DESCRIPTION
Closes #11894

## Summary of Changes
Implements a robust `debounce` utility for rate limiting and trailing/leading edge execution control.

## Features
- **Rate Limiting**: Delays invoking a function until after `wait` milliseconds have elapsed since the last time the debounced function was invoked.
- **Edge Control**: Supports `leading` and `trailing` edge execution options.
- **API Methods**: Provides `cancel()` to cancel delayed invocations and `flush()` to immediately invoke pending executions.
- **Unit Tests**: Full asynchronous unit test coverage in `apps/api/src/tests/debounce.test.js`.
