### PR TITLE
fix(security): cap upload size to prevent memory-exhaustion DoS (#12377)

### DIFF
--- a/apps/api/src/config/env.js
+++ b/apps/api/src/config/env.js
@@ -2,6 +2,7 @@ export const env = {
   nodeEnv: process.env.NODE_ENV ?? "development",
   port: Number(process.env.PORT ?? 4000),
   jwtSecret: process.env.JWT_SECRET ?? "development-secret",
+  maxUploadSizeMb: Number(process.env.MAX_UPLOAD_SIZE_MB ?? 5),
   stripeSecretKey: process.env.STRIPE_SECRET_KEY ?? "",
   databaseUrl: process.env.DATABASE_URL ?? ""
 };

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,15 @@
+import multer from "multer";
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
+
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE") {
+    return fail(res, "Uploaded file exceeds the maximum allowed size", 413);
   }
 
   return res.status(500).json({

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -1,8 +1,15 @@
 import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
+import { env } from "../config/env.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: env.maxUploadSizeMb * 1024 * 1024,
+    files: 1
+  }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
## Summary

Fixes #12377 (parent bounty #11398)

The upload route used `multer.memoryStorage()` with **no `limits`**, so every request could buffer an arbitrarily large file in RAM. Combined with the shared 200 req/15min rate limiter, this is a trivial remote memory-exhaustion DoS.

## Changes

1. **`apps/api/src/routes/uploadRoutes.js`**
   - `limits.fileSize`: `MAX_UPLOAD_SIZE_MB` (default **5 MB**) × 1 MB
   - `limits.files: 1` (matches the existing `upload.single("file")` usage)

2. **`apps/api/src/config/env.js`**
   - New `maxUploadSizeMb` setting (`MAX_UPLOAD_SIZE_MB`, default 5) so operators can tune the cap

3. **`apps/api/src/middleware/errorHandler.js`**
   - Map `MulterError` with code `LIMIT_FILE_SIZE` to **HTTP 413** using the API's standard `{ success: false, message }` failure envelope, instead of falling through to the generic 500

## Notes on scope

- Other `MulterError` codes (parser errors → 400) are intentionally **not** touched here — they are tracked in separate issues (#12247 / #12269) owned by their authors; this PR only handles the size-limit error introduced by this fix.
- Auth on the upload route is tracked separately in #12367 and out of scope here.

## Testing

- `node --check` passes on all three modified files
- Upload under the limit → behaves as before (201)
- Upload over the limit → aborted mid-stream by multer, API returns `413 { success: false, message: "Uploaded file exceeds the maximum allowed size" }` instead of buffering the file or crashing