### PR TITLE
fix(auth): prevent admin role selffix(auth): prevent admin role self-assignment during registration (#12385)-assignment during registration

### DIFF
--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,12 +1,20 @@
 import { signAccessToken } from "../utils/jwt.js";
 
+const ALLOWED_ROLES = ['client', 'freelancer'];
+
 export async function registerUser(payload) {
+  // Validate role - prevent admin self-assignment
+  const role = payload.role || 'client';
+  if (!ALLOWED_ROLES.includes(role)) {
+    throw new Error('Invalid role. Allowed roles: client, freelancer');
+  }
+
   // TODO: persist new user via Prisma
   return {
     id: `usr_${Date.now()}`,
     email: payload.email,
-    role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    role: role,
+    token: signAccessToken({ sub: `usr_${Date.now()}`, role: role })
   };
 }
 


### PR DESCRIPTION
## Summary
Prevents privilege escalation by validating the `role` field during user registration.

## Changes
- Added `ALLOWED_ROLES` constant with valid public roles
- Added validation to reject unauthorized roles (including `admin`)
- Returns error for invalid role attempts

## File Changed
`apps/api/src/services/authService.js`

## Testing
- Invalid roles are rejected with error message
- Valid roles (`client`, `freelancer`) work normally
- Default role is `client` when not specified

Closes #12385