### PR TITLE
docs: add security policy to prevent payout fraud via issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+Please report security vulnerabilities through GitHub's private
+vulnerability reporting feature, not through public issues.\n
+## Payout & Bounty Policy
+
+- All bounty payouts are processed exclusively through the Algora
+  platform or other officially designated payment systems.
+- Payout requests will **never** be handled via GitHub issues.
+- Contributors will **never** be asked to provide cryptocurrency
+  wallet addresses in a public issue.
+- If someone requests direct cryptocurrency payment via an issue,
+  treat it as a potential fraud attempt and report it.
+
+## Recognizing Social Engineering
+
+Be alert for issues that:
+- Request direct payment to a crypto wallet
+- Use urgency language ("Urgent", "ASAP", "immediate")
+- Ask to move communication off-platform (email, chat apps)
+- Claim a reward/bounty status without verifiable PR ownership
+
+If you encounter such an issue, do not engage — close it and
+contact the repository maintainers through verified channels.


### PR DESCRIPTION
## Summary  Issue #7458 was a **fraudulent social engineering attempt** — not a code bug. The reporter claimed a completed bounty and requested direct payment to a USDT (TRC20) cryptocurrency wallet, bypassing the official Algora payout system.  This PR adds a `SECURITY.md` policy file to:  - Clarif