### PR TITLE
fix(users): block credential fields + server-controlled IDs (#12333, #12306, #12302)

### DIFF
--- a/apps/api/src/services/userService.js
+++ b/apps/api/src/services/userService.js
@@ -1,11 +1,50 @@
 const users = [];
+let userCounter = 0;
 
-export async function listUsers() {
-  return users;
+// Fields that should never be stored or returned
+const BLOCKED_FIELDS = new Set([
+  'password', 'passwordHash', 'token', 'resetToken',
+  'secret', 'apiKey', 'privateKey', 'credential',
+]);
+
+/**
+ * Generate a unique user ID, safe for same-millisecond calls.
+ */
+function generateUserId() {
+  userCounter++;
+  return `usr_${Date.now()}_${userCounter}`;
 }
 
-export async function createUser(payload) {
-  const user = { id: `usr_${Date.now()}`, ...payload };
+/**
+ * Remove blocked credential fields from an object.
+ * @param {Object} obj
+ * @returns {Object} Cleaned copy (does not mutate original)
+ */
+function sanitize(obj) {
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (!BLOCKED_FIELDS.has(key)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/** @internal Test-only: clear all stored users */
+export function _reset() {
+  users.length = 0;
+}
+
+export async function listUsers() {
+  // Return sanitized copies — no credential fields leaked
+  return users.map(sanitize);
+}
+
+export async function createUser(payload = {}) {
+  const user = {
+    ...sanitize(payload),
+    id: generateUserId(),
+  };
   users.push(user);
-  return user;
+  return sanitize(user); // response also sanitized
 }

--- a/apps/api/src/tests/userService.test.js
+++ b/apps/api/src/tests/userService.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as userService from '../services/userService.js';
+
+describe('userService', () => {
+  beforeEach(async () => {
+    userService._reset();
+  });
+
+  it('should create a user with server-generated id', async () => {
+    const user = await userService.createUser({ email: 'test@example.com' });
+    expect(user.id).toMatch(/^usr_\d+_\d+$/);
+    expect(user.email).toBe('test@example.com');
+  });
+
+  it('should not allow payload to override id', async () => {
+    const user = await userService.createUser({ id: 'hacked_usr' });
+    expect(user.id).not.toBe('hacked_usr');
+  });
+
+  it('should block credential fields from being stored', async () => {
+    const user = await userService.createUser({
+      email: 'test@example.com',
+      password: 's3cret!',
+      token: 'jwt_token_123',
+      apiKey: 'sk_live_xxx',
+    });
+    expect(user.password).toBeUndefined();
+    expect(user.token).toBeUndefined();
+    expect(user.apiKey).toBeUndefined();
+    expect(user.email).toBe('test@example.com'); // normal field preserved
+  });
+
+  it('should not expose credentials in listUsers', async () => {
+    await userService.createUser({ email: 'a@b.com', password: 'hidden' });
+    await userService.createUser({ email: 'c@d.com', resetToken: 'token_xyz' });
+    const users = await userService.listUsers();
+    expect(users.length).toBe(2);
+    for (const u of users) {
+      expect(u.password).toBeUndefined();
+      expect(u.resetToken).toBeUndefined();
+      expect(u.token).toBeUndefined();
+    }
+  });
+
+  it('should generate unique IDs for same-millisecond creations', async () => {
+    const items = await Promise.all([
+      userService.createUser({}),
+      userService.createUser({}),
+      userService.createUser({}),
+    ]);
+    const ids = items.map(u => u.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- **Credential filtering**: Blocks `password`, `passwordHash`, `token`, `resetToken`, `secret`, `apiKey`, `privateKey`, `credential` from being stored or returned
- **Server-controlled IDs**: Monotonic counter suffix prevents same-millisecond collisions
- Payload cannot override server-generated fields
- Both `createUser` response and `listUsers` output are sanitized

## Test Coverage
- 5 tests: basic creation, id override blocked, credential filtering (create), credential filtering (list), same-millisecond uniqueness

Closes #12333, #12306, #12302