### PR TITLE
fix(api): reject missing file upload submissions with 400 (fixes #2850)

### DIFF
--- a/apps/api/src/controllers/uploadController.js
+++ b/apps/api/src/controllers/uploadController.js
@@ -1,8 +1,13 @@
-import { ok } from "../utils/response.js";
+import { ok, fail } from "../utils/response.js";
 
 export async function uploadFile(req, res) {
+  if (!req.file) {
+    return fail(res, "No file uploaded", 400);
+  }
+
   return ok(res, {
-    filename: req.file?.originalname ?? null,
-    status: req.file ? "uploaded" : "no-file"
+    filename: req.file.originalname,
+    status: "uploaded"
   }, 201);
 }
+

--- a/apps/api/src/tests/uploadRoutes.test.js
+++ b/apps/api/src/tests/uploadRoutes.test.js
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function startApp(t) {
+  const server = createApp().listen(0, "127.0.0.1");
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  t.after(
+    () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      })
+  );
+
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test("POST /api/uploads rejects requests without file with 400 Bad Request", async (t) => {
+  const baseUrl = await startApp(t);
+  const res = await fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+  });
+  const json = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(json.success, false);
+  assert.equal(json.message, "No file uploaded");
+});
+
+test("POST /api/uploads rejects multipart request missing the file field with 400", async (t) => {
+  const baseUrl = await startApp(t);
+  const formData = new FormData();
+  formData.append("title", "sample document");
+  const res = await fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+  const json = await res.json();
+  assert.equal(res.status, 400);
+  assert.equal(json.success, false);
+  assert.equal(json.message, "No file uploaded");
+});
+
+test("POST /api/uploads accepts valid file upload and returns 201 with uploaded status", async (t) => {
+  const baseUrl = await startApp(t);
+  const formData = new FormData();
+  const fileBlob = new Blob(["Sample file content"], { type: "text/plain" });
+  formData.append("file", fileBlob, "sample_document.txt");
+
+  const res = await fetch(`${baseUrl}/api/uploads`, {
+    method: "POST",
+    body: formData,
+  });
+  const json = await res.json();
+  assert.equal(res.status, 201);
+  assert.equal(json.success, true);
+  assert.equal(json.data.filename, "sample_document.txt");
+  assert.equal(json.data.status, "uploaded");
+});


### PR DESCRIPTION
## Summary
Fixes #2850 (reissue via #743).

`POST /api/uploads` previously accepted empty multipart requests or requests missing a file field, returning `201 Created` with `{ status: "no-file" }`. This change validates `req.file` in `uploadController.js` and returns `400 Bad Request` (`{ success: false, message: "No file uploaded" }`) when no file is present, reserving `201 Created` strictly for valid file uploads.

## Changes Made
- **File Validation**: Updated `apps/api/src/controllers/uploadController.js` to verify `req.file` exists before responding with `201`. Returns `fail(res, "No file uploaded", 400)` when missing.
- **Automated Tests**: Added regression test suite in `apps/api/src/tests/uploadRoutes.test.js` validating:
  1. `POST /api/uploads` without body returns HTTP 400 Bad Request.
  2. `POST /api/uploads` multipart request missing `file` field returns HTTP 400 Bad Request.
  3. `POST /api/uploads` with valid multipart file payload returns HTTP 201 Created with `{ status: "uploaded" }`.

## Validation
```
npm test -w apps/api
```
Output:
```
TAP version 13
# Subtest: POST /api/uploads rejects requests without file with 400 Bad Request
ok 7 - POST /api/uploads rejects requests without file with 400 Bad Request
# Subtest: POST /api/uploads rejects multipart request missing the file field with 400
ok 8 - POST /api/uploads rejects multipart request missing the file field with 400
# Subtest: POST /api/uploads accepts valid file upload and returns 201 with uploaded status
ok 9 - POST /api/uploads accepts valid file upload and returns 201 with uploaded status
1..9
# tests 9
# suites 0
# pass 9
# fail 0
```
All 9 test assertions passing.
