### PR TITLE
fix(api): validate user creation input and prevent client-controlled ids (fixes #1766)

### DIFF
--- a/apps/api/src/controllers/userController.js
+++ b/apps/api/src/controllers/userController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { fail } from "../utils/response.js";
 import { createUser, listUsers } from "../services/userService.js";
 
 export async function getUsers(req, res) {
@@ -6,5 +7,9 @@ export async function getUsers(req, res) {
 }
 
 export async function postUser(req, res) {
-  return ok(res, await createUser(req.body), 201);
+  try {
+    return ok(res, await createUser(req.body), 201);
+  } catch (error) {
+    return fail(res, error.message, 400);
+  }
 }

--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,12 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const email = typeof payload?.email === "string" ? payload.email.trim() : "";
+  if (!email || !email.includes("@")) {
+    throw new Error("email is required and must be a valid email address");
+  }
+  // Server-generated id: client-supplied id is never accepted.
+  const user = { id: `usr_${Date.now()}`, email };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user-input.test.js
+++ b/apps/api/src/tests/user-input.test.js
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function startServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
+
+test("POST /api/users with empty payload is rejected (400)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ id: "user-1" });
+    const response = await fetch(`${server.baseUrl}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 400);
+  } finally {
+    await server.close();
+  }
+});
+
+test("POST /api/users client-supplied id is ignored (server id used)", async () => {
+  const server = await startServer();
+  try {
+    const token = signAccessToken({ id: "user-1" });
+    const response = await fetch(`${server.baseUrl}/api/users`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ id: "usr_malicious", email: "alice@example.com" }),
+    });
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.ok(payload.data.id.startsWith("usr_"));
+    assert.notEqual(payload.data.id, "usr_malicious");
+    assert.equal(payload.data.email, "alice@example.com");
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Description
createUser requires a valid email and always generates the id server-side; client-supplied id is ignored. Controller maps validation errors to 400.

Closes #1766

## Tests
- 400 empty payload, 201 with server-generated id (2/2 pass)