### PR TITLE
fix: make proposal ids collision resistant

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { id: `prp_${randomUUID()}`, ...payload };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalIdCollision.test.js
+++ b/apps/api/src/tests/proposalIdCollision.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createProposal } from "../services/proposalService.js";
+
+test("createProposal generates distinct ids even within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1787930000000;
+
+  try {
+    const first = await createProposal({ jobId: "job_1", coverLetter: "first" });
+    const second = await createProposal({ jobId: "job_1", coverLetter: "second" });
+
+    assert.match(first.id, /^prp_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^prp_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, second.id);
+    assert.equal(first.coverLetter, "first");
+    assert.equal(second.coverLetter, "second");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

- replace millisecond-only proposal IDs with `prp_`-prefixed UUIDs
- add focused regression coverage proving two proposal creations remain distinct when `Date.now()` is fixed to the same millisecond
- preserve ordinary proposal payload fields and the existing response shape

Closes #12179

## Validation

- `node --test apps/api/src/tests/proposalIdCollision.test.js` ✅
- `git diff --check` ✅

Scope is limited to proposal ID collision resistance. Caller-supplied ID ownership, route validation, authentication, persistence, and unrelated proposal behavior are intentionally out of scope.
