### PR TITLE
feat(utils): implement pick utility to create object of picked properties (#11884)

### DIFF
--- a/apps/api/src/tests/pick.test.js
+++ b/apps/api/src/tests/pick.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { pick } from "../utils/pick.js";
+
+describe("pick Utility", () => {
+    it("picks specified keys from an object", () => {
+        const obj = { a: 1, b: "2", c: 3 };
+        assert.deepEqual(pick(obj, ["a", "c"]), { a: 1, c: 3 });
+        assert.deepEqual(pick(obj, "b"), { b: "2" });
+    });
+
+    it("ignores non-existent keys", () => {
+        const obj = { a: 1, b: 2 };
+        assert.deepEqual(pick(obj, ["a", "z"]), { a: 1 });
+    });
+
+    it("handles null, undefined, or primitive objects safely", () => {
+        assert.deepEqual(pick(null, ["a"]), {});
+        assert.deepEqual(pick(undefined, ["a"]), {});
+        assert.deepEqual(pick(123, ["a"]), {});
+    });
+
+    it("prevents prototype pollution", () => {
+        const obj = { __proto__: { evil: true }, a: 1 };
+        const picked = pick(obj, ["__proto__", "a"]);
+        assert.deepEqual(picked, { a: 1 });
+        assert.equal({}.evil, undefined);
+    });
+});

--- a/apps/api/src/utils/pick.js
+++ b/apps/api/src/utils/pick.js
@@ -1,0 +1,37 @@
+/**
+ * Pick utility.
+ * Creates an object composed of the picked object properties.
+ */
+
+/**
+ * Creates an object composed of the picked object properties.
+ * Prototype pollution safe.
+ * @param {Object} object The source object.
+ * @param {string[]|string} paths The property paths to pick.
+ * @returns {Object} Returns the new object with picked properties.
+ */
+export function pick(object, paths) {
+    if (object == null || typeof object !== "object") {
+        return {};
+    }
+
+    const keys = Array.isArray(paths) ? paths : [paths];
+    const result = {};
+
+    for (const key of keys) {
+        if (typeof key !== "string" && typeof key !== "number") {
+            continue;
+        }
+
+        const prop = String(key);
+        if (prop === "__proto__" || prop === "constructor" || prop === "prototype") {
+            continue;
+        }
+
+        if (prop in object) {
+            result[prop] = object[prop];
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
Closes #11884

## Summary of Changes
Implements a prototype-pollution safe `pick` utility function to create an object composed of the selected properties.

## Features
- **Key Picking**: Extracts specific properties from an object given an array of keys or single key.
- **Prototype Pollution Safe**: Ignores `__proto__`, `constructor`, and `prototype` properties.
- **Defensive Design**: Returns empty objects for `null`, `undefined`, or primitive values without throwing.
- **Unit Tests**: Full unit test suite in `apps/api/src/tests/pick.test.js`.
