### PR TITLE
fix(api): compute admin metrics from real stores

### DIFF
--- a/apps/api/src/services/adminService.js
+++ b/apps/api/src/services/adminService.js
@@ -1,8 +1,12 @@
+import { listJobs } from "./jobService.js";
+import { listUsers } from "./userService.js";
+
 export async function getAdminMetrics() {
+  const [jobs, users] = await Promise.all([listJobs(), listUsers()]);
   return {
-    openJobs: 42,
-    activeFreelancers: 185,
-    flaggedAccounts: 3,
-    monthlyVolume: 128900
+    openJobs: jobs.filter((job) => job.status === "open").length,
+    activeFreelancers: users.filter((user) => user.role === "freelancer").length,
+    flaggedAccounts: 0,
+    monthlyVolume: 0
   };
 }

--- a/apps/api/src/tests/adminMetrics.test.js
+++ b/apps/api/src/tests/adminMetrics.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getAdminMetrics } from "../services/adminService.js";
+import { createJob } from "../services/jobService.js";
+import { createUser } from "../services/userService.js";
+
+test("getAdminMetrics computes counts from real stores", async () => {
+  const before = await getAdminMetrics();
+
+  await createJob({
+    title: "Compute metrics",
+    description: "Jobs should be counted.",
+    budgetMin: 10,
+    budgetMax: 20,
+    categoryId: "cat_dev"
+  });
+  await createUser({ email: "f@example.com", role: "freelancer" });
+
+  const after = await getAdminMetrics();
+
+  assert.equal(after.openJobs, before.openJobs + 1);
+  assert.equal(after.activeFreelancers, before.activeFreelancers + 1);
+  assert.equal(after.flaggedAccounts, 0);
+  assert.equal(after.monthlyVolume, 0);
+});


### PR DESCRIPTION
## Problem

`GET /api/admin/metrics` returned hardcoded constants (`openJobs: 42`, `activeFreelancers: 185`, `flaggedAccounts: 3`, `monthlyVolume: 128900`) — fabricated numbers that never change.

## Fix

`getAdminMetrics` now computes `openJobs` and `activeFreelancers` from the job and user stores. Metrics without a data source yet (`flaggedAccounts`, `monthlyVolume`) report `0` instead of fabricated values.

## Tests

`src/tests/adminMetrics.test.js`: creates a job and a freelancer user, asserts both counts increment. Suite green.

Closes #12430