### PR TITLE
fix: make job ids collision resistant

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { id: `job_${randomUUID()}`, status: "open", ...payload };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobIdCollision.test.js
+++ b/apps/api/src/tests/jobIdCollision.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJob } from "../services/jobService.js";
+
+test("createJob generates distinct ids even within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1787930000000;
+
+  try {
+    const first = await createJob({ title: "First job" });
+    const second = await createJob({ title: "Second job" });
+
+    assert.match(first.id, /^job_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^job_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, second.id);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

- contributor-owned reissue of the creator-limited job-id collision report #10846 under parent bounty #743
- replace millisecond-only job ids with `job_`-prefixed UUIDs
- add focused regression coverage proving two creations remain distinct when `Date.now()` is fixed to the same millisecond
- keep the change scoped to job id collision resistance only

## Validation

- `node --test apps/api/src/tests/jobIdCollision.test.js` ✅
- `git diff --check` ✅

The broader API test glob depends on repository packages that are not installed in this checkout; no dependency or package-script changes were made to work around the environment.

Closes #12173