### PR TITLE
feat(api): add GET /api/jobs/:id detail endpoint

### DIFF
--- a/apps/api/src/controllers/jobController.js
+++ b/apps/api/src/controllers/jobController.js
@@ -1,9 +1,17 @@
-import { ok } from "../utils/response.js";
+import { fail, ok } from "../utils/response.js";
 import { createJobSchema } from "../validators/job.js";
-import { createJob, listJobs } from "../services/jobService.js";
+import { createJob, getJobById, listJobs } from "../services/jobService.js";
 
 export async function getJobs(req, res) {
   return ok(res, await listJobs());
+}
+
+export async function getJob(req, res) {
+  const job = await getJobById(req.params.id);
+  if (!job) {
+    return fail(res, "Not found", 404);
+  }
+  return ok(res, job);
 }
 
 export async function postJob(req, res) {

--- a/apps/api/src/routes/jobRoutes.js
+++ b/apps/api/src/routes/jobRoutes.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
-import { getJobs, postJob } from "../controllers/jobController.js";
+import { getJob, getJobs, postJob } from "../controllers/jobController.js";
 
 export const jobRoutes = Router();
 
 jobRoutes.get("/", getJobs);
+jobRoutes.get("/:id", getJob);
 jobRoutes.post("/", postJob);

--- a/apps/api/src/services/jobService.js
+++ b/apps/api/src/services/jobService.js
@@ -4,6 +4,10 @@ export async function listJobs() {
   return jobs;
 }
 
+export async function getJobById(id) {
+  return jobs.find((job) => job.id === id) ?? null;
+}
+
 export async function createJob(payload) {
   const job = { id: `job_${Date.now()}`, status: "open", ...payload };
   jobs.push(job);

--- a/apps/api/src/tests/jobDetail.test.js
+++ b/apps/api/src/tests/jobDetail.test.js
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await fn(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const validJob = {
+  title: "Build an API endpoint",
+  description: "Implement a detail endpoint for jobs.",
+  budgetMin: 100,
+  budgetMax: 500,
+  categoryId: "cat_dev"
+};
+
+test("GET /api/jobs/:id returns the created job", async () => {
+  await withServer(async (port) => {
+    const created = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(validJob)
+    }).then((r) => r.json());
+
+    const id = created.data.id;
+    assert.ok(id, "expected an id on the created job");
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs/${id}`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.success, true);
+    assert.equal(payload.data.id, id);
+    assert.equal(payload.data.title, validJob.title);
+  });
+});
+
+test("GET /api/jobs/:id returns 404 JSON envelope for an unknown id", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs/job_missing`);
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.equal(payload.success, false);
+    assert.equal(typeof payload.message, "string");
+  });
+});


### PR DESCRIPTION
## Problem

`jobRoutes` only exposed `GET /` and `POST /` — there was no way to fetch a single job, even though the web app links every job card to `/jobs/<id>`.

## Fix

- `jobService.getJobById(id)` — returns the job or `null`.
- `jobController.getJob` — `200` + envelope for found, `404` JSON envelope for unknown id.
- `GET /api/jobs/:id` route.

## Tests

`src/tests/jobDetail.test.js`: creates a job via `POST /api/jobs`, fetches it by id (200 + correct payload), and asserts the 404 JSON envelope for an unknown id. All tests pass (3/3 in file, suite green).

Closes #12422