### PR TITLE
fix(api): ensure collision-resistant server-controlled review IDs (Closes #12298)

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,11 +1,17 @@
+import { randomUUID } from "crypto";
+
 const reviews = [];
 
 export async function listReviews() {
   return reviews;
 }
 
-export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+export async function createReview(payload = {}) {
+  const { id: _ignoredId, ...safePayload } = payload;
+  const review = {
+    ...safePayload,
+    id: `rev_${Date.now()}_${randomUUID().slice(0, 8)}`,
+  };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview, listReviews } from "../services/reviewService.js";
+
+test("createReview generates unique server-controlled review IDs", async () => {
+  const r1 = await createReview({ id: "override_attempt_1", rating: 5, comment: "Great work!" });
+  assert.notEqual(r1.id, "override_attempt_1");
+  assert.ok(r1.id.startsWith("rev_"));
+  assert.equal(r1.rating, 5);
+  assert.equal(r1.comment, "Great work!");
+
+  const r2 = await createReview({ rating: 4, comment: "Good communication" });
+  assert.notEqual(r1.id, r2.id);
+  assert.ok(r2.id.startsWith("rev_"));
+});
+
+test("createReview creates distinct IDs even under simultaneous creation", async () => {
+  const creations = await Promise.all(
+    Array.from({ length: 20 }, (_, i) => createReview({ rating: 5, index: i }))
+  );
+  const ids = creations.map((r) => r.id);
+  const uniqueIds = new Set(ids);
+  assert.equal(uniqueIds.size, ids.length);
+});


### PR DESCRIPTION
### Summary
Ensures server-controlled review IDs in `apps/api/src/services/reviewService.js`. Removes the risk of payload `id` overriding server-assigned identifiers and incorporates randomUUID entropy to prevent ID collisions under simultaneous creation.

Closes #12298

### Changes
1. **`apps/api/src/services/reviewService.js`**:
   - Destructured payload to omit user-supplied `id`.
   - Used `rev_${Date.now()}_${randomUUID().slice(0, 8)}` for collision-resistant unique identifiers.
2. **`apps/api/src/tests/reviewService.test.js`**:
   - Added unit test asserting caller ID override protection.
   - Added unit test asserting uniqueness under simultaneous creations.