### PR TITLE
feat(utils): implement defaults utility with prototype pollution protection (#11856)

### DIFF
--- a/apps/api/src/tests/defaults.test.js
+++ b/apps/api/src/tests/defaults.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { defaults } from "../utils/defaults.js";
+
+describe("defaults Utility", () => {
+    it("fills in undefined properties from sources", () => {
+        const target = { a: 1 };
+        const res = defaults(target, { b: 2 }, { a: 3, c: 4 });
+        assert.deepEqual(res, { a: 1, b: 2, c: 4 });
+    });
+
+    it("respects left-to-right source precedence", () => {
+        const target = {};
+        const res = defaults(target, { a: 1 }, { a: 2 });
+        assert.equal(res.a, 1);
+    });
+
+    it("prevents prototype pollution", () => {
+        const target = {};
+        const evil = JSON.parse('{"__proto__": {"polluted": true}}');
+        defaults(target, evil);
+        assert.equal({}.polluted, undefined);
+    });
+
+    it("handles null and undefined sources safely", () => {
+        const target = { a: 1 };
+        assert.deepEqual(defaults(target, null, undefined, { b: 2 }), { a: 1, b: 2 });
+    });
+});

--- a/apps/api/src/utils/defaults.js
+++ b/apps/api/src/utils/defaults.js
@@ -1,0 +1,34 @@
+/**
+ * Defaults utility.
+ * Assigns own and inherited enumerable string keyed properties of source objects
+ * to the destination object for all destination properties that resolve to undefined.
+ * Source objects are applied from left to right.
+ */
+
+/**
+ * Assigns default properties to target object.
+ * Prototype pollution safe.
+ * @param {Object} object The destination object.
+ * @param {...Object} sources The source objects.
+ * @returns {Object} Returns object.
+ */
+export function defaults(object, ...sources) {
+    if (object == null || typeof object !== "object") {
+        return object;
+    }
+
+    for (const source of sources) {
+        if (source && typeof source === "object") {
+            for (const key in source) {
+                if (key === "__proto__" || key === "constructor" || key === "prototype") {
+                    continue;
+                }
+                if (object[key] === undefined) {
+                    object[key] = source[key];
+                }
+            }
+        }
+    }
+
+    return object;
+}


### PR DESCRIPTION
Closes #11856

## Summary of Changes
Implements a prototype-pollution protected `defaults` utility function that assigns default properties to a destination object from multiple sources with left-to-right precedence.

## Features
- **Left-to-Right Precedence**: Preserves previously assigned default values across variadic sources.
- **Prototype Pollution Hardening**: Protects against `__proto__`, `constructor`, and `prototype` injections.
- **Safety Guards**: Tolerates non-object, `null`, and `undefined` inputs without throwing.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/defaults.test.js`.
