### PR TITLE
[Bounty $780] POST /api/auth/login signs a valid token for any credentials — authentication bypass

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node src/server.js",
     "start": "node src/server.js",
-    "test": "node --test src/tests"
+    "test": "node --test src/tests/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/apps/api/src/controllers/authController.js
+++ b/apps/api/src/controllers/authController.js
@@ -1,6 +1,6 @@
 import { registerSchema, loginSchema } from "../validators/auth.js";
 import { loginUser, refreshToken, registerUser } from "../services/authService.js";
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 
 export async function register(req, res) {
   const payload = registerSchema.parse(req.body);
@@ -8,10 +8,17 @@ export async function register(req, res) {
   return ok(res, result, 201);
 }
 
-export async function login(req, res) {
-  const payload = loginSchema.parse(req.body);
-  const result = await loginUser(payload);
-  return ok(res, result);
+export async function login(req, res, next) {
+  try {
+    const payload = loginSchema.parse(req.body);
+    const result = await loginUser(payload);
+    return ok(res, result);
+  } catch (err) {
+    if (err.status) {
+      return fail(res, err.message, err.status);
+    }
+    return next(err);
+  }
 }
 
 export async function oauthCallback(req, res) {

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,20 +1,63 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
 import { signAccessToken } from "../utils/jwt.js";
 
+// In-memory user registry until Prisma persistence is wired (see packages/db).
+const users = new Map();
+
+const KEY_LENGTH = 64;
+
+function hashPassword(password) {
+  const salt = randomBytes(16).toString("hex");
+  const derived = scryptSync(password, salt, KEY_LENGTH).toString("hex");
+  return `scrypt$${salt}$${derived}`;
+}
+
+function verifyPassword(password, storedHash) {
+  const [scheme, salt, expected] = String(storedHash ?? "").split("$");
+  if (scheme !== "scrypt" || !salt || !expected) {
+    return false;
+  }
+
+  const actual = scryptSync(password, salt, KEY_LENGTH);
+  const expectedBuffer = Buffer.from(expected, "hex");
+  return (
+    actual.length === expectedBuffer.length &&
+    timingSafeEqual(actual, expectedBuffer)
+  );
+}
+
+function invalidCredentials() {
+  const err = new Error("Invalid credentials");
+  err.status = 401;
+  return err;
+}
+
 export async function registerUser(payload) {
-  // TODO: persist new user via Prisma
-  return {
-    id: `usr_${Date.now()}`,
+  const id = `usr_${Date.now()}`;
+  users.set(payload.email, {
+    id,
     email: payload.email,
     role: payload.role,
-    token: signAccessToken({ sub: `usr_${Date.now()}`, role: payload.role })
+    passwordHash: hashPassword(payload.password)
+  });
+
+  return {
+    id,
+    email: payload.email,
+    role: payload.role,
+    token: signAccessToken({ sub: id, role: payload.role })
   };
 }
 
 export async function loginUser(payload) {
-  // TODO: verify password hash against stored user record
+  const stored = users.get(payload.email);
+  if (!stored || !verifyPassword(payload.password, stored.passwordHash)) {
+    throw invalidCredentials();
+  }
+
   return {
-    email: payload.email,
-    token: signAccessToken({ sub: "usr_existing", role: "client" })
+    email: stored.email,
+    token: signAccessToken({ sub: stored.id, role: stored.role })
   };
 }
 

--- a/apps/api/src/tests/auth.test.js
+++ b/apps/api/src/tests/auth.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+import { verifyAccessToken } from "../utils/jwt.js";
+
+async function withServer(run) {
+  const app = createApp();
+  const server = app.listen(0);
+
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  const { port } = server.address();
+  const base = `http://127.0.0.1:${port}`;
+
+  const post = async (path, body) => {
+    const response = await fetch(`${base}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    const payload = await response.json().catch(() => null);
+    return { status: response.status, payload };
+  };
+
+  try {
+    return await run({ post });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("POST /api/auth/login returns a token for the authenticated subject and role", async () => {
+  await withServer(async ({ post }) => {
+    const email = `alice+${Date.now()}@example.com`;
+    const password = "correct-horse-battery-staple";
+
+    const registered = await post("/api/auth/register", {
+      email,
+      password,
+      role: "freelancer"
+    });
+    assert.equal(registered.status, 201);
+    const { id } = registered.payload.data;
+
+    const loggedIn = await post("/api/auth/login", { email, password });
+    assert.equal(loggedIn.status, 200);
+    assert.equal(loggedIn.payload.success, true);
+
+    const claims = verifyAccessToken(loggedIn.payload.data.token);
+    assert.equal(claims.sub, id);
+    assert.equal(claims.role, "freelancer");
+  });
+});
+
+test("POST /api/auth/login rejects an unknown email with 401", async () => {
+  await withServer(async ({ post }) => {
+    const response = await post("/api/auth/login", {
+      email: `nobody+${Date.now()}@example.com`,
+      password: "any-password-value"
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(response.payload.success, false);
+    assert.match(response.payload.message, /Invalid credentials/i);
+    assert.equal(response.payload.data, undefined);
+  });
+});
+
+test("POST /api/auth/login rejects a wrong password with 401", async () => {
+  await withServer(async ({ post }) => {
+    const email = `bob+${Date.now()}@example.com`;
+    const password = "the-real-password";
+
+    await post("/api/auth/register", { email, password, role: "client" });
+    const response = await post("/api/auth/login", {
+      email,
+      password: "not-the-password"
+    });
+
+    assert.equal(response.status, 401);
+    assert.equal(response.payload.success, false);
+    assert.match(response.payload.message, /Invalid credentials/i);
+    assert.equal(response.payload.data, undefined);
+  });
+});


### PR DESCRIPTION
Fixes #12405

## Bounty context
- **Issue:** https://github.com/SecureBananaLabs/bug-bounty/issues/12405
- **Reward:** $780
- **Source:** github
- **Stack:** not inferred
- **Claim notes:** `loginUser` must resolve the user record by email, verify the submitted password against a stored hash (e.g. bcrypt), reject with 401 when the record is missing or the hash does not match, and sign the token for the authenticated user's ...

## Summary
[Bounty $780] POST /api/auth/login signs a valid token for any credentials — authentication bypass

Automated implementation for the linked bounty issue.

## Changes
```
apps/api/package.json                      |  2 +-
 apps/api/src/controllers/authController.js | 17 ++++--
 apps/api/src/services/authService.js       | 55 ++++++++++++++++--
 apps/api/src/tests/auth.test.js            | 90 ++++++++++++++++++++++++++++++
 4 files changed, 152 insertions(+), 12 deletions(-)
```

## Test plan
- [ ] CI passes
- [ ] Change addresses the linked issue acceptance criteria
- [ ] Added or updated tests where applicable
- [ ] Ran `4. Implement and test only the changes needed for that single issue.`
- [ ] Ran `Include test coverage or evidence of validation when applicable.`