### PR TITLE
fix(api): enforce admin role on admin routes (fixes #1770)

### DIFF
--- a/apps/api/src/middleware/requireAdmin.js
+++ b/apps/api/src/middleware/requireAdmin.js
@@ -1,0 +1,8 @@
+import { fail } from "../utils/response.js";
+
+export function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Admin role required", 403);
+  }
+  return next();
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { requireAdmin } from "../middleware/requireAdmin.js";
 
 export const adminRoutes = Router();
 
-adminRoutes.use(authMiddleware);
+adminRoutes.use(authMiddleware, requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/admin-rbac.test.js
+++ b/apps/api/src/tests/admin-rbac.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
+
+test("GET /api/admin/metrics without token is rejected (401)", async () => {
+  const server = await startServer();
+  try {
+    const response = await fetch(`${server.baseUrl}/api/admin/metrics`);
+    assert.equal(response.status, 401);
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /api/admin/metrics with non-admin token is rejected (403)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ sub: "usr_client", role: "client" });
+    const response = await fetch(`${server.baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    assert.equal(response.status, 403);
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /api/admin/metrics with admin token succeeds (200)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ sub: "usr_admin", role: "admin" });
+    const response = await fetch(`${server.baseUrl}/api/admin/metrics`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    assert.equal(response.status, 200);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Description
New requireAdmin middleware checks req.user.role === 'admin'; admin routes now apply authMiddleware + requireAdmin, so any authenticated client/freelancer can no longer access /api/admin/*.

Closes #1770

## Tests
- 401 no token, 403 non-admin, 200 admin (3/3 pass)