### PR TITLE
fix(auth): disallow admin role self-assignment in public registration schema (Closes #12277)

### DIFF
--- a/apps/api/src/tests/registration_role.test.js
+++ b/apps/api/src/tests/registration_role.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerSchema } from "../validators/auth.js";
+
+test("public registerSchema validates user roles and disallows admin self-assignment", () => {
+  // 1. Omitted role defaults to 'client'
+  const defaultRole = registerSchema.safeParse({
+    email: "client@example.com",
+    password: "securePassword123"
+  });
+  assert.equal(defaultRole.success, true);
+  assert.equal(defaultRole.data.role, "client");
+
+  // 2. Explicit 'client' is accepted
+  const explicitClient = registerSchema.safeParse({
+    email: "client2@example.com",
+    password: "securePassword123",
+    role: "client"
+  });
+  assert.equal(explicitClient.success, true);
+  assert.equal(explicitClient.data.role, "client");
+
+  // 3. Explicit 'freelancer' is accepted
+  const explicitFreelancer = registerSchema.safeParse({
+    email: "freelancer@example.com",
+    password: "securePassword123",
+    role: "freelancer"
+  });
+  assert.equal(explicitFreelancer.success, true);
+  assert.equal(explicitFreelancer.data.role, "freelancer");
+
+  // 4. 'admin' role is strictly rejected
+  const adminAttempt = registerSchema.safeParse({
+    email: "attacker@example.com",
+    password: "securePassword123",
+    role: "admin"
+  });
+  assert.equal(adminAttempt.success, false);
+  assert.equal(adminAttempt.error.issues[0].path[0], "role");
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
### Problem Summary
In `apps/api/src/validators/auth.js`, the public `registerSchema` allowed unauthenticated users to self-assign the `admin` role upon registration, resulting in privilege escalation for any caller specifying `role: "admin"`.

---

### Root Cause Analysis
`registerSchema` included `"admin"` directly within the `z.enum(["client", "freelancer", "admin"])` list without requiring administrative authorization.

---

### Solution & Implementation Details
1. **Role Restriction**: Updated `registerSchema` in `apps/api/src/validators/auth.js` to only accept standard application roles: `client` and `freelancer` (defaulting to `client`).
2. **Rejection of Privilege Escalation**: Requests attempting to register with `role: "admin"` are rejected at the validation layer with HTTP 400.
3. **Regression Test Coverage**: Added `apps/api/src/tests/registration_role.test.js` testing default role assignment, explicit `client` registration, explicit `freelancer` registration, and rejection of `admin` registration.

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: All tests passed.
- Verified clean working tree with zero untracked artifacts.

---

### Issue Reference
Closes #12277

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`