### PR TITLE
fix(api): return JSON for rate-limit 429 responses

### DIFF
--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
+import { fail } from "../utils/response.js";
 
 export const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 200,
   standardHeaders: "draft-7",
-  legacyHeaders: false
+  legacyHeaders: false,
+  handler: (req, res) => fail(res, "Too many requests", 429)
 });

--- a/apps/api/src/tests/rateLimit.test.js
+++ b/apps/api/src/tests/rateLimit.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("rate-limit rejection uses the shared JSON failure envelope", async () => {
+  const server = await listen(createApp());
+
+  try {
+    const { port } = server.address();
+    let response;
+    for (let i = 0; i < 201; i += 1) {
+      response = await fetch(`http://127.0.0.1:${port}/health`);
+    }
+
+    assert.equal(response.status, 429);
+    assert.match(response.headers.get("content-type") ?? "", /^application\/json\b/);
+    assert.deepEqual(await response.json(), {
+      success: false,
+      message: "Too many requests"
+    });
+  } finally {
+    await close(server);
+  }
+});


### PR DESCRIPTION
## Summary

- keep the existing 200-request / 15-minute rate-limit policy unchanged
- use the shared API failure helper for rejected requests
- return HTTP 429 as `application/json` with `{ success: false, message: "Too many requests" }`
- add focused regression coverage for the 201st request

Closes #12185

## Validation

- `node --test apps/api/src/tests/health.test.js apps/api/src/tests/rateLimit.test.js` ✅ (2/2)
- regression confirms request 201 returns 429 JSON
- `git diff --check` ✅

No changes to the window, request limit, IP keying, or standard rate-limit headers.
