### PR TITLE
Protect message IDs from override and collisions (#12296)

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,11 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    ...payload,
+    id: `msg_${Date.now()}_${randomUUID()}`,
+    sentAt: new Date().toISOString(),
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps id server-owned", async () => {
+  const message = await sendMessage({ id: "attacker-controlled", text: "hello" });
+
+  assert.notEqual(message.id, "attacker-controlled");
+  assert.match(message.id, /^msg_\d+_[0-9a-f-]{36}$/i);
+  assert.equal(message.text, "hello");
+});
+
+test("sendMessage generates unique IDs for same-millisecond sends", async (t) => {
+  const originalNow = Date.now;
+  Date.now = () => 1234567890;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+
+  const first = await sendMessage({ text: "first" });
+  const second = await sendMessage({ text: "second" });
+
+  assert.notEqual(first.id, second.id);
+  assert.match(first.id, /^msg_1234567890_[0-9a-f-]{36}$/i);
+  assert.match(second.id, /^msg_1234567890_[0-9a-f-]{36}$/i);
+});


### PR DESCRIPTION
## Summary

Fixes #12296 under parent bounty #11398.

- Keeps message IDs server-owned even when callers supply `id`
- Adds `randomUUID()` entropy while preserving the existing `msg_` prefix
- Prevents same-millisecond message ID collisions
- Preserves ordinary payload fields and `sentAt`
- Adds focused regression tests for ID override and same-millisecond uniqueness

## Validation

The change is intentionally limited to `apps/api/src/services/messageService.js` and a focused `messageService.test.js` regression test.

The tests cover:
- caller attempts to override the message ID
- two messages created in the same millisecond still receiving different IDs
- preservation of normal payload fields

AI assistance was used in preparing this contribution.

Closes #12296