### PR TITLE
feat(utils): implement once utility to restrict function invocation (#11872)

### DIFF
--- a/apps/api/src/tests/once.test.js
+++ b/apps/api/src/tests/once.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { once } from "../utils/once.js";
+
+describe("once Utility", () => {
+    it("invokes the target function exactly once and caches the result", () => {
+        let callCount = 0;
+        const initialize = once((x) => {
+            callCount++;
+            return x * 2;
+        });
+
+        assert.equal(initialize(5), 10);
+        assert.equal(callCount, 1);
+
+        assert.equal(initialize(10), 10);
+        assert.equal(initialize(20), 10);
+        assert.equal(callCount, 1);
+    });
+
+    it("preserves `this` binding on invocation", () => {
+        const context = {
+            multiplier: 3,
+            calc: once(function (n) {
+                return n * this.multiplier;
+            }),
+        };
+
+        assert.equal(context.calc(4), 12);
+        assert.equal(context.calc(10), 12);
+    });
+
+    it("throws TypeError if target is not a function", () => {
+        assert.throws(() => once(null), TypeError);
+        assert.throws(() => once(123), TypeError);
+    });
+});

--- a/apps/api/src/utils/once.js
+++ b/apps/api/src/utils/once.js
@@ -1,0 +1,27 @@
+/**
+ * Once utility.
+ * Creates a function that is restricted to invoking func once.
+ * Repeat calls to the function return the value of the first invocation.
+ */
+
+/**
+ * Creates a function that is restricted to invoking func once.
+ * @param {Function} func The function to restrict.
+ * @returns {Function} Returns the new restricted function.
+ */
+export function once(func) {
+    if (typeof func !== "function") {
+        throw new TypeError("Expected a function");
+    }
+
+    let called = false;
+    let result;
+
+    return function (...args) {
+        if (!called) {
+            called = true;
+            result = func.apply(this, args);
+        }
+        return result;
+    };
+}


### PR DESCRIPTION
Closes #11872

## Summary of Changes
Implements a lightweight, robust `once` utility function that restricts execution of a target function to exactly one time and returns the memoized result on all subsequent calls.

## Features
- **Execution Guard**: Guarantees idempotent single-execution behavior.
- **Context Preservation**: Preserves the original `this` binding and passes arguments accurately.
- **Strict Validation**: Throws a `TypeError` when non-function targets are provided.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/once.test.js`.
