### PR TITLE
fix: return HTTP 400 for malformed JSON request bodies

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -4,6 +4,13 @@ export function errorHandler(err, req, res, next) {
     return next(err);
   }
 
+  if (err?.type === "entity.parse.failed" && err?.status === 400) {
+    return res.status(400).json({
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  }
+
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/malformedJson.test.js
+++ b/apps/api/src/tests/malformedJson.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("malformed JSON request bodies return HTTP 400", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"email":'
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(payload, {
+      success: false,
+      message: "Malformed JSON request body"
+    });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12318 under parent bounty #11398.

Express JSON parse failures are client errors, but the shared error handler currently turns them into HTTP 500 responses. This change recognizes body-parser's `entity.parse.failed` 400 error and returns a stable client-safe failure response without echoing malformed body contents.

## Changes

- map malformed JSON parse errors to HTTP 400;
- return `{ success: false, message: "Malformed JSON request body" }`;
- preserve HTTP 500 for unrelated unexpected errors;
- add focused integration coverage using an intentionally malformed JSON request.

## Validation

GitHub Actions on the exact branch: `npm ci` PASS; `node --test apps/api/src/tests/malformedJson.test.js` PASS.

The temporary validation workflow was removed before submission. Final production/test scope is limited to the shared error middleware and one focused regression test.

AI-assisted contribution; the regression was executed before submission.