### PR TITLE
Protect notification ID and unread state (#12293)

### DIFF
--- a/apps/api/src/services/notificationService.js
+++ b/apps/api/src/services/notificationService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const notifications = [];
 
 export async function listNotifications() {
@@ -5,7 +7,11 @@ export async function listNotifications() {
 }
 
 export async function createNotification(payload) {
-  const notification = { id: `ntf_${Date.now()}`, read: false, ...payload };
+  const notification = {
+    ...payload,
+    id: `ntf_${Date.now()}_${randomUUID()}`,
+    read: false
+  };
   notifications.push(notification);
   return notification;
 }

--- a/apps/api/src/tests/notificationService.test.js
+++ b/apps/api/src/tests/notificationService.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createNotification } from "../services/notificationService.js";
+
+test("notification creation keeps id and unread state server-owned", async () => {
+  const notification = await createNotification({
+    id: "ntf_attacker",
+    read: true,
+    userId: "usr_123",
+    message: "New proposal"
+  });
+
+  assert.notEqual(notification.id, "ntf_attacker");
+  assert.match(notification.id, /^ntf_\d+_[0-9a-f-]{36}$/);
+  assert.equal(notification.read, false);
+  assert.equal(notification.userId, "usr_123");
+  assert.equal(notification.message, "New proposal");
+});
+
+test("notification ids remain unique within the same millisecond", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1_725_000_000_000;
+
+  try {
+    const first = await createNotification({ message: "First" });
+    const second = await createNotification({ message: "Second" });
+
+    assert.match(first.id, /^ntf_1725000000000_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^ntf_1725000000000_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, second.id);
+    assert.equal(first.read, false);
+    assert.equal(second.read, false);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12293.

Notification creation currently spreads caller-controlled payload fields after `id` and `read: false`, allowing both protected fields to be overwritten. Timestamp-only IDs can also collide within the same millisecond.

## Changes

- Spread ordinary payload fields first, then assign the server-controlled notification ID and initial `read: false` state.
- Keep the `ntf_` prefix while adding `randomUUID()` entropy after the timestamp.
- Preserve ordinary notification fields.
- Add focused regression coverage proving caller `id`/`read` overrides are ignored and same-millisecond IDs remain unique.

## Validation

Validated on the exact branch with GitHub Actions before submission:

```text
npm ci                                                    PASS
node --test apps/api/src/tests/notificationService.test.js PASS
```

The temporary validation workflow was removed before submission. Final diff against upstream `ad7b19f8` contains only `notificationService.js` and `notificationService.test.js`.

Parent bounty: #11398.