### PR TITLE
Fix public registration admin role self-assignment  Description:

### DIFF
--- a/apps/api/src/tests/authValidator.test.js
+++ b/apps/api/src/tests/authValidator.test.js
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+const baseRegistration = {
+  email: "user@example.com",
+  password: "password123"
+};
+
+test("registration defaults omitted role to client", () => {
+  const result = registerSchema.parse(baseRegistration);
+  assert.equal(result.role, "client");
+});
+
+test("registration accepts client role", () => {
+  const result = registerSchema.parse({ ...baseRegistration, role: "client" });
+  assert.equal(result.role, "client");
+});
+
+test("registration accepts freelancer role", () => {
+  const result = registerSchema.parse({ ...baseRegistration, role: "freelancer" });
+  assert.equal(result.role, "freelancer");
+});
+
+test("registration rejects admin role", () => {
+  const result = registerSchema.safeParse({ ...baseRegistration, role: "admin" });
+  assert.equal(result.success, false);
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #12211.

Public registration no longer permits callers to self-assign the `admin` role. The registration validator now accepts only `client` and `freelancer`, while preserving `client` as the default.

## Changes

- Remove `admin` from `registerSchema` public role enum.
- Preserve default `client` behavior.
- Add focused regression tests covering:
  - omitted role defaults to `client`
  - explicit `client` accepted
  - explicit `freelancer` accepted
  - `admin` rejected

## Scope

The change is intentionally limited to public registration validation and regression coverage.

Parent bounty: #11398