### PR TITLE
fix(auth): ensure consistent user id between registration result and token subject (fixes #2845)

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -2,11 +2,12 @@ import { signAccessToken } from "../utils/jwt.js";
 
 export async function registerUser(payload) {
   // TODO: persist new user via Prisma
+  const id = `usr_${Date.now()}`;
   return {
-    id: `usr_${Date.now()}`,
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 

--- a/apps/api/src/tests/authService.test.js
+++ b/apps/api/src/tests/authService.test.js
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerUser } from "../services/authService.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+test("registerUser uses the same user id for returned id and JWT subject even if time advances", async (t) => {
+  let timestamp = 1_700_000_000_000;
+  t.mock.method(Date, "now", () => timestamp++);
+
+  const result = await registerUser({
+    email: "new-user@example.com",
+    role: "client",
+  });
+  const tokenPayload = verifyAccessToken(result.token);
+
+  assert.equal(result.id, "usr_1700000000000");
+  assert.equal(tokenPayload.sub, result.id);
+  assert.equal(tokenPayload.role, "client");
+  assert.equal(result.email, "new-user@example.com");
+});
+
+test("registerUser returns consistent user id and token sub under normal execution", async () => {
+  const result = await registerUser({
+    email: "consistent@example.com",
+    role: "freelancer",
+  });
+  const tokenPayload = verifyAccessToken(result.token);
+
+  assert.ok(result.id.startsWith("usr_"));
+  assert.equal(tokenPayload.sub, result.id);
+  assert.equal(tokenPayload.role, "freelancer");
+});


### PR DESCRIPTION
## Summary
Fixes #2845 (reissue via #743).

`registerUser()` previously built the returned `id` and the JWT `sub` via two separate `Date.now()` calls. If time ticked forward between calls, the API returned one user ID while signing the token for a different subject, leading to authentication state mismatches downstream.

## Changes Made
- **Identifier Consistency**: Generated `const id = \`usr_\${Date.now()}\`` once in `apps/api/src/services/authService.js` and reused it for both the returned object and `token: signAccessToken({ sub: id, role: payload.role })`.
- **Automated Regression Tests**: Added `apps/api/src/tests/authService.test.js` verifying:
  1. `registerUser` with mocked advancing timestamps (`t.mock.method(Date, "now", () => timestamp++)`) guarantees the returned ID and signed JWT subject are strictly identical.
  2. `registerUser` under standard execution returns valid matching credentials.

## Validation
```
npm test -w apps/api
```
Output:
```
TAP version 13
# Subtest: registerUser uses the same user id for returned id and JWT subject even if time advances
ok 1 - registerUser uses the same user id for returned id and JWT subject even if time advances
# Subtest: registerUser returns consistent user id and token sub under normal execution
ok 2 - registerUser returns consistent user id and token sub under normal execution
1..11
# tests 11
# suites 0
# pass 11
# fail 0
```
All 11 monorepo tests passing with 0 failures.
