### PR TITLE
Map Multer upload parser errors to HTTP 400

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,13 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err?.name === "MulterError") {
+    return res.status(400).json({
+      success: false,
+      message: err.message
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/uploadErrors.test.js
+++ b/apps/api/src/tests/uploadErrors.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads maps Multer parser errors to 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const form = new FormData();
+    form.append("avatar", new Blob(["test"], { type: "text/plain" }), "test.txt");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /unexpected field/i);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
Closes #12247.

## Summary

Map Multer multipart parser errors to HTTP 400 instead of treating malformed client upload input as an internal server error.

## Changes

* Detect `MulterError` in the shared API error handler.
* Return the existing `{ success: false, message }` failure shape with status 400.
* Preserve the existing HTTP 500 behavior for unrelated unexpected errors.
* Add focused regression coverage for an unexpected multipart file field.

## Scope

No changes to upload authentication, file-size limits, MIME filtering, storage behavior, or unrelated API routes.

Parent bounty: #11398
