### PR TITLE
fix(api): enforce budgetMax >= budgetMin in job schema validation (Closes #12273)

### DIFF
--- a/apps/api/src/tests/job_budget.test.js
+++ b/apps/api/src/tests/job_budget.test.js
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJobSchema, updateJobSchema } from "../validators/job.js";
+
+test("job schema validates budgetMax >= budgetMin", () => {
+  // 1. Inverted range rejected in createJobSchema
+  const inverted = createJobSchema.safeParse({
+    title: "Senior Node.js Backend Engineer",
+    description: "Build robust REST APIs and auth middleware",
+    budgetMin: 500,
+    budgetMax: 100,
+    categoryId: "cat_dev",
+    skills: ["node", "express"]
+  });
+
+  assert.equal(inverted.success, false);
+  const error = inverted.error.issues[0];
+  assert.equal(error.path[0], "budgetMax");
+  assert.match(error.message, /budgetMax must be greater than or equal to budgetMin/i);
+
+  // 2. Valid range accepted in createJobSchema
+  const valid = createJobSchema.safeParse({
+    title: "Senior Node.js Backend Engineer",
+    description: "Build robust REST APIs and auth middleware",
+    budgetMin: 100,
+    budgetMax: 500,
+    categoryId: "cat_dev",
+    skills: ["node", "express"]
+  });
+
+  assert.equal(valid.success, true);
+  assert.equal(valid.data.budgetMin, 100);
+  assert.equal(valid.data.budgetMax, 500);
+
+  // 3. Equal bounds (fixed price) accepted
+  const fixedPrice = createJobSchema.safeParse({
+    title: "Senior Node.js Backend Engineer",
+    description: "Build robust REST APIs and auth middleware",
+    budgetMin: 250,
+    budgetMax: 250,
+    categoryId: "cat_dev"
+  });
+
+  assert.equal(fixedPrice.success, true);
+  assert.equal(fixedPrice.data.budgetMin, 250);
+  assert.equal(fixedPrice.data.budgetMax, 250);
+
+  // 4. Inverted update rejected in updateJobSchema
+  const invertedUpdate = updateJobSchema.safeParse({
+    budgetMin: 1000,
+    budgetMax: 200
+  });
+
+  assert.equal(invertedUpdate.success, false);
+  assert.match(invertedUpdate.error.issues[0].message, /budgetMax must be greater than or equal to budgetMin/i);
+
+  // 5. Valid partial update accepted in updateJobSchema
+  const validPartialUpdate = updateJobSchema.safeParse({
+    budgetMin: 300
+  });
+
+  assert.equal(validPartialUpdate.success, true);
+  assert.equal(validPartialUpdate.data.budgetMin, 300);
+});

--- a/apps/api/src/validators/job.js
+++ b/apps/api/src/validators/job.js
@@ -1,12 +1,37 @@
 import { z } from "zod";
 
-export const createJobSchema = z.object({
-  title: z.string().min(4),
-  description: z.string().min(10),
-  budgetMin: z.number().nonnegative(),
-  budgetMax: z.number().nonnegative(),
-  categoryId: z.string().min(1),
-  skills: z.array(z.string().min(1)).default([])
-});
+export const createJobSchema = z
+  .object({
+    title: z.string().min(4),
+    description: z.string().min(10),
+    budgetMin: z.number().nonnegative(),
+    budgetMax: z.number().nonnegative(),
+    categoryId: z.string().min(1),
+    skills: z.array(z.string().min(1)).default([])
+  })
+  .refine((data) => data.budgetMax >= data.budgetMin, {
+    message: "budgetMax must be greater than or equal to budgetMin",
+    path: ["budgetMax"]
+  });
 
-export const updateJobSchema = createJobSchema.partial();
+export const updateJobSchema = z
+  .object({
+    title: z.string().min(4).optional(),
+    description: z.string().min(10).optional(),
+    budgetMin: z.number().nonnegative().optional(),
+    budgetMax: z.number().nonnegative().optional(),
+    categoryId: z.string().min(1).optional(),
+    skills: z.array(z.string().min(1)).optional()
+  })
+  .refine(
+    (data) => {
+      if (data.budgetMin !== undefined && data.budgetMax !== undefined) {
+        return data.budgetMax >= data.budgetMin;
+      }
+      return true;
+    },
+    {
+      message: "budgetMax must be greater than or equal to budgetMin",
+      path: ["budgetMax"]
+    }
+  );


### PR DESCRIPTION
### Problem Summary
In `apps/api/src/validators/job.js`, `createJobSchema` and `updateJobSchema` lacked cross-field range validation between `budgetMin` and `budgetMax`. Inverted ranges (where `budgetMin` exceeds `budgetMax`) passed validation, allowing inconsistent budget data into the application.

---

### Root Cause Analysis
`createJobSchema` and `updateJobSchema` defined `budgetMin` and `budgetMax` as separate `z.number().nonnegative()` fields without a `.refine()` boundary check comparing both fields.

---

### Solution & Implementation Details
1. **Cross-Field Refinement**: Added `.refine((data) => data.budgetMax >= data.budgetMin)` to `createJobSchema` with an error message path targeting `budgetMax`.
2. **Partial Update Support**: Added conditional range validation to `updateJobSchema` ensuring bounds are checked whenever both `budgetMin` and `budgetMax` are specified in a partial update.
3. **Unit Test Coverage**: Added `apps/api/src/tests/job_budget.test.js` validating inverted rejection, valid ranges, equal budget boundaries, and partial updates.

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: All tests passed.
- Verified clean git working tree with zero untracked artifacts.

---

### Issue Reference
Closes #12273

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`