### PR TITLE
feat(utils): implement castArray and toArray collection coercion utilities (#11810)

### DIFF
--- a/apps/api/src/tests/castArray.test.js
+++ b/apps/api/src/tests/castArray.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { castArray, toArray } from "../utils/castArray.js";
+
+describe("castArray and toArray Utilities", () => {
+    it("castArray wraps non-array values into an array", () => {
+        assert.deepEqual(castArray(1), [1]);
+        assert.deepEqual(castArray({ a: 1 }), [{ a: 1 }]);
+        assert.deepEqual(castArray("abc"), ["abc"]);
+        assert.deepEqual(castArray(null), [null]);
+        assert.deepEqual(castArray(undefined), [undefined]);
+        assert.deepEqual(castArray(), []);
+    });
+
+    it("castArray returns array directly without re-wrapping", () => {
+        const array = [1, 2, 3];
+        assert.equal(castArray(array), array);
+    });
+
+    it("toArray converts strings, maps, sets, and objects to arrays", () => {
+        assert.deepEqual(toArray("foo"), ["f", "o", "o"]);
+        assert.deepEqual(toArray({ a: 1, b: 2 }), [1, 2]);
+        assert.deepEqual(toArray(new Set([1, 2, 3])), [1, 2, 3]);
+
+        const map = new Map([["a", 1], ["b", 2]]);
+        assert.deepEqual(toArray(map), [["a", 1], ["b", 2]]);
+    });
+
+    it("toArray handles null, undefined, or primitives safely", () => {
+        assert.deepEqual(toArray(null), []);
+        assert.deepEqual(toArray(undefined), []);
+        assert.deepEqual(toArray(123), []);
+    });
+});

--- a/apps/api/src/utils/castArray.js
+++ b/apps/api/src/utils/castArray.js
@@ -1,0 +1,47 @@
+/**
+ * CastArray and ToArray utilities.
+ * Converts or wraps values into standard arrays.
+ */
+
+/**
+ * Casts value as an array if it's not one.
+ * @param {*} [value] The value to inspect.
+ * @returns {Array} Returns the cast array.
+ */
+export function castArray(...args) {
+    if (args.length === 0) {
+        return [];
+    }
+    const value = args[0];
+    return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * Converts value to an array.
+ * @param {*} value The value to convert.
+ * @returns {Array} Returns the converted array.
+ */
+export function toArray(value) {
+    if (value == null) {
+        return [];
+    }
+    if (Array.isArray(value)) {
+        return value.slice();
+    }
+    if (typeof value === "string") {
+        return Array.from(value);
+    }
+    if (value instanceof Map) {
+        return Array.from(value.entries());
+    }
+    if (value instanceof Set) {
+        return Array.from(value.values());
+    }
+    if (typeof value[Symbol.iterator] === "function") {
+        return Array.from(value);
+    }
+    if (typeof value === "object") {
+        return Object.values(value);
+    }
+    return [];
+}


### PR DESCRIPTION
Closes #11810

## Summary of Changes
Implements collection coercion utilities `castArray` (wrapping non-arrays) and `toArray` (converting Maps, Sets, strings, iterables, and objects to arrays).

## Features
- **Array Identity**: `castArray` returns existing arrays directly without re-wrapping.
- **Polymorphic Conversion**: `toArray` supports iterable protocols, Maps, Sets, strings, and standard objects.
- **Unit Tests**: Full unit test coverage in `apps/api/src/tests/castArray.test.js`.
