### PR TITLE
fix(api): require authMiddleware on POST /api/reviews (fixes #2776)

### DIFF
--- a/apps/api/src/routes/reviewRoutes.js
+++ b/apps/api/src/routes/reviewRoutes.js
@@ -1,7 +1,9 @@
 import { Router } from "express";
 import { getReviews, postReview } from "../controllers/reviewController.js";
+import { authMiddleware } from "../middleware/auth.js";
 
 export const reviewRoutes = Router();
 
 reviewRoutes.get("/", getReviews);
-reviewRoutes.post("/", postReview);
+reviewRoutes.post("/", authMiddleware, postReview);
+

--- a/apps/api/src/tests/reviewRoutes.test.js
+++ b/apps/api/src/tests/reviewRoutes.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { signAccessToken } from "../utils/jwt.js";
+
+function startTestServer() {
+  const app = createApp();
+  const server = app.listen(0);
+  return new Promise((resolve, reject) => {
+    server.once("listening", () => {
+      const { port } = server.address();
+      const baseUrl = `http://127.0.0.1:${port}`;
+      const close = () => new Promise((res, rej) => server.close((err) => (err ? rej(err) : res())));
+      resolve({ baseUrl, close });
+    });
+    server.once("error", reject);
+  });
+}
+
+test("GET /api/reviews is public and returns 200", async () => {
+  const { baseUrl, close } = await startTestServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/reviews`);
+    const json = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(json.success, true);
+    assert.ok(Array.isArray(json.data));
+  } finally {
+    await close();
+  }
+});
+
+test("POST /api/reviews returns 401 Unauthorized when missing Authorization header", async () => {
+  const { baseUrl, close } = await startTestServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "Great work!" }),
+    });
+    const json = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(json.success, false);
+    assert.equal(json.message, "Unauthorized");
+  } finally {
+    await close();
+  }
+});
+
+test("POST /api/reviews returns 401 Unauthorized when Authorization header does not start with Bearer", async () => {
+  const { baseUrl, close } = await startTestServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Basic dXNlcjpwYXNz",
+      },
+      body: JSON.stringify({ rating: 5, comment: "Great work!" }),
+    });
+    const json = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(json.success, false);
+    assert.equal(json.message, "Unauthorized");
+  } finally {
+    await close();
+  }
+});
+
+test("POST /api/reviews returns 401 when token is invalid", async () => {
+  const { baseUrl, close } = await startTestServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer invalid.jwt.token",
+      },
+      body: JSON.stringify({ rating: 5, comment: "Great work!" }),
+    });
+    const json = await res.json();
+    assert.equal(res.status, 401);
+    assert.equal(json.success, false);
+    assert.equal(json.message, "Invalid token");
+  } finally {
+    await close();
+  }
+});
+
+test("POST /api/reviews returns 201 and creates review when valid Bearer token provided", async () => {
+  const { baseUrl, close } = await startTestServer();
+  try {
+    const validToken = signAccessToken({ sub: "usr_123", email: "user@example.com" });
+    const payload = { rating: 5, comment: "Outstanding service!" };
+    const res = await fetch(`${baseUrl}/api/reviews`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${validToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    const json = await res.json();
+    assert.equal(res.status, 201);
+    assert.equal(json.success, true);
+    assert.equal(json.data.rating, 5);
+    assert.equal(json.data.comment, "Outstanding service!");
+    assert.ok(json.data.id);
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## Summary
Fixes #2776 (reissue via #743).

`POST /api/reviews` was previously exposed without authentication middleware, allowing unauthenticated requests to create reviews. This change injects `authMiddleware` before `postReview` so that unauthenticated requests are rejected with 401 Unauthorized while maintaining public access to `GET /api/reviews`.

## Changes Made
- **Route Protection**: Updated `apps/api/src/routes/reviewRoutes.js` to require `authMiddleware` on `POST /` before invoking `postReview`.
- **Test Coverage**: Added comprehensive test suite in `apps/api/src/tests/reviewRoutes.test.js` validating:
  1. `GET /api/reviews` remains publicly accessible (HTTP 200).
  2. `POST /api/reviews` without an `Authorization` header returns HTTP 401 Unauthorized (`{ success: false, message: "Unauthorized" }`).
  3. `POST /api/reviews` without `Bearer` prefix returns HTTP 401 Unauthorized.
  4. `POST /api/reviews` with an invalid token returns HTTP 401 Unauthorized (`{ success: false, message: "Invalid token" }`).
  5. `POST /api/reviews` with a valid Bearer token returns HTTP 201 Created and saves the review.

## Validation
Ran full automated test suite using Node.js test runner:
```
npm test -w apps/api
```
Output:
```
TAP version 13
# Subtest: GET /health returns ok payload
ok 1 - GET /health returns ok payload
# Subtest: GET /api/reviews is public and returns 200
ok 2 - GET /api/reviews is public and returns 200
# Subtest: POST /api/reviews returns 401 Unauthorized when missing Authorization header
ok 3 - POST /api/reviews returns 401 Unauthorized when missing Authorization header
# Subtest: POST /api/reviews returns 401 Unauthorized when Authorization header does not start with Bearer
ok 4 - POST /api/reviews returns 401 Unauthorized when Authorization header does not start with Bearer
# Subtest: POST /api/reviews returns 401 when token is invalid
ok 5 - POST /api/reviews returns 401 when token is invalid
# Subtest: POST /api/reviews returns 201 and creates review when valid Bearer token provided
ok 6 - POST /api/reviews returns 201 and creates review when valid Bearer token provided
1..6
# tests 6
# suites 0
# pass 6
# fail 0
# cancelled 0
# skipped 0
# todo 0
```
All 6 tests passing with 0 failures.
