### PR TITLE
Protect job IDs from override and collisions (#12307)

### DIFF
--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 const jobs = [];
 
 export async function listJobs() {
@@ -5,7 +7,11 @@ export async function listJobs() {
 }
 
 export async function createJob(payload) {
-  const job = { id: `job_${Date.now()}`, status: "open", ...payload };
+  const job = {
+    status: "open",
+    ...payload,
+    id: `job_${Date.now()}_${randomUUID()}`,
+  };
   jobs.push(job);
   return job;
 }

--- a/apps/api/src/tests/jobService.test.js
+++ b/apps/api/src/tests/jobService.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createJob } from "../services/jobService.js";
+
+test("createJob keeps IDs server-owned and collision-resistant", async () => {
+  const originalNow = Date.now;
+  Date.now = () => 1700000000000;
+
+  try {
+    const first = await createJob({ id: "caller-controlled", title: "First" });
+    const second = await createJob({ title: "Second", status: "draft" });
+
+    assert.match(first.id, /^job_1700000000000_[0-9a-f-]{36}$/i);
+    assert.notEqual(first.id, "caller-controlled");
+    assert.notEqual(first.id, second.id);
+    assert.equal(first.title, "First");
+    assert.equal(first.status, "open");
+    assert.equal(second.title, "Second");
+    assert.equal(second.status, "draft");
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12307 under parent bounty #11398.

* Keeps job IDs server-owned even when callers supply an `id`
* Uses `randomUUID()` to prevent same-millisecond ID collisions
* Preserves the existing `job_` prefix
* Preserves the default `status: "open"` behavior and legitimate payload fields
* Adds focused regression coverage for ID override and same-millisecond uniqueness

## Changes

* Updated `apps/api/src/services/jobService.js`
* Added `apps/api/src/tests/jobService.test.js`

## Validation

The regression test covers:

* caller-supplied ID override protection
* unique IDs when `Date.now()` returns the same value
* preservation of normal job payload fields
* preservation of existing status behavior

AI assistance was used in preparing this contribution.

Closes #12307
