### PR TITLE
fix: keep message IDs server-owned and collision-resistant

### DIFF
--- a/apps/api/src/services/messageService.js
+++ b/apps/api/src/services/messageService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const messages = [];
 
 export async function listMessages() {
@@ -5,7 +7,11 @@ export async function listMessages() {
 }
 
 export async function sendMessage(payload) {
-  const message = { id: `msg_${Date.now()}`, ...payload, sentAt: new Date().toISOString() };
+  const message = {
+    ...payload,
+    id: `msg_${randomUUID()}`,
+    sentAt: new Date().toISOString(),
+  };
   messages.push(message);
   return message;
 }

--- a/apps/api/src/tests/messageService.test.js
+++ b/apps/api/src/tests/messageService.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sendMessage } from "../services/messageService.js";
+
+test("sendMessage keeps IDs server-owned and unique", async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => 1700000000000;
+
+  try {
+    const first = await sendMessage({
+      id: "caller-controlled",
+      senderId: "usr_1",
+      recipientId: "usr_2",
+      body: "Hello",
+    });
+    const second = await sendMessage({
+      senderId: "usr_1",
+      recipientId: "usr_2",
+      body: "Again",
+    });
+
+    assert.match(first.id, /^msg_[0-9a-f-]{36}$/);
+    assert.match(second.id, /^msg_[0-9a-f-]{36}$/);
+    assert.notEqual(first.id, "caller-controlled");
+    assert.notEqual(first.id, second.id);
+    assert.equal(first.senderId, "usr_1");
+    assert.equal(first.recipientId, "usr_2");
+    assert.equal(first.body, "Hello");
+    assert.ok(Number.isFinite(Date.parse(first.sentAt)));
+  } finally {
+    Date.now = originalDateNow;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12300 under parent bounty #11398.

`sendMessage()` currently allows caller payloads to overwrite the generated message ID and relies on `Date.now()` for uniqueness. This change keeps the existing `msg_` prefix, preserves `sentAt`, and makes message identifiers server-owned and collision-resistant with `crypto.randomUUID()`.

## Changes

- preserve ordinary caller payload fields while writing protected `id` and `sentAt` last;
- generate message IDs as `msg_<uuid>`;
- add focused regression coverage proving caller-supplied IDs cannot override the generated ID and same-millisecond creations remain distinct.

## Validation

`node --test apps/api/src/tests/messageService.test.js`

Result: 1 test passed, 0 failed.

AI-assisted contribution; the focused regression test was executed before submission.