### PR TITLE
Protect user IDs from override and collisions (#12306)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const users = [];
 
 export async function listUsers() {
@@ -5,7 +7,10 @@ export async function listUsers() {
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = {
+    ...payload,
+    id: `usr_${Date.now()}_${randomUUID()}`,
+  };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createUser } from "../services/userService.js";
+
+test("createUser keeps id server-owned", async () => {
+  const user = await createUser({ id: "attacker-controlled", name: "Test" });
+
+  assert.notEqual(user.id, "attacker-controlled");
+  assert.match(user.id, /^usr_\d+_[0-9a-f-]{36}$/i);
+  assert.equal(user.name, "Test");
+});
+
+test("createUser generates unique IDs for same-millisecond users", async (t) => {
+  const originalNow = Date.now;
+  Date.now = () => 1234567890;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+
+  const first = await createUser({ name: "First" });
+  const second = await createUser({ name: "Second" });
+
+  assert.notEqual(first.id, second.id);
+  assert.match(first.id, /^usr_1234567890_[0-9a-f-]{36}$/i);
+  assert.match(second.id, /^usr_1234567890_[0-9a-f-]{36}$/i);
+});


### PR DESCRIPTION
## Summary

Fixes #12306 under parent bounty #11398.

- Keeps user IDs server-owned even when callers supply `id`
- Adds `randomUUID()` entropy while preserving the existing `usr_` prefix
- Prevents same-millisecond user ID collisions
- Preserves legitimate user payload fields
- Adds focused regression tests for ID override and same-millisecond uniqueness

## Validation

The change is intentionally limited to `apps/api/src/services/userService.js` and a focused `userService.test.js` regression test.

The tests cover the intended regression cases, but they have not been executed in this environment.

AI assistance was used in preparing this contribution.

Closes #12306