### PR TITLE
fix(auth): verify requester on refresh endpoint (#2847)

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -22,6 +22,6 @@ export async function oauthCallback(req, res) {
 }
 
 export async function refresh(req, res) {
-  const result = await refreshToken();
+  const result = await refreshToken(req.user);
   return ok(res, result);
 }

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const authRoutes = Router();
 
 authRoutes.post("/register", register);
 authRoutes.post("/login", login);
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", authMiddleware, refresh);

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -18,6 +18,9 @@ export async function loginUser(payload) {
   };
 }
 
-export async function refreshToken() {
-  return { token: signAccessToken({ sub: "usr_existing", role: "client" }) };
+export async function refreshToken(user) {
+  if (!user || !user.sub) {
+    throw new Error("Invalid user payload: missing subject");
+  }
+  return { token: signAccessToken({ sub: user.sub, role: user.role }) };
 }


### PR DESCRIPTION
## Summary

Fixes #2847 (💎 **Bounty: $780**)

### Problem
- `POST /api/auth/refresh` issued tokens **without verifying the requester**
- Refreshed token was always signed with hardcoded `usr_existing` / role `client`
- Any caller (authenticated or not) could get a token for a different user

### Changes
1. **authRoutes.js**: Add authMiddleware to the /refresh route
2. **authController.js**: Pass verified req.user payload to refreshToken()
3. **authService.js**: Sign refreshed token for the authenticated user's identity

### Security Impact
- Unauthenticated callers now get 401
- Token is signed for actual authenticated user (not hardcoded)
- Removes usr_existing identity from refresh flow