### PR TITLE
docs: add apps/api/.env.example documenting API environment variables (Closes #12155)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,14 @@
+# API Environment Variables
+
+PORT=3001
+NODE_ENV=development
+
+# JWT Settings
+JWT_SECRET=super_secret_key_change_me_in_production
+JWT_EXPIRES_IN=1d
+
+# CORS
+CORS_ORIGIN=http://localhost:3000
+
+# Database URL for Prisma
+DATABASE_URL="postgresql://johndoe:randompassword@localhost:5432/mydb?schema=public"


### PR DESCRIPTION
Fixes #12155

Added the missing documentation/example file as requested by the issue to improve the developer experience.