### PR TITLE
Trim job text fields before validation

### DIFF
--- a/apps/api/src/tests/jobValidator.test.js
+++ b/apps/api/src/tests/jobValidator.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema } from "../validators/job.js";
+
+test("createJobSchema rejects whitespace-only text fields", () => {
+  const result = createJobSchema.safeParse({
+    title: "    ",
+    description: "          ",
+    budgetMin: 10,
+    budgetMax: 20,
+    categoryId: "   ",
+    skills: ["   "]
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("createJobSchema trims accepted text fields", () => {
+  const result = createJobSchema.parse({
+    title: "  Build app  ",
+    description: "  Build a production app  ",
+    budgetMin: 10,
+    budgetMax: 20,
+    categoryId: "  web  ",
+    skills: ["  React  ", " TypeScript "]
+  });
+
+  assert.equal(result.title, "Build app");
+  assert.equal(result.description, "Build a production app");
+  assert.equal(result.categoryId, "web");
+  assert.deepEqual(result.skills, ["React", "TypeScript"]);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
+  title: z.string().trim().min(4),
+  description: z.string().trim().min(10),
   budgetMin: z.number().nonnegative(),
   budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
+  categoryId: z.string().trim().min(1),
+  skills: z.array(z.string().trim().min(1)).default([])
 });
 
 export const updateJobSchema = createJobSchema.partial();


### PR DESCRIPTION
Closes #12259.

## Summary

Normalize job text inputs before applying their existing minimum-length validation rules so whitespace-only values are rejected.

## Changes

* Trim `title` before enforcing the existing 4-character minimum.
* Trim `description` before enforcing the existing 10-character minimum.
* Trim `categoryId` before enforcing the existing non-empty requirement.
* Trim each `skills` entry before enforcing the existing non-empty requirement.
* Preserve the existing budget validation and update-schema behavior.
* Add focused validator regression coverage for whitespace rejection and trim normalization.

## Scope

Production change is limited to `apps/api/src/validators/job.js` plus focused validator regression tests.

Parent bounty: #11398
