### PR TITLE
fix(api): ensure collision-resistant server-controlled job IDs (Closes #12304)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,11 +1,18 @@
+import { randomUUID } from "crypto";
+
 const jobs = [];
 
 export async function listJobs() {
   return jobs;
 }
 
-export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+export async function createJob(payload = {}) {
+  const { id: _ignoredId, ...safePayload } = payload;
+  const job = {
+    status: "open",
+    ...safePayload,
+    id: `job_${Date.now()}_${randomUUID().slice(0, 8)}`,
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createJob, listJobs } from "../services/jobService.js";
+
+test("createJob generates unique server-controlled job IDs and default status", async () => {
+  const j1 = await createJob({ id: "override_attempt_1", title: "Full Stack Engineer", budget: 5000 });
+  assert.notEqual(j1.id, "override_attempt_1");
+  assert.ok(j1.id.startsWith("job_"));
+  assert.equal(j1.title, "Full Stack Engineer");
+  assert.equal(j1.budget, 5000);
+  assert.equal(j1.status, "open");
+
+  const j2 = await createJob({ title: "Smart Contract Auditor", budget: 8000 });
+  assert.notEqual(j1.id, j2.id);
+  assert.ok(j2.id.startsWith("job_"));
+});
+
+test("createJob creates distinct IDs even under simultaneous creation", async () => {
+  const creations = await Promise.all(
+    Array.from({ length: 20 }, (_, i) => createJob({ title: `Job ${i}`, index: i }))
+  );
+  const ids = creations.map((j) => j.id);
+  const uniqueIds = new Set(ids);
+  assert.equal(uniqueIds.size, ids.length);
+});


### PR DESCRIPTION
### Summary
Ensures server-controlled job IDs in `apps/api/src/services/jobService.js`. Removes the vulnerability of user payload `id` overriding server-assigned identifiers and incorporates randomUUID entropy to prevent ID collisions under simultaneous creation.

Closes #12304

### Changes
1. **`apps/api/src/services/jobService.js`**:
   - Destructured payload to omit user-supplied `id`.
   - Used `job_${Date.now()}_${randomUUID().slice(0, 8)}` for collision-resistant unique identifiers.
2. **`apps/api/src/tests/jobService.test.js`**:
   - Added unit test asserting caller ID override protection and default open status.
   - Added unit test asserting uniqueness under simultaneous creations.