### PR TITLE
fix(api): target test files explicitly in test script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Summary
- Update apps/api test script from node --test src/tests to node --test src/tests/*.test.js so the runner explicitly executes intended test files.

Implementation
- Single-line change in apps/api/package.json.

Testing
- npm install --no-audit --no-fund
- npm test
- Result: 1 pass, 0 fail (GET /health returns ok payload).

Bounty
- Closes #11393 (parent Algora bounty #743).