### PR TITLE
fix(api): add authMiddleware to payment and notification routes (#12370)

### DIFF
--- a/apps/api/src/routes/notificationRoutes.js
+++ b/apps/api/src/routes/notificationRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getNotifications, postNotification } from "../controllers/notificationController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const notificationRoutes = Router();
 
+notificationRoutes.use(authMiddleware);
 notificationRoutes.get("/", getNotifications);
 notificationRoutes.post("/", postNotification);

--- a/apps/api/src/routes/paymentRoutes.js
+++ b/apps/api/src/routes/paymentRoutes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { createPayment } from "../controllers/paymentController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const paymentRoutes = Router();
 
+paymentRoutes.use(authMiddleware);
 paymentRoutes.post("/", createPayment);

--- a/apps/api/src/tests/auth_routes_protection.test.js
+++ b/apps/api/src/tests/auth_routes_protection.test.js
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+test("POST /api/payments rejects unauthenticated requests with 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/payments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Connection": "close" },
+    body: JSON.stringify({ amount: 1000 })
+  });
+  const data = await res.json();
+
+  assert.equal(res.status, 401);
+  assert.equal(data.success, false);
+  assert.equal(data.message, "Unauthorized");
+
+  server.closeAllConnections?.();
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test("GET /api/notifications rejects unauthenticated requests with 401", async () => {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/api/notifications`, {
+    headers: { "Connection": "close" }
+  });
+  const data = await res.json();
+
+  assert.equal(res.status, 401);
+  assert.equal(data.success, false);
+  assert.equal(data.message, "Unauthorized");
+
+  server.closeAllConnections?.();
+  await new Promise((resolve) => server.close(resolve));
+});


### PR DESCRIPTION
### Summary
Closes #12370
Addresses bounty criteria in #743

### Changes
- Protected `paymentRoutes` with `authMiddleware` so payment intent creation requires valid bearer tokens.
- Protected `notificationRoutes` with `authMiddleware` for both GET and POST operations.
- Added comprehensive unit/integration tests in `apps/api/src/tests/auth_routes_protection.test.js` asserting 401 Unauthorized for unauthenticated requests.

### Verification
```
# Subtest: POST /api/payments rejects unauthenticated requests with 401
ok 1 - POST /api/payments rejects unauthenticated requests with 401
# Subtest: GET /api/notifications rejects unauthenticated requests with 401
ok 2 - GET /api/notifications rejects unauthenticated requests with 401
# Subtest: GET /health returns ok payload
ok 3 - GET /health returns ok payload
# pass 3, fail 0
```