### PR TITLE
fix(api): ensure collision-resistant server-controlled user IDs (Closes #12302)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,17 @@
+import { randomUUID } from "crypto";
+
 const users = [];
 
 export async function listUsers() {
   return users;
 }
 
-export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+export async function createUser(payload = {}) {
+  const { id: _ignoredId, ...safePayload } = payload;
+  const user = {
+    ...safePayload,
+    id: `usr_${Date.now()}_${randomUUID().slice(0, 8)}`,
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser generates unique server-controlled user IDs", async () => {
+  const u1 = await createUser({ id: "override_attempt_1", name: "Alice", email: "alice@example.com" });
+  assert.notEqual(u1.id, "override_attempt_1");
+  assert.ok(u1.id.startsWith("usr_"));
+  assert.equal(u1.name, "Alice");
+  assert.equal(u1.email, "alice@example.com");
+
+  const u2 = await createUser({ name: "Bob", email: "bob@example.com" });
+  assert.notEqual(u1.id, u2.id);
+  assert.ok(u2.id.startsWith("usr_"));
+});
+
+test("createUser creates distinct IDs even under simultaneous creation", async () => {
+  const creations = await Promise.all(
+    Array.from({ length: 20 }, (_, i) => createUser({ name: `User ${i}`, index: i }))
+  );
+  const ids = creations.map((u) => u.id);
+  const uniqueIds = new Set(ids);
+  assert.equal(uniqueIds.size, ids.length);
+});


### PR DESCRIPTION
### Summary
Ensures server-controlled user IDs in `apps/api/src/services/userService.js`. Removes the vulnerability of user payload `id` overriding server-assigned identifiers and incorporates randomUUID entropy to prevent ID collisions under simultaneous creation.

Closes #12302

### Changes
1. **`apps/api/src/services/userService.js`**:
   - Destructured payload to omit user-supplied `id`.
   - Used `usr_${Date.now()}_${randomUUID().slice(0, 8)}` for collision-resistant unique identifiers.
2. **`apps/api/src/tests/userService.test.js`**:
   - Added unit test asserting caller ID override protection.
   - Added unit test asserting uniqueness under simultaneous creations.