### PR TITLE
fix(api): return JSON envelope for rate-limit 429 responses (Closes #12185)

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,0 +1,6 @@
+import rateLimit from "express-rate-limit";
+export const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  handler: (req, res) => res.status(429).json({ error: "Too many requests, please try again later." })
+});


### PR DESCRIPTION
Fixes #12185

Automated fix.