### PR TITLE
feat(utils): implement conforms and conformsTo schema predicate utilities (#11822)

### DIFF
--- a/apps/api/src/tests/conforms.test.js
+++ b/apps/api/src/tests/conforms.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { conforms, conformsTo } from "../utils/conforms.js";
+
+describe("conforms and conformsTo Utilities", () => {
+    const object = { a: 1, b: 2, c: "hello" };
+
+    it("conformsTo checks if object satisfies predicate map", () => {
+        const pass = conformsTo(object, {
+            a: (n) => n > 0,
+            b: (n) => n === 2,
+            c: (s) => typeof s === "string",
+        });
+        assert.equal(pass, true);
+
+        const fail = conformsTo(object, {
+            b: (n) => n > 10,
+        });
+        assert.equal(fail, false);
+    });
+
+    it("conforms creates a reusable curried predicate function", () => {
+        const isEligible = conforms({
+            a: (n) => n >= 1,
+            b: (n) => n % 2 === 0,
+        });
+        assert.equal(isEligible(object), true);
+        assert.equal(isEligible({ a: 0, b: 2 }), false);
+    });
+
+    it("handles null and undefined safely", () => {
+        assert.equal(conformsTo(null, { a: () => true }), false);
+        assert.equal(conformsTo(object, null), false);
+        assert.equal(conforms(null)(object), false);
+    });
+});

--- a/apps/api/src/utils/conforms.js
+++ b/apps/api/src/utils/conforms.js
@@ -1,0 +1,40 @@
+/**
+ * Conforms and ConformsTo utilities.
+ * Checks if object conforms to source predicates.
+ */
+
+/**
+ * Checks if object conforms to source by invoking the predicate properties of source.
+ * @param {Object} object The object to inspect.
+ * @param {Object} source The object of property predicates to conform to.
+ * @returns {boolean} Returns true if object conforms, else false.
+ */
+export function conformsTo(object, source) {
+    if (object == null || source == null || typeof source !== "object") {
+        return false;
+    }
+
+    const keys = Object.keys(source);
+    for (const key of keys) {
+        const predicate = source[key];
+        if (typeof predicate === "function") {
+            const result = predicate(object[key]);
+            if (!result) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Creates a function that invokes the predicate properties of source.
+ * @param {Object} source The object of property predicates to conform to.
+ * @returns {Function} Returns the new spec function.
+ */
+export function conforms(source) {
+    return function (object) {
+        return conformsTo(object, source);
+    };
+}


### PR DESCRIPTION
Closes #11822

## Summary of Changes
Implements schema conformance validation utilities `conforms` and `conformsTo` that match object properties against predicate functions.

## Features
- **Schema Validation**: Tests objects against key-predicate maps.
- **Curried Constructor**: `conforms(spec)` returns a reusable validation predicate.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/conforms.test.js`.
