### PR TITLE
fix: add authMiddleware to POST /api/reviews endpoint

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
## Summary

Closes #2776

The `POST /api/reviews` endpoint was missing authentication middleware, allowing unauthenticated users to create reviews. This adds the existing `authMiddleware` before the `postReview` controller to require a valid Bearer token.

### Changes
- Import `authMiddleware` from `../middleware/auth.js`
- Apply `authMiddleware` as the first handler on `reviewRoutes.post("/", ...)`

### Testing
- Existing auth middleware is already used on other protected routes in this codebase
- No new dependencies or logic introduced; only route composition changed

This is a minimal, surgical fix that matches the pattern established in the rest of the API.