### PR TITLE
Preserve server-generated user IDs

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,7 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { ...payload, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser preserves a server-generated id", async () => {
+  const user = await createUser({
+    id: "client_supplied_id",
+    email: "user@example.com"
+  });
+
+  assert.notEqual(user.id, "client_supplied_id");
+  assert.match(user.id, /^usr_\d+$/);
+
+  const storedUsers = await listUsers();
+  assert.equal(storedUsers.at(-1).id, user.id);
+});


### PR DESCRIPTION
Closes #12249.

## Summary

Ensure user creation keeps the server-generated `usr_...` identifier even when the request payload includes an `id` field.

## Changes

* Prevent caller-supplied `id` values from overriding the generated user ID.
* Add focused regression coverage proving supplied IDs are ignored.
* Preserve legitimate payload fields and the existing response shape.

## Scope

Production change is limited to `apps/api/src/services/userService.js` plus focused service test coverage.

Parent bounty: #11398
