### PR TITLE
fix(api): preserve server-owned id and default open status in jobService (Fixes #12265, Ref #743)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -5,7 +5,11 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = {
+    ...payload,
+    id: `job_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    status: "open",
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob creates a job with server-owned id and default open status", async () => {
+  const payload = {
+    title: "Senior Node.js Developer",
+    description: "Build high-throughput microservices and APIs.",
+    budgetMin: 5000,
+    budgetMax: 8000,
+    categoryId: "cat_backend",
+    skills: ["Node.js", "Express", "PostgreSQL"],
+  };
+
+  const job = await createJob(payload);
+
+  assert.ok(job.id.startsWith("job_"), "Job ID should start with 'job_'");
+  assert.equal(job.status, "open", "Job status should default to 'open'");
+  assert.equal(job.title, payload.title);
+  assert.equal(job.description, payload.description);
+  assert.equal(job.budgetMin, payload.budgetMin);
+  assert.equal(job.budgetMax, payload.budgetMax);
+  assert.equal(job.categoryId, payload.categoryId);
+  assert.deepEqual(job.skills, payload.skills);
+});
+
+test("createJob does not allow caller-provided id to override server id", async () => {
+  const maliciousPayload = {
+    id: "custom_injected_id_999",
+    title: "Security Auditor",
+    description: "Perform audit on platform smart contracts.",
+    budgetMin: 3000,
+    budgetMax: 6000,
+    categoryId: "cat_security",
+    skills: ["Security"],
+  };
+
+  const job = await createJob(maliciousPayload);
+
+  assert.notEqual(job.id, "custom_injected_id_999", "Injected ID must be overwritten by server");
+  assert.ok(job.id.startsWith("job_"), "Server must assign a valid 'job_' ID");
+  assert.equal(job.status, "open");
+});
+
+test("createJob does not allow caller-provided status to override default open status", async () => {
+  const spoofedStatusPayload = {
+    status: "closed",
+    title: "Frontend React Engineer",
+    description: "Implement responsive UI components in Next.js.",
+    budgetMin: 4000,
+    budgetMax: 7000,
+    categoryId: "cat_frontend",
+    skills: ["React", "TypeScript"],
+  };
+
+  const job = await createJob(spoofedStatusPayload);
+
+  assert.equal(job.status, "open", "Initial status must strictly be 'open'");
+});
+
+test("listJobs returns all accumulated created jobs", async () => {
+  const allJobs = await listJobs();
+  assert.ok(Array.isArray(allJobs), "listJobs should return an array");
+  assert.ok(allJobs.length >= 3, "listJobs should contain created jobs");
+});


### PR DESCRIPTION
Fixes #12265
Ref #743

## 🛠️ Summary of Changes
- Fixed the object spread ordering in `apps/api/src/services/jobService.js` to ensure server-generated `id` and default `status: "open"` cannot be overwritten by client-supplied payload properties.
- Added comprehensive unit tests in `apps/api/src/tests/jobService.test.js` covering:
  - Default server `job_` ID generation and `status: "open"`.
  - Rejection of client-injected `id` overrides.
  - Rejection of client-injected `status` overrides.
  - Full preservation of legitimate job payload attributes (`title`, `description`, `budgetMin`, `budgetMax`, `categoryId`, `skills`).
  - Job accumulation in `listJobs()`.

## 🧪 Test Verification
```text
✔ createJob creates a job with server-owned id and default open status (1.89ms)
✔ createJob does not allow caller-provided id to override server id (0.31ms)
✔ createJob does not allow caller-provided status to override default open status (0.20ms)
✔ listJobs returns all accumulated created jobs (1.26ms)
✔ GET /health returns ok payload (107.3ms)
```

**Algora Bounty Claimant:**
- GitHub: @techsp13
- EVM Address: `0x01E7862BEd361b72784c0819AD68548D85A9ad49`
