### PR TITLE
fix: reject privileged roles during public registration

### DIFF
--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,10 +1,13 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
-  const payload = registerSchema.parse(req.body);
-  const result = await registerUser(payload);
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return fail(res, "Invalid registration data", 400);
+  }
+  const result = await registerUser(parsed.data);
   return ok(res, result, 201);
 }
 

--- a/apps/api/src/tests/registration.test.js
+++ b/apps/api/src/tests/registration.test.js
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { register } from "../controllers/authController.js";
+import { registerSchema } from "../validators/auth.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+const credentials = { email: "signup@example.test", password: "test-password-123" };
+
+function responseRecorder() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; }
+  };
+}
+
+test("public registration schema rejects administrator roles", () => {
+  assert.equal(registerSchema.safeParse({ ...credentials, role: "admin" }).success, false);
+});
+
+test("registration returns 400 without issuing a token for an administrator role", async () => {
+  const res = responseRecorder();
+  await register({ body: { ...credentials, role: "admin" } }, res);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.data, undefined);
+  assert.equal(res.body.token, undefined);
+});
+
+for (const role of ["client", "freelancer", undefined]) {
+  test(`registration preserves the permitted role ${role ?? "default client"}`, async () => {
+    const res = responseRecorder();
+    const body = { ...credentials };
+    if (role !== undefined) body.role = role;
+    await register({ body }, res);
+    assert.equal(res.statusCode, 201);
+    assert.equal(res.body.success, true);
+    assert.equal(res.body.data.role, role ?? "client");
+    assert.equal(verifyAccessToken(res.body.data.token).role, role ?? "client");
+  });
+}
+
+test("invalid signup input returns 400 without rejecting the async controller", async () => {
+  for (const body of [undefined, {}, { ...credentials, role: "owner" }, { ...credentials, email: "invalid" }]) {
+    const res = responseRecorder();
+    await register({ body }, res);
+    assert.equal(res.statusCode, 400);
+    assert.equal(res.body.success, false);
+    assert.equal(res.body.data, undefined);
+  }
+});

--- a/apps/api/src/validators/auth.js
+++ b/apps/api/src/validators/auth.js
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
-  role: z.enum(["client", "freelancer", "admin"]).default("client")
+  role: z.enum(["client", "freelancer"]).default("client")
 });
 
 export const loginSchema = z.object({


### PR DESCRIPTION
Closes #12402

Restricts public signup to client and freelancer roles, preserves the default client role, and returns HTTP 400 for invalid signup data.

Validation: six new regression tests had 3 failures before the fix and all passed afterward. All seven API tests pass with node --test src/tests/*.test.js. git diff --check passes. The unchanged npm test directory argument does not resolve on Node 24.19.0; explicit test-file discovery was used.

Prepared and tested with OpenAI Codex assistance using local synthetic data. No hosted service was tested. This fix addresses registration only.

Contributor attempt under #743. Please confirm the reward for this individual contribution; no bounty award or amount is assumed.