### PR TITLE
docs: add apps/api/.env.example documenting API environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,21 @@ Prisma schema is available in `packages/db/prisma/schema.prisma` with models for
 ## Environment Variables
 
 Each app/package expects its own `.env` values for DB, auth, and integrations.
+
+The API workspace ships a documented example at `apps/api/.env.example`. Copy it
+to `apps/api/.env` and adjust the values before running the API:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+```
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `NODE_ENV` | Runtime mode (`development`, `production`, `test`) | `development` |
+| `PORT` | HTTP port the Express server listens on | `4000` |
+| `JWT_SECRET` | Secret used to sign and verify JWTs | `development-secret` |
+| `STRIPE_SECRET_KEY` | Stripe secret key for payment processing | *(empty)* |
+| `DATABASE_URL` | Database connection string | *(empty)* |
+
+Values are read in `apps/api/src/config/env.js`. Do not use the JWT default in
+production.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,15 @@
+# Runtime mode: development | production | test (default: development)
+NODE_ENV=development
+
+# HTTP port the Express server listens on (default: 4000)
+PORT=4000
+
+# Secret used to sign and verify JWTs.
+# No hardcoded production value is acceptable — set a strong secret in production.
+JWT_SECRET=change-me-to-a-long-random-string
+
+# Stripe secret key for payment processing (optional; empty by default)
+STRIPE_SECRET_KEY=
+
+# Database connection string (optional; Prisma wiring is a placeholder today)
+DATABASE_URL=


### PR DESCRIPTION
## Summary

The `apps/api` workspace reads its runtime configuration from environment variables in `apps/api/src/config/env.js`, but shipped no example env file and the root README only vaguely stated that each package expects its own `.env` values.

This PR:

- Adds `apps/api/.env.example` documenting every variable the API reads (`NODE_ENV`, `PORT`, `JWT_SECRET`, `STRIPE_SECRET_KEY`, `DATABASE_URL`), with defaults matching `apps/api/src/config/env.js`.
- Updates the README "Environment Variables" section to reference the example file and summarize each variable's default.

Closes #12155
