### PR TITLE
feat(utils): implement deep set and setWith path assignment utilities (#11832)

### DIFF
--- a/apps/api/src/tests/set.test.js
+++ b/apps/api/src/tests/set.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { set, setWith } from "../utils/set.js";
+
+describe("set and setWith Utilities", () => {
+    it("sets nested values creating intermediate objects", () => {
+        const object = { a: { b: 2 } };
+        set(object, "a.b", 3);
+        assert.equal(object.a.b, 3);
+
+        set(object, "x[0].y.z", 5);
+        assert.equal(object.x[0].y.z, 5);
+        assert.ok(Array.isArray(object.x));
+    });
+
+    it("prevents prototype pollution attacks", () => {
+        const evil = {};
+        set(evil, "__proto__.polluted", "yes");
+        set(evil, "constructor.prototype.polluted", "yes");
+        assert.equal({}.polluted, undefined);
+        assert.equal(Object.prototype.polluted, undefined);
+    });
+
+    it("setWith allows customizer to instantiate custom objects", () => {
+        const object = {};
+        setWith(object, "[0][1]", "val", Object);
+        assert.deepEqual(object, { "0": { "1": "val" } });
+    });
+
+    it("handles null or non-object root safely", () => {
+        assert.equal(set(null, "a.b", 1), null);
+        assert.equal(set(123, "a.b", 1), 123);
+    });
+});

--- a/apps/api/src/utils/set.js
+++ b/apps/api/src/utils/set.js
@@ -1,0 +1,89 @@
+/**
+ * Set and SetWith utilities.
+ * Sets the value at path of object, creating missing structures.
+ */
+
+function toPath(path) {
+    if (Array.isArray(path)) {
+        return path;
+    }
+    if (typeof path !== "string") {
+        return [];
+    }
+
+    return path
+        .replace(/\[(\w+)\]/g, ".$1")
+        .replace(/^\./, "")
+        .split(".")
+        .filter(Boolean);
+}
+
+function isIndex(val) {
+    return /^\d+$/.test(String(val));
+}
+
+/**
+ * Sets the value at path of object.
+ * Prototype pollution safe.
+ * @param {Object} object The object to modify.
+ * @param {Array|string} path The path of the property to set.
+ * @param {*} value The value to set.
+ * @returns {Object} Returns object.
+ */
+export function set(object, path, value) {
+    return setWith(object, path, value);
+}
+
+/**
+ * This method is like set except that it accepts customizer to produce path objects.
+ * @param {Object} object The object to modify.
+ * @param {Array|string} path The path of the property to set.
+ * @param {*} value The value to set.
+ * @param {Function} [customizer] The function to customize assigned values.
+ * @returns {Object} Returns object.
+ */
+export function setWith(object, path, value, customizer) {
+    if (object == null || typeof object !== "object") {
+        return object;
+    }
+
+    const segments = toPath(path);
+    if (segments.length === 0) {
+        return object;
+    }
+
+    let current = object;
+    for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+
+        // Prototype pollution guard
+        if (seg === "__proto__" || seg === "constructor" || seg === "prototype") {
+            return object;
+        }
+
+        const nextSeg = segments[i + 1];
+        let nextObj = current[seg];
+
+        if (typeof customizer === "function") {
+            const customVal = customizer(nextObj, seg, current);
+            if (customVal !== undefined) {
+                nextObj = customVal;
+                current[seg] = nextObj;
+            }
+        }
+
+        if (nextObj == null || typeof nextObj !== "object") {
+            nextObj = isIndex(nextSeg) ? [] : {};
+            current[seg] = nextObj;
+        }
+
+        current = current[seg];
+    }
+
+    const lastSeg = segments[segments.length - 1];
+    if (lastSeg !== "__proto__" && lastSeg !== "constructor" && lastSeg !== "prototype") {
+        current[lastSeg] = value;
+    }
+
+    return object;
+}


### PR DESCRIPTION
Closes #11832

## Summary of Changes
Implements prototype-pollution safe mutable deep path assignment utilities `set` and `setWith` with dynamic intermediate array/object instantiations.

## Features
- **Auto Structure Creation**: Distinguishes numeric indices (creates Arrays) from named properties (creates Objects).
- **Prototype Pollution Hardened**: Prohibits assignment or path traversal across `__proto__`, `constructor`, or `prototype`.
- **Customizer Support**: `setWith` allows overriding default collection constructor factories.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/set.test.js`.
