### PR TITLE
fix: keep review IDs server-owned and collision-resistant

### DIFF
--- a/apps/api/src/services/reviewService.js
+++ b/apps/api/src/services/reviewService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const reviews = [];
 
 export async function listReviews() {
@@ -5,7 +7,7 @@ export async function listReviews() {
 }
 
 export async function createReview(payload) {
-  const review = { id: `rev_${Date.now()}`, ...payload };
+  const review = { ...payload, id: `rev_${randomUUID()}` };
   reviews.push(review);
   return review;
 }

--- a/apps/api/src/tests/reviewService.test.js
+++ b/apps/api/src/tests/reviewService.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createReview } from "../services/reviewService.js";
+
+test("createReview keeps IDs server-owned and unique", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => 1700000000000;
+
+  try {
+    const first = await createReview({
+      id: "caller-controlled",
+      rating: 5,
+      comment: "Great work",
+    });
+    const second = await createReview({ rating: 4, comment: "Solid" });
+
+    assert.match(first.id, /^rev_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^rev_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, "caller-controlled");
+    assert.notEqual(first.id, second.id);
+    assert.equal(first.rating, 5);
+    assert.equal(first.comment, "Great work");
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12301 under parent bounty #11398.

`createReview()` currently allows caller payloads to overwrite the generated review ID and uses `Date.now()` as the entire uniqueness source. This change keeps the existing `rev_` prefix while making the identifier server-owned and collision-resistant with `crypto.randomUUID()`.

## Changes

- spread ordinary review payload fields before the protected `id` field;
- generate review IDs as `rev_<uuid>`;
- add focused regression coverage proving a caller-supplied ID cannot override the generated ID and that two same-millisecond creations remain distinct.

## Validation

`node --test apps/api/src/tests/reviewService.test.js`

Result: 1 test passed, 0 failed.

AI-assisted contribution; the focused regression test was executed before submission.