### PR TITLE
feat(utils): implement findKey and findLastKey object search utilities (#11840)

### DIFF
--- a/apps/api/src/tests/findKey.test.js
+++ b/apps/api/src/tests/findKey.test.js
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { findKey, findLastKey } from "../utils/findKey.js";
+
+describe("findKey and findLastKey Utilities", () => {
+    const users = {
+        barney: { age: 36, active: true },
+        fred: { age: 40, active: false },
+        pebbles: { age: 1, active: true },
+    };
+
+    it("findKey finds first key matching predicate function", () => {
+        assert.equal(findKey(users, (o) => o.age < 40), "barney");
+    });
+
+    it("findLastKey finds last key matching predicate function", () => {
+        assert.equal(findLastKey(users, (o) => o.age < 40), "pebbles");
+    });
+
+    it("supports object matches property shorthand", () => {
+        assert.equal(findKey(users, { age: 1, active: true }), "pebbles");
+        assert.equal(findKey(users, ["active", false]), "fred");
+        assert.equal(findKey(users, "active"), "barney");
+        assert.equal(findLastKey(users, "active"), "pebbles");
+    });
+
+    it("returns undefined when no matches found or invalid object", () => {
+        assert.equal(findKey(users, (o) => o.age > 100), undefined);
+        assert.equal(findKey(null), undefined);
+        assert.equal(findLastKey(undefined), undefined);
+    });
+});

--- a/apps/api/src/utils/findKey.js
+++ b/apps/api/src/utils/findKey.js
@@ -1,0 +1,73 @@
+/**
+ * FindKey and FindLastKey utilities.
+ * Returns the key of the first (or last) element predicate returns truthy for.
+ */
+
+function getPredicate(predicate) {
+    if (typeof predicate === "function") {
+        return predicate;
+    }
+    if (Array.isArray(predicate) && predicate.length === 2) {
+        return (val) => val != null && val[predicate[0]] === predicate[1];
+    }
+    if (typeof predicate === "object" && predicate !== null) {
+        return (val) => {
+            if (val == null) return false;
+            for (const k in predicate) {
+                if (val[k] !== predicate[k]) return false;
+            }
+            return true;
+        };
+    }
+    if (typeof predicate === "string") {
+        return (val) => Boolean(val && val[predicate]);
+    }
+    return Boolean;
+}
+
+/**
+ * Returns the key of the first element predicate returns truthy for.
+ * @param {Object} object The object to inspect.
+ * @param {Function|Object|Array|string} [predicate] The function invoked per iteration.
+ * @returns {string|undefined} Returns the key of the matched element, else undefined.
+ */
+export function findKey(object, predicate) {
+    if (object == null || typeof object !== "object") {
+        return undefined;
+    }
+
+    const fn = getPredicate(predicate);
+    const keys = Object.keys(object);
+
+    for (const key of keys) {
+        if (fn(object[key], key, object)) {
+            return key;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Returns the key of the last element predicate returns truthy for.
+ * @param {Object} object The object to inspect.
+ * @param {Function|Object|Array|string} [predicate] The function invoked per iteration.
+ * @returns {string|undefined} Returns the key of the matched element, else undefined.
+ */
+export function findLastKey(object, predicate) {
+    if (object == null || typeof object !== "object") {
+        return undefined;
+    }
+
+    const fn = getPredicate(predicate);
+    const keys = Object.keys(object);
+
+    for (let i = keys.length - 1; i >= 0; i--) {
+        const key = keys[i];
+        if (fn(object[key], key, object)) {
+            return key;
+        }
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
Closes #11840

## Summary of Changes
Implements forward and reverse key searching utilities `findKey` and `findLastKey` with predicate functions and matcher shorthands.

## Features
- **Bi-directional Iteration**: Supports forward (`findKey`) and reverse (`findLastKey`) object traversal.
- **Flexible Predicates**: Supports custom functions, key/value tuples, object matching, and truthy property keys.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/findKey.test.js`.
