### PR TITLE
fix(api): return 400 for malformed JSON instead of 500 (#12318)

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,32 @@
+// Body-parser error types that indicate client-sent malformed input
+const CLIENT_ERROR_TYPES = [
+  'entity.parse.failed',
+  'entity.not.json',
+  'entity.encoding.unsupported',
+  'charset.not.supported',
+  'encoding.unsupported',
+];
+
+/**
+ * Shared API error middleware.
+ * Returns 400 for malformed request bodies (JSON parse errors, etc.).
+ * Returns 500 for unexpected server errors.
+ */
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  // Client-side errors: malformed request body
+  if (CLIENT_ERROR_TYPES.includes(err.type)) {
+    return res.status(400).json({
+      success: false,
+      message: 'Invalid request body. Please check your JSON syntax.',
+    });
+  }
+
+  // Unexpected server error
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/errorHandler.test.js
+++ b/apps/api/src/tests/errorHandler.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { errorHandler } from '../middleware/errorHandler.js';
+
+function createMocks() {
+  const res = {
+    headersSent: false,
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.body = data; return this; },
+  };
+  const next = vi.fn();
+  return { res, next };
+}
+
+describe('errorHandler', () => {
+  it('should return 400 for entity.parse.failed (malformed JSON)', () => {
+    const { res, next } = createMocks();
+    const err = { type: 'entity.parse.failed' };
+    errorHandler(err, {}, res, next);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Invalid request body. Please check your JSON syntax.',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for entity.not.json', () => {
+    const { res, next } = createMocks();
+    errorHandler({ type: 'entity.not.json' }, {}, res, next);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('should return 500 for unexpected errors', () => {
+    const { res, next } = createMocks();
+    const err = new Error('something broke');
+    errorHandler(err, {}, res, next);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      message: 'Unexpected server error',
+    });
+  });
+
+  it('should call next if headers already sent', () => {
+    const { res, next } = createMocks();
+    res.headersSent = true;
+    errorHandler(new Error('test'), {}, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should not echo malformed request contents in message', () => {
+    const { res, next } = createMocks();
+    errorHandler({ type: 'entity.parse.failed' }, {}, res, next);
+    // Message should be generic, not contain user input
+    expect(res.body.message).not.toContain('{');
+    expect(res.body.message).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
## Summary
- Recognizes body-parser parse errors (`entity.parse.failed`, etc.) in shared error middleware
- Returns HTTP 400 with generic client-safe message (no request body echo)
- Preserves HTTP 500 for genuine server errors
- Handles: entity.parse.failed, entity.not.json, entity.encoding.unsupported, charset.not.supported, encoding.unsupported

## Test Coverage
- 5 tests: malformed JSON 400, non-JSON 400, unexpected 500, headersSent passthrough, message safety (no content echo)

Closes #12318