### PR TITLE
feat(utils): implement chunk utility to split array into groups (#11880)

### DIFF
--- a/apps/api/src/tests/chunk.test.js
+++ b/apps/api/src/tests/chunk.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { chunk } from "../utils/chunk.js";
+
+describe("chunk Utility", () => {
+    it("chunks arrays evenly", () => {
+        const arr = ["a", "b", "c", "d"];
+        assert.deepEqual(chunk(arr, 2), [["a", "b"], ["c", "d"]]);
+    });
+
+    it("chunks arrays unevenly with remainder", () => {
+        const arr = ["a", "b", "c", "d", "e"];
+        assert.deepEqual(chunk(arr, 2), [["a", "b"], ["c", "d"], ["e"]]);
+        assert.deepEqual(chunk(arr, 3), [["a", "b", "c"], ["d", "e"]]);
+    });
+
+    it("defaults to size 1", () => {
+        const arr = [1, 2, 3];
+        assert.deepEqual(chunk(arr), [[1], [2], [3]]);
+    });
+
+    it("handles zero or negative sizes", () => {
+        assert.deepEqual(chunk([1, 2, 3], 0), []);
+        assert.deepEqual(chunk([1, 2, 3], -1), []);
+    });
+
+    it("handles null, undefined, or empty arrays safely", () => {
+        assert.deepEqual(chunk(null), []);
+        assert.deepEqual(chunk(undefined), []);
+        assert.deepEqual(chunk([]), []);
+    });
+});

--- a/apps/api/src/utils/chunk.js
+++ b/apps/api/src/utils/chunk.js
@@ -1,0 +1,33 @@
+/**
+ * Chunk utility.
+ * Creates an array of elements split into groups the length of size.
+ */
+
+/**
+ * Creates an array of elements split into groups the length of size.
+ * @param {Array} array The array to process.
+ * @param {number} [size=1] The length of each chunk.
+ * @returns {Array[]} Returns the new array of chunks.
+ */
+export function chunk(array, size = 1) {
+    if (!Array.isArray(array)) {
+        return [];
+    }
+
+    const chunkSize = Math.max(Math.floor(size), 0);
+    const length = array.length;
+
+    if (!length || chunkSize < 1) {
+        return [];
+    }
+
+    let index = 0;
+    let resIndex = 0;
+    const result = new Array(Math.ceil(length / chunkSize));
+
+    while (index < length) {
+        result[resIndex++] = array.slice(index, (index += chunkSize));
+    }
+
+    return result;
+}


### PR DESCRIPTION
Closes #11880

## Summary of Changes
Implements a fast, memory-efficient `chunk` utility function to partition an array into subsets of a specified size.

## Features
- **Partitioning**: Splits arrays into groups of specified length, retaining remaining items in the trailing chunk.
- **Defensive Arguments**: Gracefully handles non-array values, empty arrays, and sizes `<= 0`.
- **Pre-allocation**: Allocates result array size upfront with `Math.ceil(length / chunkSize)`.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/chunk.test.js`.
