### PR TITLE
fix(api): require auth on POST /api/payments (fixes #1772)

### DIFF
--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/auth.js";
 import { createPayment } from "../controllers/paymentController.js";
 
 export const paymentRoutes = Router();
 
-paymentRoutes.post("/", createPayment);
+paymentRoutes.post("/", authMiddleware, createPayment);

--- a/apps/api/src/tests/payments-auth.test.js
+++ b/apps/api/src/tests/payments-auth.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
+
+test("POST /api/payments without token is rejected (401)", async () => {
+  const server = await startServer();
+  try {
+    const response = await fetch(`${server.baseUrl}/api/payments`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount: 100 }),
+    });
+    assert.equal(response.status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /api/payments with valid token succeeds (201)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ id: "user-1" });
+    const response = await fetch(`${server.baseUrl}/api/payments`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ amount: 100 }),
+    });
+    assert.equal(response.status, 201);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Description
POST /api/payments now requires authMiddleware; unauthenticated payment intent creation is rejected.

Closes #1772

## Tests
- 401 without token, 201 with token (2/2 pass)