### PR TITLE
fix(upload): add filesize and file count limits to multer

### DIFF
--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,7 +1,22 @@
+import multer from "multer";
+
 export function errorHandler(err, req, res, next) {
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (err instanceof multer.MulterError) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      return res.status(413).json({
+        success: false,
+        message: "File too large"
+      });
+    }
+    return res.status(400).json({
+      success: false,
+      message: err.message
+    });
   }
 
   return res.status(500).json({

--- a/apps/api/src/routes/uploadRoutes.js
+++ b/apps/api/src/routes/uploadRoutes.js
@@ -2,7 +2,17 @@ import { Router } from "express";
 import multer from "multer";
 import { uploadFile } from "../controllers/uploadController.js";
 
-const upload = multer({ storage: multer.memoryStorage() });
+const maxUploadSize = process.env.MAX_UPLOAD_SIZE_MB 
+  ? parseInt(process.env.MAX_UPLOAD_SIZE_MB, 10) * 1024 * 1024 
+  : 5 * 1024 * 1024;
+
+const upload = multer({ 
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: maxUploadSize,
+    files: 1
+  }
+});
 
 export const uploadRoutes = Router();
 


### PR DESCRIPTION
Resolves #12383

This PR enforces a configurable file size limit (, defaulting to 5 MB) and file count limit (1) on multer's memoryStorage to prevent memory exhaustion DoS attacks via the upload route. It also adds proper error handling in the middleware to intercept MulterError and return a 413 Payload Too Large error when the limit is breached.