### PR TITLE
fix(api): fail-closed JWT secret — remove hardcoded default that enabled token forgery

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,33 @@
+import { randomBytes } from "crypto";
+
+// Resolve the JWT signing secret.
+//
+// A previous version fell back to the hardcoded string "development-secret".
+// Because that value lives in public source, any deployment that forgot to set
+// JWT_SECRET silently accepted attacker-forged tokens (auth bypass).
+//
+// The secure behaviour is fail-closed:
+//   - If JWT_SECRET is provided, use it.
+//   - In production with no JWT_SECRET, REFUSE TO START (throw).
+//   - In dev/test, use an ephemeral random secret so tokens are never signed
+//     with a predictable, publicly-known value.
+function resolveJwtSecret() {
+  const fromEnv = process.env.JWT_SECRET;
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "JWT_SECRET must be set in production; refusing to use an insecure default",
+    );
+  }
+  return randomBytes(32).toString("hex");
+}
+
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  jwtSecret: resolveJwtSecret(),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/tests/jwt-secret.test.js
+++ b/apps/api/src/tests/jwt-secret.test.js
@@ -1,0 +1,70 @@
+// Regression tests for JWT secret hardening (hardcoded-default auth bypass).
+//
+// Background: env.js previously fell back to the hardcoded string
+// "development-secret" when JWT_SECRET was unset. Because that value is in
+// public source, any deployment missing the env var silently accepted
+// attacker-forged tokens (full auth bypass).
+//
+// These tests verify the fix is fail-closed:
+//   1. Tokens sign + verify correctly with a configured secret.
+//   2. A token forged with the OLD default ("development-secret") is REJECTED.
+//   3. The dev fallback is an ephemeral random secret, never the old default.
+//   4. Production REFUSES TO START when JWT_SECRET is missing.
+//
+// NOTE: env.js resolves the secret at module-evaluation time, so tests that
+// need a specific environment set process.env BEFORE importing and use a
+// cache-busting query string to force re-evaluation.
+
+// Set env BEFORE importing the modules under test (static imports are hoisted,
+// so we use dynamic import below to honor these values).
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret-value";
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+
+const { signAccessToken, verifyAccessToken } = await import("../utils/jwt.js");
+
+test("signs and verifies a token with the configured secret", () => {
+  const token = signAccessToken({ sub: "user-123", role: "user" });
+  const decoded = verifyAccessToken(token);
+  assert.equal(decoded.sub, "user-123");
+  assert.equal(decoded.role, "user");
+});
+
+test("rejects a token forged with the old hardcoded default secret", () => {
+  // Attacker reads the public source, learns the previous default, and forges
+  // an admin token with it. It must NOT validate against our real secret.
+  const forged = jwt.sign({ sub: "admin", role: "admin" }, "development-secret");
+  assert.throws(
+    () => verifyAccessToken(forged),
+    /invalid signature|JsonWebTokenError/,
+  );
+});
+
+test("uses an ephemeral random secret (not the old default) in dev without JWT_SECRET", async () => {
+  const prevSecret = process.env.JWT_SECRET;
+  const prevEnv = process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+  process.env.NODE_ENV = "development";
+
+  const { env } = await import(`../config/env.js?devrand=${Date.now()}`);
+  assert.notEqual(env.jwtSecret, "development-secret");
+  assert.ok(env.jwtSecret.length >= 32, "expected a long random secret");
+
+  process.env.JWT_SECRET = prevSecret;
+  process.env.NODE_ENV = prevEnv;
+});
+
+test("refuses to start in production when JWT_SECRET is missing", async () => {
+  const prevSecret = process.env.JWT_SECRET;
+  const prevEnv = process.env.NODE_ENV;
+  delete process.env.JWT_SECRET;
+  process.env.NODE_ENV = "production";
+
+  await assert.rejects(() => import(`../config/env.js?prod=${Date.now()}`));
+
+  process.env.JWT_SECRET = prevSecret;
+  process.env.NODE_ENV = prevEnv;
+});


### PR DESCRIPTION
## Summary

Resolves #12130 (JWT secret hardcoded-default auth bypass, originally tracked via #743).

`apps/api/src/config/env.js` resolved the JWT signing secret with a hardcoded fallback:

```js
jwtSecret: process.env.JWT_SECRET ?? "development-secret",
```

That same value is used to **sign and verify** tokens (`utils/jwt.js`). Because `"development-secret"` is committed to public source, any deployment that forgets to set `JWT_SECRET` silently accepts tokens forged with that known string — a full **authentication bypass**, including admin routes (which only require a valid token via `authMiddleware`).

## Root cause

Insecure fallback: a known, source-controlled constant was used as the production secret instead of failing when the real secret is absent.

## Fix

Fail-closed secret resolution in `config/env.js`:

- `JWT_SECRET` provided → use it.
- Production **without** `JWT_SECRET` → **refuse to start** (throw) instead of falling back to a known value.
- Dev/test without `JWT_SECRET` → use an **ephemeral random** secret (never a predictable constant).

## Changed files
- `apps/api/src/config/env.js` — fail-closed `resolveJwtSecret()`.
- `apps/api/src/tests/jwt-secret.test.js` — regression tests.

## Testing (run locally BEFORE this PR)

```
$ node --test src/tests/*.test.js
# tests 5
# pass  5
# fail  0
```

Coverage:
- round-trip sign/verify with a configured secret
- a token forged with the OLD default `"development-secret"` is **rejected**
- dev fallback is a random secret, not the old default
- production without `JWT_SECRET` **refuses to start**
- existing `GET /health` test still passes

## Impact

Closes a critical auth-bypass path: attackers can no longer forge valid tokens by reusing the public default secret.

/bounty $700