### PR TITLE
Redact credential fields from user records (#12333)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,27 @@
 const users = [];
 
+const PRIVATE_USER_FIELDS = new Set([
+  "password",
+  "passwordHash",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "resetToken",
+  "apiKey"
+]);
+
+function publicUserPayload(payload) {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([key]) => !PRIVATE_USER_FIELDS.has(key))
+  );
+}
+
 export async function listUsers() {
   return users;
 }
 
 export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+  const user = { id: `usr_${Date.now()}`, ...publicUserPayload(payload) };
   users.push(user);
   return user;
 }

--- a/apps/api/src/tests/userCredentialRedaction.test.js
+++ b/apps/api/src/tests/userCredentialRedaction.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createUser, listUsers } from "../services/userService.js";
+
+test("createUser and listUsers omit credential fields", async () => {
+  const email = `credential-redaction-${Date.now()}@example.com`;
+  const created = await createUser({
+    email,
+    fullName: "Credential Redaction Test",
+    bio: "public profile",
+    role: "client",
+    password: "plaintext-secret",
+    passwordHash: "hashed-secret",
+    token: "session-secret",
+    accessToken: "access-secret",
+    refreshToken: "refresh-secret",
+    resetToken: "reset-secret",
+    apiKey: "api-secret"
+  });
+
+  assert.equal(created.email, email);
+  assert.equal(created.fullName, "Credential Redaction Test");
+  assert.equal(created.bio, "public profile");
+  assert.equal(created.role, "client");
+
+  for (const key of [
+    "password",
+    "passwordHash",
+    "token",
+    "accessToken",
+    "refreshToken",
+    "resetToken",
+    "apiKey"
+  ]) {
+    assert.equal(key in created, false, `${key} should not be returned from createUser`);
+  }
+
+  const listed = (await listUsers()).find((user) => user.email === email);
+  assert.ok(listed, "created user should appear in listUsers");
+
+  for (const key of [
+    "password",
+    "passwordHash",
+    "token",
+    "accessToken",
+    "refreshToken",
+    "resetToken",
+    "apiKey"
+  ]) {
+    assert.equal(key in listed, false, `${key} should not be exposed by listUsers`);
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #12333 under parent bounty #11398.

`createUser()` currently stores arbitrary caller payload fields and `listUsers()` returns those records unchanged, so credential/private values can be persisted and exposed through normal user API responses.

## Changes

- filter credential fields before storing user records;
- omit `password`, `passwordHash`, `token`, `accessToken`, `refreshToken`, `resetToken`, and `apiKey`;
- preserve ordinary public/profile fields;
- add focused service regression coverage proving create and list results do not expose credentials.

## Validation

GitHub Actions on the exact branch passed `npm ci` and `node --test apps/api/src/tests/userCredentialRedaction.test.js`.

The final branch was rebuilt as one clean commit on current upstream `main`; the temporary validation workflow is not present in the final diff.

This PR intentionally leaves unrelated user ID collision/override handling to the separate existing ID issue/PR.

AI assistance was used in preparing this contribution.

Closes #12333