### PR TITLE
fix(api): return 400 for invalid payloads instead of crashing

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,15 +1,25 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
+  let payload;
+  try {
+    payload = registerSchema.parse(req.body);
+  } catch (error) {
+    return fail(res, error.issues?.[0]?.message ?? "Invalid request body", 400);
+  }
   const result = await registerUser(payload);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
+  let payload;
+  try {
+    payload = loginSchema.parse(req.body);
+  } catch (error) {
+    return fail(res, error.issues?.[0]?.message ?? "Invalid request body", 400);
+  }
   const result = await loginUser(payload);
   return ok(res, result);
 }

--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,4 +1,4 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
 import { createJob, listJobs } from "../services/jobService.js";
 
@@ -7,6 +7,11 @@ export async function getJobs(req, res) {
 }
 
 export async function postJob(req, res) {
-  const payload = createJobSchema.parse(req.body);
+  let payload;
+  try {
+    payload = createJobSchema.parse(req.body);
+  } catch (error) {
+    return fail(res, error.issues?.[0]?.message ?? "Invalid job payload", 400);
+  }
   return ok(res, await createJob(payload), 201);
 }

--- a/apps/api/src/tests/validation.test.js
+++ b/apps/api/src/tests/validation.test.js
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function json(body) {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  };
+}
+
+test("POST /api/jobs rejects invalid payloads with 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, json({
+      title: "x",
+      description: "a valid description",
+      budgetMin: 10,
+      budgetMax: 100,
+      categoryId: "c1"
+    }));
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+    assert.ok(payload.message);
+  });
+});
+
+test("POST /api/jobs accepts valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/jobs`, json({
+      title: "Build a landing page",
+      description: "A polished landing page for a SaaS product.",
+      budgetMin: 500,
+      budgetMax: 1000,
+      categoryId: "cat-1",
+      skills: ["react"]
+    }));
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+  });
+});
+
+test("POST /api/auth/register rejects invalid payloads with 400", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, json({
+      email: "not-an-email",
+      password: "short",
+      role: "client"
+    }));
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.success, false);
+    assert.ok(payload.message);
+  });
+});
+
+test("POST /api/auth/register accepts valid payloads", async () => {
+  await withServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/auth/register`, json({
+      email: "a@b.com",
+      password: "password123",
+      role: "client"
+    }));
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #12153.

Invalid payloads sent to `POST /api/jobs`, `POST /api/auth/register`, and `POST /api/auth/login` caused the API to hang and crash. The Zod `schema.parse()` call inside the async controllers throws a `ZodError`, and Express 4 does not catch rejected promises from async handlers — so the error surfaced as an unhandled promise rejection: no response was ever sent to the client, and the process crashed under Node's default `--unhandled-rejections=throw` behavior.

## Changes

- `apps/api/src/controllers/jobController.js` — `postJob` now catches the Zod validation error and responds `400 Bad Request` with a JSON error message.
- `apps/api/src/controllers/authController.js` — `register` and `login` now do the same.
- `apps/api/src/tests/validation.test.js` — new tests asserting invalid payloads get `400` and valid payloads still succeed.

## Verification

```bash
cd apps/api && node --test "src/tests/**/*.test.js"
```

```
✔ GET /health returns ok payload
✔ POST /api/jobs rejects invalid payloads with 400
✔ POST /api/jobs accepts valid payloads
✔ POST /api/auth/register rejects invalid payloads with 400
✔ POST /api/auth/register accepts valid payloads
ℹ tests 5
ℹ pass 5
ℹ fail 0
```

Closes #12153
