### PR TITLE
fix(api): handle invalid PORT env without crashing startup

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -1,7 +1,18 @@
 export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
-  jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+const DEFAULT_PORT = 4000;
+const rawPort = process.env.PORT;
+let PORT = DEFAULT_PORT;
+
+if (rawPort !== undefined) {
+  const parsed = Number(rawPort);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    console.warn(`[config] Invalid PORT value "${rawPort}" - falling back to default ${DEFAULT_PORT}`);
+  } else {
+    PORT = parsed;
+  }
+}
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };


### PR DESCRIPTION
## Summary Fixes #11391 - `Number(process.env.PORT ?? 4000)` returns `NaN` for non-numeric PORT values, crashing the API on startup.  ## Changes - Validate that `PORT` is a finite positive integer before using it - Fall back to default port `4000` when validation fails - Log a warning message identi