### PR TITLE
fix(api): require authentication on all /api routes except auth endpoints

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { authMiddleware } from "./middleware/auth.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -27,16 +28,21 @@ export function createApp() {
     res.status(200).json({ ok: true, service: "api" });
   });
 
+  // Auth endpoints stay public (register/login).
   app.use("/api/auth", authRoutes);
-  app.use("/api/users", userRoutes);
-  app.use("/api/jobs", jobRoutes);
-  app.use("/api/proposals", proposalRoutes);
-  app.use("/api/payments", paymentRoutes);
-  app.use("/api/reviews", reviewRoutes);
-  app.use("/api/messages", messageRoutes);
-  app.use("/api/notifications", notificationRoutes);
-  app.use("/api/uploads", uploadRoutes);
-  app.use("/api/search", searchRoutes);
+
+  // Every other API route requires a valid bearer token. Previously these were
+  // mounted without any authentication, allowing unauthenticated access to
+  // payments, users, messages, etc. (broken access control).
+  app.use("/api/users", authMiddleware, userRoutes);
+  app.use("/api/jobs", authMiddleware, jobRoutes);
+  app.use("/api/proposals", authMiddleware, proposalRoutes);
+  app.use("/api/payments", authMiddleware, paymentRoutes);
+  app.use("/api/reviews", authMiddleware, reviewRoutes);
+  app.use("/api/messages", authMiddleware, messageRoutes);
+  app.use("/api/notifications", authMiddleware, notificationRoutes);
+  app.use("/api/uploads", authMiddleware, uploadRoutes);
+  app.use("/api/search", authMiddleware, searchRoutes);
   app.use("/api/admin", adminRoutes);
 
   app.use(errorHandler);

--- a/apps/api/src/tests/auth-enforcement.test.js
+++ b/apps/api/src/tests/auth-enforcement.test.js
@@ -1,0 +1,78 @@
+// Regression tests for authentication enforcement on /api routes.
+//
+// Background: only /api/admin applied authMiddleware; every other /api route
+// was reachable without any token (broken access control). This test verifies
+// that protected routes now REQUIRE a valid Bearer token, while the auth
+// endpoints (register/login) stay public.
+//
+// NOTE: env.js resolves the JWT secret at import time, so we set JWT_SECRET
+// before importing the app (static imports are hoisted, hence dynamic import).
+
+process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = "test-secret-value";
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { signAccessToken } from "../utils/jwt.js";
+
+const { createApp } = await import("../app.js");
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    const { port } = server.address();
+    await run(port);
+  } finally {
+    server.closeIdleConnections?.();
+    server.closeAllConnections?.();
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("protected route rejects requests without a token", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+test("protected route rejects an invalid token", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      headers: { Authorization: "Bearer not-a-real-token" },
+    });
+    assert.equal(res.status, 401);
+  });
+});
+
+test("protected route accepts a valid token", async () => {
+  const token = signAccessToken({ sub: "usr_test", role: "client" });
+  await withServer(async (port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/users`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.status, 200);
+  });
+});
+
+test("auth endpoints remain public (no token required)", async () => {
+  await withServer(async (port) => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@b.com", password: "password123" }),
+    });
+    assert.equal(res.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #12133 (broken access control: all /api routes except /api/auth lacked authentication, originally tracked via #743).

In `apps/api/src/app.js`, every router except `adminRoutes` was mounted with **no `authMiddleware`**. As a result, endpoints such as `POST /api/payments`, `POST /api/users`, `GET/POST /api/messages`, `/api/proposals`, `/api/reviews`, `/api/notifications`, `/api/uploads` and `/api/search` were reachable **without any token**.

## Root cause

Missing authentication layer on the route mount points. `grep` confirmed zero `req.user`/auth checks inside any controller; only `adminRoutes` applied `authMiddleware`.

## Fix

Apply `authMiddleware` to every `/api` route group **except** `/api/auth` (register/login must stay public):

```js
app.use("/api/auth", authRoutes);
app.use("/api/users", authMiddleware, userRoutes);
app.use("/api/jobs", authMiddleware, jobRoutes);
app.use("/api/proposals", authMiddleware, proposalRoutes);
app.use("/api/payments", authMiddleware, paymentRoutes);
app.use("/api/reviews", authMiddleware, reviewRoutes);
app.use("/api/messages", authMiddleware, messageRoutes);
app.use("/api/notifications", authMiddleware, notificationRoutes);
app.use("/api/uploads", authMiddleware, uploadRoutes);
app.use("/api/search", authMiddleware, searchRoutes);
app.use("/api/admin", adminRoutes);
```

## Testing (run locally BEFORE this PR)

```
$ node --test src/tests/*.test.js
# tests 5
# pass  5
# fail  0
```

Coverage (`tests/auth-enforcement.test.js`):
- protected route rejects a request with **no token** -> 401
- protected route rejects an **invalid token** -> 401
- protected route accepts a **valid token** -> 200
- auth endpoints (`/api/auth/login`) remain **public** -> 200

On the unfixed app, the first two tests fail (routes returned 200 without a token), confirming the bug; after the fix all four pass.

## Impact

Closes a critical broken-access-control gap: unauthenticated users can no longer create payments, users, messages, or read/write other sensitive resources.

/bounty $700