### PR TITLE
fix(api): preserve server-owned id and add schema validation in reviewService (Fixes #12267, Ref #743)

### DIFF
--- a/apps/api/src/controllers/reviewController.js
+++ b/apps/api/src/controllers/reviewController.js
@@ -1,4 +1,5 @@
 import { ok } from "../utils/response.js";
+import { createReviewSchema } from "../validators/review.js";
 import { createReview, listReviews } from "../services/reviewService.js";
 
 export async function getReviews(req, res) {
@@ -6,5 +7,6 @@ export async function getReviews(req, res) {
 }
 
 export async function postReview(req, res) {
-  return ok(res, await createReview(req.body), 201);
+  const payload = createReviewSchema.parse(req.body);
+  return ok(res, await createReview(payload), 201);
 }

--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -5,7 +5,11 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = {
+    ...payload,
+    id: `rev_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+    createdAt: new Date().toISOString(),
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+import { createReviewSchema } from "../validators/review.js";
+
+test("createReview generates server-owned rev_ ID and timestamp", async () => {
+  const payload = {
+    targetId: "user_freelancer_123",
+    rating: 5,
+    comment: "Outstanding delivery and code quality!",
+  };
+
+  const review = await createReview(payload);
+
+  assert.ok(review.id.startsWith("rev_"), "Review ID must start with rev_");
+  assert.equal(review.targetId, payload.targetId);
+  assert.equal(review.rating, 5);
+  assert.equal(review.comment, payload.comment);
+  assert.ok(review.createdAt, "Review must include createdAt timestamp");
+});
+
+test("createReview does not allow client-supplied id to override server id", async () => {
+  const injectedPayload = {
+    id: "injected_rev_999",
+    targetId: "user_client_456",
+    rating: 4,
+    comment: "Great communication throughout the milestone.",
+  };
+
+  const review = await createReview(injectedPayload);
+
+  assert.notEqual(review.id, "injected_rev_999", "Injected ID must be overwritten");
+  assert.ok(review.id.startsWith("rev_"), "Server must assign a valid rev_ ID");
+});
+
+test("createReviewSchema validates rating range between 1 and 5", () => {
+  const valid = createReviewSchema.safeParse({
+    targetId: "user_1",
+    rating: 4,
+    comment: "Good job",
+  });
+  assert.equal(valid.success, true);
+
+  const invalidLow = createReviewSchema.safeParse({
+    targetId: "user_1",
+    rating: 0,
+    comment: "Bad",
+  });
+  assert.equal(invalidLow.success, false, "Rating 0 must be rejected");
+
+  const invalidHigh = createReviewSchema.safeParse({
+    targetId: "user_1",
+    rating: 6,
+    comment: "Over the top",
+  });
+  assert.equal(invalidHigh.success, false, "Rating 6 must be rejected");
+});
+
+test("listReviews returns accumulated reviews", async () => {
+  const reviews = await listReviews();
+  assert.ok(Array.isArray(reviews));
+  assert.ok(reviews.length >= 2);
+});

--- a/apps/api/src/validators/review.js
+++ b/apps/api/src/validators/review.js
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const createReviewSchema = z.object({
+  targetId: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().min(3).max(1000),
+});
+
+export const updateReviewSchema = createReviewSchema.partial();


### PR DESCRIPTION
Fixes #12267
Ref #743

## 🛠️ Summary of Changes
- Fixed object spread ordering in `apps/api/src/services/reviewService.js` to ensure server-generated `id` and `createdAt` cannot be overwritten by client-supplied payload properties.
- Implemented `createReviewSchema` and `updateReviewSchema` in `apps/api/src/validators/review.js` enforcing:
  - `targetId`: Required non-empty string.
  - `rating`: Integer strictly between 1 and 5.
  - `comment`: Valid string with length boundaries (3..1000).
- Integrated schema validation into `apps/api/src/controllers/reviewController.js` for `POST /api/reviews`.
- Added comprehensive unit tests in `apps/api/src/tests/reviewService.test.js` covering:
  - Server `rev_` ID generation and timestamp assignment.
  - Rejection of client-injected `id` overrides.
  - Rating boundary validation (rejecting <= 0 and >= 6).
  - Review accumulation in `listReviews()`.

## 🧪 Test Verification
```text
✔ createReview generates server-owned rev_ ID and timestamp (33.8ms)
✔ createReview does not allow client-supplied id to override server id (0.8ms)
✔ createReviewSchema validates rating range between 1 and 5 (3.6ms)
✔ listReviews returns accumulated reviews (0.3ms)
✔ GET /health returns ok payload (232.3ms)
```

**Algora Bounty Claimant:**
- GitHub: @techsp13
- EVM Address: `0x01E7862BEd361b72784c0819AD68548D85A9ad49`
