### PR TITLE
Use fixed-precision Decimal for monetary fields

### DIFF
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -45,8 +45,8 @@ model Job {
   id            String      @id @default(cuid())
   title         String
   description   String
-  budgetMin     Float
-  budgetMax     Float
+  budgetMin     Decimal     @db.Decimal(12, 2)
+  budgetMax     Decimal     @db.Decimal(12, 2)
   status        JobStatus   @default(OPEN)
   clientId      String
   client        User        @relation("ClientJobs", fields: [clientId], references: [id])
@@ -61,7 +61,7 @@ model Job {
 model Proposal {
   id            String      @id @default(cuid())
   coverLetter   String
-  bidAmount     Float
+  bidAmount     Decimal     @db.Decimal(12, 2)
   estDuration   String
   jobId         String
   job           Job         @relation(fields: [jobId], references: [id])
@@ -72,7 +72,7 @@ model Proposal {
 
 model Payment {
   id            String      @id @default(cuid())
-  amount        Float
+  amount        Decimal     @db.Decimal(12, 2)
   currency      String      @default("USD")
   status        String
   stripeRef     String?


### PR DESCRIPTION
Closes #12257.

## Summary

Replace floating-point storage for monetary Prisma fields with fixed-precision PostgreSQL decimal columns.

## Changes

* Change `Job.budgetMin` to `Decimal @db.Decimal(12, 2)`.
* Change `Job.budgetMax` to `Decimal @db.Decimal(12, 2)`.
* Change `Proposal.bidAmount` to `Decimal @db.Decimal(12, 2)`.
* Change `Payment.amount` to `Decimal @db.Decimal(12, 2)`.
* Keep all unrelated schema fields unchanged.

## Scope

Only `packages/db/prisma/schema.prisma` is changed.

Parent bounty: #11398
