### PR TITLE
Add sanitized .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Safe local-development defaults. Replace secrets before real deployment.
+NODE_ENV=development
+PORT=4000
+JWT_SECRET=replace-with-a-long-random-development-secret
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/freelanceflow
+STRIPE_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 dist
 .env
 .env.*
+!.env.example
 coverage
 *.log


### PR DESCRIPTION
Closes #12261.

## Summary

Allow the repository to track a sanitized `.env.example` while continuing to ignore real environment files.

## Changes

* Explicitly unignore `.env.example` after the existing `.env.*` rule.
* Add a checked-in `.env.example` containing placeholder/local-development values for:

  * `NODE_ENV`
  * `PORT`
  * `JWT_SECRET`
  * `DATABASE_URL`
  * `STRIPE_SECRET_KEY`
* Keep real credentials and secrets out of the repository.

## Scope

Only `.gitignore` and `.env.example` are changed.

Parent bounty: #11398
