### PR TITLE
fix(web): add baseline security headers via next.config

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,20 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders
+      }
+    ];
+  }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Problem

`apps/api` sets security headers via helmet, but `apps/web` (Next.js 16) sent none — `next.config.js` was empty. Next.js doesn't emit security headers by default, leaving the app open to clickjacking and MIME sniffing.

## Fix

`headers()` in `next.config.js` now applies to all routes:
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

## Verification

- `npm run build -w apps/web` passes.
- Verified live: `next start` + `curl -I /` returns all four headers.

Closes #12424