### PR TITLE
fix(api): reject JWTs missing required identity claims in auth middleware (Closes #12271)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -1,6 +1,8 @@
 import { fail } from "../utils/response.js";
 import { verifyAccessToken } from "../utils/jwt.js";
 
+const VALID_ROLES = new Set(["client", "freelancer", "admin"]);
+
 export function authMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith("Bearer ")) {
@@ -8,7 +10,17 @@ export function authMiddleware(req, res, next) {
   }
 
   try {
-    req.user = verifyAccessToken(authHeader.slice(7));
+    const payload = verifyAccessToken(authHeader.slice(7));
+    if (!payload || typeof payload !== "object") {
+      return fail(res, "Invalid token", 401);
+    }
+
+    const sub = typeof payload.sub === "string" ? payload.sub.trim() : "";
+    if (!sub || !VALID_ROLES.has(payload.role)) {
+      return fail(res, "Invalid token", 401);
+    }
+
+    req.user = payload;
     return next();
   } catch {
     return fail(res, "Invalid token", 401);

--- a/apps/api/src/tests/auth_claims.test.js
+++ b/apps/api/src/tests/auth_claims.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+test("authMiddleware validates required identity claims in JWT", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    // 1. Missing Authorization header -> 401 Unauthorized
+    const unauthRes = await fetch(`${baseUrl}/api/admin/metrics`);
+    const unauthPayload = await unauthRes.json();
+    assert.equal(unauthRes.status, 401);
+    assert.equal(unauthPayload.success, false);
+    assert.equal(unauthPayload.message, "Unauthorized");
+
+    // 2. Token missing 'sub' claim -> 401 Invalid token
+    const missingSubToken = signAccessToken({ role: "admin" });
+    const missingSubRes = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${missingSubToken}` }
+    });
+    const missingSubPayload = await missingSubRes.json();
+    assert.equal(missingSubRes.status, 401);
+    assert.equal(missingSubPayload.success, false);
+    assert.equal(missingSubPayload.message, "Invalid token");
+
+    // 3. Token with empty string 'sub' -> 401 Invalid token
+    const emptySubToken = signAccessToken({ sub: "   ", role: "admin" });
+    const emptySubRes = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${emptySubToken}` }
+    });
+    const emptySubPayload = await emptySubRes.json();
+    assert.equal(emptySubRes.status, 401);
+    assert.equal(emptySubPayload.success, false);
+    assert.equal(emptySubPayload.message, "Invalid token");
+
+    // 4. Token with invalid role -> 401 Invalid token
+    const invalidRoleToken = signAccessToken({ sub: "usr_123", role: "super_admin" });
+    const invalidRoleRes = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${invalidRoleToken}` }
+    });
+    const invalidRolePayload = await invalidRoleRes.json();
+    assert.equal(invalidRoleRes.status, 401);
+    assert.equal(invalidRolePayload.success, false);
+    assert.equal(invalidRolePayload.message, "Invalid token");
+
+    // 5. Valid token with valid sub and role -> 200 OK
+    const validToken = signAccessToken({ sub: "usr_123", role: "admin" });
+    const validRes = await fetch(`${baseUrl}/api/admin/metrics`, {
+      headers: { Authorization: `Bearer ${validToken}` }
+    });
+    const validPayload = await validRes.json();
+    assert.equal(validRes.status, 200);
+    assert.equal(validPayload.success, true);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
### Problem Summary
`authMiddleware` previously accepted any JWT whose cryptographic signature passed, without validating that essential identity claims (`sub` and `role`) were present and valid. Tokens missing `sub` or containing unrecognized roles could reach protected routes and leave `req.user` in an invalid state.

---

### Root Cause Analysis
`apps/api/src/middleware/auth.js` directly assigned `req.user = verifyAccessToken(...)` upon signature verification, without checking if `payload.sub` is a non-empty string or if `payload.role` matches one of the application's supported roles (`client`, `freelancer`, `admin`).

---

### Solution & Implementation Details
1. **Claim Invariant Validation**: Updated `authMiddleware` in `apps/api/src/middleware/auth.js` to validate that `payload.sub` is a non-empty string and `payload.role` belongs to `VALID_ROLES` (`client`, `freelancer`, `admin`).
2. **Fail-Closed 401 Response**: Returned the standard HTTP 401 `fail(res, "Invalid token", 401)` response when claims are missing or malformed.
3. **Integration Test Suite**: Added `apps/api/src/tests/auth_claims.test.js` testing unauthenticated requests, tokens missing `sub`, tokens with empty `sub`, tokens with invalid roles, and valid tokens.

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: All tests passed.
- Verified clean git working tree with zero foreign metadata files.

---

### Issue Reference
Closes #12271

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`