### PR TITLE
fix(reviews): require auth middleware for POST /api/reviews (#12365)

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);


### PR DESCRIPTION
Closes #12365

Adds uthMiddleware to the POST /api/reviews route so only authenticated users can create reviews, preventing unauthorized review spam and reputation-flow abuse.

/claim #743