### PR TITLE
Fix Card native section prop forwarding

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function Card({ title, children, style, ...props }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...props}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
Closes #12245.

## Summary

Update the shared `Card` component so consumers can pass native `<section>` attributes while preserving the existing title/children rendering and default card styles.

## Changes

* Extend props with `React.HTMLAttributes<HTMLElement>`.
* Forward native section props including `id`, `className`, `aria-*`, `data-*`, event handlers, and `style`.
* Merge caller-provided `style` on top of the default border, radius, and padding styles.
* Keep the change focused to `packages/ui/src/Card.tsx`.

## Validation

The branch contains a single focused file change.

Parent bounty: #11398
