### PR TITLE
Prevent admin self-assignment during public registration

### DIFF
--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Fixes #12211.

## Summary

Public registration currently allows callers to select the `admin` role.

The registration service then uses the supplied role directly when returning the user and signing the access token, so a public caller can self-assign administrative privileges.

This change restricts public registration to:

- `client`
- `freelancer`

`client` remains the default role.

## Change

Updated `registerSchema` so `admin` is no longer accepted through the public registration endpoint.

## Validation

The registration flow was traced through:

`authController.register()`  
→ `registerSchema.parse(req.body)`  
→ `registerUser(payload)`

`registerUser()` uses `payload.role` directly in both the returned user object and the signed access token, so rejecting `admin` at the validation boundary prevents public admin self-assignment.

## Scope

This fix is intentionally limited to the public registration role validation.

Parent bounty: #11398