### PR TITLE
Fix Button native prop forwarding

### DIFF
--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 
-export function Button({ children }: { children: React.ReactNode }) {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, style, ...props }: ButtonProps) {
   return (
     <button
+      {...props}
       style={{
         background: "#5468ff",
         color: "white",
         border: "none",
         borderRadius: 8,
         padding: "0.6rem 0.9rem",
-        cursor: "pointer"
+        cursor: "pointer",
+        ...style
       }}
     >
       {children}


### PR DESCRIPTION
## Summary

Fixes #12208.

The shared `Button` component now accepts standard native button attributes via `React.ButtonHTMLAttributes<HTMLButtonElement>` and forwards them to the underlying `<button>` element.

This enables props such as `onClick`, `disabled`, `type`, `name`, `aria-*`, `data-*`, and `className` while preserving the existing default styling. A caller-provided `style` object is merged on top of the defaults.

## Validation

* Existing children behavior is preserved.
* Native button props are forwarded directly to the rendered `<button>`.
* Caller styles can override the component defaults without replacing unrelated defaults.
* No UI package-specific test runner is configured, so the change is intentionally limited to the typed component implementation.
