### PR TITLE
feat(utils): implement omit utility to create object without omitted properties (#11882)

### DIFF
--- a/apps/api/src/tests/omit.test.js
+++ b/apps/api/src/tests/omit.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { omit } from "../utils/omit.js";
+
+describe("omit Utility", () => {
+    it("omits specified keys from an object", () => {
+        const obj = { a: 1, b: "2", c: 3 };
+        assert.deepEqual(omit(obj, ["a", "c"]), { b: "2" });
+        assert.deepEqual(omit(obj, "b"), { a: 1, c: 3 });
+    });
+
+    it("handles non-existent keys", () => {
+        const obj = { a: 1, b: 2 };
+        assert.deepEqual(omit(obj, ["z"]), { a: 1, b: 2 });
+    });
+
+    it("handles null, undefined, or primitive objects safely", () => {
+        assert.deepEqual(omit(null, ["a"]), {});
+        assert.deepEqual(omit(undefined, ["a"]), {});
+        assert.deepEqual(omit(123, ["a"]), {});
+    });
+
+    it("prevents prototype pollution", () => {
+        const obj = { a: 1, b: 2 };
+        const result = omit(obj, ["b"]);
+        assert.deepEqual(result, { a: 1 });
+        assert.equal({}.polluted, undefined);
+    });
+});

--- a/apps/api/src/utils/omit.js
+++ b/apps/api/src/utils/omit.js
@@ -1,0 +1,34 @@
+/**
+ * Omit utility.
+ * The opposite of pick; this method creates an object composed of the own and inherited
+ * enumerable property paths of object that are not omitted.
+ */
+
+/**
+ * Creates an object composed of the own and inherited enumerable property paths of object that are not omitted.
+ * Prototype pollution safe.
+ * @param {Object} object The source object.
+ * @param {string[]|string} paths The property paths to omit.
+ * @returns {Object} Returns the new object.
+ */
+export function omit(object, paths) {
+    if (object == null || typeof object !== "object") {
+        return {};
+    }
+
+    const omitList = Array.isArray(paths) ? paths : [paths];
+    const omitSet = new Set(omitList.map(String));
+    const result = {};
+
+    for (const key in object) {
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            continue;
+        }
+
+        if (!omitSet.has(key)) {
+            result[key] = object[key];
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
Closes #11882

## Summary of Changes
Implements a prototype-pollution safe `omit` utility function to create an object composed of the properties that are not omitted.

## Features
- **Key Exclusion**: Omit properties from an object given an array of keys or single key.
- **Prototype Pollution Safe**: Ignores `__proto__`, `constructor`, and `prototype` properties.
- **Defensive Design**: Returns empty objects for `null`, `undefined`, or primitive values without throwing.
- **Unit Tests**: Full unit test suite in `apps/api/src/tests/omit.test.js`.
