### PR TITLE
fix(api): require auth on POST /api/reviews (fixes #2776)

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { getReviews, postReview } from "../controllers/reviewController.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);

--- a/apps/api/src/tests/review-auth.test.js
+++ b/apps/api/src/tests/review-auth.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
+
+test("POST /api/reviews without token is rejected (401)", async () => {
+  const server = await startServer();
+  try {
+    const response = await fetch(`${server.baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "spam" }),
+    });
+    assert.equal(response.status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /api/reviews with valid token succeeds (201)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ id: "user-1" });
+    const response = await fetch(`${server.baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ rating: 5, comment: "great" }),
+    });
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.data.rating, 5);
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /api/reviews stays public (200)", async () => {
+  const server = await startServer();
+  try {
+    const response = await fetch(`${server.baseUrl}/api/reviews`);
+    assert.equal(response.status, 200);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary
POST /api/reviews allowed unauthenticated review creation (spam/abuse of reputation flows). Adds authMiddleware to the mutating route; GET /api/reviews stays public.

## Changes
- `apps/api/src/routes/reviewRoutes.js`: `reviewRoutes.post("/", authMiddleware, postReview)`
- `apps/api/src/tests/review-auth.test.js`: 3 new tests

## Tests
- POST without token → 401 ✅
- POST with valid token → 201 ✅
- GET stays public → 200 ✅

Fixes #2776