### PR TITLE
fix(auth): return 400 for invalid register/login payloads

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,17 +1,26 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
-import { loginUser, refreshToken, registerUser } from "../services/authService.js";
+const { success, error } = require('../utils/response');
+const { registerSchema, loginSchema } = require('../validators/auth');
 import { ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+    const validation = registerSchema.safeParse(req.body);
+    if (!validation.success) {
+      return error(res, validation.error.issues.map(i => ({ field: i.path.join('.'), message: i.message })), 400);
+    }
+    const user = await authService.register(validation.data);
+    return success(res, user, 'User registered successfully', 201);
   return ok(res, result, 201);
 }
 
 export async function login(req, res) {
   const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+    const validation = loginSchema.safeParse(req.body);
+    if (!validation.success) {
+      return error(res, validation.error.issues.map(i => ({ field: i.path.join('.'), message: i.message })), 400);
+    }
+    const result = await authService.login(validation.data);
+    return success(res, result, 'Login successful');
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -1,8 +1,15 @@
-import { z } from "zod";
+const { z } = require('zod');
 
-export const registerSchema = z.object({
+exports.registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
+  name: z.string().min(1).optional(),
+});
+
+exports.loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
   role: z.enum(["client", "freelancer", "admin"]).default("client")
 });
 


### PR DESCRIPTION
## Summary Auth endpoints were returning 500 errors when clients sent malformed or incomplete payloads because validation errors from the service layer were not being caught and normalized.  ## Changes - Added Zod schemas (`registerSchema`, `loginSchema`) in `apps/api/src/validators/auth.js` - Updat