### PR TITLE
Use collision-resistant server-owned payment IDs (#12291)

### DIFF
--- a/apps/api/src/services/paymentService.js
+++ b/apps/api/src/services/paymentService.js
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 export async function createPaymentIntent(payload) {
   // TODO: integrate Stripe SDK and return client secret.
   return {
-    paymentId: `pay_${Date.now()}`,
+    paymentId: `pay_${Date.now()}_${randomUUID()}`,
     amount: payload.amount,
     currency: payload.currency ?? "usd",
     provider: "stripe"

--- a/apps/api/src/tests/paymentService.test.js
+++ b/apps/api/src/tests/paymentService.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPaymentIntent } from "../services/paymentService.js";
+
+test("payment intents remain unique within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1_725_000_000_000;
+
+  try {
+    const first = await createPaymentIntent({ amount: 1250, currency: "gbp" });
+    const second = await createPaymentIntent({ amount: 1250, currency: "gbp" });
+
+    assert.match(first.paymentId, /^pay_1725000000000_[0-9a-f-]{36}$/);
+    assert.match(second.paymentId, /^pay_1725000000000_[0-9a-f-]{36}$/);
+    assert.notEqual(first.paymentId, second.paymentId);
+    assert.deepEqual(
+      { amount: first.amount, currency: first.currency, provider: first.provider },
+      { amount: 1250, currency: "gbp", provider: "stripe" }
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("payment intent preserves the default currency", async () => {
+  const payment = await createPaymentIntent({ amount: 500 });
+
+  assert.equal(payment.amount, 500);
+  assert.equal(payment.currency, "usd");
+  assert.equal(payment.provider, "stripe");
+  assert.match(payment.paymentId, /^pay_\d+_[0-9a-f-]{36}$/);
+});


### PR DESCRIPTION
## Summary

Fixes #12291.

Payment intent creation currently derives `paymentId` only from `Date.now()`, so two intents created in the same millisecond can share an ID.

## Changes

- Keep the `pay_` prefix while adding `randomUUID()` entropy after the timestamp.
- Preserve amount, currency/default currency, provider, and the existing response shape.
- Add focused service regression coverage proving same-millisecond IDs remain unique and ordinary payload/default behavior is preserved.

## Validation

Validated on the exact branch with GitHub Actions before submission:

```text
npm ci                                               PASS
node --test apps/api/src/tests/paymentService.test.js PASS
```

The temporary validation workflow was removed before submission. Final diff against upstream `9c70a836` contains only `paymentService.js` and `paymentService.test.js`.

Parent bounty: #11398.