### PR TITLE
feat(utils): implement nested path resolution utilities get and at (#11834)

### DIFF
--- a/apps/api/src/tests/at.test.js
+++ b/apps/api/src/tests/at.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { at, get } from "../utils/at.js";
+
+describe("at and get Utilities", () => {
+    const object = { a: [{ b: { c: 3 } }, 4], x: { y: "hello" } };
+
+    it("get resolves nested dot and bracket notation paths", () => {
+        assert.equal(get(object, "a[0].b.c"), 3);
+        assert.equal(get(object, ["a", "0", "b", "c"]), 3);
+        assert.equal(get(object, "x.y"), "hello");
+    });
+
+    it("get returns defaultValue for undefined or missing paths", () => {
+        assert.equal(get(object, "a.b.c", "default"), "default");
+        assert.equal(get(object, "nonexistent", null), null);
+    });
+
+    it("get protects against prototype pollution access", () => {
+        assert.equal(get(object, "__proto__.polluted", "safe"), "safe");
+        assert.equal(get(object, "constructor.prototype", "safe"), "safe");
+    });
+
+    it("at extracts multiple paths into an array", () => {
+        const res = at(object, "a[0].b.c", "a[1]", "x.y");
+        assert.deepEqual(res, [3, 4, "hello"]);
+    });
+
+    it("handles null and undefined safely", () => {
+        assert.equal(get(null, "a.b", "fallback"), "fallback");
+        assert.deepEqual(at(null, "a.b"), []);
+    });
+});

--- a/apps/api/src/utils/at.js
+++ b/apps/api/src/utils/at.js
@@ -1,0 +1,73 @@
+/**
+ * At and Get utilities.
+ * Resolves nested paths on objects and returns extracted values.
+ */
+
+function toPath(path) {
+    if (Array.isArray(path)) {
+        return path;
+    }
+    if (typeof path !== "string") {
+        return [];
+    }
+
+    return path
+        .replace(/\[(\w+)\]/g, ".$1")
+        .replace(/^\./, "")
+        .split(".")
+        .filter(Boolean);
+}
+
+/**
+ * Gets the value at path of object.
+ * Prototype pollution safe.
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path of the property to get.
+ * @param {*} [defaultValue] The value returned for undefined resolved values.
+ * @returns {*} Returns the resolved value.
+ */
+export function get(object, path, defaultValue) {
+    if (object == null) {
+        return defaultValue;
+    }
+
+    const segments = toPath(path);
+    let current = object;
+
+    for (const seg of segments) {
+        if (seg === "__proto__" || seg === "constructor" || seg === "prototype") {
+            return defaultValue;
+        }
+        if (current == null) {
+            return defaultValue;
+        }
+        current = current[seg];
+    }
+
+    return current === undefined ? defaultValue : current;
+}
+
+/**
+ * Creates an array of values corresponding to paths of object.
+ * @param {Object} object The object to iterate over.
+ * @param {...(string|string[])} paths The property paths to pick.
+ * @returns {Array} Returns the picked values.
+ */
+export function at(object, ...paths) {
+    if (object == null) {
+        return [];
+    }
+
+    const flattenedPaths = [];
+    for (const p of paths) {
+        if (Array.isArray(p) && p.length > 0 && Array.isArray(p[0])) {
+            flattenedPaths.push(...p);
+        } else if (Array.isArray(p)) {
+            flattenedPaths.push(p);
+        } else {
+            flattenedPaths.push(p);
+        }
+    }
+
+    return flattenedPaths.map((p) => get(object, p));
+}


### PR DESCRIPTION
Closes #11834

## Summary of Changes
Implements safe, prototype-pollution resistant nested path resolution utilities `get` and `at` supporting both dot and array-bracket access notation.

## Features
- **Flexible Path Notation**: Resolves paths like `'a[0].b.c'` as well as array segments `['a', '0', 'b', 'c']`.
- **Prototype Hardening**: Blocks traversal of `__proto__`, `constructor`, and `prototype`.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/at.test.js`.
