### PR TITLE
fix(web): link all existing pages in Navigation

### DIFF
--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,10 +3,14 @@ import Link from "next/link";
 const links = [
   ["/", "Home"],
   ["/jobs", "Jobs"],
+  ["/jobs/post", "Post a Job"],
   ["/freelancers/search", "Find Freelancers"],
   ["/dashboard/client", "Client Dashboard"],
   ["/dashboard/freelancer", "Freelancer Dashboard"],
   ["/messaging", "Messaging"],
+  ["/notifications", "Notifications"],
+  ["/billing", "Billing"],
+  ["/settings", "Settings"],
   ["/admin", "Admin"]
 ];
 


### PR DESCRIPTION
## Problem

`Navigation.tsx` linked 7 routes, but the app also serves `/jobs/post`, `/notifications`, `/billing`, and `/settings` — unreachable without typing the URL.

## Fix

Added the four missing links (Post a Job, Notifications, Billing, Settings).

## Verification

`npm run build -w apps/web` — compiles and typechecks clean; all 13 routes prerender.

Closes #12428