### PR TITLE
fix: preserve notification server-owned fields

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -5,7 +5,7 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = { ...payload, id: `ntf_${Date.now()}`, read: false };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notification.test.js
+++ b/apps/api/src/tests/notification.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("createNotification preserves server-owned id and unread state", async () => {
+  const notification = await createNotification({
+    id: "client_forged_id",
+    read: true,
+    message: "hello",
+  });
+
+  assert.match(notification.id, /^ntf_\d+$/);
+  assert.notEqual(notification.id, "client_forged_id");
+  assert.equal(notification.read, false);
+  assert.equal(notification.message, "hello");
+});


### PR DESCRIPTION
## Summary

- Preserve notification `id` as server-owned state.
- Preserve new notifications as unread (`read: false`).
- Add focused regression coverage proving request payloads cannot override either field while ordinary payload fields remain intact.

Closes #12171

## Validation

- `node --test apps/api/src/tests/notification.test.js` ✅
- `git diff --check` ✅

The repository dependencies are not installed in this local checkout, so the unrelated health test cannot resolve packages such as `cors` here. I did not alter package scripts or unrelated files to work around that environment condition.
