### PR TITLE
Fix Card component native section prop forwarding (#12245)

### DIFF
--- a/packages/ui/src/Card.tsx
+++ b/packages/ui/src/Card.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 
-export function Card({ title, children }: { title: string; children: React.ReactNode }) {
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function Card({ title, children, style, ...sectionProps }: CardProps) {
   return (
-    <section style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem" }}>
+    <section
+      {...sectionProps}
+      style={{ border: "1px solid #ddd", borderRadius: 8, padding: "1rem", ...style }}
+    >
       <h3>{title}</h3>
       <div>{children}</div>
     </section>


### PR DESCRIPTION
## Summary

Fixes #12245.

Updates the shared `Card` component so it forwards native `<section>` props while preserving the existing component API and default styling.

## Changes

- Extends `React.HTMLAttributes<HTMLElement>`
- Forwards native section props such as `id`, `className`, `aria-*`, `data-*`, and event handlers
- Preserves existing `title` and `children` rendering
- Preserves the default border, border radius, and padding
- Merges caller-provided `style` with the default styles

## Scope

The production change is limited to:

`packages/ui/src/Card.tsx`

## Bounty

Submitted for #12245 under parent bounty #11398.