### PR TITLE
Fix Next.js 16 dynamic route params

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,10 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+export default async function FreelancerProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
+
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{username}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,10 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
Closes #12251.

## Summary

Fix the Next.js 16 App Router `PageProps` type failure on the two dynamic web routes.

## Changes

* Make the job detail page async and type `params` as `Promise<{ id: string }>`.
* Await `params` before rendering the job ID.
* Make the freelancer profile page async and type `params` as `Promise<{ username: string }>`.
* Await `params` before rendering the username.
* Preserve the existing rendered content and route behavior.

## Scope

Only these two dynamic pages are changed:

* `apps/web/app/jobs/[id]/page.tsx`
* `apps/web/app/freelancers/[username]/page.tsx`

Parent bounty: #11398
