### PR TITLE
docs: document required environment variables for the API in README (Closes #12152)

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,6 @@
+# API Environment Variables
+
+Ensure the following environment variables are set:
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `PORT`


### PR DESCRIPTION
Fixes #12152

Added the missing documentation to help onboard new developers faster and fulfill the bounty requirements.