### PR TITLE
Isolate API rate-limit counters per createApp instance

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -1,7 +1,7 @@
 import cors from "cors";
 import express from "express";
 import helmet from "helmet";
-import { apiLimiter } from "./middleware/rateLimit.js";
+import { createApiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
@@ -21,7 +21,7 @@ export function createApp() {
   app.use(helmet());
   app.use(cors());
   app.use(express.json());
-  app.use(apiLimiter);
+  app.use(createApiLimiter());
 
   app.get("/health", (req, res) => {
     res.status(200).json({ ok: true, service: "api" });

--- a/apps/api/src/middleware/rateLimit.js
+++ b/apps/api/src/middleware/rateLimit.js
@@ -1,8 +1,10 @@
 import rateLimit from "express-rate-limit";
 
-export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 200,
-  standardHeaders: "draft-7",
-  legacyHeaders: false
-});
+export function createApiLimiter() {
+  return rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 200,
+    standardHeaders: "draft-7",
+    legacyHeaders: false
+  });
+}

--- a/apps/api/src/tests/rateLimitIsolation.test.js
+++ b/apps/api/src/tests/rateLimitIsolation.test.js
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function listen(app) {
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  return server;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("createApp instances have isolated API rate-limit counters", async () => {
+  const firstServer = await listen(createApp());
+  const firstPort = firstServer.address().port;
+
+  try {
+    for (let request = 0; request < 200; request += 1) {
+      const response = await fetch(`http://127.0.0.1:${firstPort}/api/search`);
+      assert.equal(response.status, 200);
+    }
+
+    const limitedResponse = await fetch(`http://127.0.0.1:${firstPort}/api/search`);
+    assert.equal(limitedResponse.status, 429);
+  } finally {
+    await close(firstServer);
+  }
+
+  const secondServer = await listen(createApp());
+  const secondPort = secondServer.address().port;
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${secondPort}/api/search`);
+    assert.equal(response.status, 200);
+  } finally {
+    await close(secondServer);
+  }
+});


### PR DESCRIPTION
Closes #12255.

## Summary

Ensure each `createApp()` call receives a fresh `express-rate-limit` instance instead of reusing one module-level limiter with shared in-memory counters.

## Changes

* Replace the exported singleton limiter with a `createApiLimiter()` factory.
* Instantiate a fresh limiter inside each `createApp()` call.
* Preserve the existing 15-minute window and 200-request limit.
* Preserve draft-7 standard headers and disabled legacy headers.
* Add focused regression coverage proving an exhausted first app does not cause a newly-created second app to start rate-limited.

## Scope

Production changes are limited to:

* `apps/api/src/middleware/rateLimit.js`
* `apps/api/src/app.js`

plus focused rate-limit isolation regression coverage.

Parent bounty: #11398
