### PR TITLE
fix(api): preserve server-generated id during user creation (Closes #12279)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -5,7 +5,8 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...data } = payload || {};
+  const user = { ...data, id: `usr_${Date.now()}` };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/user_service.test.js
+++ b/apps/api/src/tests/user_service.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("userService.createUser preserves server-generated ID and prevents client override", async () => {
+  // 1. Standard creation without ID
+  const user1 = await createUser({
+    name: "Alice Engineer",
+    email: "alice@example.com",
+    role: "freelancer"
+  });
+
+  assert.ok(user1.id.startsWith("usr_"));
+  assert.equal(user1.email, "alice@example.com");
+  assert.equal(user1.role, "freelancer");
+
+  // 2. Creation with malicious/custom ID override attempt
+  const user2 = await createUser({
+    id: "injected_attacker_id_9999",
+    name: "Bob Client",
+    email: "bob@example.com",
+    role: "client"
+  });
+
+  assert.notEqual(user2.id, "injected_attacker_id_9999");
+  assert.ok(user2.id.startsWith("usr_"));
+  assert.equal(user2.name, "Bob Client");
+  assert.equal(user2.email, "bob@example.com");
+
+  // 3. Confirm listed users in repository contain server-assigned IDs
+  const allUsers = await listUsers();
+  const foundUser2 = allUsers.find((u) => u.email === "bob@example.com");
+  assert.ok(foundUser2);
+  assert.equal(foundUser2.id, user2.id);
+  assert.notEqual(foundUser2.id, "injected_attacker_id_9999");
+});


### PR DESCRIPTION
### Problem Summary
In `apps/api/src/services/userService.js`, `createUser()` previously used `{ id: generatedId, ...payload }`. Because `payload` was spread after the generated ID, requests containing an `id` field could overwrite the server-generated identifier in the user repository.

---

### Root Cause Analysis
Object spread ordering allowed client-controlled properties to override the `id` property previously set on the object.

---

### Solution & Implementation Details
1. **Server-Generated ID Protection**: Updated `createUser()` in `apps/api/src/services/userService.js` to destructure and discard any caller-supplied `id`, authoritatively setting `id: usr_${Date.now()}` on the stored user record.
2. **Payload Preservation**: Kept all legitimate user profile fields (name, email, role) intact.
3. **Unit Test Coverage**: Added `apps/api/src/tests/user_service.test.js` asserting that caller-supplied IDs cannot overwrite generated identifiers and verifying repository state.

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: All tests passed.
- Verified clean git working tree with zero untracked artifacts.

---

### Issue Reference
Closes #12279

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`