### PR TITLE
feat(utils): implement has and hasIn nested property presence utilities (#11828)

### DIFF
--- a/apps/api/src/tests/has.test.js
+++ b/apps/api/src/tests/has.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { has, hasIn } from "../utils/has.js";
+
+describe("has and hasIn Utilities", () => {
+    const object = { a: { b: 2 } };
+    const other = Object.create({ a: { b: 2 } });
+    other.direct = true;
+
+    it("has checks for direct nested properties", () => {
+        assert.equal(has(object, "a.b"), true);
+        assert.equal(has(object, ["a", "b"]), true);
+        assert.equal(has(object, "a.c"), false);
+    });
+
+    it("has vs hasIn on inherited properties", () => {
+        assert.equal(has(other, "direct"), true);
+        assert.equal(has(other, "a.b"), false); // inherited on root
+        assert.equal(hasIn(other, "a.b"), true);
+    });
+
+    it("prevents prototype pollution exploration", () => {
+        assert.equal(has({}, "__proto__"), false);
+        assert.equal(hasIn({}, "__proto__"), false);
+    });
+
+    it("handles null and undefined safely", () => {
+        assert.equal(has(null, "a.b"), false);
+        assert.equal(hasIn(undefined, "a.b"), false);
+    });
+});

--- a/apps/api/src/utils/has.js
+++ b/apps/api/src/utils/has.js
@@ -1,0 +1,77 @@
+/**
+ * Has and HasIn utilities.
+ * Checks if path is a direct (or inherited) property of object.
+ */
+
+function toPath(path) {
+    if (Array.isArray(path)) {
+        return path;
+    }
+    if (typeof path !== "string") {
+        return [];
+    }
+
+    return path
+        .replace(/\[(\w+)\]/g, ".$1")
+        .replace(/^\./, "")
+        .split(".")
+        .filter(Boolean);
+}
+
+function hasPath(object, path, checkDirect) {
+    if (object == null) {
+        return false;
+    }
+
+    const segments = toPath(path);
+    if (segments.length === 0) {
+        return false;
+    }
+
+    let current = object;
+    for (let i = 0; i < segments.length; i++) {
+        const seg = segments[i];
+
+        if (seg === "__proto__" || seg === "constructor" || seg === "prototype") {
+            return false;
+        }
+
+        if (current == null) {
+            return false;
+        }
+
+        if (checkDirect && !Object.prototype.hasOwnProperty.call(current, seg)) {
+            return false;
+        }
+
+        if (!checkDirect && !(seg in Object(current))) {
+            return false;
+        }
+
+        current = current[seg];
+    }
+
+    return true;
+}
+
+/**
+ * Checks if path is a direct property of object.
+ * Prototype pollution safe.
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path to check.
+ * @returns {boolean} Returns true if path exists, else false.
+ */
+export function has(object, path) {
+    return hasPath(object, path, true);
+}
+
+/**
+ * Checks if path is a direct or inherited property of object.
+ * Prototype pollution safe.
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path to check.
+ * @returns {boolean} Returns true if path exists, else false.
+ */
+export function hasIn(object, path) {
+    return hasPath(object, path, false);
+}


### PR DESCRIPTION
Closes #11828

## Summary of Changes
Implements prototype-safe nested property existence checkers `has` (direct own properties) and `hasIn` (direct or prototype-inherited properties).

## Features
- **Direct vs Inherited Support**: Distinguishes `hasOwnProperty` hierarchy from `in` chain lookups.
- **Deep Path Resolution**: Supports string dot-paths `'a.b.c'` and array segments `['a', 'b', 'c']`.
- **Prototype Pollution Guard**: Safely prevents traversal across `__proto__`, `constructor`, and `prototype`.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/has.test.js`.
