### PR TITLE
fix: make payment ids collision resistant

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: `pay_${randomUUID()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentIdCollision.test.js
+++ b/apps/api/src/tests/paymentIdCollision.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("createPaymentIntent generates distinct ids even within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1787930000000;
+
+  try {
+    const first = await createPaymentIntent({ amount: 1000, currency: "usd" });
+    const second = await createPaymentIntent({ amount: 1000, currency: "usd" });
+
+    assert.match(first.paymentId, /^pay_[0-9a-f-]{36}$/);
+    assert.match(second.paymentId, /^pay_[0-9a-f-]{36}$/);
+    assert.notEqual(first.paymentId, second.paymentId);
+    assert.equal(first.amount, 1000);
+    assert.equal(first.currency, "usd");
+    assert.equal(first.provider, "stripe");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

- replace millisecond-only mock payment ids with `pay_`-prefixed UUIDs
- add focused regression coverage proving two creations remain distinct even when `Date.now()` is fixed to the same millisecond
- preserve the existing response shape and payment fields

Closes #12175

## Validation

- `node --test apps/api/src/tests/paymentIdCollision.test.js` ✅
- `git diff --check` ✅

Scope is limited to payment id collision resistance. No Stripe SDK integration, capture flow, authentication, persistence, or unrelated validation changes are included.
