### PR TITLE
Fix admin role escalation + ZodError process crash

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,27 +1,28 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
 import { ok } from "../utils/response.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
-export async function register(req, res) {
+export const register = asyncHandler(async (req, res) => {
   const payload = registerSchema.parse(req.body);
   const result = await registerUser(payload);
   return ok(res, result, 201);
-}
+});
 
-export async function login(req, res) {
+export const login = asyncHandler(async (req, res) => {
   const payload = loginSchema.parse(req.body);
   const result = await loginUser(payload);
   return ok(res, result);
-}
+});
 
-export async function oauthCallback(req, res) {
+export const oauthCallback = asyncHandler(async (req, res) => {
   return ok(res, {
     provider: req.params.provider,
     status: "callback-received"
   });
-}
+});
 
-export async function refresh(req, res) {
+export const refresh = asyncHandler(async (req, res) => {
   const result = await refreshToken();
   return ok(res, result);
-}
+});

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,4 +1,25 @@
+import { fail } from "../utils/response.js";
+
+/**
+ * Central error handler.
+ * FIX (issue #12327): ZodError from async route handlers crashed the process —
+ * Express 4 does not catch rejected promises from async handlers automatically.
+ * We now detect Zod-style validation failures (err.issues / err.name === "ZodError")
+ * and return a clean 400 instead of an unhandled crash + 500.
+ */
 export function errorHandler(err, req, res, next) {
+  // Zod validation failure (thrown inside async handlers)
+  if (err?.name === "ZodError" || Array.isArray(err?.issues)) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: (err.issues || []).map((i) => ({
+        path: i.path?.join(".") ?? "",
+        message: i.message
+      }))
+    });
+  }
+
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);

--- a/apps/api/src/routes/adminRoutes.js
+++ b/apps/api/src/routes/adminRoutes.js
@@ -1,8 +1,17 @@
-import { Router } from "express";
-import { metrics } from "../controllers/adminController.js";
+import { fail } from "../utils/response.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { metrics } from "../controllers/adminController.js";
+import { Router } from "express";
 
 export const adminRoutes = Router();
 
+function requireAdmin(req, res, next) {
+  if (req.user?.role !== "admin") {
+    return fail(res, "Forbidden", 403);
+  }
+  next();
+}
+
 adminRoutes.use(authMiddleware);
+adminRoutes.use(requireAdmin);
 adminRoutes.get("/metrics", metrics);

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,10 @@
+/**
+ * Wraps async route handlers so thrown errors (incl. ZodError) reach errorHandler.
+ * Express 4 does NOT catch rejected promises from async handlers — without this
+ * wrapper a single bad request body crashes the whole process (issue #12326/#12327).
+ */
+export function asyncHandler(fn) {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,7 +1203,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Fixes #12326

/claim #743

## What

Two-layer fix for the admin privilege escalation + a process-crash bug discovered while testing:

1. **`validators/auth.js`** — removed `admin` from the public register role enum (no more self-service admin role)
2. **`routes/adminRoutes.js`** — added `requireAdmin` guard on `/api/admin/metrics` (403 for non-admin tokens instead of full metrics disclosure)
3. **`utils/asyncHandler.js`** (new) + **`controllers/authController.js`** — Express 4 does not catch rejected promises from async handlers; a bad request body (ZodError) previously crashed the entire process. All auth handlers now wrapped.
4. **`middleware/errorHandler.js`** — clean 400 with field-level errors on ZodError instead of unhandled 500/crash

## Verification (live server, end-to-end)

| Test | Before | After |
|------|--------|-------|
| `POST /api/auth/register` with `role:"admin"` | 201 + admin-signed token | **400** validation error |
| `POST /api/auth/register` with `role:"client"` | 201 | 201 ✅ |
| `GET /api/admin/metrics` with client token | **200 + full metrics** | **403 Forbidden** |
| `GET /api/admin/metrics` without token | 401 | 401 ✅ |
| Malformed role body | **process crash** (unhandled ZodError) | **400** JSON field errors |

Tested by booting the actual Express app (`createApp()`) and hitting the real endpoints with fetch.

## Note on demo video

Screen-recording demo video will be attached within 24h (human step in progress). All verification steps above are reproducible via the table — boot the app and hit the endpoints directly.