### PR TITLE
fix(api): return 400 for malformed JSON bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,11 +1,14 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
-  return res.status(500).json({
-    success: false,
-    message: "Unexpected server error"
-  });
+  if (err?.type === "entity.parse.failed") {
+    return fail(res, "Invalid JSON body", 400);
+  }
+
+  console.error("Unhandled API error:", err);
+  return fail(res, "Unexpected server error", 500);
 }

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("malformed JSON returns a structured 400 response", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"title":'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, { success: false, message: "Invalid JSON body" });
+
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(health.status, 200);
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

- classify body-parser `entity.parse.failed` errors as HTTP 400
- return the shared JSON failure envelope with a stable `Invalid JSON body` message
- avoid logging malformed request-body contents as an unexpected server error
- preserve the existing 500 path for unrelated exceptions

Closes #12183

## Validation

- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/malformedJson.test.js` ✅ (2/2)
- focused regression verifies malformed JSON returns 400 JSON
- focused regression verifies the API remains healthy after the malformed request
- `git diff --check` ✅

This intentionally does not address the separate async Zod/controller rejection issue.
