### PR TITLE
fix(api): return JSON 404 envelope for unmatched routes

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import { apiLimiter } from "./middleware/rateLimit.js";
 import { errorHandler } from "./middleware/errorHandler.js";
+import { notFound } from "./middleware/notFound.js";
 import { authRoutes } from "./routes/authRoutes.js";
 import { userRoutes } from "./routes/userRoutes.js";
 import { jobRoutes } from "./routes/jobRoutes.js";
@@ -39,6 +40,7 @@ export function createApp() {
   app.use("/api/search", searchRoutes);
   app.use("/api/admin", adminRoutes);
 
+  app.use(notFound);
   app.use(errorHandler);
   return app;
 }

--- a/apps/api/src/middleware/notFound.js
+++ b/apps/api/src/middleware/notFound.js
@@ -1,0 +1,5 @@
+import { fail } from "../utils/response.js";
+
+export function notFound(req, res) {
+  return fail(res, "Not found", 404);
+}

--- a/apps/api/src/tests/notFound.test.js
+++ b/apps/api/src/tests/notFound.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await fn(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("unmatched API route returns 404 JSON envelope", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/does-not-exist`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  });
+});
+
+test("unmatched route under a mounted prefix returns 404 JSON envelope", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs/unknown/sub/path`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(payload, { success: false, message: "Not found" });
+  });
+});
+
+test("defined routes still respond normally", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, service: "api" });
+  });
+});


### PR DESCRIPTION
## Problem

Unmatched routes (e.g. `GET /api/does-not-exist`) fell through to Express's default handler, which returns an HTML `Cannot GET` page. Every defined route uses the `{ success, ... }` JSON envelope, so API clients that parse JSON broke on 404s.

## Fix

- New `notFound` middleware (`apps/api/src/middleware/notFound.js`) mounted after all routes and before `errorHandler`, returning `fail(res, "Not found", 404)`.

## Tests

`src/tests/notFound.test.js` covers:
- unknown route → 404 + JSON envelope
- unknown path under a mounted prefix → 404 + JSON envelope
- `GET /health` still 200

All tests pass locally: `npm test -w apps/api` (4/4).

Closes #12418