### PR TITLE
feat(utils): implement times utility for repeated invocation (#11858)

### DIFF
--- a/apps/api/src/tests/times.test.js
+++ b/apps/api/src/tests/times.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { times } from "../utils/times.js";
+
+describe("times Utility", () => {
+    it("invokes iteratee n times with index", () => {
+        const res = times(3, (i) => i * 2);
+        assert.deepEqual(res, [0, 2, 4]);
+    });
+
+    it("defaults to identity function when iteratee is omitted", () => {
+        assert.deepEqual(times(4), [0, 1, 2, 3]);
+    });
+
+    it("returns empty array for zero or negative numbers", () => {
+        assert.deepEqual(times(0), []);
+        assert.deepEqual(times(-5), []);
+    });
+
+    it("handles invalid or non-numeric n safely", () => {
+        assert.deepEqual(times(null), []);
+        assert.deepEqual(times(undefined), []);
+        assert.deepEqual(times(NaN), []);
+    });
+});

--- a/apps/api/src/utils/times.js
+++ b/apps/api/src/utils/times.js
@@ -1,0 +1,31 @@
+/**
+ * Times utility.
+ * Invokes the iteratee n times, returning an array of the results of each invocation.
+ * The iteratee is invoked with one argument; (index).
+ */
+
+/**
+ * Invokes the iteratee n times, returning an array of the results.
+ * @param {number} n The number of times to invoke iteratee.
+ * @param {Function} [iteratee=(i) => i] The function invoked per iteration.
+ * @returns {Array} Returns the array of results.
+ */
+export function times(n, iteratee = (i) => i) {
+    if (n === undefined || isNaN(n)) {
+        return [];
+    }
+
+    const count = Math.max(0, Math.floor(n));
+    if (count === 0) {
+        return [];
+    }
+
+    const fn = typeof iteratee === "function" ? iteratee : (i) => i;
+    const result = new Array(count);
+
+    for (let i = 0; i < count; i++) {
+        result[i] = fn(i);
+    }
+
+    return result;
+}


### PR DESCRIPTION
Closes #11858

## Summary of Changes
Implements a fast, memory pre-allocated `times` utility function to invoke an iteratee $N$ times with index passing.

## Features
- **Pre-allocation**: Uses fixed-size arrays `new Array(count)` for maximum V8 throughput.
- **Identity Fallback**: Defaults to `identity` function when iteratee is omitted.
- **Safety Checks**: Gracefully handles non-numeric, null, or negative arguments.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/times.test.js`.
