### PR TITLE
fix(web): await dynamic route params on Next.js 16

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,14 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+export default async function FreelancerProfilePage({
+  params
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{username}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,10 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Summary

- update the two dynamic App Router pages to use the Next.js 16 async `params` contract
- await route params before rendering job ids and freelancer usernames
- keep routing, mock data, styling, and unrelated pages unchanged

Closes #12181

## Validation

- `npm run build -w apps/web` ✅
- `git diff --check` ✅
- production smoke: `GET /jobs/job-101` returns 200 and renders `job-101` ✅
- production smoke: `GET /freelancers/maya-dev` returns 200 and renders `maya-dev` ✅

Before the fix those two production responses returned HTTP 200 but rendered the dynamic value as an empty string.
