### PR TITLE
feat(utils): implement invoke and invokeMap method execution utilities (#11824)

### DIFF
--- a/apps/api/src/tests/invoke.test.js
+++ b/apps/api/src/tests/invoke.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { invoke, invokeMap } from "../utils/invoke.js";
+
+describe("invoke and invokeMap Utilities", () => {
+    const object = {
+        a: [{ b: { sort: function (fn) { return [3, 1, 2].sort(fn); } } }],
+    };
+
+    it("invoke calls method at nested path with arguments", () => {
+        const res = invoke(object, "a[0].b.sort", (a, b) => a - b);
+        assert.deepEqual(res, [1, 2, 3]);
+    });
+
+    it("invokeMap invokes method on each item in array", () => {
+        const arrays = [[5, 1, 7], [3, 2, 1]];
+        const res = invokeMap(arrays, "sort");
+        assert.deepEqual(res, [[1, 5, 7], [1, 2, 3]]);
+    });
+
+    it("invokeMap accepts a direct function with item context", () => {
+        const numbers = [123, 456];
+        const res = invokeMap(numbers, String.prototype.split, "");
+        assert.deepEqual(res, [["1", "2", "3"], ["4", "5", "6"]]);
+    });
+
+    it("prevents prototype pollution exploration", () => {
+        assert.equal(invoke({}, "__proto__.toString"), undefined);
+        assert.equal(invoke({}, "constructor.prototype.toString"), undefined);
+    });
+
+    it("handles null and undefined safely", () => {
+        assert.equal(invoke(null, "a.b"), undefined);
+        assert.deepEqual(invokeMap(null, "sort"), []);
+    });
+});

--- a/apps/api/src/utils/invoke.js
+++ b/apps/api/src/utils/invoke.js
@@ -1,0 +1,80 @@
+/**
+ * Invoke and InvokeMap utilities.
+ * Invokes methods at nested paths of objects or across collection items.
+ */
+
+function toPath(path) {
+    if (Array.isArray(path)) {
+        return path;
+    }
+    if (typeof path !== "string") {
+        return [];
+    }
+
+    return path
+        .replace(/\[(\w+)\]/g, ".$1")
+        .replace(/^\./, "")
+        .split(".")
+        .filter(Boolean);
+}
+
+/**
+ * Invokes the method at path of object.
+ * Prototype pollution safe.
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path of the method to invoke.
+ * @param {...*} args The arguments to invoke the method with.
+ * @returns {*} Returns the result of the invoked method.
+ */
+export function invoke(object, path, ...args) {
+    if (object == null) {
+        return undefined;
+    }
+
+    const segments = toPath(path);
+    let current = object;
+    let parent = null;
+
+    for (const seg of segments) {
+        if (seg === "__proto__" || seg === "constructor" || seg === "prototype") {
+            return undefined;
+        }
+        if (current == null) {
+            return undefined;
+        }
+        parent = current;
+        current = current[seg];
+    }
+
+    if (typeof current === "function") {
+        return current.apply(parent, args);
+    }
+
+    return undefined;
+}
+
+/**
+ * Invokes the method at path of each element in collection.
+ * @param {Array|Object} collection The collection to iterate over.
+ * @param {Array|string|Function} path The path of the method to invoke or the function invoked per iteration.
+ * @param {...*} args The arguments to invoke each method with.
+ * @returns {Array} Returns the array of results.
+ */
+export function invokeMap(collection, path, ...args) {
+    if (collection == null) {
+        return [];
+    }
+
+    const items = Array.isArray(collection) ? collection : Object.values(collection);
+    const isFn = typeof path === "function";
+
+    return items.map((item) => {
+        if (item == null) {
+            return undefined;
+        }
+        if (isFn) {
+            return path.apply(item, args);
+        }
+        return invoke(item, path, ...args);
+    });
+}


### PR DESCRIPTION
Closes #11824

## Summary of Changes
Implements prototype-pollution safe method invocation utilities `invoke` (invoking methods at deep nested object paths) and `invokeMap` (invoking methods or functions across collection elements).

## Features
- **Context-Preserved Method Calling**: Invokes functions with `this` bound to their parent containers.
- **Collection Mapping**: `invokeMap` processes arrays and objects by method name or direct function references.
- **Prototype Hardened**: Rejects path traversal across `__proto__`, `constructor`, and `prototype`.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/invoke.test.js`.
