### PR TITLE
fix(api): cap JSON body size and map entity.too.large to 413

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -20,7 +20,7 @@ export function createApp() {
 
   app.use(helmet());
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: "100kb" }));
   app.use(apiLimiter);
 
   app.get("/health", (req, res) => {

--- a/apps/api/src/middleware/errorHandler.js
+++ b/apps/api/src/middleware/errorHandler.js
@@ -1,9 +1,15 @@
+import { fail } from "../utils/response.js";
+
 export function errorHandler(err, req, res, next) {
-  console.error("Unhandled API error:", err);
   if (res.headersSent) {
     return next(err);
   }
 
+  if (err?.type === "entity.too.large") {
+    return fail(res, "Payload too large", 413);
+  }
+
+  console.error("Unhandled API error:", err);
   return res.status(500).json({
     success: false,
     message: "Unexpected server error"

--- a/apps/api/src/tests/bodyLimit.test.js
+++ b/apps/api/src/tests/bodyLimit.test.js
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../app.js";
+
+async function withServer(fn) {
+  const app = createApp();
+  const server = app.listen(0);
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  try {
+    await fn(server.address().port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+test("oversized JSON body returns 413 JSON envelope, not 500", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ padding: "x".repeat(200 * 1024) })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.success, false);
+    assert.equal(payload.message, "Payload too large");
+  });
+});
+
+test("normal JSON body still reaches the route", async () => {
+  await withServer(async (port) => {
+    const response = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Small job",
+        description: "Within the body limit.",
+        budgetMin: 10,
+        budgetMax: 20,
+        categoryId: "cat_dev"
+      })
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.success, true);
+  });
+});


### PR DESCRIPTION
## Problem

`express.json()` ran with no body-size limit — arbitrarily large request bodies were buffered in memory on every POST route (memory-exhaustion DoS). Oversized bodies that body-parser did reject surfaced as generic `500` responses instead of `413`.

## Fix

- `express.json({ limit: "100kb" })`.
- `errorHandler` maps `entity.too.large` to `413` + the standard JSON envelope; other errors still reach the 500 path. Moved `res.headersSent` delegation first so in-flight errors still delegate correctly.

## Tests

`src/tests/bodyLimit.test.js`: ~200kb body → `413` JSON envelope; normal body → `201`. Suite green.

Closes #12426