### PR TITLE
Reject JWTs missing required identity claims

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,8 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const allowedRoles = new Set(["client", "freelancer", "admin"]);
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +10,20 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const claims = verifyAccessToken(authHeader.slice(7));
+    const hasValidIdentity =
+      claims &&
+      typeof claims === "object" &&
+      !Array.isArray(claims) &&
+      typeof claims.sub === "string" &&
+      claims.sub.trim().length > 0 &&
+      allowedRoles.has(claims.role);
+
+    if (!hasValidIdentity) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = claims;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/authClaims.test.js
+++ b/apps/api/src/tests/authClaims.test.js
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authMiddleware } from "../middleware/auth.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    }
+  };
+}
+
+function runAuth(payload) {
+  const token = signAccessToken(payload);
+  const req = { headers: { authorization: `Bearer ${token}` } };
+  const res = createResponse();
+  let nextCalled = false;
+
+  authMiddleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { req, res, nextCalled };
+}
+
+test("authMiddleware accepts valid identity claims", () => {
+  const result = runAuth({ sub: "usr_123", role: "client" });
+  assert.equal(result.nextCalled, true);
+  assert.equal(result.req.user.sub, "usr_123");
+  assert.equal(result.req.user.role, "client");
+});
+
+test("authMiddleware rejects a token missing sub", () => {
+  const result = runAuth({ role: "client" });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.res.statusCode, 401);
+  assert.deepEqual(result.res.body, { success: false, message: "Invalid token" });
+});
+
+test("authMiddleware rejects a blank sub", () => {
+  const result = runAuth({ sub: "   ", role: "client" });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.res.statusCode, 401);
+});
+
+test("authMiddleware rejects an unknown role", () => {
+  const result = runAuth({ sub: "usr_123", role: "owner" });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.res.statusCode, 401);
+});


### PR DESCRIPTION
Closes #12253.

## Summary

Harden `authMiddleware` so a successfully signed JWT is accepted only when it contains the identity claims protected routes rely on.

## Changes

* Require a non-empty string `sub` claim.
* Require `role` to be one of `client`, `freelancer`, or `admin`.
* Preserve valid application-issued access tokens.
* Return the existing HTTP 401 `Invalid token` response for invalid claim sets.
* Add focused regression coverage for valid identity claims, missing/blank `sub`, and unsupported roles.

## Scope

Production change is limited to `apps/api/src/middleware/auth.js` plus focused middleware regression tests.

Parent bounty: #11398
