### PR TITLE
Fix createJob protected field overrides

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,7 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = { ...payload, id: `job_${Date.now()}`, status: "open" };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/job-service-protected-fields.test.js
+++ b/apps/api/src/tests/job-service-protected-fields.test.js
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps generated id and open status server-owned", async () => {
+  const job = await createJob({
+    title: "Server-owned fields",
+    description: "Verify callers cannot replace protected job fields.",
+    budgetMin: 100,
+    budgetMax: 200,
+    categoryId: "cat_1",
+    skills: [],
+    id: "attacker-controlled-id",
+    status: "closed"
+  });
+
+  assert.match(job.id, /^job_\d+$/);
+  assert.notEqual(job.id, "attacker-controlled-id");
+  assert.equal(job.status, "open");
+});


### PR DESCRIPTION
Fixes #12210.

## Summary

Keep the job identifier and initial `open` status server-owned during creation.

The request payload is now spread first, then the generated `id` and required initial `status` are assigned so caller-controlled values cannot overwrite them.

## Changes

- Preserve ordinary payload fields.
- Generate the `job_*` id after spreading the payload.
- Force new jobs to start with `status: "open"`.
- Add a focused regression test proving caller-supplied `id` and `status` values are ignored.

## Scope

No authentication, persistence, validation, or unrelated job behavior is changed.

Parent bounty: #11398