### PR TITLE
fix(auth): require credential verification on login

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,20 @@
 export function errorHandler(err, req, res, next) {
+  // Zod validation errors -> 400 with field details
+  if (err?.errors?.length) {
+    return res.status(400).json({
+      success: false,
+      message: "Validation failed",
+      errors: err.errors.map(({ path, message }) => ({ path: path.join("."), message }))
+    });
+  }
+  // Domain errors carry an explicit status (e.g. 401 from bad credentials)
+  if (err?.status && err.status >= 400 && err.status < 500) {
+    return res.status(err.status).json({ success: false, message: err.message });
+  }
   console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
-
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/routes/authRoutes.js
+++ b/apps/api/src/routes/authRoutes.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { login, oauthCallback, refresh, register } from "../controllers/authController.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
 
 export const authRoutes = Router();
 
-authRoutes.post("/register", register);
-authRoutes.post("/login", login);
+authRoutes.post("/register", asyncHandler(register));
+authRoutes.post("/login", asyncHandler(login));
 authRoutes.get("/oauth/:provider/callback", oauthCallback);
-authRoutes.post("/refresh", refresh);
+authRoutes.post("/refresh", asyncHandler(refresh));

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,62 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
+// Minimal in-memory user registry until the Prisma persistence TODO lands.
+// Register seeds this map; login verifies the submitted password against the
+// stored hash instead of blindly signing a token for a hard-coded subject.
+const users = new Map();
+
+const KEY_LENGTH = 64;
+
+function hashPassword(password) {
+  const salt = randomBytes(16).toString("hex");
+  const derived = scryptSync(password, salt, KEY_LENGTH).toString("hex");
+  return `scrypt$${salt}$${derived}`;
+}
+
+function verifyPassword(password, storedHash) {
+  const [scheme, salt, expected] = String(storedHash ?? "").split("$");
+  if (scheme !== "scrypt" || !salt || !expected) {
+    return false;
+  }
+  const actual = scryptSync(password, salt, KEY_LENGTH);
+  const expectedBuffer = Buffer.from(expected, "hex");
+  return (
+    actual.length === expectedBuffer.length &&
+    timingSafeEqual(actual, expectedBuffer)
+  );
+}
+
+function invalidCredentials() {
+  const err = new Error("Invalid credentials");
+  err.status = 401;
+  return err;
+}
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  users.set(payload.email, {
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  });
+  return {
+    id,
+    email: payload.email,
+    role: payload.role,
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const stored = users.get(payload.email);
+  if (!stored || !verifyPassword(payload.password, stored.passwordHash)) {
+    throw invalidCredentials();
+  }
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: stored.email,
+    token: signAccessToken({ sub: stored.id, role: stored.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+// The forged subject the pre-fix implementation hard-coded for every caller.
+const LEGACY_HARD_CODED_SUBJECT = "usr_existing";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  const post = async (path, body) => {
+    const response = await fetch(`${base}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    const payload = await response.json().catch(() => null);
+    return { status: response.status, payload };
+  };
+
+  try {
+    return await run({ post });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function decodePayload(token) {
+  return JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString());
+}
+
+test("POST /api/auth/login returns a token for the authenticated subject and role", async () => {
+  await withServer(async ({ post }) => {
+    const email = `alice+${Date.now()}@example.com`;
+    const password = "correct-horse-battery-staple";
+
+    const registered = await post("/api/auth/register", { email, password, role: "freelancer" });
+    assert.equal(registered.status, 201);
+    const { id } = registered.payload.data;
+
+    const loggedIn = await post("/api/auth/login", { email, password });
+    assert.equal(loggedIn.status, 200);
+
+    const { token } = loggedIn.payload.data;
+    const payload = decodePayload(token);
+
+    assert.equal(payload.sub, id, "token subject must be the authenticated user's id");
+    assert.equal(payload.role, "freelancer", "token must carry the user's own role");
+    assert.notEqual(payload.sub, LEGACY_HARD_CODED_SUBJECT);
+  });
+});
+
+test("POST /api/auth/login rejects an unknown email with 401", async () => {
+  await withServer(async ({ post }) => {
+    const response = await post("/api/auth/login", {
+      email: `nobody+${Date.now()}@example.com`,
+      password: "any-password-value"
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(response.payload.success, false);
+    assert.match(response.payload.message, /Invalid credentials/i);
+    assert.equal(response.payload.data, undefined, "no token may be issued");
+  });
+});
+
+test("POST /api/auth/login rejects a wrong password with 401", async () => {
+  await withServer(async ({ post }) => {
+    const email = `bob+${Date.now()}@example.com`;
+    const password = "the-real-password";
+
+    await post("/api/auth/register", { email, password, role: "client" });
+    const response = await post("/api/auth/login", { email, password: "not-the-password" });
+
+    assert.equal(response.status, 401);
+    assert.equal(response.payload.success, false);
+    assert.match(response.payload.message, /Invalid credentials/i);
+    assert.equal(response.payload.data, undefined, "no token may be issued");
+  });
+});
+
+test("POST /api/auth/login rejects a malformed body with 400", async () => {
+  await withServer(async ({ post }) => {
+    const response = await post("/api/auth/login", { email: "not-an-email" });
+
+    assert.equal(response.status, 400);
+    assert.equal(response.payload.success, false);
+    assert.match(response.payload.message, /Validation failed/i);
+    assert.equal(response.payload.data, undefined, "no token may be issued");
+  });
+});

--- a/apps/api/src/utils/asyncHandler.js
+++ b/apps/api/src/utils/asyncHandler.js
@@ -1,0 +1,8 @@
+// Express 4 does not forward rejections from async handlers to next(), so an
+// async controller that throws leaves the request hanging with no response.
+// Wrap async handlers so domain errors reach the error middleware.
+export function asyncHandler(handler) {
+  return function wrapped(req, res, next) {
+    return Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## Problem

`POST /api/auth/login` issued a valid 15-minute access token for **any** credentials. `loginUser` in `apps/api/src/services/authService.js` was a TODO stub: it never resolved the user record, never verified the password, and signed a token with a hard-coded `sub: "usr_existing"` and `role: "client"`. A request with `{"email":"x@x.com","password":"anything"}` returned a signed JWT for an existing user.

A second, related defect: `POST /api/auth/login` with unknown or wrong credentials never rejected — the request **hung with no response** (details below).

## Fix

**1. Verify credentials before signing (`authService.js`)**
- `registerUser` stores a hash instead of the plaintext password: `scryptSync` (Node stdlib, no new dependency) with a 16-byte random salt per user, key length 64.
- `loginUser` resolves the record by email, verifies the submitted password against the stored hash with `timingSafeEqual` (constant-time), and throws a `401 "Invalid credentials"` domain error when the record is missing or the hash does not match.
- On success the token is signed for the authenticated subject and role only:

```js
return {
  email: stored.email,
  token: signAccessToken({ sub: stored.id, role: stored.role })
};
```

## Root cause of the hanging rejection

Express 4 does not forward rejections from `async` handlers to `next()`. `loginUser` rejecting with a 401 produced an unhandled promise rejection and **no HTTP response at all** — the client waited until it timed out. The 401 path was therefore unreachable, not merely incorrect.

- Added `apps/api/src/utils/asyncHandler.js` and wrapped the auth route handlers so async errors reach the error middleware.
- `errorHandler.js` now maps Zod validation failures to `400` with field details, and domain errors carrying a `status` to that status, before falling through to the existing `500`.

## Tests

Route-level tests over the real Express app (`apps/api/src/tests/auth.test.js`), covering exactly the behaviors named in the issue:

| Case | Expected | Result |
|---|---|---|
| valid credentials → token | `200`, token `sub` = registered user id, `role` preserved, `sub !== "usr_existing"` | pass |
| unknown email | `401`, no token in payload | pass |
| wrong password | `401`, no token in payload | pass |
| malformed body (invalid email) | `400`, no token in payload | pass |

```
✔ POST /api/auth/login returns a token for the authenticated subject and role
✔ POST /api/auth/login rejects an unknown email with 401
✔ POST /api/auth/login rejects a wrong password with 401
✔ POST /api/auth/login rejects a malformed body with 400
✔ GET /health returns ok payload
  tests 5 · pass 5 · fail 0
```

Verified with `npm test` from the workspace root (the documented command), Node v24.12.0.

## Note on the test script

`apps/api/package.json` had `"test": "node --test src/tests"`, which fails on the current Node LTS line before any test executes (`Cannot find module .../src/tests` — the runner treats the path as a module rather than a directory). Corrected to `node --test` so default test discovery runs the suite. Without this the auth tests could not be exercised by the documented command. Flagging it explicitly since it is adjacent to the issue scope — happy to split it out if you prefer.

Closes #12405
