### PR TITLE
fix(security): add missing auth middleware to 4 endpoints (#2773)

### DIFF
--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/authMiddleware.js";
 import { getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
-jobRoutes.post("/", postJob);
+jobRoutes.post("/", authMiddleware, postJob);

--- a/apps/api/src/routes/messageRoutes.js
+++ b/apps/api/src/routes/messageRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/authMiddleware.js";
 import { getMessages, postMessage } from "../controllers/messageController.js";
 
 export const messageRoutes = Router();
 
 messageRoutes.get("/", getMessages);
-messageRoutes.post("/", postMessage);
+messageRoutes.post("/", authMiddleware, postMessage);

--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,7 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/authMiddleware.js";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
-
 export const notificationRoutes = Router();
 
 notificationRoutes.get("/", getNotifications);
-notificationRoutes.post("/", postNotification);
+notificationRoutes.post("/", authMiddleware, postNotification);

--- a/apps/api/src/routes/proposalRoutes.js
+++ b/apps/api/src/routes/proposalRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
+import { authMiddleware } from "../middleware/authMiddleware.js";
 import { getProposals, postProposal } from "../controllers/proposalController.js";
 
 export const proposalRoutes = Router();
 
 proposalRoutes.get("/", getProposals);
-proposalRoutes.post("/", postProposal);
+proposalRoutes.post("/", authMiddleware, postProposal);


### PR DESCRIPTION
## Summary

Fixes **#2773** (💎 **$780**) + 3 additional unauthenticated endpoints

### Problem

Four more API endpoints were completely unauthenticated:

| Endpoint | Issue | Risk |
|---|---|---|
| `POST /api/proposals` | #2776 | Anyone can create proposals |
| `POST /api/jobs` | — | Anyone can post jobs |
| `POST /api/messages` | — | Anyone can send messages |
| `POST /api/notifications` | — | Anyone can create notifications |

### Fix

Added `authMiddleware` to all POST routes. Same pattern as PRs #12347, #12348, #12357.

### Files Changed
- `routes/proposalRoutes.js` — +2 lines
- `routes/jobRoutes.js` — +2 lines
- `routes/messageRoutes.js` — +2 lines
- `routes/notificationRoutes.js` — +2 lines