### PR TITLE
feat(utils): implement collection predicate partition helper partition (#11907)

### DIFF
--- a/apps/api/src/tests/partition.test.js
+++ b/apps/api/src/tests/partition.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { partition } from '../utils/partition.js';
+
+describe('partition', () => {
+  it('should split array into two groups', () => {
+    const [even, odd] = partition([1, 2, 3, 4, 5], (n) => n % 2 === 0);
+    expect(even).toEqual([2, 4]);
+    expect(odd).toEqual([1, 3, 5]);
+  });
+
+  it('should return empty arrays for non-array input', () => {
+    expect(partition(null, () => true)).toEqual([[], []]);
+    expect(partition(undefined, () => true)).toEqual([[], []]);
+    expect(partition('hello', () => true)).toEqual([[], []]);
+  });
+
+  it('should pass index and array to predicate', () => {
+    const predicate = vi.fn((item, index) => index < 3);
+    const [matches, rest] = partition([10, 20, 30, 40, 50], predicate);
+    expect(matches).toEqual([10, 20, 30]);
+    expect(rest).toEqual([40, 50]);
+    expect(predicate).toHaveBeenCalledTimes(5);
+  });
+
+  it('should handle empty array', () => {
+    expect(partition([], () => true)).toEqual([[], []]);
+  });
+
+  it('should put all items in matches when predicate always true', () => {
+    const [matches, nonMatches] = partition([1, 2, 3], () => true);
+    expect(matches).toEqual([1, 2, 3]);
+    expect(nonMatches).toEqual([]);
+  });
+
+  it('should put all items in nonMatches when predicate always false', () => {
+    const [matches, nonMatches] = partition([1, 2, 3], () => false);
+    expect(matches).toEqual([]);
+    expect(nonMatches).toEqual([1, 2, 3]);
+  });
+});

--- a/apps/api/src/utils/partition.js
+++ b/apps/api/src/utils/partition.js
@@ -1,0 +1,23 @@
+/**
+ * Split an array into two groups based on a predicate.
+ * @param {Array} array - The array to partition
+ * @param {Function} predicate - (item, index, array) => boolean
+ * @returns {[Array, Array]} Tuple of [matches, nonMatches]
+ */
+export function partition(array, predicate) {
+  if (!Array.isArray(array)) return [[], []];
+
+  const matches = [];
+  const nonMatches = [];
+
+  for (let i = 0; i < array.length; i++) {
+    const item = array[i];
+    if (predicate(item, i, array)) {
+      matches.push(item);
+    } else {
+      nonMatches.push(item);
+    }
+  }
+
+  return [matches, nonMatches];
+}


### PR DESCRIPTION
## Summary
- Implements `partition(array, predicate)` in `apps/api/src/utils/partition.js`
- Returns tuple `[matches, nonMatches]` based on predicate
- Passes item, index, and array to predicate
- Handles non-array input gracefully (returns [[], []])

## Test Coverage
- 6 tests: basic split, non-array input, index/array passthrough, empty array, all-match, no-match

Closes #11907