### PR TITLE
Enforce admin role authorization on admin routes (#12287)

### DIFF
--- a/apps/api/src/middleware/auth.js
+++ b/apps/api/src/middleware/auth.js
@@ -14,3 +14,13 @@ export function authMiddleware(req, res, next) {
     return fail(res, "Invalid token", 401);
   }
 }
+
+export function requireRole(role) {
+  return function roleMiddleware(req, res, next) {
+    if (req.user?.role !== role) {
+      return fail(res, "Forbidden", 403);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import { metrics } from "../controllers/adminController.js";
-import { authMiddleware } from "../middleware/auth.js";
+import { authMiddleware, requireRole } from "../middleware/auth.js";
 
 export const adminRoutes = Router();
 
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireRole("admin"));
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/tests/adminAuthorization.test.js
+++ b/apps/api/src/tests/adminAuthorization.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const server = createApp().listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function getMetrics(baseUrl, role) {
+  const headers = {};
+  if (role) {
+    headers.authorization = `Bearer ${signAccessToken({ sub: `${role}-user`, role })}`;
+  }
+
+  const response = await fetch(`${baseUrl}/api/admin/metrics`, { headers });
+  const payload = await response.json();
+  return { response, payload };
+}
+
+test("admin metrics require authentication and admin role", async () => {
+  await withServer(async (baseUrl) => {
+    const unauthenticated = await getMetrics(baseUrl);
+    assert.equal(unauthenticated.response.status, 401);
+    assert.deepEqual(unauthenticated.payload, { success: false, message: "Unauthorized" });
+
+    for (const role of ["client", "freelancer"]) {
+      const forbidden = await getMetrics(baseUrl, role);
+      assert.equal(forbidden.response.status, 403);
+      assert.deepEqual(forbidden.payload, { success: false, message: "Forbidden" });
+    }
+
+    const admin = await getMetrics(baseUrl, "admin");
+    assert.equal(admin.response.status, 200);
+    assert.equal(admin.payload.success, true);
+    assert.deepEqual(admin.payload.data, {
+      openJobs: 42,
+      activeFreelancers: 185,
+      flaggedAccounts: 3,
+      monthlyVolume: 128900
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #12287.

Authenticated non-admin users can currently reach `/api/admin/*` because the route only mounts `authMiddleware`. This PR adds a focused role-authorization layer and requires `admin` after authentication.

## Changes

- Add reusable `requireRole(role)` middleware using the existing failure envelope.
- Mount `requireRole("admin")` on admin routes after `authMiddleware`.
- Preserve HTTP 401 for unauthenticated requests.
- Return HTTP 403 `{ success: false, message: "Forbidden" }` for authenticated `client` and `freelancer` users.
- Preserve HTTP 200 for valid `admin` users.
- Add an integration regression test covering 401, both 403 roles, and 200 admin access.

## Validation

Validated on the exact branch with GitHub Actions before submission:

```text
npm ci                                                    PASS
node --test apps/api/src/tests/adminAuthorization.test.js PASS
```

The temporary validation workflow was removed before submission. Final diff against upstream `75dd6122` is limited to three files: `auth.js`, `adminRoutes.js`, and `adminAuthorization.test.js`.

Parent bounty: #11398.