### PR TITLE
Use collision-resistant server-owned proposal IDs (#12289)

### DIFF
--- a/apps/api/src/services/proposalService.js
+++ b/apps/api/src/services/proposalService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const proposals = [];
 
 export async function listProposals() {
@@ -5,7 +7,7 @@ export async function listProposals() {
 }
 
 export async function createProposal(payload) {
-  const proposal = { id: `prp_${Date.now()}`, ...payload };
+  const proposal = { ...payload, id: `prp_${Date.now()}_${randomUUID()}` };
   proposals.push(proposal);
   return proposal;
 }

--- a/apps/api/src/tests/proposalService.test.js
+++ b/apps/api/src/tests/proposalService.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createProposal } from "../services/proposalService.js";
+
+test("proposal IDs are server-owned and unique within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1770000000000;
+
+  try {
+    const first = await createProposal({
+      id: "caller-controlled",
+      jobId: "job-1",
+      freelancerId: "user-1",
+      bidAmount: 125,
+      coverLetter: "First proposal"
+    });
+    const second = await createProposal({
+      jobId: "job-1",
+      freelancerId: "user-2",
+      bidAmount: 130,
+      coverLetter: "Second proposal"
+    });
+
+    assert.notEqual(first.id, "caller-controlled");
+    assert.match(first.id, /^prp_1770000000000_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^prp_1770000000000_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, second.id);
+
+    assert.equal(first.jobId, "job-1");
+    assert.equal(first.freelancerId, "user-1");
+    assert.equal(first.bidAmount, 125);
+    assert.equal(first.coverLetter, "First proposal");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12289.

Proposal creation currently uses `{ id: `prp_${Date.now()}`, ...payload }`, so a caller can overwrite the ID and same-millisecond creations can collide.

## Changes

- Generate the ID after spreading the payload so it remains server-owned.
- Keep the `prp_` prefix while adding `randomUUID()` entropy after the timestamp.
- Preserve legitimate proposal fields and response shape.
- Add focused regression coverage proving caller-provided IDs are ignored and same-millisecond proposals remain unique.

## Validation

Validated on the exact branch with GitHub Actions before submission:

```text
npm ci                                                PASS
node --test apps/api/src/tests/proposalService.test.js PASS
```

The temporary validation workflow was removed before submission. Final diff against upstream `2624556c` contains only `proposalService.js` and `proposalService.test.js`.

Parent bounty: #11398.