### PR TITLE
fix(api): ensure collision-resistant server-controlled proposal IDs (Closes #12281)

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,11 +1,20 @@
+import crypto from "crypto";
+
 const proposals = [];
+let sequence = 0;
 
 export async function listProposals() {
   return proposals;
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const { id: _ignoredId, ...data } = payload || {};
+  sequence = (sequence + 1) % 1000000;
+  const randomSuffix = crypto.randomBytes(4).toString("hex");
+  const proposal = {
+    ...data,
+    id: `prp_${Date.now()}_${sequence}_${randomSuffix}`
+  };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposal_service.test.js
+++ b/apps/api/src/tests/proposal_service.test.js
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal, listProposals } from "../services/proposalService.js";
+
+test("proposalService.createProposal generates unique collision-resistant IDs and prevents client override", async () => {
+  // 1. Same-millisecond concurrent creation produces unique IDs
+  const concurrentCalls = Array.from({ length: 20 }, (_, i) =>
+    createProposal({
+      jobId: "job_100",
+      freelancerId: `freelancer_${i}`,
+      bidAmount: 500 + i
+    })
+  );
+
+  const results = await Promise.all(concurrentCalls);
+  const ids = results.map((r) => r.id);
+  const uniqueIds = new Set(ids);
+
+  assert.equal(ids.length, 20);
+  assert.equal(uniqueIds.size, 20, "All concurrent proposal IDs must be distinct");
+  for (const id of ids) {
+    assert.ok(id.startsWith("prp_"));
+  }
+
+  // 2. Caller-supplied ID override attempt is rejected
+  const customIdAttempt = await createProposal({
+    id: "injected_proposal_id_9999",
+    jobId: "job_200",
+    freelancerId: "freelancer_malicious",
+    bidAmount: 1000
+  });
+
+  assert.notEqual(customIdAttempt.id, "injected_proposal_id_9999");
+  assert.ok(customIdAttempt.id.startsWith("prp_"));
+  assert.equal(customIdAttempt.jobId, "job_200");
+
+  // 3. Confirm listed proposals reflect the correct server IDs
+  const allProposals = await listProposals();
+  const found = allProposals.find((p) => p.freelancerId === "freelancer_malicious");
+  assert.ok(found);
+  assert.equal(found.id, customIdAttempt.id);
+  assert.notEqual(found.id, "injected_proposal_id_9999");
+});


### PR DESCRIPTION
### Problem Summary
In `apps/api/src/services/proposalService.js`, `createProposal()` generated identifiers solely using `Date.now()` and spread `payload` after the generated ID. This caused ID collisions when proposals were created concurrently in the same millisecond and allowed caller-supplied `id` fields to override the server-generated identifier.

---

### Root Cause Analysis
- `Date.now()` lacks sub-millisecond entropy for concurrent invocations.
- Object spread syntax `{ id: ..., ...payload }` allowed client-supplied `id` properties to overwrite the server ID.

---

### Solution & Implementation Details
1. **Collision Resistance**: Integrated monotonic sequencing and cryptographic random byte entropy with timestamp generation (`prp_${Date.now()}_${sequence}_${randomSuffix}`).
2. **Server Ownership**: Stripped caller-controlled `id` fields, guaranteeing that the generated ID is always authoritative.
3. **Unit Test Coverage**: Added `apps/api/src/tests/proposal_service.test.js` verifying 20 concurrent same-millisecond creations produce distinct IDs and confirming caller overrides are rejected.

---

### Verification & Test Results
- Ran `node --test apps/api/src/tests/*.test.js`: All tests passed.
- Verified clean git working tree with zero untracked artifacts.

---

### Issue Reference
Closes #12281

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`