### PR TITLE
fix(web): await params in dynamic route pages for Next 16

### DIFF
--- a/apps/web/app/freelancers/[username]/page.tsx
+++ b/apps/web/app/freelancers/[username]/page.tsx
@@ -1,8 +1,9 @@
-export default function FreelancerProfilePage({ params }: { params: { username: string } }) {
+export default async function FreelancerProfilePage({ params }: { params: Promise<{ username: string }> }) {
+  const { username } = await params;
   return (
     <section className="card">
       <h2>Freelancer Profile</h2>
-      <p>Profile: <strong>{params.username}</strong></p>
+      <p>Profile: <strong>{username}</strong></p>
       <p>Portfolio, reviews, and active proposals appear here.</p>
     </section>
   );

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -1,8 +1,9 @@
-export default function JobDetailPage({ params }: { params: { id: string } }) {
+export default async function JobDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   return (
     <section className="card">
       <h2>Job Detail</h2>
-      <p>Viewing details for <strong>{params.id}</strong>.</p>
+      <p>Viewing details for <strong>{id}</strong>.</p>
       <p>Responsibilities, milestones, and proposals would be shown here.</p>
     </section>
   );


### PR DESCRIPTION
## Problem

Since Next.js 15, `params` is a Promise and must be awaited. This repo is on `next@16.2.6`, where synchronous `params` access errors — so `/jobs/[id]` and `/freelancers/[username]` were broken.

## Fix

Both dynamic pages are now `async` server components that `await params` before reading the route value.

## Verification

`npm run build -w apps/web` — compiles clean, TypeScript passes, both routes prerender correctly (`ƒ Dynamic`).

Closes #12420