### PR TITLE
fix(api): map Multer parser errors to HTTP 400 in global error middleware (Closes #12269)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,16 @@
+import multer from "multer";
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err instanceof multer.MulterError || err?.name === "MulterError") {
+    return fail(res, err.message, 400);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/upload_error.test.js
+++ b/apps/api/src/tests/upload_error.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/uploads maps unexpected file field to HTTP 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    // 1. Submit multipart form data with unexpected field name
+    const form = new FormData();
+    form.append("invalid_field", new Blob(["test content"], { type: "text/plain" }), "test.txt");
+
+    const response = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: form
+    });
+
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.success, false);
+    assert.match(payload.message, /Unexpected field/i);
+
+    // 2. Submit multipart form data with valid field name
+    const validForm = new FormData();
+    validForm.append("file", new Blob(["hello world"], { type: "text/plain" }), "hello.txt");
+
+    const validResponse = await fetch(`${baseUrl}/api/uploads`, {
+      method: "POST",
+      body: validForm
+    });
+
+    const validPayload = await validResponse.json();
+
+    assert.equal(validResponse.status, 201);
+    assert.equal(validPayload.success, true);
+    assert.equal(validPayload.data.filename, "hello.txt");
+    assert.equal(validPayload.data.status, "uploaded");
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
### Problem Summary
When client requests submit malformed multipart/form-data payloads to `POST /api/uploads` (such as unexpected file field names), Multer raises a `MulterError`. The centralized API error handler previously treated this client-side parsing error as an unhandled server exception and returned HTTP 500 Internal Server Error.

---

### Root Cause Analysis
`apps/api/src/middleware/errorHandler.js` did not recognize `MulterError` instances, falling through to the generic unhandled error path which responds with HTTP 500.

---

### Solution & Implementation Details
1. **Error Interception**: Imported `multer` and mapped `MulterError` instances in `apps/api/src/middleware/errorHandler.js` to return HTTP 400 Bad Request using the standard response utility (`fail(res, err.message, 400)`).
2. **Preserve Server Error Handling**: Preserved default HTTP 500 response behavior for unrelated unhandled exceptions.
3. **Integration Test Suite**: Added `apps/api/src/tests/upload_error.test.js` testing both unexpected multipart field names (verifying HTTP 400) and valid file uploads (verifying HTTP 201).

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: 2/2 tests passed (including `health.test.js` and `upload_error.test.js`).
- Verified clean git status with zero foreign metadata files.

---

### Issue Reference
Closes #12269

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`